### PR TITLE
Fix hepatitisME model

### DIFF
--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -590,6 +590,11 @@ let get_block block prog =
   | GeneratedQuantities -> prog.generatedquantitiesblock
   | Data -> prog.datablock
 
+let migrate_checks_to_end_of_block stmts =
+  let is_check = contains_fn (string_of_internal_fn FnCheck) in
+  let checks, not_checks = List.partition_tf ~f:is_check stmts in
+  not_checks @ checks
+
 let trans_prog filename p : typed_prog =
   (*
      1. prepare_params: add read_param calls (same call should constrain?)
@@ -641,12 +646,14 @@ let trans_prog filename p : typed_prog =
       (trans_stmt
          {dread= Some ReadData; dconstrain= Some Check; dadlevel= DataOnly})
       datablock
+    |> migrate_checks_to_end_of_block
   in
   let prepare_data =
     datab
     @ map
         (trans_stmt {dread= None; dconstrain= Some Check; dadlevel= DataOnly})
         transformeddatablock
+    |> migrate_checks_to_end_of_block
   in
   let modelb =
     map
@@ -660,10 +667,11 @@ let trans_prog filename p : typed_prog =
          ; dconstrain= Some Constrain
          ; dadlevel= AutoDiffable })
       parametersblock
-    @ map
-        (trans_stmt
-           {dread= None; dconstrain= Some Check; dadlevel= AutoDiffable})
-        transformedparametersblock
+    @ ( map
+          (trans_stmt
+             {dread= None; dconstrain= Some Check; dadlevel= AutoDiffable})
+          transformedparametersblock
+      |> migrate_checks_to_end_of_block )
     @
     match modelb with
     | [] -> []

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -412,9 +412,6 @@ let trans_decl {dread; dconstrain; dadlevel} smeta sizedtype transform
     | Some Check -> check_decl decl_type decl_id transform smeta dadlevel
     | _ -> []
   in
-  (* XXX Currently working on sigma_y in hepatitisME.stan
-     the sigma definition only occurs much later.
-  *)
   (decl :: read_stmts) @ constrain_stmts @ checks
 
 let unwrap_block_or_skip = function
@@ -614,9 +611,6 @@ let trans_prog filename p : typed_prog =
      unconstrained param names: same, but also some funky
         adjustments for unconstrained space: ???
 *)
-  (* XXX need to write a function for moving checks to the end of transformed parameters,
-  transformed data blocks before merging into other blocks.
-  *)
   let { Ast.functionblock
       ; datablock
       ; transformeddatablock

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -412,6 +412,9 @@ let trans_decl {dread; dconstrain; dadlevel} smeta sizedtype transform
     | Some Check -> check_decl decl_type decl_id transform smeta dadlevel
     | _ -> []
   in
+  (* XXX Currently working on sigma_y in hepatitisME.stan
+     the sigma definition only occurs much later.
+  *)
   (decl :: read_stmts) @ constrain_stmts @ checks
 
 let unwrap_block_or_skip = function
@@ -606,6 +609,9 @@ let trans_prog filename p : typed_prog =
      unconstrained param names: same, but also some funky
         adjustments for unconstrained space: ???
 *)
+  (* XXX need to write a function for moving checks to the end of transformed parameters,
+  transformed data blocks before merging into other blocks.
+  *)
   let { Ast.functionblock
       ; datablock
       ; transformeddatablock

--- a/src/middle/Middle.mli
+++ b/src/middle/Middle.mli
@@ -83,7 +83,7 @@ val binop :
   -> mtype_loc_ad with_expr
   -> mtype_loc_ad with_expr
 
-val contains_fn : string -> bool -> ('a, 'b) stmt_with -> bool
+val contains_fn : string -> ('a, 'b) stmt_with -> bool
 val mir_int : int -> mtype_loc_ad with_expr
 
 val mock_for :

--- a/src/middle/Middle.mli
+++ b/src/middle/Middle.mli
@@ -82,3 +82,11 @@ val binop :
   -> operator
   -> mtype_loc_ad with_expr
   -> mtype_loc_ad with_expr
+
+val contains_fn : string -> bool -> ('a, 'b) stmt_with -> bool
+val mir_int : int -> mtype_loc_ad with_expr
+
+val mock_for :
+     int
+  -> (mtype_loc_ad, location_span) stmt_with
+  -> (mtype_loc_ad, location_span) stmt_with

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -34,8 +34,9 @@ let rec stantype_prim_str = function
   | UArray t -> stantype_prim_str t
   | _ -> "double"
 
-let local_scalar ut ad =
+let rec local_scalar ut ad =
   match (ut, ad) with
+  | UArray t, _ -> local_scalar t ad
   | _, DataOnly | UInt, AutoDiffable -> stantype_prim_str ut
   | _, AutoDiffable -> "local_scalar_t__"
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -294,7 +294,6 @@ let separated_output_vars p =
     p.output_vars
 
 let pp_string_lit = fmt "%S"
-let mir_int i = {expr= Lit (Int, string_of_int i); emeta= internal_meta}
 
 let rec pp_for_loop_iteratee ?(index_ids = []) ppf (iteratee, dims, pp_body) =
   let iter d pp_body =
@@ -501,63 +500,6 @@ using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
 using namespace stan::math; |}
