### PR TITLE
Monotone framework

### DIFF
--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -120,7 +120,7 @@ type stmt_loc =
 
 type stmt_loc_num =
   { slocn: string sexp_opaque [@compare.ignore]
-  ; stmtn: stmt_loc statement
+  ; stmtn: stmt_loc_num statement
   ; num: int }
 [@@deriving sexp, hash]
 

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -45,11 +45,11 @@ and expr =
   | BinOp of expr * operator * expr
   | TernaryIf of expr * expr * expr
   | Indexed of expr * index list
-[@@deriving sexp, hash]
+[@@deriving sexp, hash, map]
 
-type adtype = Ast.autodifftype [@@deriving sexp, hash]
-type sizedtype = expr Ast.sizedtype [@@deriving sexp, hash]
-type unsizedtype = Ast.unsizedtype [@@deriving sexp, hash]
+type adtype = Ast.autodifftype [@@deriving sexp, hash, map]
+type sizedtype = expr Ast.sizedtype [@@deriving sexp, hash, map]
+type unsizedtype = Ast.unsizedtype [@@deriving sexp, hash, map]
 
 (* This directive silences some spurious warnings from ppx_deriving *)
 [@@@ocaml.warning "-A"]
@@ -85,7 +85,7 @@ and 's statement =
       ; fdname: string
       ; fdargs: fun_arg_decl
       ; fdbody: 's }
-[@@deriving sexp, hash]
+[@@deriving sexp, hash, map]
 
 (** A "top var" is a global variable visible to the I/O of Stan.
    Local vs. Global vardecls
@@ -112,17 +112,17 @@ type 's prog =
   ; gqb: top_var_table * 's
   ; prog_name: string
   ; prog_path: string }
-[@@deriving sexp]
+[@@deriving sexp, map]
 
 type stmt_loc =
   {sloc: string sexp_opaque [@compare.ignore]; stmt: stmt_loc statement}
-[@@deriving sexp, hash]
+[@@deriving sexp, hash, map]
 
 type stmt_loc_num =
   { slocn: string sexp_opaque [@compare.ignore]
   ; stmtn: stmt_loc_num statement
   ; num: int }
-[@@deriving sexp, hash]
+[@@deriving sexp, hash, map]
 
 (* ===================== Some helper functions ====================== *)
 
@@ -135,3 +135,18 @@ let rec map_toplevel_stmts f {sloc; stmt} =
   | _ -> f {sloc; stmt}
 
 let tvdecl_to_decl {tvident; tvtype; tvloc; _} = (tvident, tvtype, tvloc)
+
+let rec unnumbered_statement_of_numbered_statement {stmtn; slocn; _} =
+  { stmt= map_statement unnumbered_statement_of_numbered_statement stmtn
+  ; sloc= slocn }
+
+let numbered_statement_of_unnumbered_statement {stmt; sloc} =
+  failwith "TODO: not yet implemented"
+
+(** Forgetful function from numbered to unnumbered programs *)
+let unnumbered_prog_of_numbered_prog p =
+  map_prog unnumbered_statement_of_numbered_statement p
+
+(** Decorate statements in Mir with unique numbers *)
+let numbered_prog_of_unnumbered_prog p =
+  map_prog numbered_statement_of_unnumbered_statement p

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -118,6 +118,12 @@ type stmt_loc =
   {sloc: string sexp_opaque [@compare.ignore]; stmt: stmt_loc statement}
 [@@deriving sexp, hash]
 
+type stmt_loc_num =
+  { slocn: string sexp_opaque [@compare.ignore]
+  ; stmtn: stmt_loc statement
+  ; num: int }
+[@@deriving sexp, hash]
+
 (* ===================== Some helper functions ====================== *)
 
 (** Dives into any number of nested blocks and lists, but will not recurse other

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -423,145 +423,46 @@ let transfer_gen_kill_alt p gen kill =
    expression pass. *)
 let available_expressions_transfer
     (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t)
-    (_ : (int, Mir.expr Set.Poly.t * Mir.expr Set.Poly.t) Map.Poly.t) =
+    (anticipated_expressions :
+      (int, Mir.expr Set.Poly.t entry_exit) Map.Poly.t) =
   ( module struct
     type labels = int
     type properties = Mir.expr Set.Poly.t
 
     let transfer_function l p =
       let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
-      let gen =
-        match mir_node with
-        | Mir.Assignment (_, _) -> failwith "<case>"
-        | Mir.TargetPE _ -> failwith "<case>"
-        | Mir.NRFunApp (_, _) -> failwith "<case>"
-        | Mir.Check _ -> failwith "<case>"
-        | Mir.Break -> failwith "<case>"
-        | Mir.Continue -> failwith "<case>"
-        | Mir.Return _ -> failwith "<case>"
-        | Mir.Skip -> failwith "<case>"
-        | Mir.IfElse (_, _, _) -> failwith "<case>"
-        | Mir.While (_, _) -> failwith "<case>"
-        | Mir.For _ -> failwith "<case>"
-        | Mir.Block _ -> failwith "<case>"
-        | Mir.SList _ -> failwith "<case>"
-        | Mir.Decl _ -> failwith "<case>"
-        | Mir.FunDef _ -> failwith "<case>"
-      in
-      let kill =
-        match mir_node with
-        | Mir.Assignment (_, _) -> failwith "<case>"
-        | Mir.TargetPE _ -> failwith "<case>"
-        | Mir.NRFunApp (_, _) -> failwith "<case>"
-        | Mir.Check _ -> failwith "<case>"
-        | Mir.Break -> failwith "<case>"
-        | Mir.Continue -> failwith "<case>"
-        | Mir.Return _ -> failwith "<case>"
-        | Mir.Skip -> failwith "<case>"
-        | Mir.IfElse (_, _, _) -> failwith "<case>"
-        | Mir.While (_, _) -> failwith "<case>"
-        | Mir.For _ -> failwith "<case>"
-        | Mir.Block _ -> failwith "<case>"
-        | Mir.SList _ -> failwith "<case>"
-        | Mir.Decl _ -> failwith "<case>"
-        | Mir.FunDef _ -> failwith "<case>"
-      in
+      let gen = (Map.find_exn anticipated_expressions l).entry in
+      let kill = killed_expressions_stmt p mir_node in
       transfer_gen_kill_alt p gen kill
   end
   : TRANSFER_FUNCTION )
 
 let postponable_expressions_transfer
-    (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t) =
+    (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t)
+    (earliest : (int, Mir.expr Set.Poly.t) Map.Poly.t) =
   ( module struct
     type labels = int
     type properties = Mir.expr Set.Poly.t
 
     let transfer_function l p =
       let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
-      let gen =
-        match mir_node with
-        | Mir.Assignment (_, _) -> failwith "<case>"
-        | Mir.TargetPE _ -> failwith "<case>"
-        | Mir.NRFunApp (_, _) -> failwith "<case>"
-        | Mir.Check _ -> failwith "<case>"
-        | Mir.Break -> failwith "<case>"
-        | Mir.Continue -> failwith "<case>"
-        | Mir.Return _ -> failwith "<case>"
-        | Mir.Skip -> failwith "<case>"
-        | Mir.IfElse (_, _, _) -> failwith "<case>"
-        | Mir.While (_, _) -> failwith "<case>"
-        | Mir.For _ -> failwith "<case>"
-        | Mir.Block _ -> failwith "<case>"
-        | Mir.SList _ -> failwith "<case>"
-        | Mir.Decl _ -> failwith "<case>"
-        | Mir.FunDef _ -> failwith "<case>"
-      in
-      let kill =
-        match mir_node with
-        | Mir.Assignment (_, _) -> failwith "<case>"
-        | Mir.TargetPE _ -> failwith "<case>"
-        | Mir.NRFunApp (_, _) -> failwith "<case>"
-        | Mir.Check _ -> failwith "<case>"
-        | Mir.Break -> failwith "<case>"
-        | Mir.Continue -> failwith "<case>"
-        | Mir.Return _ -> failwith "<case>"
-        | Mir.Skip -> failwith "<case>"
-        | Mir.IfElse (_, _, _) -> failwith "<case>"
-        | Mir.While (_, _) -> failwith "<case>"
-        | Mir.For _ -> failwith "<case>"
-        | Mir.Block _ -> failwith "<case>"
-        | Mir.SList _ -> failwith "<case>"
-        | Mir.Decl _ -> failwith "<case>"
-        | Mir.FunDef _ -> failwith "<case>"
-      in
+      let gen = Map.find_exn earliest l in
+      let kill = top_used_expressions_stmt mir_node in
       transfer_gen_kill_alt p gen kill
   end
   : TRANSFER_FUNCTION )
 
 let used_expressions_transfer
