### PR TITLE
MIR Pretty Printer

### DIFF
--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -282,21 +282,21 @@ let pp_transform_inits pp_s ppf {transform_inits; _} =
 
 let pp_prog pp_e pp_s ppf prog =
   Format.open_vbox 0 ;
-  (pp_functions_block pp_s) ppf prog ;
+  pp_functions_block pp_s ppf prog ;
   Fmt.cut ppf () ;
-  (pp_input_vars pp_e) ppf prog ;
+  pp_input_vars pp_e ppf prog ;
   Fmt.cut ppf () ;
-  (pp_prepare_data pp_s) ppf prog ;
+  pp_prepare_data pp_s ppf prog ;
   Fmt.cut ppf () ;
-  (pp_prepare_params pp_s) ppf prog ;
+  pp_prepare_params pp_s ppf prog ;
   Fmt.cut ppf () ;
-  (pp_log_prob pp_s) ppf prog ;
+  pp_log_prob pp_s ppf prog ;
   Fmt.cut ppf () ;
-  (pp_generate_quantities pp_s) ppf prog ;
+  pp_generate_quantities pp_s ppf prog ;
   Fmt.cut ppf () ;
-  (pp_transform_inits pp_s) ppf prog ;
+  pp_transform_inits pp_s ppf prog ;
   Fmt.cut ppf () ;
-  (pp_output_vars pp_e) ppf prog ;
+  pp_output_vars pp_e ppf prog ;
   Format.close_box ()
 
 type expr_typed_located =

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -236,10 +236,10 @@ let pp_io_block ppf = function
 type 'e io_var = string * ('e sizedtype * io_block) [@@deriving sexp]
 
 let pp_io_var pp_e ppf (name, (sized_ty, io_block)) =
-  Fmt.pf ppf "@[<h>%a %s %a;@]" (pp_sizedtype pp_e) (sized_ty, Ast.Identity)
+  Fmt.pf ppf "@[<h>%a %a %s;@]" 
+    pp_io_block io_block
+    (pp_sizedtype pp_e) (sized_ty, Ast.Identity)
     name
-    (angle_brackets @@ angle_brackets pp_io_block)
-    io_block
 
 let pp_block label pp_elem ppf elems =
   Fmt.pf ppf {|@[<v2>%a {@ %a@]@ }|} pp_keyword label

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -238,7 +238,7 @@ type 'e io_var = string * ('e sizedtype * io_block) [@@deriving sexp]
 let pp_io_var pp_e ppf (name, (sized_ty, io_block)) =
   Fmt.pf ppf "@[<h>%a %s %a@]" (pp_sizedtype pp_e) (sized_ty, Ast.Identity)
     name
-    (angle_brackets pp_io_block)
+    (angle_brackets @@ angle_brackets pp_io_block)
     io_block
 
 let pp_block label pp_elem ppf elems =
@@ -297,7 +297,7 @@ let pp_transform_inits pp_s ppf {transform_inits; _} =
   ; prog_path: string }
    *)
 let pp_prog pp_e pp_s ppf prog =
-  Fmt.pf ppf "@[<v>@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;@]"
+  Fmt.pf ppf "@[<v>@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@]"
     (pp_functions_block pp_s) prog (pp_input_vars pp_e) prog
     (pp_prepare_data pp_s) prog (pp_prepare_params pp_s) prog
     (pp_log_prob pp_s) prog

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -236,7 +236,7 @@ let pp_io_block ppf = function
 type 'e io_var = string * ('e sizedtype * io_block) [@@deriving sexp]
 
 let pp_io_var pp_e ppf (name, (sized_ty, io_block)) =
-  Fmt.pf ppf "@[<h>%a %s %a@]" (pp_sizedtype pp_e) (sized_ty, Ast.Identity)
+  Fmt.pf ppf "@[<h>%a %s %a;@]" (pp_sizedtype pp_e) (sized_ty, Ast.Identity)
     name
     (angle_brackets @@ angle_brackets pp_io_block)
     io_block

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -58,10 +58,7 @@ and pp_index pp_e ppf = function
   | Upfrom index -> Fmt.pf ppf {|%a:|} pp_e index
   | Downfrom index -> Fmt.pf ppf {|:%a|} pp_e index
   | Between (lower, upper) -> Fmt.pf ppf {|%a:%a|} pp_e lower pp_e upper