-
-let rec expr_contains_fn fname accum e =
-  accum
-  ||
-  match e.expr with
-  | FunApp (_, name, _) when name = fname -> true
-  | x -> fold_expr (expr_contains_fn fname) accum x
-
-let%test "expr contains fn" =
-  internal_funapp FnReadData [] ()
-  |> expr_contains_fn (string_of_internal_fn FnReadData) false
-
-let rec contains_fn fname accum {stmt; _} =
-  accum
-  ||
-  match stmt with
-  | NRFunApp (_, fname', _) when fname' = fname -> true
-  | _ -> fold_statement (expr_contains_fn fname) (contains_fn fname) accum stmt
-
-let mock_stmt stmt = {stmt; smeta= no_span}
-
-let mock_for i body =
-  For
-    { loopvar= "lv"
-    ; lower= mir_int 0
-    ; upper= mir_int i
-    ; body= mock_stmt (Block [body]) }
-  |> mock_stmt
-
-let%test "contains fn" =
-  let f =
-    mock_for 8
-      (mock_for 9
-         (mock_stmt
-            (Assignment (("v", []), internal_funapp FnReadData [] internal_meta))))
-  in
-  contains_fn
-    (string_of_internal_fn FnReadData)
-    false
-    (mock_stmt (Block [f; mock_stmt Break]))
-
-let%test "contains nrfn" =
-  let f =
-    mock_for 8
-      (mock_for 9
-         (mock_stmt
-            (NRFunApp (CompilerInternal, string_of_internal_fn FnWriteParam, []))))
-  in
-  contains_fn
-    (string_of_internal_fn FnWriteParam)
-    false
-    (mock_stmt
-       (Block
-          [ mock_stmt
-              (NRFunApp
-                 (CompilerInternal, string_of_internal_fn FnWriteParam, []))
-          ; f ]))
 
 let pos = "pos__"
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -505,8 +505,7 @@ let pos = "pos__"
 
 let add_pos_reset ({stmt; smeta} as s) =
   match stmt with
-  | For {body; _}
-    when contains_fn (string_of_internal_fn FnReadData) false body ->
+  | For {body; _} when contains_fn (string_of_internal_fn FnReadData) body ->
       [{stmt= Assignment ((pos, []), loop_bottom); smeta}; s]
   | _ -> [s]
 
@@ -520,8 +519,8 @@ let rec invert_read_fors ({stmt; smeta} as s) =
   in
   match stmt with
   | For {body; _}
-    when contains_fn (string_of_internal_fn FnReadData) false body
-         || contains_fn (string_of_internal_fn FnWriteParam) false body ->
+    when contains_fn (string_of_internal_fn FnReadData) body
+         || contains_fn (string_of_internal_fn FnWriteParam) body ->
       let final, args = unwind s in
       List.fold ~init:final
         ~f:(fun accum (loopvar, lower, upper) ->

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -48,7 +48,6 @@ class eight_schools_ncp_model : public prob_grad {
     
     
     assign(J, nil_index_list(), context__.vals_i("J")[(1 - 1)], "assigning variable J");
-    check_greater_or_equal(function__, "J", J, 0);
     y = std::vector<double>(J, 0);
     
     pos__ = 1;
@@ -65,6 +64,7 @@ class eight_schools_ncp_model : public prob_grad {
                                                                     [(pos__ - 1)], "assigning variable sigma[(sym1__ - 1)]");
       assign(pos__, nil_index_list(), (stan::model::deep_copy(pos__) + 1), "assigning variable pos__");
     }
+    check_greater_or_equal(function__, "J", J, 0);
     for (size_t sym1__ = 1; sym1__ <= J; ++sym1__) {
       check_greater_or_equal(function__, "sigma[sym1__]",
                              stan::model::rvalue(sigma, cons_list(index_uni(sym1__), nil_index_list()), "pretty printed e"),
@@ -391,14 +391,14 @@ class one_var_per_block_model : public prob_grad {
                context__.vals_r("datavar")[(pos__ - 1)], "assigning variable datavar[(sym1__ - 1), (sym2__ - 1)]");
         assign(pos__, nil_index_list(), (stan::model::deep_copy(pos__) + 1), "assigning variable pos__");
       }}
+    tdatavar = std::vector<std::vector<double>>(1, std::vector<double>(1, 0));
+    
+    tdatavar = {{2.0}};
     for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
       for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
         check_greater_or_equal(function__, "datavar[sym1__, sym2__]",
                                stan::model::rvalue(datavar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), "pretty printed e"),
                                0);}}
-    tdatavar = std::vector<std::vector<double>>(1, std::vector<double>(1, 0));
-    
-    tdatavar = {{2.0}};
     for (size_t sym1__ = 1; sym1__ <= 1; ++sym1__) {
       for (size_t sym2__ = 1; sym2__ <= 1; ++sym2__) {
         check_greater_or_equal(function__, "tdatavar[sym1__, sym2__]",
@@ -461,14 +461,14 @@ class one_var_per_block_model : public prob_grad {
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> tparam;
       tparam = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(N));
       
+      for (size_t n = 1; n <= N; ++n) {
+        assign(tparam, cons_list(index_uni(n), nil_index_list()), multiply(stan::model::rvalue(param, cons_list(index_uni(n), nil_index_list()), "pretty printed e"), 2), "assigning variable tparam[(n - 1)]");
+      }
       for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           check_greater_or_equal(function__, "tparam[sym1__, sym2__]",
                                  stan::model::rvalue(tparam, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), "pretty printed e"),
                                  0);}}
-      for (size_t n = 1; n <= N; ++n) {
-        assign(tparam, cons_list(index_uni(n), nil_index_list()), multiply(stan::model::rvalue(param, cons_list(index_uni(n), nil_index_list()), "pretty printed e"), 2), "assigning variable tparam[(n - 1)]");
-      }
       {
         std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> modellocal;
         modellocal = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(N));


### PR DESCRIPTION
Turns out using declarations to immediately generate checks doesn't work - you need to move the checks to the end of their respective blocks because they may be assigning the variables (and modifying them) at arbitrary locations in the block, and they need to be checked after that.