### PR TITLE
Prefix operator fix

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -41,7 +41,9 @@ and identifier =
 (** Arithmetic and logical operators *)
 and operator =
   | Plus
+  | PPlus
   | Minus
+  | PMinus
   | Times
   | Divide
   | Modulo
@@ -57,7 +59,7 @@ and operator =
   | Leq
   | Greater
   | Geq
-  | Not
+  | PNot
   | Transpose
 
 (** Indices for array access *)

--- a/lib/Operators.ml
+++ b/lib/Operators.ml
@@ -87,9 +87,6 @@ let operator_name op = Sexp.to_string [%sexp (op : Ast.operator)] ^ "__"
 let operator_return_type op =
   operator_return_type_from_string (operator_name op)
 
-let operator_return_type_prefix op =
-  operator_return_type_from_string ("P" ^ operator_name op)
-
 (** Print all the signatures of a stan math operator, for the purposes of error messages. *)
 let pretty_print_all_operator_signatures name =
   let all_names = Hashtbl.find_multi operator_names name in
@@ -97,7 +94,3 @@ let pretty_print_all_operator_signatures name =
     (List.map
        ~f:Stan_math_signatures.pretty_print_all_stan_math_function_signatures
        all_names)
-
-(** Print all the signatures of a stan math operator, for the purposes of error messages. *)
-let pretty_print_all_operator_signatures_prefix name =
-  pretty_print_all_operator_signatures ("P" ^ name)

--- a/lib/Operators.mli
+++ b/lib/Operators.mli
@@ -11,15 +11,8 @@ val operator_name : Ast.operator -> string
 val operator_return_type :
   Ast.operator -> typed_expression list -> returntype option
 
-(* Same as [operator_return_type op args] but for prefix nodes. temp hack - XXX*)
-val operator_return_type_prefix :
-  Ast.operator -> typed_expression list -> returntype option
-
 val pretty_print_all_operator_signatures : string -> string
 (** Print all the signatures of a stan math operator, for the purposes of error messages. *)
-
-(* XXX Hacked for prefix *)
-val pretty_print_all_operator_signatures_prefix : string -> string
 
 (* The name of the TernaryIf operator *)
 val ternary_if : string

--- a/lib/Parse.ml
+++ b/lib/Parse.ml
@@ -162,7 +162,7 @@ let%expect_test "parse minus unary" =
              (assign_indices ()) (assign_op Assign)
              (assign_rhs
               ((expr_untyped
-                (PrefixOp Minus
+                (PrefixOp PMinus
                  ((expr_untyped (Variable ((name x) (id_loc <opaque>))))
                   (expr_untyped_loc <opaque>))))
                (expr_untyped_loc <opaque>)))))
@@ -191,14 +191,14 @@ let%expect_test "parse unary over binary" =
                     (expr_untyped_loc <opaque>))
                    Minus
                    ((expr_untyped
-                     (PrefixOp Minus
+                     (PrefixOp PMinus
                       ((expr_untyped (Variable ((name x) (id_loc <opaque>))))
                        (expr_untyped_loc <opaque>))))
                     (expr_untyped_loc <opaque>))))
                  (expr_untyped_loc <opaque>))
                 Minus
                 ((expr_untyped
-                  (PrefixOp Minus
+                  (PrefixOp PMinus
                    ((expr_untyped (Variable ((name x) (id_loc <opaque>))))
                     (expr_untyped_loc <opaque>))))
                  (expr_untyped_loc <opaque>))))

--- a/lib/Pretty_printing.ml
+++ b/lib/Pretty_printing.ml
@@ -53,8 +53,8 @@ and pretty_print_returntype = function
 and pretty_print_identifier id = id.name
 
 and pretty_print_operator = function
-  | Plus -> "+"
-  | Minus -> "-"
+  | Plus | PPlus -> "+"
+  | Minus | PMinus -> "-"
   | Times -> "*"
   | Divide -> "/"
   | Modulo -> "%"
@@ -70,7 +70,7 @@ and pretty_print_operator = function
   | Leq -> "<="
   | Greater -> ">"
   | Geq -> ">="
-  | Not -> "!"
+  | PNot -> "!"
   | Transpose -> "'"
 
 and pretty_print_index = function

--- a/lib/Semantic_check.ml
+++ b/lib/Semantic_check.ml
@@ -481,7 +481,7 @@ and semantic_check_expression cf {expr_untyped_loc= loc; expr_untyped} =
   | PrefixOp (op, e) -> (
       let uop = semantic_check_operator op
       and ue = semantic_check_expression cf e in
-      match operator_return_type_prefix uop [ue] with
+      match operator_return_type uop [ue] with
       | Some (ReturnType ut) ->
           { expr_typed= PrefixOp (uop, ue)
           ; expr_typed_ad_level= lub_ad_e [ue]
@@ -491,7 +491,7 @@ and semantic_check_expression cf {expr_untyped_loc= loc; expr_untyped} =
           semantic_error ~loc
             ( "Ill-typed arguments supplied to prefix operator "
             ^ pretty_print_operator uop ^ ". Available signatures: "
-            ^ pretty_print_all_operator_signatures_prefix (operator_name uop)
+            ^ pretty_print_all_operator_signatures (operator_name uop)
             ^ "\nInstead supplied argument of incompatible type: "
             ^ pretty_print_unsizedtype ue.expr_typed_type
             ^ "." ) )

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -391,11 +391,11 @@ common_expression:
 
 %inline prefixOp:
   | BANG
-    {   grammar_logger "prefix_bang" ; Not }
+    {   grammar_logger "prefix_bang" ; PNot }
   | MINUS
-    {  grammar_logger "prefix_minus" ; Minus }
+    {  grammar_logger "prefix_minus" ; PMinus }
   | PLUS
-    {   grammar_logger "prefix_plus" ; Plus }
+    {   grammar_logger "prefix_plus" ; PPlus }
 
 %inline postfixOp:
   | TRANSPOSE


### PR DESCRIPTION
The PR https://github.com/stan-dev/stanc3/pull/73 introduced a bug in the treatment of prefix operators, causing prefix (unary) minus and plus to be translated into the Mir as binary minus and plus. The PR fixes that bug. There is a unit test included which was failing before this PR, which checks that the prefix minus gets translated to the MIR correctly.