-  | MultiIndex index ->
-      (* TODO: I'm not sure what a multi-index is so this formatting probably
-          makes no sense... *)
-      Fmt.pf ppf {|~%a|} pp_e index
+  | MultiIndex index -> Fmt.pf ppf {|%a|} pp_e index
 
 type unsizedtype = Ast.unsizedtype [@@deriving sexp, hash]
 type 'e sizedtype = 'e Ast.sizedtype [@@deriving sexp, hash, map]
@@ -215,8 +212,8 @@ let rec pp_statement pp_e pp_s ppf = function
         Fmt.pf ppf {|@[<v2>%a %s%a {@ %a@]@ }|} pp_unsizedtype rt fdname
           Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
           fdargs pp_s fdbody
-    | _ ->
-        Fmt.pf ppf {|@[<v2>%s%a {@ %a@]@ }|} fdname
+    | None ->
+        Fmt.pf ppf {|@[<v2>%s %s%a {@ %a@]@ }|} "void" fdname
           Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
           fdargs pp_s fdbody )
 
@@ -236,10 +233,8 @@ let pp_io_block ppf = function
 type 'e io_var = string * ('e sizedtype * io_block) [@@deriving sexp]
 
 let pp_io_var pp_e ppf (name, (sized_ty, io_block)) =
-  Fmt.pf ppf "@[<h>%a %a %s;@]" 
-    pp_io_block io_block
-    (pp_sizedtype pp_e) (sized_ty, Ast.Identity)
-    name
+  Fmt.pf ppf "@[<h>%a %a %s;@]" pp_io_block io_block (pp_sizedtype pp_e)
+    (sized_ty, Ast.Identity) name
 
 let pp_block label pp_elem ppf elems =
   Fmt.pf ppf {|@[<v2>%a {@ %a@]@ }|} pp_keyword label
@@ -285,24 +280,24 @@ let pp_generate_quantities pp_s ppf {generate_quantities; _} =
 let pp_transform_inits pp_s ppf {transform_inits; _} =
   pp_block "transform_inits" pp_s ppf transform_inits
 
-(* { functions_block: 's list
-  ; input_vars: 'e io_var list
-  ; prepare_data: 's list (* data & transformed data decls and statements *)
-  ; prepare_params: 's list (* param & tparam decls and statements *)
-  ; log_prob: 's list (*assumes data & params are in scope and ready*)
-  ; generate_quantities: 's list (* assumes data & params ready & in scope*)
-  ; transform_inits: 's list
-  ; output_vars: 'e io_var list
-  ; prog_name: string
-  ; prog_path: string }
-   *)
 let pp_prog pp_e pp_s ppf prog =
