### PR TITLE
context_flags immutable with functional updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     agent none
     stages {
         stage("Build & Test") {
-            agent {
+            agent { 
                 dockerfile {
                     filename 'docker/dev-ubuntu/Dockerfile'
                     args "-u root --privileged --entrypoint=''" // TODO: set up a proper user in Dockerfile

--- a/lib/Semantic_check.ml
+++ b/lib/Semantic_check.ml
@@ -12,22 +12,19 @@ open Errors
 open Type_conversion
 open Pretty_printing
 
-(* Idea: we have a semantic checking function for each AST node.
-   Each such calls the corresponding checking functions for its children
-   left-to-right. *)
+(* There is a semantic checking function for each AST node that calls
+   the checking functions for its children left to right. *)
 
-(* NB DANGER: this file specifies an imperative tree algorithm which
-   decorates the AST while operating on two bits of state:
-   1) a global symbol table vm
-   2) some context flags context_flags, to communicate information down
-      the AST   *)
+(* Top level function semantic_check_program declares the AST while operating
+   on (1) a global symbol table vm, and (2) structure of type context_flags_record
+   to communicate information down the AST. *)
 
 let check_that_all_functions_have_definition = ref true
 let model_name = ref ""
 let vm = Symbol_table.initialize ()
 
-(* Some imperative context flags that mainly serve to throw semantic errors in a more
-   informative location than would be natural if we treated these functionally. *)
+(* Record structure holding flags and other markers about context to be
+   used for error reporting. *)
 type context_flags_record =
   { mutable current_block: originblock
   ; mutable in_fun_def: bool
@@ -35,14 +32,6 @@ type context_flags_record =
   ; mutable in_rng_fun_def: bool
   ; mutable in_lp_fun_def: bool
   ; mutable loop_depth: int }
-
-let context_flags =
-  { current_block= Functions
-  ; in_fun_def= false
-  ; in_returning_fun_def= false
-  ; in_rng_fun_def= false
-  ; in_lp_fun_def= false
-  ; loop_depth= 0 }
 
 (* Some helper functions *)
 let dup_exists l =
@@ -249,10 +238,17 @@ let rec semantic_check_program
   (* NB: We always want to make sure we start with an empty symbol table, in
      case we are processing multiple files in one run. *)
   let _ = unsafe_clear_symbol_table vm in
-  let _ = context_flags.current_block <- Functions in
-  let semantic_check_statements = List.map ~f:semantic_check_statement in
+  let semantic_check_statements context_flags
+    = List.map ~f:(semantic_check_statement context_flags) in
   let open Option.Monad_infix in
-  let ufb = fb >>| List.map ~f:semantic_check_statement in
+  let context_flags =  { current_block= Functions
+                       ; in_fun_def= false
+                       ; in_returning_fun_def= false
+                       ; in_rng_fun_def= false
+                       ; in_lp_fun_def= false
+                       ; loop_depth= 0 } in 
+  let ufb = fb >>| semantic_check_statements
+                     { context_flags with current_block = Functions } in
   (* Check that all declared functions have a definition *)
   let _ =
     if
@@ -263,21 +259,21 @@ let rec semantic_check_program
         "Some function is declared without specifying a definition."
     (* TODO: insert better location in the error above *)
   in
-  let _ = context_flags.current_block <- Data in
-  let udb = db >>| semantic_check_statements in
-  let _ = context_flags.current_block <- TData in
-  let utdb = tdb >>| semantic_check_statements in
-  let _ = context_flags.current_block <- Param in
-  let upb = pb >>| semantic_check_statements in
-  let _ = context_flags.current_block <- TParam in
-  let utpb = tpb >>| semantic_check_statements in
-  let _ = context_flags.current_block <- Model in
+  let udb = db >>| semantic_check_statements
+                     { context_flags with current_block = Data } in
+  let utdb = tdb >>| semantic_check_statements
+                     { context_flags with current_block = TData } in
+  let upb = pb >>| semantic_check_statements
+                     { context_flags with current_block = Param } in
+  let utpb = tpb >>| semantic_check_statements
+                       { context_flags with current_block = TParam } in
   (* Model top level variables only assigned and read in model  *)
   let _ = Symbol_table.begin_scope vm in
-  let umb = mb >>| semantic_check_statements in
+  let umb = mb >>| semantic_check_statements
+                     { context_flags with current_block = Model } in
   let _ = Symbol_table.end_scope vm in
-  let _ = context_flags.current_block <- GQuant in
-  let ugb = gb >>| semantic_check_statements in
+  let ugb = gb >>| semantic_check_statements
+                     { context_flags with current_block = GQuant } in
   { functionblock= ufb
   ; datablock= udb
   ; transformeddatablock= utdb
@@ -346,11 +342,11 @@ and semantic_check_unsizedtype = function
 and semantic_error_e {expr_typed_loc; _} msg =
   semantic_error ~loc:expr_typed_loc msg
 
-and semantic_check_sizedtype = function
+and semantic_check_sizedtype context_flags = function
   | SInt -> SInt
   | SReal -> SReal
   | SVector e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let _ =
         if not (check_of_int_type ue) then
           semantic_error_e ue
@@ -360,7 +356,7 @@ and semantic_check_sizedtype = function
       in
       SVector ue
   | SRowVector e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let _ =
         if not (check_of_int_type ue) then
           semantic_error_e ue
@@ -370,8 +366,8 @@ and semantic_check_sizedtype = function
       in
       SRowVector ue
   | SMatrix (e1, e2) ->
-      let ue1 = semantic_check_expression e1
-      and ue2 = semantic_check_expression e2 in
+      let ue1 = semantic_check_expression context_flags e1
+      and ue2 = semantic_check_expression context_flags e2 in
       let _ =
         if not (check_of_int_type ue1) then
           semantic_error_e ue1
@@ -388,8 +384,8 @@ and semantic_check_sizedtype = function
       in
       SMatrix (ue1, ue2)
   | SArray (st, e) ->
-      let ust = semantic_check_sizedtype st in
-      let ue = semantic_check_expression e in
+      let ust = semantic_check_sizedtype context_flags st in
+      let ue = semantic_check_expression context_flags e in
       let _ =
         if not (check_of_int_type ue) then
           semantic_error_e ue
@@ -399,10 +395,10 @@ and semantic_check_sizedtype = function
       in
       SArray (ust, ue)
 
-and semantic_check_transformation = function
+and semantic_check_transformation context_flags = function
   | Identity -> Identity
   | Lower e ->
-      let ue = semantic_check_expression e in
+     let ue = semantic_check_expression context_flags e in
       let _ =
         if not (check_of_int_or_real_type ue) then
           semantic_error_e ue
@@ -412,7 +408,7 @@ and semantic_check_transformation = function
       in
       Lower ue
   | Upper e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let _ =
         if not (check_of_int_or_real_type ue) then
           semantic_error_e ue
@@ -422,8 +418,8 @@ and semantic_check_transformation = function
       in
       Upper ue
   | LowerUpper (e1, e2) ->
-      let ue1 = semantic_check_expression e1 in
-      let ue2 = semantic_check_expression e2 in
+      let ue1 = semantic_check_expression context_flags e1 in
+      let ue2 = semantic_check_expression context_flags e2 in
       let _ =
         if not (check_of_int_or_real_type ue1) then
           semantic_error_e ue1
@@ -442,8 +438,8 @@ and semantic_check_transformation = function
       in
       LowerUpper (ue1, ue2)
   | OffsetMultiplier (e1, e2) ->
-      let ue1 = semantic_check_expression e1 in
-      let ue2 = semantic_check_expression e2 in
+      let ue1 = semantic_check_expression context_flags e1 in
+      let ue2 = semantic_check_expression context_flags e2 in
       let _ =
         if not (check_of_int_or_real_type ue1) then
           semantic_error_e ue1
@@ -473,12 +469,12 @@ and semantic_check_transformation = function
 and lub_ad_e exprs =
   lub_ad_type (List.map ~f:(fun x -> x.expr_typed_ad_level) exprs)
 
-and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
+and semantic_check_expression context_flags {expr_untyped_loc= loc; expr_untyped} =
   match expr_untyped with
   | TernaryIf (e1, e2, e3) -> (
-      let ue1 = semantic_check_expression e1 in
-      let ue2 = semantic_check_expression e2 in
-      let ue3 = semantic_check_expression e3 in
+      let ue1 = semantic_check_expression context_flags e1 in
+      let ue2 = semantic_check_expression context_flags e2 in
+      let ue3 = semantic_check_expression context_flags e3 in
       match operator_return_type_from_string "TernaryIf" [ue1; ue2; ue3] with
       | Some (ReturnType ut) ->
           { expr_typed= TernaryIf (ue1, ue2, ue3)
@@ -498,9 +494,9 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
             ^ pretty_print_unsizedtype ue3.expr_typed_type
             ^ "." ) )
   | BinOp (e1, op, e2) -> (
-      let ue1 = semantic_check_expression e1
+      let ue1 = semantic_check_expression context_flags e1
       and uop = semantic_check_operator op
-      and ue2 = semantic_check_expression e2 in
+      and ue2 = semantic_check_expression context_flags e2 in
       match operator_return_type uop [ue1; ue2] with
       | Some (ReturnType ut) ->
           { expr_typed= BinOp (ue1, uop, ue2)
@@ -519,7 +515,7 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
             ^ "." ) )
   | PrefixOp (op, e) -> (
       let uop = semantic_check_operator op
-      and ue = semantic_check_expression e in
+      and ue = semantic_check_expression context_flags e in
       match operator_return_type_prefix uop [ue] with
       | Some (ReturnType ut) ->
           { expr_typed= PrefixOp (uop, ue)
@@ -535,7 +531,7 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
             ^ pretty_print_unsizedtype ue.expr_typed_type
             ^ "." ) )
   | PostfixOp (e, op) -> (
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let uop = semantic_check_operator op in
       match operator_return_type op [ue] with
       | Some (ReturnType ut) ->
@@ -578,7 +574,7 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
       ; expr_typed_loc= loc }
   | FunApp (id, es) -> (
       let uid = semantic_check_identifier id
-      and ues = List.map ~f:semantic_check_expression es in
+      and ues = List.map ~f:(semantic_check_expression context_flags) es in
       let _ =
         if uid.name = "map_rect" then
           match ues with
@@ -714,7 +710,7 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
             "Only functions with names ending in _lpdf, _lpmf, _lcdf, _lccdf \
              can make use of conditional notation."
       in
-      let ues = List.map ~f:semantic_check_expression es in
+      let ues = List.map ~f:(semantic_check_expression context_flags) es in
       (* Target+= can only be used in model and functions with right suffix (same for tilde etc) *)
       let _ =
         if
@@ -832,7 +828,7 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
       ; expr_typed_type= UReal
       ; expr_typed_loc= loc }
   | ArrayExpr es ->
-      let ues = List.map ~f:semantic_check_expression es in
+      let ues = List.map ~f:(semantic_check_expression context_flags) es in
       let elementtypes = List.map ~f:(fun y -> y.expr_typed_type) ues in
       (* Array expressions must be of uniform type. (Or mix of int and real) *)
       let _ =
@@ -860,7 +856,7 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
       ; expr_typed_type= array_type
       ; expr_typed_loc= loc }
   | RowVectorExpr es ->
-      let ues = List.map ~f:semantic_check_expression es in
+      let ues = List.map ~f:(semantic_check_expression context_flags) es in
       let elementtypes = List.map ~f:(fun y -> y.expr_typed_type) ues in
       let ut =
         if List.for_all ~f:(fun x -> x = UReal || x = UInt) elementtypes then
@@ -878,14 +874,14 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
       ; expr_typed_type= ut
       ; expr_typed_loc= loc }
   | Paren e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       { expr_typed= Paren ue
       ; expr_typed_ad_level= ue.expr_typed_ad_level
       ; expr_typed_type= ue.expr_typed_type
       ; expr_typed_loc= loc }
   | Indexed (e, indices) ->
-      let ue = semantic_check_expression e in
-      let uindices = List.map ~f:semantic_check_index indices in
+      let ue = semantic_check_expression context_flags e in
+      let uindices = List.map ~f:(semantic_check_index context_flags) indices in
       let uindices_with_types =
         List.map
           ~f:(function
@@ -958,17 +954,17 @@ and semantic_check_expression {expr_untyped_loc= loc; expr_untyped} =
 (* Probably nothing to do here *)
 and semantic_check_operator i = i
 
-and semantic_check_printable = function
+and semantic_check_printable context_flags = function
   | PString s -> PString s
   (* Print/reject expressions cannot be of function type. *)
   | PExpr e -> (
-      let ue = semantic_check_expression e in
+    let ue = semantic_check_expression context_flags e in
       match ue.expr_typed_type with
       | UFun _ | UMathLibraryFunction ->
           semantic_error ~loc:ue.expr_typed_loc "Functions cannot be printed."
       | _ -> PExpr ue )
 
-and semantic_check_statement s =
+and semantic_check_statement context_flags s =
   let loc = s.stmt_untyped_loc in
   match s.stmt_untyped with
   | Assignment
@@ -977,7 +973,7 @@ and semantic_check_statement s =
       ; assign_op= assop
       ; assign_rhs= e } -> (
       let ue2 =
-        semantic_check_expression
+        semantic_check_expression context_flags
           { expr_untyped=
               Indexed
                 ( {expr_untyped= Variable id; expr_untyped_loc= id.id_loc}
@@ -991,7 +987,7 @@ and semantic_check_statement s =
         | _ -> fatal_error ()
       in
       let uassop = semantic_check_assignmentoperator assop in
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let uidoblock =
         match Option.map ~f:fst (Symbol_table.look vm uid.name) with
         | Some b -> b
@@ -1044,7 +1040,7 @@ and semantic_check_statement s =
             else "" ) )
   | NRFunApp (id, es) -> (
       let uid = semantic_check_identifier id in
-      let ues = List.map ~f:semantic_check_expression es in
+      let ues = List.map ~f:(semantic_check_expression context_flags) es in
       let _ =
         if
           String.is_suffix uid.name ~suffix:"_lp"
@@ -1119,7 +1115,7 @@ and semantic_check_statement s =
                 ^ ("'" ^ uid.name ^ "'")
                 ^ " was supplied." ) ) )
   | TargetPE e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       (* We check typing of ~ and target += *)
       let _ =
         match ue.expr_typed_type with
@@ -1143,7 +1139,7 @@ and semantic_check_statement s =
       ; stmt_typed_returntype= NoReturnType
       ; stmt_typed_loc= loc }
   | IncrementLogProb e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let _ =
         match ue.expr_typed_type with
         | UFun _ | UMathLibraryFunction ->
