### PR TITLE
Fix integration tests to run on Windows too

### DIFF
--- a/test/integration/run_bin_on_args.ml
+++ b/test/integration/run_bin_on_args.ml
@@ -1,8 +1,22 @@
 open Core_kernel
 
+let maybe_convert_cmd_to_windows cmd =
+  let pattern = "/install/default/bin/" in
+  let to_windows str =
+    String.substr_replace_first ~pattern ~with_:"/install/default.windows/bin/"
+      str
+  in
+  let path =
+    String.prefix cmd
+      (String.substr_index_exn ~pattern cmd + String.length pattern)
+  in
+  if Sys.file_exists (to_windows path) then to_windows cmd else cmd
+
 let run_capturing_output cmd =
   let noflags = Array.create ~len:0 "" in
-  let stdout, stdin, stderr = Unix.open_process_full cmd noflags in
+  let stdout, stdin, stderr =
+    Unix.open_process_full (maybe_convert_cmd_to_windows cmd) noflags
+  in
   let chns = [stdout; stderr] in
   let out = List.map ~f:In_channel.input_lines chns in
   ignore (Unix.close_process_full (stdout, stdin, stderr)) ;


### PR DESCRIPTION
This PR makes sure that the integration tests can be run on Windows as well. It leads to the following behaviour:
- `dune runtest` will try to run the integration tests with the binary built in the `default.windows` context, if it exists;
- if not, then it simply uses the binary in the `default` context.

That is, on OSX / Linux, your workflow will stay the same and on WSL it will be such that
- `make clean`;  `dune runtest` will build an Ubuntu binary and run the tests on it;
- `make clean`; `dune build -x windows @runtest` will build a Windows binary and run the tests on it.