-    (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t) =
+    (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t)
+    (latest : (int, Mir.expr Set.Poly.t) Map.Poly.t) =
   ( module struct
     type labels = int
     type properties = Mir.expr Set.Poly.t
 
     let transfer_function l p =
       let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
-      let gen =
-        match mir_node with
-        | Mir.Assignment (_, _) -> failwith "<case>"
-        | Mir.TargetPE _ -> failwith "<case>"
-        | Mir.NRFunApp (_, _) -> failwith "<case>"
-        | Mir.Check _ -> failwith "<case>"
-        | Mir.Break -> failwith "<case>"
-        | Mir.Continue -> failwith "<case>"
-        | Mir.Return _ -> failwith "<case>"
-        | Mir.Skip -> failwith "<case>"
-        | Mir.IfElse (_, _, _) -> failwith "<case>"
-        | Mir.While (_, _) -> failwith "<case>"
-        | Mir.For _ -> failwith "<case>"
-        | Mir.Block _ -> failwith "<case>"
-        | Mir.SList _ -> failwith "<case>"
-        | Mir.Decl _ -> failwith "<case>"
-        | Mir.FunDef _ -> failwith "<case>"
-      in
-      let kill =
-        match mir_node with
-        | Mir.Assignment (_, _) -> failwith "<case>"
-        | Mir.TargetPE _ -> failwith "<case>"
-        | Mir.NRFunApp (_, _) -> failwith "<case>"
-        | Mir.Check _ -> failwith "<case>"
-        | Mir.Break -> failwith "<case>"
-        | Mir.Continue -> failwith "<case>"
-        | Mir.Return _ -> failwith "<case>"
-        | Mir.Skip -> failwith "<case>"
-        | Mir.IfElse (_, _, _) -> failwith "<case>"
-        | Mir.While (_, _) -> failwith "<case>"
-        | Mir.For _ -> failwith "<case>"
-        | Mir.Block _ -> failwith "<case>"
-        | Mir.SList _ -> failwith "<case>"
-        | Mir.Decl _ -> failwith "<case>"
-        | Mir.FunDef _ -> failwith "<case>"
-      in
+      let gen = top_used_expressions_stmt mir_node in
+      let kill = Map.find_exn latest l in
       transfer_gen_kill_alt p gen kill
   end
   : TRANSFER_FUNCTION )
@@ -615,8 +516,9 @@ functor
           ~f:(fun ~key ~data:_ accum ->
             let analysis_in_data = Hashtbl.find_exn analysis_in key in
             Map.add_exn accum ~key
-              ~data:(analysis_in_data, T.transfer_function key analysis_in_data)
-            )
+              ~data:
+                { entry= analysis_in_data
+                ; exit= T.transfer_function key analysis_in_data } )
           F.successors
       in
       analysis_in_out

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -474,13 +474,12 @@ functor
         done
       in
       (* STEP 3: present final results *)
-      let analysis_out = Hashtbl.create (module F) in
-      let _ =
-        Set.iter
-          ~f:(fun l ->
-            Hashtbl.add_exn analysis_in ~key:l
+      let analysis_out =
+        Set.fold ~init:Map.Poly.empty
+          ~f:(fun accum l ->
+            Map.add_exn accum ~key:l
               ~data:(T.transfer_function l (Hashtbl.find_exn analysis_in l)) )
           nodes
       in
-      (analysis_in, analysis_out)
+      (Map.Poly.of_hashtbl_exn analysis_in, analysis_out)
   end

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -4,9 +4,6 @@ open Core_kernel
 open Monotone_framework_sigs
 
 (* TODO: write instance of FLOWGRAPH for Stan flowgraph of Stan MIR *)
-
-(** Reverse flowgraphs to be used for reverse analyses.
-    Observe that this respects the invariants listed for a FLOWGRAPH *)
 let flowgraph_of_mir (_ : Mir.stmt_loc Mir.prog) :
     (module FLOWGRAPH) * (int, Mir.stmt_loc) Map.Poly.t =
   ( ( module struct
@@ -22,6 +19,8 @@ let flowgraph_of_mir (_ : Mir.stmt_loc Mir.prog) :
     : FLOWGRAPH )
   , failwith "NOT YET IMPLEMENTED" )
 
+(** Reverse flowgraphs to be used for reverse analyses.
+    Observe that this respects the invariants listed for a FLOWGRAPH *)
 module Reverse (F : FLOWGRAPH) : FLOWGRAPH = struct
   type labels = F.labels
   type t = labels

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -70,7 +70,8 @@ module Constant_propagation_lattice
     (Values : PREFLATSET) : LATTICE =
   New_bot (Dual_partial_function_lattice (Variables) (Values))
 
-(* Note: this is also the lattice for a very busy expressions analysis
+(* Note: this is also the lattice for a very busy expressions (anticipated
+   expressions) analysis
    (the only difference is that that analysis is performed on the reverse
    flow graph instead) *)
 module Available_expressions_lattice (Expressions : PREFLATSET) : LATTICE =
@@ -80,6 +81,8 @@ Dual_powerset_lattice (struct
   let extreme = Set.Poly.empty
 end)
 
+(* Note: this is also the lattice for a used expression analysis (but with
+   expressions rather than variables, also run backwards) *)
 module Live_variables_lattice (Variables : PREFLATSET) : LATTICE =
 Powerset_lattice (struct
   type vals = Variables.vals

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -39,7 +39,7 @@ module Powerset_lattice (S : PREPOWERSET) : LATTICE = struct
   let initial = S.initial
 end
 
-module Dual_powerset_lattice (S : PREPOWERSET) : LATTICE = struct
+module Dual_powerset_lattice (S : PREDUALPOWERSET) : LATTICE = struct
   type properties = S.vals Set.Poly.t
 
   let bottom = S.total
@@ -93,8 +93,8 @@ module Constant_propagation_lattice
    expressions) analysis
    (the only difference is that that analysis is performed on the reverse
    flow graph instead) *)
-module Available_expressions_lattice (Expressions : PREPOWERSET) : LATTICE =
-Dual_powerset_lattice (struct
+module Available_expressions_lattice (Expressions : PREDUALPOWERSET) :
+  LATTICE = Dual_powerset_lattice (struct
   type vals = Expressions.vals
 
   let initial = Set.Poly.empty
@@ -108,7 +108,6 @@ Powerset_lattice (struct
   type vals = Variables.vals
 
   let initial = Set.Poly.empty
-  let total = Errors.fatal_error ()
 end)
 
 module Reaching_definitions_lattice
@@ -117,7 +116,6 @@ module Reaching_definitions_lattice
   type vals = Variables.vals * Labels.vals option
 
   let initial = Set.Poly.map ~f:(fun x -> (x, None)) Variables.initial
-  let total = Errors.fatal_error ()
 end)
 
 module Monotone_framework : MONOTONE_FRAMEWORK =

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -126,9 +126,264 @@ end)
    merged *)
 
 let flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t = Map.Poly.empty