@@ -1166,7 +1162,7 @@ and semantic_check_statement s =
       ; stmt_typed_returntype= NoReturnType
       ; stmt_typed_loc= loc }
   | Tilde {arg= e; distribution= id; args= es; truncation= t} ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let uid = semantic_check_identifier id in
       let _ =
         if
@@ -1177,8 +1173,8 @@ and semantic_check_statement s =
             "~-statement expects a distribution name without '_lpdf' or \
              '_lpmf' suffix."
       in
-      let ues = List.map ~f:semantic_check_expression es in
-      let ut = semantic_check_truncation t in
+      let ues = List.map ~f:(semantic_check_expression context_flags) es in
+      let ut = semantic_check_truncation context_flags t in
       (* Target+= can only be used in model and functions with right suffix (same for tilde etc) *)
       let _ =
         if
@@ -1319,7 +1315,7 @@ and semantic_check_statement s =
             "Expression return statements may only be used inside returning \
              function definitions."
       in
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       { stmt_typed= Return ue
       ; stmt_typed_returntype= Complete (ReturnType ue.expr_typed_type)
       ; stmt_typed_loc= loc }
@@ -1335,12 +1331,12 @@ and semantic_check_statement s =
       ; stmt_typed_returntype= Complete Void
       ; stmt_typed_loc= loc }
   | Print ps ->
