### PR TITLE
Fixing bad tests compound assign

### DIFF
--- a/test/integration/examples-bad/new/compound-assign-decl-bad1.stan
+++ b/test/integration/examples-bad/new/compound-assign-decl-bad1.stan
@@ -1,1 +1,1 @@
-model { real T[1]= {5.0};}
+model { real T[1] <- {5.0};}

--- a/test/integration/examples-bad/new/compound-assign-decl-bad2.stan
+++ b/test/integration/examples-bad/new/compound-assign-decl-bad2.stan
@@ -1,1 +1,1 @@
-transformed data { real T[1] = {1.1};}
+transformed data { real T[1] <- {1.1};}

--- a/test/integration/examples-bad/new/stanc.expected
+++ b/test/integration/examples-bad/new/stanc.expected
@@ -145,7 +145,43 @@ Expect a statement or top-level variable declaration.
 
   $ ../../../../../install/default/bin/stanc compound-assign-decl-bad1.stan
 
+Warning: deprecated language construct used in file compound-assign-decl-bad1.stan, line 1, column 19:
+   -------------------------------------------------
+     1:  model { real T[1] <- {5.0};}
+                            ^
+   -------------------------------------------------
+
+assignment operator <- is deprecated in the Stan language; use = instead.
+
+
+Syntax error in file compound-assign-decl-bad1.stan, line 1, columns 14-17, parsing error:
+   -------------------------------------------------
+     1:  model { real T[1] <- {5.0};}
+                          ^
+   -------------------------------------------------
+
+Expected  ";" or "=" expression ";".
+
+
   $ ../../../../../install/default/bin/stanc compound-assign-decl-bad2.stan
+
+Warning: deprecated language construct used in file compound-assign-decl-bad2.stan, line 1, column 30:
+   -------------------------------------------------
+     1:  transformed data { real T[1] <- {1.1};}
+                                       ^
+   -------------------------------------------------
+
+assignment operator <- is deprecated in the Stan language; use = instead.
+
+
+Syntax error in file compound-assign-decl-bad2.stan, line 1, columns 25-28, parsing error:
+   -------------------------------------------------
+     1:  transformed data { real T[1] <- {1.1};}
+                                     ^
+   -------------------------------------------------
+
+Expected  ";" or "=" expression ";".
+
 
   $ ../../../../../install/default/bin/stanc fun-app-bad1.stan
 


### PR DESCRIPTION
This fixes issue https://github.com/stan-dev/stanc3/issues/47 .

These tests got modified when I switched all of our test models away from using the deprecated syntax <- . They are back to their original now.