+
+module Constant_propagation_transfer : TRANSFER_FUNCTION = struct
+  type labels = int
+  type properties = (string, Mir.expr) Map.Poly.t option
+
+  let transfer_function l p =
+    match p with
+    | None -> None
+    | Some m ->
+        let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
+        Some
+          ( match mir_node with
+          | Mir.Assignment (Var s, Mir.Lit (t, v)) ->
+              Map.set m ~key:s ~data:(Mir.Lit (t, v))
+          | Mir.Decl {decl_id= s; _} | Mir.Assignment (Var s, _) ->
+              Map.remove m s
+          | Mir.Assignment (_, _)
+           |Mir.TargetPE _
+           |Mir.NRFunApp (_, _)
+           |Mir.Check _ | Mir.Break | Mir.Continue | Mir.Return _ | Mir.Skip
+           |Mir.IfElse (_, _, _)
+           |Mir.While (_, _)
+           |Mir.For _ | Mir.Block _ | Mir.SList _ | Mir.FunDef _ ->
+              m )
+end
+
 let transfer_gen_kill p gen kill = Set.union gen (Set.diff p kill)
 
+module Reaching_definitions_transfer : TRANSFER_FUNCTION = struct
+  type labels = int
+  type properties = (string * labels option) Set.Poly.t
+
+  let transfer_function l p =
+    let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
+    let gen =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    let kill =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    transfer_gen_kill p gen kill
+end
+
+module Live_variables_transfer : TRANSFER_FUNCTION = struct
+  type labels = int
+  type properties = string Set.Poly.t
+
+  let transfer_function l p =
+    let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
+    let gen =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    let kill =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    transfer_gen_kill p gen kill
+end
+
+module Anticipated_expressions_transfer : TRANSFER_FUNCTION = struct
+  type labels = int
+  type properties = Mir.expr Set.Poly.t
+
+  let transfer_function l p =
+    let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
+    let gen =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    let kill =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    (* NOTE: this is note quite the usual gen kill pattern *)
+    Set.union gen (Set.diff p kill)
+end
+
+(* NOTE: we want to implement lazy code motion. Aho describes a slightly
+   different available expression pass for that that uses the anticipated
+   expression pass. *)
 module Available_expressions_transfer : TRANSFER_FUNCTION = struct
+  type labels = int
+  type properties = Mir.expr Set.Poly.t
+
+  let transfer_function l p =
+    let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
+    let gen =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    let kill =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    transfer_gen_kill p gen kill
+end
+
+module Postponable_expressions_transfer : TRANSFER_FUNCTION = struct
+  type labels = int
+  type properties = Mir.expr Set.Poly.t
+
+  let transfer_function l p =
+    let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
+    let gen =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    let kill =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    transfer_gen_kill p gen kill
+end
+
+module Used_expressions_transfer : TRANSFER_FUNCTION = struct
   type labels = int
   type properties = Mir.expr Set.Poly.t
 

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -111,22 +111,17 @@ functor
       and type properties = L.properties)
   ->
   struct
-    let mfp ~reverse =
-      (* STEP 0: set up whether to perform a forward or reverse analysis *)
-      let edges, initials, sucessors =
-        if reverse then (F.rev_edges (), F.finals, F.predecessors)
-        else (F.edges (), F.initials, F.sucessors)
-      in
+    let mfp () =
       (* STEP 1: initialize data structures *)
       (* TODO: does the order here affect the efficiency of the algorithm much? *)
-      let workstack = Stack.of_list (Set.to_list edges) in
+      let workstack = Stack.of_list (Set.to_list (F.edges ())) in
       let analysis_in = Hashtbl.create (module F) in
       let _ =
         Set.iter
           ~f:(fun l ->
             Hashtbl.add_exn analysis_in ~key:l
-              ~data:(if Set.mem initials l then L.initial else L.bottom) )
-          F.nodes
+              ~data:(if Set.mem F.initials l then L.initial else L.bottom) )
+          (F.nodes ())
       in
       (* STEP 2: iterate *)
       let _ =
@@ -141,7 +136,8 @@ functor
               Hashtbl.set analysis_in ~key:l'
                 ~data:(L.lub old_analysis_out_l' new_analysis_out_l')
           in
-          Set.iter (sucessors l') ~f:(fun l'' -> Stack.push workstack (l', l''))
+          Set.iter (F.sucessors l') ~f:(fun l'' ->
+              Stack.push workstack (l', l'') )
         done
       in
       (* STEP 3: present final results *)
@@ -151,7 +147,7 @@ functor
           ~f:(fun l ->
             Hashtbl.add_exn analysis_in ~key:l
               ~data:(T.transfer_function l (Hashtbl.find_exn analysis_in l)) )
-          F.nodes
+          (F.nodes ())
       in
       (analysis_in, analysis_out)
   end

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -17,7 +17,7 @@ module Powerset_lattice (S : PREPOWERSET) : LATTICE = struct
   let bottom = Set.Poly.empty
   let lub s1 s2 = Set.Poly.union s1 s2
   let leq s1 s2 = Set.Poly.is_subset s1 ~of_:s2
-  let extreme = S.extreme
+  let initial = S.initial
 end
 
 module Dual_powerset_lattice (S : PREPOWERSET) : LATTICE = struct
@@ -26,7 +26,7 @@ module Dual_powerset_lattice (S : PREPOWERSET) : LATTICE = struct
   let bottom = Set.Poly.empty
   let lub s1 s2 = Set.Poly.inter s1 s2
   let leq s1 s2 = Set.Poly.is_subset s2 ~of_:s1
-  let extreme = S.extreme
+  let initial = S.initial
 end
 
 module New_bot (L : LATTICE) : LATTICE = struct
@@ -42,7 +42,7 @@ module New_bot (L : LATTICE) : LATTICE = struct
     | Some s1 -> ( function Some s2 -> L.leq s1 s2 | None -> false )
     | None -> fun _ -> true
 
-  let extreme = Some L.extreme
+  let initial = Some L.initial
 end
 
 module Dual_partial_function_lattice (Dom : PREPOWERSET) (Codom : PREFLATSET) :
@@ -56,13 +56,13 @@ module Dual_partial_function_lattice (Dom : PREPOWERSET) (Codom : PREFLATSET) :
     Map.filteri ~f s1
 
   let leq s1 s2 =
-    Set.for_all Dom.extreme ~f:(fun k ->
+    Set.for_all Dom.initial ~f:(fun k ->
         match (Map.find s1 k, Map.find s2 k) with
         | Some x, Some y -> x = y
         | Some _, None | None, None -> true
         | None, Some _ -> false )
 
-  let extreme = Map.Poly.empty
+  let initial = Map.Poly.empty
 end
 
 module Constant_propagation_lattice
@@ -78,7 +78,7 @@ module Available_expressions_lattice (Expressions : PREFLATSET) : LATTICE =
 Dual_powerset_lattice (struct
   type vals = Expressions.vals
 
-  let extreme = Set.Poly.empty
+  let initial = Set.Poly.empty
 end)
 
 (* Note: this is also the lattice for a used expression analysis (but with
@@ -87,7 +87,7 @@ module Live_variables_lattice (Variables : PREFLATSET) : LATTICE =
 Powerset_lattice (struct
   type vals = Variables.vals
 
-  let extreme = Set.Poly.empty
+  let initial = Set.Poly.empty
 end)
 
 module Reaching_definitions_lattice
@@ -95,7 +95,7 @@ module Reaching_definitions_lattice
     (Labels : PREFLATSET) : LATTICE = Powerset_lattice (struct
   type vals = Variables.vals * Labels.vals option
 
-  let extreme = Set.Poly.map ~f:(fun x -> (x, None)) Variables.extreme
+  let initial = Set.Poly.map ~f:(fun x -> (x, None)) Variables.initial
 end)
 
 module Monotone_framework : MONOTONE_FRAMEWORK =
@@ -122,7 +122,7 @@ functor
         Set.iter
           ~f:(fun l ->
             Hashtbl.add_exn analysis_in ~key:l
-              ~data:(if Set.mem initials l then L.extreme else L.bottom) )
+              ~data:(if Set.mem initials l then L.initial else L.bottom) )
           F.nodes
       in
       (* STEP 2: iterate *)

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -8,7 +8,9 @@ open Monotone_framework_sigs
                                                  reaching definitions
                                                  live variables
                                                  constant propagation
-                                                 very busy expressions *)
+                                                 very busy expressions (anticipated expressions)
+                                                 used expressions
+                                                 postponable expressions *)
 
 (** Reverse flowgraphs to be used for reverse analyses.
     Observe that this respects the invariants listed for a FLOWGRAPH *)

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -3,16 +3,13 @@
 open Core_kernel
 open Monotone_framework_sigs
 
-(* TODO: write instances of LATTICE for 
-                                        function type
-                                        reaching def example
-         write instance of FLOWGRAPH for Stan flowgraph of Stan MIR
+(* TODO: write instance of FLOWGRAPH for Stan flowgraph of Stan MIR
                                          inverse flow graph of flow graph
-         write instance of TRANSFER_FUNCTION for available Expressions
+         write instance of TRANSFER_FUNCTION for available expressions
                                                  reaching definitions
-                                                 live Variables
+                                                 live variables
                                                  constant propagation
-                                                 very busy Expressions *)
+                                                 very busy expressions *)
 
 module Powerset_lattice (S : PREPOWERSET) : LATTICE = struct
   type properties = S.vals Set.Poly.t

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -23,7 +23,7 @@ end
 module Dual_powerset_lattice (S : PREPOWERSET) : LATTICE = struct
   type properties = S.vals Set.Poly.t
 
-  let bottom = Set.Poly.empty
+  let bottom = S.total
   let lub s1 s2 = Set.Poly.inter s1 s2
   let leq s1 s2 = Set.Poly.is_subset s2 ~of_:s1
   let initial = S.initial
@@ -74,11 +74,12 @@ module Constant_propagation_lattice
    expressions) analysis
    (the only difference is that that analysis is performed on the reverse
    flow graph instead) *)