-      let ups = List.map ~f:semantic_check_printable ps in
+      let ups = List.map ~f:(semantic_check_printable context_flags) ps in
       { stmt_typed= Print ups
       ; stmt_typed_returntype= NoReturnType
       ; stmt_typed_loc= loc }
   | Reject ps ->
-      let ups = List.map ~f:semantic_check_printable ps in
+      let ups = List.map ~f:(semantic_check_printable context_flags) ps in
       { stmt_typed= Reject ups
       ; stmt_typed_returntype= AnyReturnType
       ; stmt_typed_loc= loc }
@@ -1349,7 +1345,7 @@ and semantic_check_statement s =
       ; stmt_typed_returntype= NoReturnType
       ; stmt_typed_loc= loc }
   | IfThenElse (e, s1, os2) ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       (* For, while, for each, if constructs take expressions of valid type *)
       let _ =
         if not (check_of_int_or_real_type ue) then
@@ -1359,8 +1355,8 @@ and semantic_check_statement s =
             ^ pretty_print_unsizedtype ue.expr_typed_type
             ^ "." )
       in
-      let us1 = semantic_check_statement s1 in
-      let uos2 = Option.map ~f:semantic_check_statement os2 in
+      let us1 = semantic_check_statement context_flags s1 in
+      let uos2 = Option.map ~f:(semantic_check_statement context_flags) os2 in
       let srt1 = us1.stmt_typed_returntype in
       let srt2 =
         match uos2 with
