### PR TITLE
Partially evaluate indexed array and row_vector expressions

### DIFF
--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -679,7 +679,8 @@ let rec eval_expr (e : Middle.expr_typed_located) =
       | Indexed (e, l) -> (
         match (e.expr, l) with
         | FunApp (t, f, elts), i :: _
-          when f = string_of_internal_fn FnMakeArray -> (
+          when f = string_of_internal_fn FnMakeArray
+          || f = string_of_internal_fn FnMakeRowVec -> (
           match i with
           | All -> FunApp (t, f, elts)
           | Single e -> failwith "<case>"

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -2016,6 +2016,7 @@ let%expect_test "partial evaluation" =
           print(i + (1+2));
           print(log(1-i));
           print({453, 24, 6}[]);
+          print({453, 24, 6}[:]);
           print({453, 24, 6}[3]);
           print({453, 24, 6}[4]);
           print({453, 24, 6}[0]);
@@ -2059,6 +2060,7 @@ let%expect_test "partial evaluation" =
             FnPrint__((i + 3));
             FnPrint__(log1m(i));
             FnPrint__(FnMakeArray__(453, 24, 6));
+            FnPrint__(FnMakeArray__(453, 24, 6));
             FnPrint__(6);
             FnPrint__(FnMakeArray__(453, 24, 6)[4]);
             FnPrint__(FnMakeArray__(453, 24, 6)[0]);
@@ -2066,7 +2068,7 @@ let%expect_test "partial evaluation" =
             FnPrint__(24);
             FnPrint__(24);
             FnPrint__(FnMakeArray__(453, 24, 6)[(1 + i)]);
-            FnPrint__(FnMakeArray__(FnMakeArray__(453, 24), FnMakeArray__(6))[1, 2]);
+            FnPrint__(24);
             FnPrint__(24);
             FnPrint__(24);
             FnPrint__(FnMakeArray__(24, 6));

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -2015,6 +2015,20 @@ let%expect_test "partial evaluation" =
           print(1+2);
           print(i + (1+2));
           print(log(1-i));
+          print({453, 24, 6}[]);
+          print({453, 24, 6}[3]);
+          print({453, 24, 6}[4]);
+          print({453, 24, 6}[0]);
+          print({453, 24, 6}[1]);
+          print({453, 24, 6}[2]);
+          print({453, 24, 6}[1 + 1]);
+          print({453, 24, 6}[1 + i]);
+          print({{453, 24}, {6}}[1, 2]); // Still wrong
+          print({{453, 24}, {6}}[1][2]);
+          print([[453, 24], [6]][1][2]);
+          print({453, 24, 6}[2:]);
+          print({453, 24, 6}[:2]);
+          print({453, 24, 6}[{1, 3}]);
         }
       }
       |}
@@ -2044,6 +2058,20 @@ let%expect_test "partial evaluation" =
             FnPrint__(3);
             FnPrint__((i + 3));
             FnPrint__(log1m(i));
+            FnPrint__(FnMakeArray__(453, 24, 6));
+            FnPrint__(6);
+            FnPrint__(FnMakeArray__(453, 24, 6)[4]);
+            FnPrint__(FnMakeArray__(453, 24, 6)[0]);
+            FnPrint__(453);
+            FnPrint__(24);
+            FnPrint__(24);
+            FnPrint__(FnMakeArray__(453, 24, 6)[(1 + i)]);
+            FnPrint__(FnMakeArray__(FnMakeArray__(453, 24), FnMakeArray__(6))[1, 2]);
+            FnPrint__(24);
+            FnPrint__(24);
+            FnPrint__(FnMakeArray__(24, 6));
+            FnPrint__(FnMakeArray__(453, 24));
+            FnPrint__(FnMakeArray__(453, 6));
           }
         }
       }

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -2024,7 +2024,7 @@ let%expect_test "partial evaluation" =
           print({453, 24, 6}[2]);
           print({453, 24, 6}[1 + 1]);
           print({453, 24, 6}[1 + i]);
-          print({{453, 24}, {6}}[1, 2]); // Still wrong
+          print({{453, 24}, {6}}[1, 2]);
           print({{453, 24}, {6}}[1][2]);
           print([[453, 24], [6]][1][2]);
           print({453, 24, 6}[2:]);


### PR DESCRIPTION
This upgrades the partial evaluator with some cool capacities.

Basically, to evaluate `{24, 35, 46}[2]` to `35`.