-module Available_expressions_lattice (Expressions : PREFLATSET) : LATTICE =
+module Available_expressions_lattice (Expressions : PREPOWERSET) : LATTICE =
 Dual_powerset_lattice (struct
   type vals = Expressions.vals
 
   let initial = Set.Poly.empty
+  let total = Expressions.total
 end)
 
 (* Note: this is also the lattice for a used expression analysis (but with
@@ -88,6 +89,7 @@ Powerset_lattice (struct
   type vals = Variables.vals
 
   let initial = Set.Poly.empty
+  let total = Errors.fatal_error ()
 end)
 
 module Reaching_definitions_lattice
@@ -96,6 +98,7 @@ module Reaching_definitions_lattice
   type vals = Variables.vals * Labels.vals option
 
   let initial = Set.Poly.map ~f:(fun x -> (x, None)) Variables.initial
+  let total = Errors.fatal_error ()
 end)
 
 module Monotone_framework : MONOTONE_FRAMEWORK =

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -277,6 +277,11 @@ let rec free_vars_stmt (s : Mir.stmt_loc Mir.statement) =
       Set.Poly.diff (free_vars_stmt b.stmt)
         (Set.Poly.of_list (List.map ~f:(fun (_, s, _) -> s) l))
 
+(* TODO: in the live variables analysis, we probably want to assume that
+   target, parameters, transformed parameters and generated quantities are
+   always live.
+   We could either do that by initializing suitably or by just adding
+   them later in the dead code elimination pass. *)
 let live_variables_transfer (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t)
     =
   ( module struct
@@ -296,6 +301,7 @@ let live_variables_transfer (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t)
          |Mir.Check _ | Mir.Break | Mir.Continue | Mir.Return _ | Mir.Skip
          |Mir.IfElse (_, _, _)
          |Mir.While (_, _)
+         (* TODO: double check - should decls kill a variable? No right? *)
          |Mir.For _ | Mir.Block _ | Mir.SList _ | Mir.Decl _ | Mir.FunDef _ ->
             Set.Poly.empty
       in

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -3,11 +3,7 @@
 open Core_kernel
 open Monotone_framework_sigs
 
-(* TODO: write instance of FLOWGRAPH for Stan flowgraph of Stan MIR
-         write instance of TRANSFER_FUNCTION for available expressions
-                                                 very busy expressions (anticipated expressions)
-                                                 used expressions
-                                                 postponable expressions *)
+(* TODO: write instance of FLOWGRAPH for Stan flowgraph of Stan MIR *)
 
 (** Reverse flowgraphs to be used for reverse analyses.
     Observe that this respects the invariants listed for a FLOWGRAPH *)
@@ -325,8 +321,9 @@ let live_variables_transfer (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t)
   end
   : TRANSFER_FUNCTION )
 
-(* TODO: Should we count constants and variables as used expressions?
-   I am doing so now, but suspect it is not neccessary.*)
+(* Note: we do not count constants or variables are expressions
+   (as there is no computation needed for them, so they do not
+   need to take part in any optimizations for expression placement).*)
 let rec used_expressions_expr (e : Mir.expr) =
   Set.Poly.union (Set.Poly.singleton e)
     ( match e with

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -64,7 +64,7 @@ module New_bot (L : LATTICE) : LATTICE = struct
   let initial = Some L.initial
 end
 
-module Dual_partial_function_lattice (Dom : PREPOWERSET) (Codom : PREFLATSET) :
+module Dual_partial_function_lattice (Dom : PREPOWERSET) (Codom : TYPE) :
   LATTICE = struct
   type properties = (Dom.vals, Codom.vals) Map.Poly.t
 
@@ -84,17 +84,16 @@ module Dual_partial_function_lattice (Dom : PREPOWERSET) (Codom : PREFLATSET) :
   let initial = Map.Poly.empty
 end
 
-module Constant_propagation_lattice
-    (Variables : PREPOWERSET)
-    (Values : PREFLATSET) : LATTICE =
+module Constant_propagation_lattice (Variables : PREPOWERSET) (Values : TYPE) :
+  LATTICE =
   New_bot (Dual_partial_function_lattice (Variables) (Values))
 
 (* Note: this is also the lattice for a very busy expressions (anticipated
    expressions) analysis
    (the only difference is that that analysis is performed on the reverse
    flow graph instead) *)
-module Available_expressions_lattice (Expressions : PREDUALPOWERSET) :
-  LATTICE = Dual_powerset_lattice (struct
+module Available_expressions_lattice (Expressions : PREDUALSET) : LATTICE =
+Dual_powerset_lattice (struct
   type vals = Expressions.vals
 
   let initial = Set.Poly.empty
@@ -103,16 +102,17 @@ end)
 
 (* Note: this is also the lattice for a used expression analysis (but with
    expressions rather than variables, also run backwards) *)
-module Live_variables_lattice (Variables : PREFLATSET) : LATTICE =
+(* TODO: can we give these better names? *)
+(* TODO: can we reduce the requirements on the parameters for these lattices? *)
+module Live_variables_lattice (Variables : TYPE) : LATTICE =
 Powerset_lattice (struct
   type vals = Variables.vals
 
   let initial = Set.Poly.empty
 end)
 
-module Reaching_definitions_lattice
-    (Variables : PREPOWERSET)
-    (Labels : PREFLATSET) : LATTICE = Powerset_lattice (struct
+module Reaching_definitions_lattice (Variables : PREPOWERSET) (Labels : TYPE) :
+  LATTICE = Powerset_lattice (struct
   type vals = Variables.vals * Labels.vals option
 
   let initial = Set.Poly.map ~f:(fun x -> (x, None)) Variables.initial

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -122,6 +122,57 @@ module Reaching_definitions_lattice (Variables : INITIALTYPE) (Labels : TYPE) :
   let initial = Set.Poly.map ~f:(fun x -> (x, None)) Variables.initial
 end)
 
+(* TODO: this is temporary until Ryan's code to get the real flow graph is
+   merged *)
+
+let flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t = Map.Poly.empty
+let transfer_gen_kill p gen kill = Set.union gen (Set.diff p kill)
+
+module Available_expressions_transfer : TRANSFER_FUNCTION = struct
+  type labels = int
+  type properties = Mir.expr Set.Poly.t
+
+  let transfer_function l p =
+    let mir_node = (Map.find_exn flowgraph_to_mir l).stmt in
+    let gen =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    let kill =
+      match mir_node with
+      | Mir.Assignment (_, _) -> failwith "<case>"
+      | Mir.TargetPE _ -> failwith "<case>"
+      | Mir.NRFunApp (_, _) -> failwith "<case>"
+      | Mir.Check _ -> failwith "<case>"
+      | Mir.Break -> failwith "<case>"
+      | Mir.Continue -> failwith "<case>"
+      | Mir.Return _ -> failwith "<case>"
+      | Mir.Skip -> failwith "<case>"
+      | Mir.IfElse (_, _, _) -> failwith "<case>"
+      | Mir.While (_, _) -> failwith "<case>"
+      | Mir.For _ -> failwith "<case>"
+      | Mir.Block _ -> failwith "<case>"
+      | Mir.SList _ -> failwith "<case>"
+      | Mir.Decl _ -> failwith "<case>"
+      | Mir.FunDef _ -> failwith "<case>"
+    in
+    transfer_gen_kill p gen kill
+end
+
 module Monotone_framework : MONOTONE_FRAMEWORK =
 functor
   (F : FLOWGRAPH)

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -394,7 +394,7 @@ let top_used_expressions_stmt (s : Mir.stmt_loc Mir.statement) =
       Set.Poly.union_list [used_expressions_expr e1; used_expressions_expr e2]
   | Mir.Block _ | Mir.SList _ -> Set.Poly.empty
 
-let rec killed_expressions_stmt (p : Mir.expr Set.Poly.t)
+let killed_expressions_stmt (p : Mir.expr Set.Poly.t)
     (s : Mir.stmt_loc Mir.statement) =
   Set.Poly.filter p ~f:(fun e ->
       let free_vars = free_vars_expr e in

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -761,6 +761,8 @@ let lazy_expressions_mfp (mir : Mir.stmt_loc Mir.prog)
          ~f:(fun x -> used_expressions_stmt x.stmt)
          [mir.functionsb; snd mir.gqb; snd mir.modelb; snd mir.tdatab])
   in
+  (* TODO: we need to watch out in the lazy code motion pass that the autodiff and
+     block structure imposes real boundaries on how much we can move code around. *)
   let used_expr = used flowgraph_to_mir in
   let expressions_initial_total_type =
     ( module struct

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -4,7 +4,6 @@ open Core_kernel
 open Monotone_framework_sigs
 
 (* TODO: write instance of FLOWGRAPH for Stan flowgraph of Stan MIR
-                                         inverse flow graph of flow graph
          write instance of TRANSFER_FUNCTION for available expressions
                                                  reaching definitions
                                                  live variables

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -395,6 +395,8 @@ let killed_expressions_stmt (p : Mir.expr Set.Poly.t)
     (s : Mir.stmt_loc Mir.statement) =
   Set.Poly.filter p ~f:(fun e ->
       let free_vars = free_vars_expr e in
+      (* Note: a simple test for membership would be more efficient here,
+         but it would require us to duplicate some code. *)
       let assigned_vars = assigned_vars_stmt s in
       not (Set.is_empty (Set.Poly.inter free_vars assigned_vars)) )
 

--- a/lib/Monotone_framework.ml
+++ b/lib/Monotone_framework.ml
@@ -65,7 +65,6 @@ module Dual_partial_function_lattice (Dom : PREPOWERSET) (Codom : PREFLATSET) :
   let extreme = Map.Poly.empty
 end
 
-(* TODO: set extreme below in these two prepowersets*)
 module Constant_propagation_lattice
     (Variables : PREPOWERSET)
     (Values : PREFLATSET) : LATTICE =

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -3,7 +3,7 @@
     This gives a modular way of implementing many static analyses. *)
 open Core_kernel
 
-(** The API for a data flowgraph, needed for the mfp algorithm
+(** The API for a flowgraph, needed for the mfp algorithm
     in the monotone framework *)
 module type FLOWGRAPH = sig
   type labels
@@ -11,12 +11,9 @@ module type FLOWGRAPH = sig
   include Base__.Hashtbl_intf.Key with type t = labels
 
   val initials : labels Set.Poly.t
-  val finals : labels Set.Poly.t
-  val nodes : labels Set.Poly.t
+  val nodes : unit -> labels Set.Poly.t
   val edges : unit -> (labels * labels) Set.Poly.t
-  val rev_edges : unit -> (labels * labels) Set.Poly.t
   val sucessors : labels -> labels Set.Poly.t
-  val predecessors : labels -> labels Set.Poly.t
 end
 
 (** The minimal data we need to use a type in forming a lattice of various kinds *)
@@ -67,8 +64,8 @@ end
     equations/inequalities are generated from the transfer function.
     Returns a hash table of the (input_properties, output_properties) for
     each node l in the flow graph.
-    A boolean reverse determines whether the analysis should be reverse or
-    forward. *)
+    The analysis performed is always a forward analysis. 
+    For a reverse analysis, supply the reverse flow graph.*)
 module type MONOTONE_FRAMEWORK = functor
   (F : FLOWGRAPH)
   (L : LATTICE)
@@ -78,6 +75,6 @@ module type MONOTONE_FRAMEWORK = functor
       and type properties = L.properties)
   -> sig
   val mfp :
-       reverse:bool
+       unit
     -> (T.labels, T.properties) Hashtbl.t * (T.labels, T.properties) Hashtbl.t
 end

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -4,7 +4,9 @@
 open Core_kernel
 
 (** The API for a flowgraph, needed for the mfp algorithm
-    in the monotone framework *)
+    in the monotone framework.
+    Assumed invariants: successors contains all graph nodes as keys
+                        initials is a subset of the graph nodes *)
 module type FLOWGRAPH = sig
   type labels
 

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -22,23 +22,23 @@ module type TYPE = sig
 end
 
 (** The data we need to form a powerset lattice *)
-module type PREPOWERSET = sig
+module type INITIALTYPE = sig
   type vals
 
   val initial : vals Set.Poly.t
 end
 
 (** The data we need to form e.g. an available xpressions lattice*)
-module type PREDUALSET = sig
+module type TOTALTYPE = sig
   type vals
 
   val total : vals Set.Poly.t
 end
 
 (** The data we need to form a dual powerset lattice *)
-module type PREDUALPOWERSET = sig
-  include PREPOWERSET
-  include PREDUALSET with type vals := vals
+module type INITIALTOTALTYPE = sig
+  include INITIALTYPE
+  include TOTALTYPE with type vals := vals
 end
 
 (** The API for a complete (possibly non-distributive) lattice,

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -17,10 +17,8 @@ module type FLOWGRAPH = sig
 end
 
 (** The minimal data we need to use a type in forming a lattice of various kinds *)
-module type PREFLATSET = sig
+module type TYPE = sig
   type vals
-
-  val ( = ) : vals -> vals -> bool
 end
 
 (** The data we need to form a powerset lattice *)
@@ -30,12 +28,17 @@ module type PREPOWERSET = sig
   val initial : vals Set.Poly.t
 end
 
-(** The data we need to form a dual powerset lattice *)
-module type PREDUALPOWERSET = sig
+(** The data we need to form e.g. an available xpressions lattice*)
+module type PREDUALSET = sig
   type vals
 
-  val initial : vals Set.Poly.t
   val total : vals Set.Poly.t
+end
+
+(** The data we need to form a dual powerset lattice *)
+module type PREDUALPOWERSET = sig
+  include PREPOWERSET
+  include PREDUALSET with type vals := vals
 end
 
 (** The API for a complete (possibly non-distributive) lattice,

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -31,6 +31,7 @@ module type PREPOWERSET = sig
   type vals
 
   val initial : vals Set.Poly.t
+  val total : vals Set.Poly.t
 end
 
 (** The API for a complete (possibly non-distributive) lattice,

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -23,14 +23,14 @@ end
 
 (** The data we need to form a powerset lattice *)
 module type INITIALTYPE = sig
-  type vals
+  include TYPE
 
   val initial : vals Set.Poly.t
 end
 
 (** The data we need to form e.g. an available xpressions lattice*)
 module type TOTALTYPE = sig
-  type vals
+  include TYPE
 
   val total : vals Set.Poly.t
 end

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -72,7 +72,7 @@ end
     point of the equations/inequalities defined between property lattice
     elements at the entry and exit of different flowgraph nodes, where these
     equations/inequalities are generated from the transfer function.
-    Returns a hash table of the (input_properties, output_properties) for
+    Returns a map of the (input_properties, output_properties) for
     each node l in the flow graph.
     The analysis performed is always a forward analysis. 
     For a reverse analysis, supply the reverse flow graph.*)
@@ -84,8 +84,5 @@ module type MONOTONE_FRAMEWORK = functor
      with type labels = F.labels
       and type properties = L.properties)
   -> sig
-  val mfp :
-       unit
-    -> (T.labels, T.properties) Map.Poly.t
-       * (T.labels, T.properties) Map.Poly.t
+  val mfp : unit -> (T.labels, T.properties * T.properties) Map.Poly.t
 end

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -1,4 +1,5 @@
-(** The API for a monotone framework, as described in Nielson, Nielson, and Hankin.
+(** The API for a monotone framework, as described in 2.3-2.4 of
+    Nielson, Nielson, and Hankin or 9.3 of Aho et al..
     This gives a modular way of implementing many static analyses. *)
 open Core_kernel
 
@@ -10,9 +11,12 @@ module type FLOWGRAPH = sig
   include Base__.Hashtbl_intf.Key with type t = labels
 
   val initials : labels Set.Poly.t
+  val finals : labels Set.Poly.t
   val nodes : labels Set.Poly.t
-  val edges : (labels * labels) Set.Poly.t
+  val edges : unit -> (labels * labels) Set.Poly.t
+  val rev_edges : unit -> (labels * labels) Set.Poly.t
   val sucessors : labels -> labels Set.Poly.t
+  val predecessors : labels -> labels Set.Poly.t
 end
 
 (** The minimal data we need to use a type in forming a lattice of various kinds *)
@@ -59,7 +63,9 @@ end
     elements at the entry and exit of different flowgraph nodes, where these
     equations/inequalities are generated from the transfer function.
     Returns a hash table of the (input_properties, output_properties) for
-    each node l in the flow graph. *)
+    each node l in the flow graph.
+    A boolean reverse determines whether the analysis should be reverse or
+    forward. *)
 module type MONOTONE_FRAMEWORK = functor
   (F : FLOWGRAPH)
   (L : LATTICE)
@@ -69,6 +75,6 @@ module type MONOTONE_FRAMEWORK = functor
       and type properties = L.properties)
   -> sig
   val mfp :
-       unit
+       reverse:bool
     -> (T.labels, T.properties) Hashtbl.t * (T.labels, T.properties) Hashtbl.t
 end

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -86,5 +86,6 @@ module type MONOTONE_FRAMEWORK = functor
   -> sig
   val mfp :
        unit
-    -> (T.labels, T.properties) Hashtbl.t * (T.labels, T.properties) Hashtbl.t
+    -> (T.labels, T.properties) Map.Poly.t
+       * (T.labels, T.properties) Map.Poly.t
 end

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -11,9 +11,7 @@ module type FLOWGRAPH = sig
   include Base__.Hashtbl_intf.Key with type t = labels
 
   val initials : labels Set.Poly.t
-  val nodes : unit -> labels Set.Poly.t
-  val edges : unit -> (labels * labels) Set.Poly.t
-  val sucessors : labels -> labels Set.Poly.t
+  val successors : (labels, labels Set.Poly.t) Map.Poly.t
 end
 
 (** The minimal data we need to use a type in forming a lattice of various kinds *)

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -68,6 +68,8 @@ module type TRANSFER_FUNCTION = sig
   val transfer_function : labels -> properties -> properties
 end
 
+type 'a entry_exit = {entry: 'a; exit: 'a}
+
 (** The API for a monotone framework. mfp computes the minimal fixed
     point of the equations/inequalities defined between property lattice
     elements at the entry and exit of different flowgraph nodes, where these
@@ -84,5 +86,5 @@ module type MONOTONE_FRAMEWORK = functor
      with type labels = F.labels
       and type properties = L.properties)
   -> sig
-  val mfp : unit -> (T.labels, T.properties * T.properties) Map.Poly.t
+  val mfp : unit -> (T.labels, T.properties entry_exit) Map.Poly.t
 end

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -1,4 +1,5 @@
-(** The API for a monotone framework *)
+(** The API for a monotone framework, as described in Nielson, Nielson, and Hankin.
+    This gives a modular way of implementing many static analyses. *)
 open Core_kernel
 
 (** The API for a data flowgraph, needed for the mfp algorithm
@@ -14,12 +15,14 @@ module type FLOWGRAPH = sig
   val sucessors : labels -> labels Set.Poly.t
 end
 
+(** The minimal data we need to use a type in forming a lattice of various kinds *)
 module type PREFLATSET = sig
   type vals
 
   val ( = ) : vals -> vals -> bool
 end
 
+(** The data we need to form a powerset lattice *)
 module type PREPOWERSET = sig
   type vals
 
@@ -51,6 +54,12 @@ module type TRANSFER_FUNCTION = sig
   val transfer_function : labels -> properties -> properties
 end
 
+(** The API for a monotone framework. mfp computes the minimal fixed
+    point of the equations/inequalities defined between property lattice
+    elements at the entry and exit of different flowgraph nodes, where these
+    equations/inequalities are generated from the transfer function.
+    Returns a hash table of the (input_properties, output_properties) for
+    each node l in the flow graph. *)
 module type MONOTONE_FRAMEWORK = functor
   (F : FLOWGRAPH)
   (L : LATTICE)

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -28,6 +28,13 @@ module type PREPOWERSET = sig
   type vals
 
   val initial : vals Set.Poly.t
+end
+
+(** The data we need to form a dual powerset lattice *)
+module type PREDUALPOWERSET = sig
+  type vals
+
+  val initial : vals Set.Poly.t
   val total : vals Set.Poly.t
 end
 

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -30,7 +30,7 @@ end
 module type PREPOWERSET = sig
   type vals
 
-  val extreme : vals Set.Poly.t
+  val initial : vals Set.Poly.t
 end
 
 (** The API for a complete (possibly non-distributive) lattice,
@@ -41,8 +41,8 @@ module type LATTICE = sig
   val bottom : properties
   val leq : properties -> properties -> bool
 
-  val extreme : properties
-  (**  An extremal value, which might not be the top element.
+  val initial : properties
+  (**  An initial value, which might not be the top element.
        The idea is that this is the property that you start with
        (you assume to be true at the start of your analysis). *)
 

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -78,13 +78,9 @@ type 'a entry_exit = {entry: 'a; exit: 'a}
     each node l in the flow graph.
     The analysis performed is always a forward analysis. 
     For a reverse analysis, supply the reverse flow graph.*)
-module type MONOTONE_FRAMEWORK = functor
-  (F : FLOWGRAPH)
-  (L : LATTICE)
-  (T :
-     TRANSFER_FUNCTION
-     with type labels = F.labels
-      and type properties = L.properties)
-  -> sig
-  val mfp : unit -> (T.labels, T.properties entry_exit) Map.Poly.t
+module type MONOTONE_FRAMEWORK = sig
+  type labels
+  type properties
+
+  val mfp : unit -> (labels, properties entry_exit) Map.Poly.t
 end

--- a/lib/Monotone_framework_sigs.mli
+++ b/lib/Monotone_framework_sigs.mli
@@ -42,7 +42,9 @@ module type LATTICE = sig
   val leq : properties -> properties -> bool
 
   val extreme : properties
-  (**  An extremal value, which might not be the top element *)
+  (**  An extremal value, which might not be the top element.
+       The idea is that this is the property that you start with
+       (you assume to be true at the start of your analysis). *)
 
   val lub : properties -> properties -> properties
 end

--- a/lib/Optimize.ml
+++ b/lib/Optimize.ml
@@ -440,7 +440,7 @@ let copy_propagation (mir : stmt_loc_num prog)
   in
   map_prog constant_fold_stmt mir
 
-let is_function_call e = match e with FunApp (f, _) -> true | _ -> false
+let is_function_call e = match e with FunApp (_, _) -> true | _ -> false
 
 let is_skip_break_continue s =
   match s with Skip | Break | Continue -> true | _ -> false

--- a/lib/Optimize.ml
+++ b/lib/Optimize.ml
@@ -434,6 +434,28 @@ let list_collapsing (mir : stmt_loc prog) =
   ; prog_name= mir.prog_name
   ; prog_path= mir.prog_path }
 
+(* TODO *)
+let constant_fold_stmt _ s = s
+
+let constant_folding (mir : stmt_loc prog)
+    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
+      with type labels = int)
+    (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t) =
+  let constants =
+    Monotone_framework.constant_propagation_mfp mir
+      (module Flowgraph)
+      flowgraph_to_mir
+  in
+  match mir
+  with {functionsb; datavars; tdatab; modelb; gqb; prog_name; prog_path} ->
+    { functionsb= constant_fold_stmt constants functionsb
+    ; datavars
+    ; tdatab= (fst tdatab, constant_fold_stmt constants (snd tdatab))
+    ; modelb= (fst modelb, constant_fold_stmt constants (snd modelb))
+    ; gqb= (fst gqb, constant_fold_stmt constants (snd gqb))
+    ; prog_name
+    ; prog_path }
+
 let%expect_test "inline functions" =
   let ast =
     Parse.parse_string Parser.Incremental.program

--- a/lib/Optimize.ml
+++ b/lib/Optimize.ml
@@ -437,10 +437,10 @@ let list_collapsing (mir : stmt_loc prog) =
 (* TODO *)
 let constant_fold_stmt _ s = s
 
-let constant_folding (mir : stmt_loc prog)
+let constant_folding (mir : stmt_loc_num prog)
     (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
-    (flowgraph_to_mir : (int, Mir.stmt_loc) Map.Poly.t) =
+    (flowgraph_to_mir : (int, Mir.stmt_loc_num) Map.Poly.t) =
   let constants =
     Monotone_framework.constant_propagation_mfp mir
       (module Flowgraph)
@@ -455,6 +455,8 @@ let constant_folding (mir : stmt_loc prog)
     ; gqb= (fst gqb, constant_fold_stmt constants (snd gqb))
     ; prog_name
     ; prog_path }
+
+let _ = constant_folding
 
 let%expect_test "inline functions" =
   let ast =

--- a/lib/Partial_evaluator.ml
+++ b/lib/Partial_evaluator.ml
@@ -27,8 +27,15 @@ let rec eval (e : expr) =
   | FunApp (f, l) -> (
     match (f, List.map ~f:eval l) with
     (* TODO: deal with tilde statements and unnormalized distributions properly here *)
-    (* TODO: deal with GLM functions here *)
+    
     (* TODO: be careful here with operators which get translated to function calls *)
+    (* TODO: deal with GLM functions here. Need type information though.
+    | "bernoulli_logit_lpmf", [y; BinOp (alpha, Plus, BinOp (beta, Times, x))]
+     |"bernoulli_logit_lpmf", [y; BinOp (BinOp (beta, Times, x), Plus, alpha)]
+     |"bernoulli_logit_lpmf", [y; BinOp (alpha, Plus, BinOp (x, Times, beta))]
+     |"bernoulli_logit_lpmf", [y; BinOp (BinOp (x, Times, beta), Plus, alpha)]
+      ->
+        FunApp ("bernoulli_logit_glm_lpmf", [y; x; alpha; beta]) *)
     | "bernoulli_lpmf", [y; FunApp ("inv_logit", [alpha])] ->
         FunApp ("bernoulli_logit_lpmf", [y; alpha])
     | "bernoulli_rng", [FunApp ("inv_logit", [alpha])] ->
@@ -97,11 +104,7 @@ let rec eval (e : expr) =
             , c ) ] )
       when b = c ->
         FunApp ("trace_gen_quad_form", [d; a; b])