@@ -1372,7 +1368,7 @@ and semantic_check_statement s =
       ; stmt_typed_loc= loc
       ; stmt_typed_returntype= srt }
   | While (e, s) ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       (* For, while, for each, if constructs take expressions of valid type *)
       let _ =
         if not (check_of_int_or_real_type ue) then
@@ -1382,16 +1378,16 @@ and semantic_check_statement s =
             ^ pretty_print_unsizedtype ue.expr_typed_type
             ^ "." )
       in
-      let _ = context_flags.loop_depth <- context_flags.loop_depth + 1 in
-      let us = semantic_check_statement s in
-      let _ = context_flags.loop_depth <- context_flags.loop_depth - 1 in
+      let us = semantic_check_statement
+                 { context_flags with loop_depth = context_flags.loop_depth + 1 }
+                 s in
       { stmt_typed= While (ue, us)
       ; stmt_typed_returntype= us.stmt_typed_returntype
       ; stmt_typed_loc= loc }
   | For {loop_variable= id; lower_bound= e1; upper_bound= e2; loop_body= s} ->
       let uid = semantic_check_identifier id in
-      let ue1 = semantic_check_expression e1 in
-      let ue2 = semantic_check_expression e2 in
+      let ue1 = semantic_check_expression context_flags e1 in
+      let ue2 = semantic_check_expression context_flags e2 in
       (* For, while, for each, if constructs take expressions of valid type *)
       let _ =
         if not (check_of_int_type ue1) then
