### PR TITLE
Add `_opam` to git ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ math_iface/gen/*
 *.merlin
 test/*.log
 _build
+_opam
 .#*
 


### PR DESCRIPTION
Using and opam switch creates directory named `_opam` which should be ignored by git.