-  Fmt.pf ppf "@[<v>@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@]"
-    (pp_functions_block pp_s) prog (pp_input_vars pp_e) prog
-    (pp_prepare_data pp_s) prog (pp_prepare_params pp_s) prog
-    (pp_log_prob pp_s) prog
-    (pp_generate_quantities pp_s)
-    prog (pp_transform_inits pp_s) prog (pp_output_vars pp_e) prog
+  Format.open_vbox 0 ;
+  (pp_functions_block pp_s) ppf prog ;
+  Fmt.cut ppf () ;
+  (pp_input_vars pp_e) ppf prog ;
+  Fmt.cut ppf () ;
+  (pp_prepare_data pp_s) ppf prog ;
+  Fmt.cut ppf () ;
+  (pp_prepare_params pp_s) ppf prog ;
+  Fmt.cut ppf () ;
+  (pp_log_prob pp_s) ppf prog ;
+  Fmt.cut ppf () ;
+  (pp_generate_quantities pp_s) ppf prog ;
+  Fmt.cut ppf () ;
+  (pp_transform_inits pp_s) ppf prog ;
+  Fmt.cut ppf () ;
+  (pp_output_vars pp_e) ppf prog ;
+  Format.close_box ()
 
 type expr_typed_located =
   { texpr_type: Ast.unsizedtype

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -35,9 +35,63 @@ and 'e expr =
   | Indexed of 'e * 'e index list
 [@@deriving sexp, hash, map]
 
+let pp_builtin_syntax = Fmt.(string |> styled `Yellow)
+
+let rec pp_expr pp_e ppf = function
+  | Var varname -> Fmt.string ppf varname
+  | Lit (Str, str) -> Fmt.pf ppf "%S" str
+  | Lit (_, str) -> Fmt.string ppf str
+  | FunApp (name, args) ->
+      Fmt.string ppf name ;
+      Fmt.(list pp_e ~sep:Fmt.comma |> parens) ppf args
+  | TernaryIf (pred, texpr, fexpr) ->
+      Fmt.pf ppf {|@[%a@ %a@,%a@,%a@ %a@]|} pp_e pred pp_builtin_syntax "?"
+        pp_e texpr pp_builtin_syntax ":" pp_e fexpr
+  | Indexed (expr, indices) ->
+      Fmt.pf ppf {|@[%a%a@]|} pp_e expr
+        Fmt.(list (pp_index pp_e) ~sep:comma |> brackets)
+        indices
+
+and pp_index pp_e ppf = function
+  | All -> Fmt.char ppf ':'
+  | Single index -> pp_e ppf index
+  | Upfrom index -> Fmt.pf ppf {|%a:|} pp_e index
+  | Downfrom index -> Fmt.pf ppf {|:%a|} pp_e index
+  | Between (lower, upper) -> Fmt.pf ppf {|%a:%a|} pp_e lower pp_e upper
+  | MultiIndex index ->
+      (* TODO: I'm not sure what a multi-index is so this formatting probably
+          makes no sense... *)
+      Fmt.pf ppf {|~%a|} pp_e index
+
 type unsizedtype = Ast.unsizedtype [@@deriving sexp, hash]
 type 'e sizedtype = 'e Ast.sizedtype [@@deriving sexp, hash, map]
 type autodifftype = Ast.autodifftype [@@deriving sexp, hash]
+
+let angle_brackets pp_v ppf v = Fmt.pf ppf "@[<1><%a>@]" pp_v v
+let label str pp_v ppf v = Fmt.pf ppf "%s=%a" str pp_v v
+let pp_keyword = Fmt.(string |> styled `Blue)
+
+let pp_autodifftype ppf = function
+  | Ast.DataOnly -> pp_keyword ppf "data "
+  | Ast.AutoDiffable -> ()
+
+let rec pp_unsizedtype ppf = function
+  | Ast.UInt -> pp_keyword ppf "int"
+  | UReal -> pp_keyword ppf "real"
+  | UVector -> pp_keyword ppf "vector"
+  | URowVector -> pp_keyword ppf "row_vector"
+  | UMatrix -> pp_keyword ppf "matrix"
+  | UArray ut -> (Fmt.brackets pp_unsizedtype) ppf ut
+  | UFun (argtypes, rt) ->
+      Fmt.pf ppf {|%a => %a|}
+        Fmt.(list (pair ~sep:comma pp_autodifftype pp_unsizedtype) ~sep:comma)
+        argtypes pp_returntype rt
+  | UMathLibraryFunction ->
+      (angle_brackets Fmt.string) ppf "Stan Math function"
+
+and pp_returntype ppf = function
+  | Ast.Void -> Fmt.string ppf "void"
+  | Ast.ReturnType ut -> pp_unsizedtype ppf ut
 
 (* This directive silences some spurious warnings from ppx_deriving *)
 [@@@ocaml.warning "-A"]
@@ -74,6 +128,98 @@ and ('e, 's) statement =
       ; fdbody: 's }
 [@@deriving sexp, hash, map]
 
+let pp_fun_arg_decl ppf (autodifftype, name, unsizedtype) =
+  Fmt.pf ppf "%a%a %s" pp_autodifftype autodifftype pp_unsizedtype unsizedtype
+    name
+
+let pp_transformation pp_e ppf = function
+  | Ast.Identity -> ()
+  | Lower expr -> (pp_e |> label "lower" |> angle_brackets) ppf expr
+  | Upper expr -> (pp_e |> label "upper" |> angle_brackets) ppf expr
+  | LowerUpper (lower_expr, upper_expr) ->
+      ( Fmt.(pair ~sep:comma (pp_e |> label "lower") (pp_e |> label "upper"))
+      |> angle_brackets )
+        ppf (lower_expr, upper_expr)
+  | Offset expr -> (pp_e |> label "offet" |> angle_brackets) ppf expr
+  | Multiplier expr -> (pp_e |> label "multiplier" |> angle_brackets) ppf expr
+  | OffsetMultiplier (offset_expr, mult_expr) ->
+      ( Fmt.(
+          pair ~sep:comma (pp_e |> label "offset") (pp_e |> label "multiplier"))
+      |> angle_brackets )
+        ppf (offset_expr, mult_expr)
+  | Ordered -> (angle_brackets Fmt.string) ppf "ordered"
+  | PositiveOrdered -> (angle_brackets Fmt.string) ppf "positive_ordered"
+  | Simplex -> (angle_brackets Fmt.string) ppf "simplex"
+  | UnitVector -> (angle_brackets Fmt.string) ppf "unit_vector"
+  | CholeskyCorr -> (angle_brackets Fmt.string) ppf "cholesky_factor_corr"
+  | CholeskyCov -> (angle_brackets Fmt.string) ppf "cholesky_factor_cov"
+  | Correlation -> (angle_brackets Fmt.string) ppf "corr_matrix"
+  | Covariance -> (angle_brackets Fmt.string) ppf "cov_matrix"
+
+let rec pp_sizedtype pp_e ppf (st, trans) =
+  match st with
+  | Ast.SInt -> Fmt.pf ppf {|%s%a|} "int" (pp_transformation pp_e) trans
+  | Ast.SReal -> Fmt.pf ppf {|%s%a|} "real" (pp_transformation pp_e) trans
+  | Ast.SVector expr ->
+      Fmt.pf ppf {|vector%a%a|} (pp_transformation pp_e) trans
+        (Fmt.brackets pp_e) expr
+  | Ast.SRowVector expr ->
+      Fmt.pf ppf {|row_vector%a%a|} (pp_transformation pp_e) trans
+        (Fmt.brackets pp_e) expr
+  | Ast.SMatrix (d1_expr, d2_expr) ->
+      Fmt.pf ppf {|matrix%a%a|} (pp_transformation pp_e) trans
+        Fmt.(pair ~sep:comma pp_e pp_e |> brackets)
+        (d1_expr, d2_expr)
+  | Ast.SArray (st, expr) ->
+      Fmt.pf ppf {|array%a%a|} (pp_transformation pp_e) trans
+        Fmt.(
+          pair ~sep:comma
+            (fun ppf st -> pp_sizedtype pp_e ppf (st, Ast.Identity))
+            pp_e
+          |> brackets)
+        (st, expr)
+
+let rec pp_statement pp_e pp_s ppf = function
+  | Assignment (assignee, expr) ->
+      Fmt.pf ppf {|@[<h>%a :=@ %a;@]|} pp_e assignee pp_e expr
+  | TargetPE expr ->
+      Fmt.pf ppf {|@[<h>%a +=@ %a;@]|} pp_keyword "target" pp_e expr
+  | NRFunApp (name, args) ->
+      Fmt.pf ppf {|@[%s%a;@]|} name Fmt.(list pp_e ~sep:comma |> parens) args
+  | Break -> pp_keyword ppf "break;"
+  | Continue -> pp_keyword ppf "continue;"
+  | Skip -> pp_keyword ppf "skip;"
+  | Return (Some expr) -> Fmt.pf ppf {|%a %a;|} pp_keyword "return" pp_e expr
+  | Return _ -> pp_keyword ppf "return;"
+  | IfElse (pred, s_true, Some s_false) ->
+      Fmt.pf ppf {|@[<v2>@[%a(%a)@] {@;%a@]@;@[<v2>@[} %a@] {@;%a@]@;}|}
+        pp_builtin_syntax "if" pp_e pred pp_s s_true pp_builtin_syntax "else"
+        pp_s s_false
+  | IfElse (pred, s_true, _) ->
+      Fmt.pf ppf {|@[<v2>@[%a(%a)@] {@;%a@]@;}|} pp_builtin_syntax "if" pp_e
+        pred pp_s s_true
+  | While (pred, stmt) ->
+      Fmt.pf ppf {|@[<v2>@[%a(%a)@] {@;%a@]@;}|} pp_builtin_syntax "while" pp_e
+        pred pp_s stmt
+  | For {loopvar; lower; upper; body} ->
+      Fmt.pf ppf {|@[<v2>@[%a(%s in %a:%a)@] {@;%a@]@;}|} pp_builtin_syntax
+        "for" loopvar pp_e lower pp_e upper pp_s body
+  | Block stmts -> Fmt.pf ppf {|@[<v>%a@]|} Fmt.(list pp_s ~sep:Fmt.cut) stmts
+  | SList stmts -> Fmt.(list pp_s ~sep:Fmt.cut |> vbox) ppf stmts
+  | Decl {decl_adtype; decl_id; decl_type} ->
+      Fmt.pf ppf {|%a%a %s;|} pp_autodifftype decl_adtype (pp_sizedtype pp_e)
+        (decl_type, Ast.Identity) decl_id
+  | FunDef {fdrt; fdname; fdargs; fdbody} -> (
+    match fdrt with
+    | Some rt ->
+        Fmt.pf ppf {|@[<v2>%a %s%a {@ %a@]@ }|} pp_unsizedtype rt fdname
+          Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
+          fdargs pp_s fdbody
+    | _ ->
+        Fmt.pf ppf {|@[<v2>%s%a {@ %a@]@ }|} fdname
+          Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
+          fdargs pp_s fdbody )
+
 type io_block =
   | Data
   | Parameters
@@ -81,7 +227,27 @@ type io_block =
   | GeneratedQuantities
 [@@deriving sexp, hash]
 
+let pp_io_block ppf = function
+  | Data -> Fmt.string ppf "data"
+  | Parameters -> Fmt.string ppf "parameters"
+  | TransformedParameters -> Fmt.string ppf "transformed_parameters"
+  | GeneratedQuantities -> Fmt.string ppf "generated_quantities"
+
 type 'e io_var = string * ('e sizedtype * io_block) [@@deriving sexp]