@@ -1415,9 +1411,9 @@ and semantic_check_statement s =
       let _ = Symbol_table.enter vm uid.name (oindexblock, UInt) in
       (* Check that function args and loop identifiers are not modified in function. (passed by const ref)*)
       let _ = Symbol_table.set_read_only vm uid.name in
-      let _ = context_flags.loop_depth <- context_flags.loop_depth + 1 in
-      let us = semantic_check_statement s in
-      let _ = context_flags.loop_depth <- context_flags.loop_depth - 1 in
+      let us = semantic_check_statement 
+                 { context_flags with loop_depth = context_flags.loop_depth + 1 }
+                 s in
       let _ = Symbol_table.end_scope vm in
       { stmt_typed=
           For
@@ -1429,7 +1425,7 @@ and semantic_check_statement s =
       ; stmt_typed_loc= loc }
   | ForEach (id, e, s) ->
       let uid = semantic_check_identifier id in
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       (* For, while, for each, if constructs take expressions of valid type *)
       let loop_identifier_unsizedtype =
         match ue.expr_typed_type with
@@ -1451,16 +1447,16 @@ and semantic_check_statement s =
       in
       (* Check that function args and loop identifiers are not modified in function. (passed by const ref)*)
       let _ = Symbol_table.set_read_only vm uid.name in
