### PR TITLE
Remove SList from MIR

### DIFF
--- a/lib/Ast_to_Mir.ml
+++ b/lib/Ast_to_Mir.ml
@@ -341,17 +341,17 @@ let rec trans_stmt declc {Ast.stmt_typed; stmt_typed_loc= sloc; _} =
   match stmt_typed with
   | Ast.Assignment {assign_indices; assign_rhs; assign_identifier; assign_op}
     ->
-      let swrap_expr expr_typed =
+      let wrap_expr expr_typed =
         { Ast.expr_typed_loc= sloc
         ; expr_typed_ad_level= assign_rhs.expr_typed_ad_level
         ; expr_typed_type= assign_rhs.expr_typed_type
         ; expr_typed }
       in
-      let assignee = swrap_expr @@ Ast.Variable assign_identifier in
+      let assignee = wrap_expr @@ Ast.Variable assign_identifier in
       let assignee =
         match assign_indices with
         | [] -> assignee
-        | lst -> swrap_expr @@ Ast.Indexed (assignee, lst)
+        | lst -> wrap_expr @@ Ast.Indexed (assignee, lst)
       in
       let rhs =
         match assign_op with

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -60,9 +60,6 @@ and ('e, 's) statement =
      variables declared within it have local scope and are garbage collected
      when the block ends.*)
   | Block of 's list
-  (* An SList does not share any of Block's semantics - it is just multiple
-     (ordered!) statements*)
-  | SList of 's list
   | Decl of
       { decl_adtype: autodifftype
       ; decl_id: string
@@ -112,9 +109,7 @@ let rec sexp_of_expr_typed_located {texpr; _} =
   sexp_of_expr sexp_of_expr_typed_located texpr
 
 let rec sexp_of_stmt_loc {stmt; _} =
-  match stmt with
-  | SList ls -> sexp_of_list sexp_of_stmt_loc ls
-  | s -> sexp_of_statement sexp_of_expr_typed_located sexp_of_stmt_loc s
+  sexp_of_statement sexp_of_expr_typed_located sexp_of_stmt_loc stmt
 
 type typed_prog = (expr_typed_located, stmt_loc) prog [@@deriving sexp]
 

--- a/lib/Stan_math_code_gen.ml
+++ b/lib/Stan_math_code_gen.ml
@@ -217,7 +217,7 @@ let trans_math_fn fname =
 
 let rec pp_statement ppf {stmt; sloc} =
   ( match stmt with
-  | Block _ | SList _ | FunDef _ | Break | Continue | Skip -> ()
+  | Block _ | FunDef _ | Break | Continue | Skip -> ()
   | _ -> pp_location ppf sloc ) ;
   let pp_stmt_list = list ~sep:cut pp_statement in
   match stmt with
@@ -246,7 +246,6 @@ let rec pp_statement ppf {stmt; sloc} =
   | For {loopvar; lower; upper; body} ->
       pp_for_loop ppf (loopvar, lower, upper, pp_statement, body)
   | Block ls -> pp_block ppf (pp_stmt_list, ls)
-  | SList ls -> pp_stmt_list ppf ls
   | Decl {decl_adtype; decl_id; decl_type} ->
       pp_sized_decl ppf (decl_id, decl_type, decl_adtype)
   | FunDef {fdrt; fdname; fdargs; fdbody} -> (
@@ -352,9 +351,6 @@ let%expect_test "read int[N] y" =
     vals_i__ = context__.vals_i__("y");
     y = std::vector<int>(N, 0);
     for (size_t i_0__ = 0; i_0__ < y.size(); i_0__++) y[i_0__] = vals_i__; |}]
-
-let block_of_list s =
-  {s with stmt= (match s.stmt with SList ls -> Block ls | x -> x)}
 
 let pp_ctor ppf p =
   (* XXX:

--- a/test/integration/examples-good/code-gen/cpp.expected
+++ b/test/integration/examples-good/code-gen/cpp.expected
@@ -17,7 +17,9 @@ static char* current_statement__;
 class eight_schools_ncp_model : public prob_grad {
 
  private:
-  
+  int J;
+  std::vector<double> y;
+  std::vector<double> sigma;
  
  public:
   ~eight_schools_ncp_model() { }
@@ -226,7 +228,9 @@ udf1(const T__& a, const T__& b, std::ostream* pstream__) {
 class one_var_per_block_model : public prob_grad {
 
  private:
-  
+  int N;
+  int K;
+  std::vector<Eigen::Matrix<double, -1, 1>> datavar;
  
  public:
   ~one_var_per_block_model() { }


### PR DESCRIPTION
I think it's better to deal with the lists explicitly and just hardcode expectations about which places we expect a Block vs a single statement in the MIR. This lets us get rid of unnecessary nestings that make it pretty annoying during code gen to reliably find the globals / top vars in each of the blocks.