+
+let pp_io_var pp_e ppf (name, (sized_ty, io_block)) =
+  Fmt.pf ppf "@[<h>%a %s %a@]" (pp_sizedtype pp_e) (sized_ty, Ast.Identity)
+    name
+    (angle_brackets pp_io_block)
+    io_block
+
+let pp_block label pp_elem ppf elems =
+  Fmt.pf ppf {|@[<v2>%a {@ %a@]@ }|} pp_keyword label
+    Fmt.(list ~sep:cut pp_elem)
+    elems ;
+  Format.pp_force_newline ppf ()
+
+let pp_io_var_block label pp_e = pp_block label (pp_io_var pp_e)
 
 type ('e, 's) prog =
   { functions_block: 's list
@@ -96,6 +262,48 @@ type ('e, 's) prog =
   ; prog_path: string }
 [@@deriving sexp]
 
+let pp_input_vars pp_e ppf {input_vars; _} =
+  pp_io_var_block "input_vars" pp_e ppf input_vars
+
+let pp_output_vars pp_e ppf {output_vars; _} =
+  pp_io_var_block "output_vars" pp_e ppf output_vars
+
+let pp_functions_block pp_s ppf {functions_block; _} =
+  pp_block "functions" pp_s ppf functions_block
+
+let pp_prepare_data pp_s ppf {prepare_data; _} =
+  pp_block "prepare_data" pp_s ppf prepare_data
+
+let pp_prepare_params pp_s ppf {prepare_params; _} =
+  pp_block "prepare_params" pp_s ppf prepare_params
+
+let pp_log_prob pp_s ppf {log_prob; _} = pp_block "log_prob" pp_s ppf log_prob
+
+let pp_generate_quantities pp_s ppf {generate_quantities; _} =
+  pp_block "generate_quantities" pp_s ppf generate_quantities
+
+let pp_transform_inits pp_s ppf {transform_inits; _} =
+  pp_block "transform_inits" pp_s ppf transform_inits
+
+(* { functions_block: 's list
+  ; input_vars: 'e io_var list
+  ; prepare_data: 's list (* data & transformed data decls and statements *)
+  ; prepare_params: 's list (* param & tparam decls and statements *)
+  ; log_prob: 's list (*assumes data & params are in scope and ready*)
+  ; generate_quantities: 's list (* assumes data & params ready & in scope*)
+  ; transform_inits: 's list
+  ; output_vars: 'e io_var list
+  ; prog_name: string
+  ; prog_path: string }
+   *)
+let pp_prog pp_e pp_s ppf prog =
+  Fmt.pf ppf "@[<v>@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;%a@;@]"
+    (pp_functions_block pp_s) prog (pp_input_vars pp_e) prog
+    (pp_prepare_data pp_s) prog (pp_prepare_params pp_s) prog
+    (pp_log_prob pp_s) prog
+    (pp_generate_quantities pp_s)
+    prog (pp_transform_inits pp_s) prog (pp_output_vars pp_e) prog
+
 type expr_typed_located =
   { texpr_type: Ast.unsizedtype
   ; texpr_loc: Ast.location_span sexp_opaque [@compare.ignore]
@@ -103,10 +311,16 @@ type expr_typed_located =
   ; texpr_adlevel: autodifftype }
 [@@deriving sexp, hash, map, of_sexp]
 