-      let _ = context_flags.loop_depth <- context_flags.loop_depth + 1 in
-      let us = semantic_check_statement s in
-      let _ = context_flags.loop_depth <- context_flags.loop_depth - 1 in
+      let us = semantic_check_statement
+                 { context_flags with loop_depth = context_flags.loop_depth + 1}
+                 s in
       let _ = Symbol_table.end_scope vm in
       { stmt_typed= ForEach (uid, ue, us)
       ; stmt_typed_returntype= us.stmt_typed_returntype
       ; stmt_typed_loc= loc }
   | Block vdsl ->
       let _ = Symbol_table.begin_scope vm in
-      let uvdsl = List.map ~f:semantic_check_statement vdsl in
+      let uvdsl = List.map ~f:(semantic_check_statement context_flags) vdsl in
       let _ = Symbol_table.end_scope vm in
       (* Any statements after a break or continue or return or reject do not count for the return
       type. *)
@@ -1486,7 +1482,7 @@ and semantic_check_statement s =
       ; identifier= id
       ; initial_value= init
       ; is_global= glob } ->
-      let ust = semantic_check_sizedtype st
+     let ust = semantic_check_sizedtype context_flags st
       and not_ptq e f =
         match e.expr_typed_ad_level with AutoDiffable -> false | _ -> f ()
       in
@@ -1507,7 +1503,7 @@ and semantic_check_statement s =
           semantic_error ~loc
             "Non-data variables are not allowed in top level size declarations."
       in
-      let utrans = semantic_check_transformation trans in
+      let utrans = semantic_check_transformation context_flags trans in
       let uid = semantic_check_identifier id in
       let ut = unsizedtype_of_sizedtype ust in
       let _ = check_fresh_variable uid false in