-    | "trace", [BinOp (FunApp ("transpose", [b]), Times, BinOp (a, Times, c))]
-      when b = c ->
-        FunApp ("trace_quad_form", [a; b])
-    | "trace", [BinOp (BinOp (FunApp ("transpose", [b]), Times, a), Times, c)]
-      when b = c ->
+    | "trace", [FunApp ("quad_form", [a; b])] ->
         FunApp ("trace_quad_form", [a; b])
     | _, l' -> FunApp (f, l') )
   | BinOp (e1, op, e2) -> (

--- a/lib/Partial_evaluator.ml
+++ b/lib/Partial_evaluator.ml
@@ -187,7 +187,6 @@ let rec eval (e : expr) =
         FunApp ("diag_post_multiply", [e1'; v])
     | FunApp ("diag_matrix", [v]), Times, e2' ->
         FunApp ("diag_pre_multiply", [v; e2'])
-        
         (* Constant folding for operators *)
     | Lit (Int, i1), _, Lit (Int, i2) ->
         apply_operator_int op (Int.of_string i1) (Int.of_string i2)

--- a/lib/Partial_evaluator.ml
+++ b/lib/Partial_evaluator.ml
@@ -50,6 +50,17 @@ let rec eval (e : expr) =
     | "log", [BinOp (Lit (Int, "1"), Plus, FunApp ("exp", [x]))] ->
         FunApp ("log1p_exp", [x])
     | "log", [BinOp (Lit (Int, "1"), Plus, x)] -> FunApp ("log1p", [x])
+    | "log", [FunApp ("fabs", [FunApp ("determinant", [x])])] ->
+        FunApp ("log_determinant", [x])
+    (* TODO: can only do below for reals:
+    | "log", [BinOp (FunApp ("exp", [x]),Minus,FunApp ("exp", [y]))] ->
+    FunApp ("log_diff_exp", [x;y]) *)
+    | "log", [FunApp ("falling_factorial", l)] ->  FunApp("log_falling_factorial", l)
+    | "log", [FunApp ("inv_logit", l)] -> FunApp ("log_inv_logit", l)
+    (* TODO: can only do below for reals:
+    | "log", [BinOp (FunApp ("exp", [x]),Plus ,FunApp ("exp", [y]))] ->
+    FunApp ("log_sum_exp", [x;y]) *)
+    | "pow", [Lit (Int, "2"); x] -> FunApp ("exp2", [x])
     | "pow", [x; Lit (Int, "2")] ->
         FunApp ("square", [x]) (* TODO: insert all composite functions here *)
     | _, l' -> FunApp (f, l') )

--- a/lib/Partial_evaluator.ml
+++ b/lib/Partial_evaluator.ml
@@ -3,7 +3,24 @@
 open Core_kernel
 
 (* TODO *)
-let subst (_ : (string, Mir.expr) Map.Poly.t) (e : Mir.expr) = e
+let rec subst (m : (string, Mir.expr) Map.Poly.t) (e : Mir.expr) =
+  match e with
+  | Mir.Var s -> ( match Map.find m s with Some e' -> e' | None -> e )
+  | Mir.Lit (_, _) -> e
+  | Mir.FunApp (f, l) -> Mir.FunApp (f, List.map ~f:(subst m) l)
+  | Mir.BinOp (e1, op, e2) -> Mir.BinOp (subst m e1, op, subst m e2)
+  | Mir.TernaryIf (e1, e2, e3) ->
+      Mir.TernaryIf (subst m e1, subst m e2, subst m e3)
+  | Mir.Indexed (e, l) -> Mir.Indexed (subst m e, List.map ~f:(subst_idx m) l)
+
+and subst_idx m i =
+  match i with
+  | Mir.All -> Mir.All
+  | Mir.Single e -> Mir.Single (subst m e)
+  | Mir.Upfrom e -> Mir.Upfrom (subst m e)
+  | Mir.Downfrom e -> Mir.Downfrom (subst m e)
+  | Mir.Between (e1, e2) -> Mir.Between (subst m e1, subst m e2)
+  | Mir.MultiIndex e -> Mir.MultiIndex (subst m e)
 
 (* TODO *)
 let eval (e : Mir.expr) = e

--- a/lib/Partial_evaluator.ml
+++ b/lib/Partial_evaluator.ml
@@ -187,9 +187,8 @@ let rec eval (e : expr) =
         FunApp ("diag_post_multiply", [e1'; v])
     | FunApp ("diag_matrix", [v]), Times, e2' ->
         FunApp ("diag_pre_multiply", [v; e2'])
-        (* TODO: insert all composite functions here *)
         
-        (* Constant folding for arithmetic operators *)
+        (* Constant folding for operators *)
     | Lit (Int, i1), _, Lit (Int, i2) ->
         apply_operator_int op (Int.of_string i1) (Int.of_string i2)
     | Lit (Real, i1), _, Lit (Real, i2)
@@ -201,8 +200,7 @@ let rec eval (e : expr) =
             (Float.of_string i2)
       | _ ->
           apply_logical_operator_real op (Float.of_string i1)
-            (Float.of_string i2)
-          (* TODO: the rest of the arithmetic and logical operators *) )
+            (Float.of_string i2) )
     | e1', _, e2' -> BinOp (e1', op, e2') )
   | TernaryIf (e1, e2, e3) -> (
     match (eval e1, eval e2, eval e3) with

--- a/lib/Partial_evaluator.ml
+++ b/lib/Partial_evaluator.ml
@@ -1,0 +1,12 @@
+(* A partial evaluator for use in static analysis and optimization *)
+
+open Core_kernel
+
+(* TODO *)
+let subst (_ : (string, Mir.expr) Map.Poly.t) (e : Mir.expr) = e
+
+(* TODO *)
+let eval (e : Mir.expr) = e
+
+let eval_subst (m : (string, Mir.expr) Map.Poly.t) (e : Mir.expr) =
+  eval (subst m e)

--- a/lib/Partial_evaluator.ml
+++ b/lib/Partial_evaluator.ml
@@ -25,13 +25,16 @@ and subst_idx m i =
 let rec eval (e : expr) =
   match e with
   | Var _ | Lit (_, _) -> e
-  | FunApp (f, l) -> FunApp (f, List.map ~f:eval l)
+  | FunApp (f, l) -> (
+    match (f, List.map ~f:eval l) with (* TODO: etc *)
+                                 | _, l' -> FunApp (f, l') )
   | BinOp (e1, op, e2) -> (
     match (eval e1, op, eval e2) with
     | Lit (Int, i1), Plus, Lit (Int, i2) ->
         Lit (Int, Int.to_string (Int.of_string i1 + Int.of_string i2))
         (* TODO: etc *)
-    | (e1', _, e2') -> BinOp (e1', op, e2') )
+    | FunApp ("exp", l'), Minus, Lit (Int, "1") -> FunApp ("expm1", l')
+    | e1', _, e2' -> BinOp (e1', op, e2') )
   | TernaryIf (e1, e2, e3) -> TernaryIf (eval e1, eval e2, eval e3)
   | Indexed (e, l) -> Indexed (eval e, List.map ~f:eval_idx l)
 


### PR DESCRIPTION
This implements the monotone framework, as described in 2.3-2.4 of
Nielson, Nielson, and Hankin or 9.3 of Aho et al..
This gives a modular way of implementing many static analyses.

We give nine different instances of the framework:
- constant propagation/folding [used for constant propagation optimization]
- expression propagation/folding (aka forward substitution)  [used for forward substitution optimization]
- copy propagation [used for copy propagation optimization]
- reaching definitions [used for e.g. dependence analysis]
- live variables [used for dead code elimination optimization]
- anticipated expressions [used for lazy code motion optimization]
- available expressions [used for lazy code motion optimization]
- postponable expressions [used for lazy code motion optimization]
- used expressions [used for lazy code motion optimization].

The constant and expression propagation phases make use of a partial evaluator to apply algebraic simplifications (e.g. the compound functions in the Stan Math library and arithmetic and logical identities).

To give an instance of the framework means to give a triple of
1. a flowgraph
2. a lattice of properties
3. a transfer function.

We have implemented transfer functions (3.) for all eight analyses above as well as the corresponding property lattices (2.). Further, we have implement a function for computing the inverse flowgraph (1.), given a flowgraph. This lets us do reverse analyses like live variables, anticipated expressions, and used expressions.

The missing part in the puzzle is code to compute a flowgraph (1.) from the Mir. @rybern is writing that code. Once we have that missing part in place, we can test many instances of these analyses easily.

As an application, showing the use of this framework, we have implemented the following optimizations relying on it:
1. a constant propagation/folding optimization (which evaluates arithmetic and logical operators)
2. an expressions propagation/folding optimization (which partially evaluates expressions, using algebraic identities e.g. in operators and math library functions); this means we (almost) do not need to write compound math library function anymore in our Stan code;
3. a dead code elimination optimization.
Missing still is the complex lazy code motion optimization, which will use the remaining analyses that have been implemented.

This PR is currently clearly lacking in tests. However, it is very hard to write sensible tests without this bit of @rybern's code.