### PR TITLE
Fix #258.

### DIFF
--- a/src/middle/Middle.mli
+++ b/src/middle/Middle.mli
@@ -67,8 +67,6 @@ val pretty_print_all_math_lib_fn_sigs : string -> string
 val is_stan_math_function_name : string -> bool
 (** Check whether a string is the name of a Stan Math library function. *)
 
-val stan_distribution_name_suffix : string -> string
-
 val operator_return_type_from_string :
   string -> (autodifftype * unsizedtype) sexp_list -> returntype option
 

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -28,11 +28,6 @@ let is_stan_math_function_name name =
   let name = Utils.stdlib_distribution_name name in
   Hashtbl.mem stan_math_signatures name
 
-let stan_distribution_name_suffix name =
-  Utils.distribution_suffices
-  |> List.filter ~f:(fun sfx -> is_stan_math_function_name (name ^ sfx))
-  |> List.hd_exn
-
 let assignmentoperator_to_stan_math_fn = function
   | Plus -> Some "assign_add"
   | Minus -> Some "assign_subtract"
@@ -1119,7 +1114,8 @@ let () =
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal) ) )
       ; (AutoDiffable, UArray UReal)
-      ; (AutoDiffable, UReal); (AutoDiffable, UArray UReal)
+      ; (AutoDiffable, UReal)
+      ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
   add_qualified
@@ -1133,7 +1129,8 @@ let () =
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal) ) )
       ; (AutoDiffable, UArray UReal)
-      ; (AutoDiffable, UReal); (AutoDiffable, UArray UReal)
+      ; (AutoDiffable, UReal)
+      ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
   add_qualified
@@ -1147,7 +1144,8 @@ let () =
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal) ) )
       ; (AutoDiffable, UArray UReal)
-      ; (AutoDiffable, UReal); (AutoDiffable, UArray UReal)
+      ; (AutoDiffable, UReal)
+      ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
       ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;
@@ -1162,7 +1160,8 @@ let () =
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal) ) )
       ; (AutoDiffable, UArray UReal)
-      ; (AutoDiffable, UReal); (AutoDiffable, UArray UReal)
+      ; (AutoDiffable, UReal)
+      ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
   add_qualified
@@ -1176,7 +1175,8 @@ let () =
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal) ) )
       ; (AutoDiffable, UArray UReal)
-      ; (AutoDiffable, UReal); (AutoDiffable, UArray UReal)
+      ; (AutoDiffable, UReal)
+      ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
       ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;
@@ -1191,7 +1191,8 @@ let () =
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal) ) )
       ; (AutoDiffable, UArray UReal)
-      ; (AutoDiffable, UReal); (AutoDiffable, UArray UReal)
+      ; (AutoDiffable, UReal)
+      ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
   add_qualified
@@ -1205,7 +1206,8 @@ let () =
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal) ) )
       ; (AutoDiffable, UArray UReal)
-      ; (AutoDiffable, UReal); (AutoDiffable, UArray UReal)
+      ; (AutoDiffable, UReal)
+      ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
       ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;


### PR DESCRIPTION
Collect the names of user defined functions at the beginning of the Ast_to_Mir pass,
then hand that to trans_stmt so we can figure out how to translate Tilde nodes properly.

Also some unrelated ocamlformat changes fixing formatting on master