@@ -1546,7 +1542,7 @@ and semantic_check_statement s =
         | None -> None
         | Some e -> (
           match
-            semantic_check_statement
+            semantic_check_statement context_flags
               { stmt_untyped=
                   Assignment
                     { assign_identifier= id
@@ -1670,16 +1666,6 @@ and semantic_check_statement s =
                 ( error_string ^ " Instead found type "
                 ^ pretty_print_unsizedtype x ^ "." )
       in
-      let _ = context_flags.in_fun_def <- true in
-      let _ =
-        if is_suffix uid.name ~suffix:"_rng" then
-          context_flags.in_rng_fun_def <- true
-      in
-      let _ =
-        if is_suffix uid.name ~suffix:"_lp" then
-          context_flags.in_lp_fun_def <- true
-      in
-      let _ = if urt <> Void then context_flags.in_returning_fun_def <- true in
       let _ = Symbol_table.begin_scope vm in
       (* All function arguments are distinct *)
       let _ =
@@ -1700,7 +1686,14 @@ and semantic_check_statement s =
                | DataOnly, ut -> (Data, ut) | AutoDiffable, ut -> (Param, ut))
              uarg_types)
       in
-      let ub = semantic_check_statement b in
+      let ub = semantic_check_statement
+                 { context_flags with
+                   in_fun_def = true;
+                   in_rng_fun_def = is_suffix uid.name ~suffix:"_rng";
+                   in_lp_fun_def = is_suffix uid.name ~suffix:"_lp";
+                   in_returning_fun_def = urt <> Void;
+                 }
+                 b in
       (* Check that every trace through function body contains return statement of right type *)
       let _ =
         if
@@ -1713,19 +1706,15 @@ and semantic_check_statement s =
              in every branch."
       in
       let _ = Symbol_table.end_scope vm in
-      let _ = context_flags.in_fun_def <- false in
-      let _ = context_flags.in_returning_fun_def <- false in
-      let _ = context_flags.in_lp_fun_def <- false in
-      let _ = context_flags.in_rng_fun_def <- false in
       { stmt_typed=
           FunDef {returntype= urt; funname= uid; arguments= uargs; body= ub}
       ; stmt_typed_returntype= NoReturnType
       ; stmt_typed_loc= loc }
 
-and semantic_check_truncation = function
+and semantic_check_truncation context_flags = function
   | NoTruncate -> NoTruncate
   | TruncateUpFrom e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let loc = ue.expr_typed_loc in
       let _ =
         if not (check_of_int_or_real_type ue) then
@@ -1736,7 +1725,7 @@ and semantic_check_truncation = function
       in
       TruncateUpFrom ue
   | TruncateDownFrom e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let loc = ue.expr_typed_loc in
       let _ =
         if not (check_of_int_or_real_type ue) then
@@ -1747,8 +1736,8 @@ and semantic_check_truncation = function
       in
       TruncateDownFrom ue
   | TruncateBetween (e1, e2) ->
-      let ue1 = semantic_check_expression e1 in
-      let ue2 = semantic_check_expression e2 in
+      let ue1 = semantic_check_expression context_flags e1 in
+      let ue2 = semantic_check_expression context_flags e2 in
       let _ =
         if not (check_of_int_or_real_type ue1) then
           semantic_error_e ue1
@@ -1765,11 +1754,11 @@ and semantic_check_truncation = function
       in
       TruncateBetween (ue1, ue2)
 
-and semantic_check_index = function
+and semantic_check_index context_flags = function
   | All -> All
   (* Check that indexes have int (container) type *)
   | Single e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let loc = ue.expr_typed_loc in
       if check_of_int_type ue || check_of_int_array_type ue then Single ue
       else
@@ -1779,7 +1768,7 @@ and semantic_check_index = function
           ^ pretty_print_unsizedtype ue.expr_typed_type
           ^ "." )
   | Upfrom e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let loc = ue.expr_typed_loc in
       let _ =
         if not (check_of_int_type ue) then
@@ -1790,7 +1779,7 @@ and semantic_check_index = function
       in
       Upfrom ue
   | Downfrom e ->
-      let ue = semantic_check_expression e in
+      let ue = semantic_check_expression context_flags e in
       let loc = ue.expr_typed_loc in
       let _ =
         if not (check_of_int_type ue) then
@@ -1801,8 +1790,8 @@ and semantic_check_index = function
       in
       Downfrom ue
   | Between (e1, e2) ->
-      let ue1 = semantic_check_expression e1 in
-      let ue2 = semantic_check_expression e2 in
+      let ue1 = semantic_check_expression context_flags e1 in
+      let ue2 = semantic_check_expression context_flags e2 in
       let _ =
         if not (check_of_int_type ue1) then
           semantic_error_e ue1

--- a/lib/Semantic_check.ml
+++ b/lib/Semantic_check.ml
@@ -26,12 +26,12 @@ let vm = Symbol_table.initialize ()
 (* Record structure holding flags and other markers about context to be
    used for error reporting. *)
 type context_flags_record =
-  { mutable current_block: originblock
-  ; mutable in_fun_def: bool
-  ; mutable in_returning_fun_def: bool
-  ; mutable in_rng_fun_def: bool
-  ; mutable in_lp_fun_def: bool
-  ; mutable loop_depth: int }
+  { current_block: originblock
+  ; in_fun_def: bool
+  ; in_returning_fun_def: bool
+  ; in_rng_fun_def: bool
+  ; in_lp_fun_def: bool
+  ; loop_depth: int }
 
 (* Some helper functions *)
 let dup_exists l =


### PR DESCRIPTION
* Remove global variable `context_flags` from `Semantic_check.ml`

* Plumb immutable `context_flags` through as argument

* Use [functional updates](http://dev.realworldocaml.org/records.html#functional-updates) in place of mutability

No behavior changes, but this touches a lot of lines of code.