### PR TITLE
Extract fun_defs into their own type

### DIFF
--- a/lib/Ast_to_Mir.ml
+++ b/lib/Ast_to_Mir.ml
@@ -474,7 +474,7 @@ let rec trans_stmt declc (ts : Ast.typed_statement) =
   | Ast.Skip -> Skip |> swrap
 
 let trans_fun_def declc (ts : Ast.typed_statement) =
-  let stmt_typed = ts.stmt in
+  let stmt_typed = ts.stmt and sloc = ts.smeta.loc in
   let trans_stmt = trans_stmt {declc with dread= None; dconstrain= None} in
   (* Function definition location? *)
   let stmt =
@@ -484,7 +484,8 @@ let trans_fun_def declc (ts : Ast.typed_statement) =
             (match returntype with Void -> None | ReturnType ut -> Some ut)
         ; fdname= funname.name
         ; fdargs= List.map ~f:trans_arg arguments
-        ; fdbody= trans_stmt body |> unwrap_block }
+        ; fdbody= trans_stmt body |> unwrap_block
+        ; fdloc= sloc }
     | _ ->
         raise_s
           [%message

--- a/lib/Ast_to_Mir.ml
+++ b/lib/Ast_to_Mir.ml
@@ -452,9 +452,9 @@ let rec trans_stmt declc (ts : Ast.typed_statement) =
         ; body }
       |> swrap
   | Ast.FunDef _ ->
-    raise_s
-      [%message
-        "Found function definition statement outside of function block"]
+      raise_s
+        [%message
+          "Found function definition statement outside of function block"]
   (*TODO | Ast.FunDef {returntype; funname; arguments; body} ->
       let fdbody = trans_stmt body |> unwrap_block in
       let fdrt =
@@ -480,17 +480,15 @@ let trans_fun_def declc (ts : Ast.typed_statement) =
   let stmt =
     match stmt_typed with
     | Ast.FunDef {returntype; funname; arguments; body} ->
-      { fdrt=
-          ( match returntype with
-            | Void -> None
-            | ReturnType ut -> Some ut )
-      ; fdname= funname.name
-      ; fdargs= List.map ~f:trans_arg arguments
-      ; fdbody= trans_stmt body |> unwrap_block }
+        { fdrt=
+            (match returntype with Void -> None | ReturnType ut -> Some ut)
+        ; fdname= funname.name
+        ; fdargs= List.map ~f:trans_arg arguments
+        ; fdbody= trans_stmt body |> unwrap_block }
     | _ ->
-      raise_s
-        [%message
-          "Found non-function definition statement in function block"]
+        raise_s
+          [%message
+            "Found non-function definition statement in function block"]
   in
   stmt
 
@@ -586,10 +584,10 @@ let trans_prog filename
   { functions_block=
       (* Should this be AutoDiffable for functions here?*)
       Option.value_map functionblock ~default:[] ~f:(fun fundefs ->
-          List.map
-            fundefs
-            ~f:(fun fundef -> trans_fun_def {dread= None; dconstrain= None; dadlevel= AutoDiffable} fundef)
-          )
+          List.map fundefs ~f:(fun fundef ->
+              trans_fun_def
+                {dread= None; dconstrain= None; dadlevel= AutoDiffable}
+                fundef ) )
   ; input_vars
   ; prepare_data
   ; log_prob

--- a/lib/Ast_to_Mir.ml
+++ b/lib/Ast_to_Mir.ml
@@ -451,13 +451,17 @@ let rec trans_stmt declc (ts : Ast.typed_statement) =
         ; upper= wrap @@ FunApp (string_of_internal_fn FnLength, [iteratee])
         ; body }
       |> swrap
-  | Ast.FunDef {returntype; funname; arguments; body} ->
+  | Ast.FunDef _ ->
+    raise_s
+      [%message
+        "Found function definition statement outside of function block"]
+  (*TODO | Ast.FunDef {returntype; funname; arguments; body} ->
       let fdbody = trans_stmt body |> unwrap_block in
       let fdrt =
         match returntype with Void -> None | ReturnType ut -> Some ut
       in
       let fdargs = List.map ~f:trans_arg arguments in
-      FunDef {fdrt; fdname= funname.name; fdargs; fdbody} |> swrap
+      FunDef {fdrt; fdname= funname.name; fdargs; fdbody} |> swrap *)
   | Ast.VarDecl
       {sizedtype; transformation; identifier; initial_value; is_global} ->
       ignore is_global ;