+let rec pp_expr_typed_located ppf {texpr; _} =
+  pp_expr pp_expr_typed_located ppf texpr
+
 type stmt_loc =
   { sloc: Ast.location_span sexp_opaque [@compare.ignore]
   ; stmt: (expr_typed_located, stmt_loc) statement }
 [@@deriving hash, map, of_sexp]
+
+let rec pp_stmt_loc ppf {stmt; _} =
+  pp_statement pp_expr_typed_located pp_stmt_loc ppf stmt
 
 let rec sexp_of_expr_typed_located {texpr; _} =
   sexp_of_expr sexp_of_expr_typed_located texpr
@@ -117,6 +331,8 @@ let rec sexp_of_stmt_loc {stmt; _} =
   | s -> sexp_of_statement sexp_of_expr_typed_located sexp_of_stmt_loc s
 
 type typed_prog = (expr_typed_located, stmt_loc) prog [@@deriving sexp]
+
+let pp_typed_prog ppf prog = pp_prog pp_expr_typed_located pp_stmt_loc ppf prog
 
 (* ===================== Some helper functions and values ====================== *)
 let no_loc = {Ast.filename= ""; line_num= 0; col_num= 0; included_from= None}


### PR DESCRIPTION
Adding a pretty printer for MIR. There are a couple of choices I made which need review:

~~1.`pp_io_var` adds the name of the `io_block` in double angle brackets after the declaration e.g. `int x <<data>>;`~~
1. `pp_io_var` now pretty prints the `io_block` before the declaration in line with @bob-carpenter 's proposal [here](https://discourse.mc-stan.org/t/generalizing-the-stan-language-for-stan-3/1599?source_topic_id=1781) and SlicStan
2. `pp_index` represents a `MultiIndex` with a tilde (`~`) followed by the index expression