@@ -468,6 +472,27 @@ let rec trans_stmt declc (ts : Ast.typed_statement) =
   | Ast.Break -> Break |> swrap
   | Ast.Continue -> Continue |> swrap
   | Ast.Skip -> Skip |> swrap
+
+let trans_fun_def declc (ts : Ast.typed_statement) =
+  let stmt_typed = ts.stmt in
+  let trans_stmt = trans_stmt {declc with dread= None; dconstrain= None} in
+  (* Function definition location? *)
+  let stmt =
+    match stmt_typed with
+    | Ast.FunDef {returntype; funname; arguments; body} ->
+      { fdrt=
+          ( match returntype with
+            | Void -> None
+            | ReturnType ut -> Some ut )
+      ; fdname= funname.name
+      ; fdargs= List.map ~f:trans_arg arguments
+      ; fdbody= trans_stmt body |> unwrap_block }
+    | _ ->
+      raise_s
+        [%message
+          "Found non-function definition statement in function block"]
+  in
+  stmt
 
 let trans_prog filename
     { Ast.functionblock
@@ -560,9 +585,11 @@ let trans_prog filename
   in
   { functions_block=
       (* Should this be AutoDiffable for functions here?*)
-      map
-        (trans_stmt {dread= None; dconstrain= None; dadlevel= AutoDiffable})
-        functionblock
+      Option.value_map functionblock ~default:[] ~f:(fun fundefs ->
+          List.map
+            fundefs
+            ~f:(fun fundef -> trans_fun_def {dread= None; dconstrain= None; dadlevel= AutoDiffable} fundef)
+          )
   ; input_vars
   ; prepare_data
   ; log_prob

--- a/lib/Ast_to_Mir.ml
+++ b/lib/Ast_to_Mir.ml
@@ -455,13 +455,6 @@ let rec trans_stmt declc (ts : Ast.typed_statement) =
       raise_s
         [%message
           "Found function definition statement outside of function block"]
-  (*TODO | Ast.FunDef {returntype; funname; arguments; body} ->
-      let fdbody = trans_stmt body |> unwrap_block in
-      let fdrt =
-        match returntype with Void -> None | ReturnType ut -> Some ut
-      in
-      let fdargs = List.map ~f:trans_arg arguments in
-      FunDef {fdrt; fdname= funname.name; fdargs; fdbody} |> swrap *)
   | Ast.VarDecl
       {sizedtype; transformation; identifier; initial_value; is_global} ->
       ignore is_global ;

--- a/lib/Ast_to_Mir.ml
+++ b/lib/Ast_to_Mir.ml
@@ -469,7 +469,6 @@ let rec trans_stmt declc (ts : Ast.typed_statement) =
 let trans_fun_def declc (ts : Ast.typed_statement) =
   let stmt_typed = ts.stmt and sloc = ts.smeta.loc in
   let trans_stmt = trans_stmt {declc with dread= None; dconstrain= None} in
-  (* Function definition location? *)
   let stmt =
     match stmt_typed with
     | Ast.FunDef {returntype; funname; arguments; body} ->

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -92,6 +92,14 @@ and 'e expr =
 [@@@ocaml.warning "-A"]
 
 type fun_arg_decl = (autodifftype * string * unsizedtype) list
+[@@deriving sexp, hash, map]
+
+type 's fun_def =
+  {fdrt: unsizedtype option;
+   fdname: string;
+   fdargs: fun_arg_decl;
+   fdbody: 's}
+[@@deriving sexp, hash, map]
 
 and 'e lvalue = string * 'e index list
 
@@ -117,11 +125,6 @@ and ('e, 's) statement =
       { decl_adtype: autodifftype
       ; decl_id: string
       ; decl_type: 'e sizedtype }
-  | FunDef of
-      { fdrt: unsizedtype option
-      ; fdname: string
-      ; fdargs: fun_arg_decl
-      ; fdbody: 's }
 [@@deriving sexp, hash, map]
 
 type io_block =
@@ -134,7 +137,7 @@ type io_block =
 type 'e io_var = string * ('e sizedtype * io_block) [@@deriving sexp]
 
 type ('e, 's) prog =
-  { functions_block: 's list
+  { functions_block: 's fun_def list
   ; input_vars: 'e io_var list
   ; prepare_data: 's list (* data & transformed data decls and statements *)
   ; log_prob: 's list (*assumes data & params are in scope and ready*)
@@ -240,6 +243,18 @@ let pp_fun_arg_decl ppf (autodifftype, name, unsizedtype) =
   Fmt.pf ppf "%a%a %s" pp_autodifftype autodifftype pp_unsizedtype unsizedtype
     name
 
+let pp_fun_def pp_s ppf = function
+  | {fdrt; fdname; fdargs; fdbody} -> (
+      match fdrt with
+      | Some rt ->
+        Fmt.pf ppf {|@[<v2>%a %s%a {@ %a@]@ }|} pp_unsizedtype rt fdname
+          Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
+          fdargs pp_s fdbody
+      | None ->
+        Fmt.pf ppf {|@[<v2>%s %s%a {@ %a@]@ }|} "void" fdname
+          Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
+          fdargs pp_s fdbody )
+
 let rec pp_statement pp_e pp_s ppf = function
   | Assignment ((assignee, idcs), rhs) ->
       Fmt.pf ppf {|@[<h>%a :=@ %a;@]|} (pp_indexed pp_e) (assignee, idcs) pp_e
@@ -271,16 +286,6 @@ let rec pp_statement pp_e pp_s ppf = function
   | Decl {decl_adtype; decl_id; decl_type} ->
       Fmt.pf ppf {|%a%a %s;|} pp_autodifftype decl_adtype (pp_sizedtype pp_e)
         decl_type decl_id
-  | FunDef {fdrt; fdname; fdargs; fdbody} -> (
-    match fdrt with
-    | Some rt ->
-        Fmt.pf ppf {|@[<v2>%a %s%a {@ %a@]@ }|} pp_unsizedtype rt fdname
-          Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
-          fdargs pp_s fdbody
-    | None ->
-        Fmt.pf ppf {|@[<v2>%s %s%a {@ %a@]@ }|} "void" fdname
-          Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
-          fdargs pp_s fdbody )
 
 let pp_io_block ppf = function
   | Data -> Fmt.string ppf "data"
@@ -322,7 +327,7 @@ let pp_transform_inits pp_s ppf {transform_inits; _} =
 
 let pp_prog pp_e pp_s ppf prog =
   Format.open_vbox 0 ;
-  pp_functions_block pp_s ppf prog ;
+  pp_functions_block (pp_fun_def pp_s) ppf prog ;
   Fmt.cut ppf () ;
   pp_input_vars pp_e ppf prog ;
   Fmt.cut ppf () ;

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -17,9 +17,10 @@ type location =
   ; line_num: int
   ; col_num: int
   ; included_from: location option }
+[@@deriving sexp]
 
 (** Delimited locations *)
-type location_span = {begin_loc: location; end_loc: location}
+type location_span = {begin_loc: location; end_loc: location} [@@deriving sexp]
 
 let merge_spans left right = {begin_loc= left.begin_loc; end_loc= right.end_loc}
 
@@ -95,7 +96,11 @@ type fun_arg_decl = (autodifftype * string * unsizedtype) list
 [@@deriving sexp, hash, map]
 
 type 's fun_def =
-  {fdrt: unsizedtype option; fdname: string; fdargs: fun_arg_decl; fdbody: 's}
+  { fdrt: unsizedtype option
+  ; fdname: string
+  ; fdargs: fun_arg_decl
+  ; fdbody: 's
+  ; fdloc: location_span [@compare.ignore] }
 [@@deriving sexp, hash, map]
 
 and 'e lvalue = string * 'e index list

--- a/lib/Mir.ml
+++ b/lib/Mir.ml
@@ -95,10 +95,7 @@ type fun_arg_decl = (autodifftype * string * unsizedtype) list
 [@@deriving sexp, hash, map]
 
 type 's fun_def =
-  {fdrt: unsizedtype option;
-   fdname: string;
-   fdargs: fun_arg_decl;
-   fdbody: 's}
+  {fdrt: unsizedtype option; fdname: string; fdargs: fun_arg_decl; fdbody: 's}
 [@@deriving sexp, hash, map]
 
 and 'e lvalue = string * 'e index list
@@ -245,12 +242,12 @@ let pp_fun_arg_decl ppf (autodifftype, name, unsizedtype) =
 
 let pp_fun_def pp_s ppf = function
   | {fdrt; fdname; fdargs; fdbody} -> (
-      match fdrt with
-      | Some rt ->
+    match fdrt with
+    | Some rt ->
         Fmt.pf ppf {|@[<v2>%a %s%a {@ %a@]@ }|} pp_unsizedtype rt fdname
           Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
           fdargs pp_s fdbody
-      | None ->
+    | None ->
         Fmt.pf ppf {|@[<v2>%s %s%a {@ %a@]@ }|} "void" fdname
           Fmt.(list pp_fun_arg_decl ~sep:comma |> parens)
           fdargs pp_s fdbody )

--- a/lib/Stan_math_code_gen.ml
+++ b/lib/Stan_math_code_gen.ml
@@ -427,8 +427,7 @@ using namespace stan::math; |}
 
 let pp_prog ppf (p : (mtype_loc_ad with_expr, stmt_loc) prog) =
   pf ppf "@[<v>@ %s@ %s@ namespace %s_namespace {@ %s@ %s@ %a@ %a@ }@ @]"
-    version includes p.prog_name usings globals
-    (list ~sep:cut pp_fun_def)
+    version includes p.prog_name usings globals (list ~sep:cut pp_fun_def)
     p.functions_block pp_model p ;
   pf ppf "@,typedef %snamespace::%s stan_model;@," p.prog_name p.prog_name
 
@@ -442,8 +441,7 @@ let%expect_test "udf" =
   ; fdbody=
       Return (Some (w @@ FunApp ("add", [w @@ Var "x"; w @@ Lit (Int, "1")])))
       |> with_no_loc |> List.return |> Block |> with_no_loc }
-  |> strf "@[<v>%a" pp_fun_def
-  |> print_endline ;
+  |> strf "@[<v>%a" pp_fun_def |> print_endline ;
   [%expect
     {|
     template <typename T0__, typename T1__>

--- a/lib/Stan_math_code_gen.ml
+++ b/lib/Stan_math_code_gen.ml
@@ -188,7 +188,7 @@ let rec pp_statement ppf {stmt; smeta} =
       pp_sized_decl ppf (decl_id, decl_type, decl_adtype)
 
 let pp_fun_def ppf = function
-  | {fdrt; fdname; fdargs; fdbody} -> (
+  | {fdrt; fdname; fdargs; fdbody; _} -> (
       let argtypetemplates =
         List.mapi ~f:(fun i _ -> sprintf "T%d__" i) fdargs
       in
@@ -440,7 +440,8 @@ let%expect_test "udf" =
   ; fdargs= [(DataOnly, "x", UMatrix); (AutoDiffable, "y", URowVector)]
   ; fdbody=
       Return (Some (w @@ FunApp ("add", [w @@ Var "x"; w @@ Lit (Int, "1")])))
-      |> with_no_loc |> List.return |> Block |> with_no_loc }
+      |> with_no_loc |> List.return |> Block |> with_no_loc
+  ; fdloc= no_span }
   |> strf "@[<v>%a" pp_fun_def |> print_endline ;
   [%expect
     {|


### PR DESCRIPTION
Pulled out fun_defs, so that they can only appear in the functions_block of a prog. Currently throwing an error if AST FunDefs appear anywhere outside of the function block, or if there are any non-FunDefs in the function block.

This is a new version of PR https://github.com/stan-dev/stanc3/pull/92 to address issue https://github.com/stan-dev/stanc3/issues/78. I started over since there have been many changes to master.