### PR TITLE
Sort type signatures in output.

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -71,7 +71,9 @@ let operator_stan_math_return_type op arg_tys =
 
 let pretty_print_all_math_lib_fn_sigs name =
   let name = Utils.stdlib_distribution_name name in
-  let namematches = Hashtbl.find_multi stan_math_signatures name in
+  let namematches =
+    Hashtbl.find_multi stan_math_signatures name |> List.sort ~compare
+  in
   if List.length namematches = 0 then ""
   else
     "\n"

--- a/test/integration/bad/algebra_solver/stanc.expected
+++ b/test/integration/bad/algebra_solver/stanc.expected
@@ -11,8 +11,8 @@ Semantic error in 'bad_fun_type.stan', line 31, column 10 to column 62:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (real[], vector, real[], int[]) => vector, vector, vector, real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_fun_type_control.stan
@@ -28,8 +28,8 @@ Semantic error in 'bad_fun_type_control.stan', line 31, column 10 to column 78:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (real[], vector, real[], int[]) => vector, vector, vector, real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_theta_type.stan
@@ -45,8 +45,8 @@ Semantic error in 'bad_theta_type.stan', line 31, column 10 to column 62:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (real[], vector, real[], int[]) => vector, vector, real, real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_theta_type_control.stan
@@ -62,8 +62,8 @@ Semantic error in 'bad_theta_type_control.stan', line 31, column 10 to column 78
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (real[], vector, real[], int[]) => vector, vector, real, real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_i_type.stan
@@ -79,8 +79,8 @@ Semantic error in 'bad_x_i_type.stan', line 31, column 10 to column 62:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (vector, vector, real[], int[]) => vector, vector, vector, real[], real[].
 
   $ ../../../../../install/default/bin/stanc bad_x_i_type_control.stan
@@ -96,8 +96,8 @@ Semantic error in 'bad_x_i_type_control.stan', line 31, column 10 to column 78:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (vector, vector, real[], int[]) => vector, vector, vector, real[], real[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_r_type.stan
@@ -113,8 +113,8 @@ Semantic error in 'bad_x_r_type.stan', line 31, column 10 to column 62:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (vector, vector, real[], int[]) => vector, vector, vector, int[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_x_r_type_control.stan
@@ -130,8 +130,8 @@ Semantic error in 'bad_x_r_type_control.stan', line 31, column 10 to column 78:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (vector, vector, real[], int[]) => vector, vector, vector, int[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_r_var_type.stan
@@ -147,8 +147,8 @@ Semantic error in 'bad_x_r_var_type.stan', line 31, column 10 to column 64:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (vector, vector, real[], int[]) => vector, vector, vector, real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_x_r_var_type_control.stan
@@ -164,8 +164,8 @@ Semantic error in 'bad_x_r_var_type_control.stan', line 31, column 10 to column 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (vector, vector, real[], int[]) => vector, vector, vector, real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_y_type.stan
@@ -181,8 +181,8 @@ Semantic error in 'bad_y_type.stan', line 31, column 10 to column 62:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (real[], vector, real[], int[]) => vector, real, vector, real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_y_type_control.stan
@@ -198,7 +198,7 @@ Semantic error in 'bad_y_type_control.stan', line 31, column 10 to column 78:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'algebra_solver'. Available signatures: 
-((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 ((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[]) => vector
+((vector, vector, data real[], data int[]) => vector, vector, vector, data real[], data int[], data real, data real, data real) => vector
 Instead supplied arguments of incompatible type: (real[], vector, real[], int[]) => vector, real, vector, real[], int[], real, real, int.
 

--- a/test/integration/bad/compound-assign/stanc.expected
+++ b/test/integration/bad/compound-assign/stanc.expected
@@ -10,13 +10,13 @@ Semantic error in 'elt_divide_equals_prim.stan', line 4, column 2 to column 10:
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator ./=: lhs has type real and rhs has type real. Available signatures:
-(vector, vector) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(matrix, int) => void
 (row_vector, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
 
@@ -76,18 +76,18 @@ Semantic error in 'plus_equals_bad_var_lhs.stan', line 3, column 4 to column 14:
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type (real) => real and rhs has type real. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_bad_var_lhs2.stan
 
@@ -128,18 +128,18 @@ Semantic error in 'plus_equals_matrix_array.stan', line 7, column 2 to column 9:
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type matrix[] and rhs has type matrix[]. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_matrix_array2.stan
 
@@ -153,18 +153,18 @@ Semantic error in 'plus_equals_matrix_array2.stan', line 7, column 2 to column 1
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type matrix and rhs has type row_vector. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_matrix_shape_mismatch.stan
 
@@ -193,18 +193,18 @@ Semantic error in 'plus_equals_prim_array.stan', line 5, column 2 to column 9:
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type real[] and rhs has type real[]. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_row_vec_array.stan
 
@@ -218,18 +218,18 @@ Semantic error in 'plus_equals_row_vec_array.stan', line 5, column 2 to column 9
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type row_vector[] and rhs has type row_vector[]. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_sliced.stan
 
@@ -244,18 +244,18 @@ Semantic error in 'plus_equals_sliced.stan', line 6, column 4 to column 27:
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type vector and rhs has type matrix. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch.stan
 
@@ -269,18 +269,18 @@ Semantic error in 'plus_equals_type_mismatch.stan', line 4, column 2 to column 9
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type int and rhs has type real. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch2.stan
 
@@ -294,18 +294,18 @@ Semantic error in 'plus_equals_type_mismatch2.stan', line 4, column 2 to column 
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type real and rhs has type vector. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc plus_equals_vector_array.stan
 
@@ -319,18 +319,18 @@ Semantic error in 'plus_equals_vector_array.stan', line 5, column 2 to column 9:
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator +=: lhs has type vector[] and rhs has type vector[]. Available signatures:
-(vector, vector) => void
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, row_vector) => void
+(vector, vector) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, row_vector) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 
   $ ../../../../../install/default/bin/stanc times_equals_matrix_array.stan
 
@@ -345,15 +345,15 @@ Semantic error in 'times_equals_matrix_array.stan', line 5, column 2 to column 1
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator *=: lhs has type row_vector and rhs has type row_vector. Available signatures:
+(int, int) => void
+(real, int) => void
+(real, real) => void
 (vector, int) => void
 (vector, real) => void
-(row_vector, matrix) => void
 (row_vector, int) => void
-(real, int) => void
-(matrix, int) => void
 (row_vector, real) => void
-(real, real) => void
+(row_vector, matrix) => void
+(matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-(int, int) => void
 

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -220,12 +220,12 @@ Semantic error in 'bad_cov_exp_quad_len_data.stan', line 13, column 28 to column
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'cov_exp_quad'. Available signatures: 
-(row_vector[], row_vector[], real, real) => matrix
-(vector[], vector[], real, real) => matrix
-(real[], real[], real, real) => matrix
-(row_vector[], real, real) => matrix
-(vector[], real, real) => matrix
 (real[], real, real) => matrix
+(real[], real[], real, real) => matrix
+(vector[], real, real) => matrix
+(vector[], vector[], real, real) => matrix
+(row_vector[], real, real) => matrix
+(row_vector[], row_vector[], real, real) => matrix
 Instead supplied arguments of incompatible type: vector[], vector[], real, real[].
 
   $ ../../../../../install/default/bin/stanc bad_cov_exp_quad_len_param.stan
@@ -315,12 +315,12 @@ Semantic error in 'bad_cov_exp_quad_rvec_data.stan', line 12, column 28 to colum
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'cov_exp_quad'. Available signatures: 
-(row_vector[], row_vector[], real, real) => matrix
-(vector[], vector[], real, real) => matrix
-(real[], real[], real, real) => matrix
-(row_vector[], real, real) => matrix
-(vector[], real, real) => matrix
 (real[], real, real) => matrix
+(real[], real[], real, real) => matrix
+(vector[], real, real) => matrix
+(vector[], vector[], real, real) => matrix
+(row_vector[], real, real) => matrix
+(row_vector[], row_vector[], real, real) => matrix
 Instead supplied arguments of incompatible type: row_vector, real, real.
 
   $ ../../../../../install/default/bin/stanc bad_cov_exp_quad_rvec_vec_data.stan
@@ -336,12 +336,12 @@ Semantic error in 'bad_cov_exp_quad_rvec_vec_data.stan', line 13, column 28 to c
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'cov_exp_quad'. Available signatures: 
-(row_vector[], row_vector[], real, real) => matrix
-(vector[], vector[], real, real) => matrix
-(real[], real[], real, real) => matrix
-(row_vector[], real, real) => matrix
-(vector[], real, real) => matrix
 (real[], real, real) => matrix
+(real[], real[], real, real) => matrix
+(vector[], real, real) => matrix
+(vector[], vector[], real, real) => matrix
+(row_vector[], real, real) => matrix
+(row_vector[], row_vector[], real, real) => matrix
 Instead supplied arguments of incompatible type: row_vector[], vector[], real, real.
 
   $ ../../../../../install/default/bin/stanc bad_cov_exp_quad_rvec_vec_param.stan
@@ -372,12 +372,12 @@ Semantic error in 'bad_cov_exp_quad_sigma_data.stan', line 13, column 28 to colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'cov_exp_quad'. Available signatures: 
-(row_vector[], row_vector[], real, real) => matrix
-(vector[], vector[], real, real) => matrix
-(real[], real[], real, real) => matrix
-(row_vector[], real, real) => matrix
-(vector[], real, real) => matrix
 (real[], real, real) => matrix
+(real[], real[], real, real) => matrix
+(vector[], real, real) => matrix
+(vector[], vector[], real, real) => matrix
+(row_vector[], real, real) => matrix
+(row_vector[], row_vector[], real, real) => matrix
 Instead supplied arguments of incompatible type: vector[], vector[], real[], real.
 
   $ ../../../../../install/default/bin/stanc bad_cov_exp_quad_sigma_param.stan
@@ -467,12 +467,12 @@ Semantic error in 'bad_cov_exp_quad_vec_data.stan', line 12, column 28 to column
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'cov_exp_quad'. Available signatures: 
-(row_vector[], row_vector[], real, real) => matrix
-(vector[], vector[], real, real) => matrix
-(real[], real[], real, real) => matrix
-(row_vector[], real, real) => matrix
-(vector[], real, real) => matrix
 (real[], real, real) => matrix
+(real[], real[], real, real) => matrix
+(vector[], real, real) => matrix
+(vector[], vector[], real, real) => matrix
+(row_vector[], real, real) => matrix
+(row_vector[], row_vector[], real, real) => matrix
 Instead supplied arguments of incompatible type: vector, real, real.
 
   $ ../../../../../install/default/bin/stanc bad_cov_exp_quad_vec_rvec_data.stan
@@ -488,12 +488,12 @@ Semantic error in 'bad_cov_exp_quad_vec_rvec_data.stan', line 13, column 28 to c
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'cov_exp_quad'. Available signatures: 
-(row_vector[], row_vector[], real, real) => matrix
-(vector[], vector[], real, real) => matrix
-(real[], real[], real, real) => matrix
-(row_vector[], real, real) => matrix
-(vector[], real, real) => matrix
 (real[], real, real) => matrix
+(real[], real[], real, real) => matrix
+(vector[], real, real) => matrix
+(vector[], vector[], real, real) => matrix
+(row_vector[], real, real) => matrix
+(row_vector[], row_vector[], real, real) => matrix
 Instead supplied arguments of incompatible type: vector[], row_vector[], real, real.
 
   $ ../../../../../install/default/bin/stanc bad_cov_exp_quad_vec_rvec_param.stan

--- a/test/integration/bad/ode/adams/stanc.expected
+++ b/test/integration/bad/ode/adams/stanc.expected
@@ -11,8 +11,8 @@ Semantic error in 'bad_adams_control_function_return.stan', line 13, column 6 to
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real, real[], real, real[], real[], real[], int[], int, int, int.
 
   $ ../../../../../../install/default/bin/stanc bad_control_function_return.stan
@@ -28,8 +28,8 @@ Semantic error in 'bad_control_function_return.stan', line 13, column 6 to line 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real, real[], real, real[], real[], real[], int[], int, int, int.
 
   $ ../../../../../../install/default/bin/stanc bad_fun_type.stan
@@ -45,8 +45,8 @@ Semantic error in 'bad_fun_type.stan', line 27, column 10 to line 33, column 27:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real[], real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[].
 
   $ ../../../../../../install/default/bin/stanc bad_fun_type_control.stan
@@ -62,8 +62,8 @@ Semantic error in 'bad_fun_type_control.stan', line 27, column 10 to line 33, co
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real[], real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_t_type.stan
@@ -79,8 +79,8 @@ Semantic error in 'bad_t_type.stan', line 26, column 10 to line 32, column 27:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], matrix, real[], real[], real[], int[].
 
   $ ../../../../../../install/default/bin/stanc bad_t_type_control.stan
@@ -96,8 +96,8 @@ Semantic error in 'bad_t_type_control.stan', line 26, column 10 to line 32, colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], matrix, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_theta_type.stan
@@ -113,8 +113,8 @@ Semantic error in 'bad_theta_type.stan', line 27, column 10 to line 33, column 2
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[,], real[], int[].
 
   $ ../../../../../../install/default/bin/stanc bad_theta_type_control.stan
@@ -130,8 +130,8 @@ Semantic error in 'bad_theta_type_control.stan', line 27, column 10 to line 33, 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[,], real[], int[], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_ts_type.stan
@@ -147,8 +147,8 @@ Semantic error in 'bad_ts_type.stan', line 26, column 10 to line 32, column 27:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[,], real[], real[], int[].
 
   $ ../../../../../../install/default/bin/stanc bad_ts_type_control.stan
@@ -164,8 +164,8 @@ Semantic error in 'bad_ts_type_control.stan', line 26, column 10 to line 32, col
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[,], real[], real[], int[], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_x_int_type.stan
@@ -181,8 +181,8 @@ Semantic error in 'bad_x_int_type.stan', line 26, column 10 to line 32, column 2
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[,].
 
   $ ../../../../../../install/default/bin/stanc bad_x_int_type_control.stan
@@ -198,8 +198,8 @@ Semantic error in 'bad_x_int_type_control.stan', line 26, column 10 to line 32, 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[,], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_x_type.stan
@@ -215,8 +215,8 @@ Semantic error in 'bad_x_type.stan', line 27, column 10 to line 33, column 27:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], vector[], int[].
 
   $ ../../../../../../install/default/bin/stanc bad_x_type_control.stan
@@ -232,8 +232,8 @@ Semantic error in 'bad_x_type_control.stan', line 27, column 10 to line 33, colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], vector[], int[], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_x_var_type.stan
@@ -249,8 +249,8 @@ Semantic error in 'bad_x_var_type.stan', line 26, column 10 to line 32, column 2
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[].
 
   $ ../../../../../../install/default/bin/stanc bad_x_var_type_adams_control.stan
@@ -266,8 +266,8 @@ Semantic error in 'bad_x_var_type_adams_control.stan', line 26, column 10 to lin
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_x_var_type_control.stan
@@ -283,8 +283,8 @@ Semantic error in 'bad_x_var_type_control.stan', line 26, column 10 to line 32, 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../../install/default/bin/stanc bad_y_type.stan
@@ -300,8 +300,8 @@ Semantic error in 'bad_y_type.stan', line 26, column 10 to line 32, column 27:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[,], real, real[], real[], real[], int[].
 
   $ ../../../../../../install/default/bin/stanc bad_y_type_control.stan
@@ -317,7 +317,7 @@ Semantic error in 'bad_y_type_control.stan', line 26, column 10 to line 32, colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_adams'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[,], real, real[], real[], real[], int[], real, real, int.
 

--- a/test/integration/bad/ode/stanc.expected
+++ b/test/integration/bad/ode/stanc.expected
@@ -11,8 +11,8 @@ Semantic error in 'bad_bdf_control_function_return.stan', line 13, column 6 to l
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real, real[], real, real[], real[], real[], int[], int, int, int.
 
   $ ../../../../../install/default/bin/stanc bad_fun_type.stan
@@ -44,8 +44,8 @@ Semantic error in 'bad_fun_type_bdf.stan', line 27, column 10 to line 33, column
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real[], real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_fun_type_bdf_control.stan
@@ -61,8 +61,8 @@ Semantic error in 'bad_fun_type_bdf_control.stan', line 27, column 10 to line 33
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real[], real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_fun_type_rk45.stan
@@ -78,8 +78,8 @@ Semantic error in 'bad_fun_type_rk45.stan', line 27, column 10 to line 33, colum
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real[], real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_fun_type_rk45_control.stan
@@ -95,8 +95,8 @@ Semantic error in 'bad_fun_type_rk45_control.stan', line 27, column 10 to line 3
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real[], real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_t_type.stan
@@ -128,8 +128,8 @@ Semantic error in 'bad_t_type_bdf.stan', line 26, column 10 to line 32, column 2
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], matrix, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_t_type_bdf_control.stan
@@ -145,8 +145,8 @@ Semantic error in 'bad_t_type_bdf_control.stan', line 26, column 10 to line 32, 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], matrix, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_t_type_rk45.stan
@@ -162,8 +162,8 @@ Semantic error in 'bad_t_type_rk45.stan', line 26, column 10 to line 32, column 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], matrix, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_t_type_rk45_control.stan
@@ -179,8 +179,8 @@ Semantic error in 'bad_t_type_rk45_control.stan', line 26, column 10 to line 32,
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], matrix, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_theta_type.stan
@@ -212,8 +212,8 @@ Semantic error in 'bad_theta_type_bdf.stan', line 27, column 10 to line 33, colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[,], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_theta_type_bdf_control.stan
@@ -229,8 +229,8 @@ Semantic error in 'bad_theta_type_bdf_control.stan', line 27, column 10 to line 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[,], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_theta_type_rk45.stan
@@ -246,8 +246,8 @@ Semantic error in 'bad_theta_type_rk45.stan', line 27, column 10 to line 33, col
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[,], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_theta_type_rk45_control.stan
@@ -263,8 +263,8 @@ Semantic error in 'bad_theta_type_rk45_control.stan', line 27, column 10 to line
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[,], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_ts_type.stan
@@ -296,8 +296,8 @@ Semantic error in 'bad_ts_type_bdf.stan', line 26, column 10 to line 32, column 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[,], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_ts_type_bdf_control.stan
@@ -313,8 +313,8 @@ Semantic error in 'bad_ts_type_bdf_control.stan', line 26, column 10 to line 32,
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[,], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_ts_type_rk45.stan
@@ -330,8 +330,8 @@ Semantic error in 'bad_ts_type_rk45.stan', line 26, column 10 to line 32, column
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[,], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_ts_type_rk45_control.stan
@@ -347,8 +347,8 @@ Semantic error in 'bad_ts_type_rk45_control.stan', line 26, column 10 to line 32
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[,], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_int_type.stan
@@ -380,8 +380,8 @@ Semantic error in 'bad_x_int_type_bdf.stan', line 26, column 10 to line 32, colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[,].
 
   $ ../../../../../install/default/bin/stanc bad_x_int_type_bdf_control.stan
@@ -397,8 +397,8 @@ Semantic error in 'bad_x_int_type_bdf_control.stan', line 26, column 10 to line 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[,], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_int_type_rk45.stan
@@ -414,8 +414,8 @@ Semantic error in 'bad_x_int_type_rk45.stan', line 26, column 10 to line 32, col
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[,].
 
   $ ../../../../../install/default/bin/stanc bad_x_int_type_rk45_control.stan
@@ -431,8 +431,8 @@ Semantic error in 'bad_x_int_type_rk45_control.stan', line 26, column 10 to line
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[,], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_type.stan
@@ -464,8 +464,8 @@ Semantic error in 'bad_x_type_bdf.stan', line 27, column 10 to line 33, column 2
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], vector[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_x_type_bdf_control.stan
@@ -481,8 +481,8 @@ Semantic error in 'bad_x_type_bdf_control.stan', line 27, column 10 to line 33, 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], vector[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_type_rk45.stan
@@ -498,8 +498,8 @@ Semantic error in 'bad_x_type_rk45.stan', line 27, column 10 to line 33, column 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], vector[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_x_type_rk45_control.stan
@@ -515,8 +515,8 @@ Semantic error in 'bad_x_type_rk45_control.stan', line 27, column 10 to line 33,
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], vector[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_var_type.stan
@@ -548,8 +548,8 @@ Semantic error in 'bad_x_var_type_bdf.stan', line 26, column 10 to line 32, colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_x_var_type_bdf_control.stan
@@ -565,8 +565,8 @@ Semantic error in 'bad_x_var_type_bdf_control.stan', line 26, column 10 to line 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_x_var_type_rk45.stan
@@ -582,8 +582,8 @@ Semantic error in 'bad_x_var_type_rk45.stan', line 26, column 10 to line 32, col
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_x_var_type_rk45_control.stan
@@ -599,8 +599,8 @@ Semantic error in 'bad_x_var_type_rk45_control.stan', line 26, column 10 to line
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_y_type.stan
@@ -632,8 +632,8 @@ Semantic error in 'bad_y_type_bdf.stan', line 26, column 10 to line 32, column 2
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[,], real, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_y_type_bdf_control.stan
@@ -649,8 +649,8 @@ Semantic error in 'bad_y_type_bdf_control.stan', line 26, column 10 to line 32, 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_bdf'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[,], real, real[], real[], real[], int[], real, real, int.
 
   $ ../../../../../install/default/bin/stanc bad_y_type_rk45.stan
@@ -666,8 +666,8 @@ Semantic error in 'bad_y_type_rk45.stan', line 26, column 10 to line 32, column 
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[,], real, real[], real[], real[], int[].
 
   $ ../../../../../install/default/bin/stanc bad_y_type_rk45_control.stan
@@ -683,7 +683,7 @@ Semantic error in 'bad_y_type_rk45_control.stan', line 26, column 10 to line 32,
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[,], real, real[], real[], real[], int[], real, real, int.
 

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -838,17 +838,17 @@ Semantic error in 'err-minus-types.stan', line 4, column 6 to column 11:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator -. Available signatures: 
-(real, matrix) => matrix
-(real, row_vector) => row_vector
-(real, vector) => vector
-(matrix, real) => matrix
-(row_vector, real) => row_vector
-(vector, real) => vector
-(matrix, matrix) => matrix
-(row_vector, row_vector) => row_vector
-(vector, vector) => vector
-(real, real) => real
 (int, int) => int
+(real, real) => real
+(real, vector) => vector
+(vector, real) => vector
+(vector, vector) => vector
+(real, row_vector) => row_vector
+(row_vector, real) => row_vector
+(row_vector, row_vector) => row_vector
+(real, matrix) => matrix
+(matrix, real) => matrix
+(matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: vector, matrix.
 
   $ ../../../../install/default/bin/stanc err-nested-parens-close.stan
@@ -1321,8 +1321,8 @@ Semantic error in 'functions-bad22-ode.stan', line 15, column 11 to column 82:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'integrate_ode_rk45'. Available signatures: 
-((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 ((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[]) => real[,]
+((real, real[], real[], data real[], data int[]) => real[], real[], real, real[], real[], data real[], data int[], data real, data real, data real) => real[,]
 Instead supplied arguments of incompatible type: (real, real[], real[], real[], int[]) => real[], real[], real, real[], real[], real[], int[].
 
   $ ../../../../install/default/bin/stanc functions-bad23.stan
@@ -1710,17 +1710,17 @@ Semantic error in 'op_addition_bad.stan', line 7, column 6 to column 11:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator +. Available signatures: 
-(real, matrix) => matrix
-(real, row_vector) => row_vector
-(real, vector) => vector
-(matrix, real) => matrix
-(row_vector, real) => row_vector
-(vector, real) => vector
-(matrix, matrix) => matrix
-(row_vector, row_vector) => row_vector
-(vector, vector) => vector
-(real, real) => real
 (int, int) => int
+(real, real) => real
+(real, vector) => vector
+(vector, real) => vector
+(vector, vector) => vector
+(real, row_vector) => row_vector
+(row_vector, real) => row_vector
+(row_vector, row_vector) => row_vector
+(real, matrix) => matrix
+(matrix, real) => matrix
+(matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: matrix, vector.
 
   $ ../../../../install/default/bin/stanc op_divide_bad.stan
@@ -1735,14 +1735,14 @@ Semantic error in 'op_divide_bad.stan', line 7, column 6 to column 11:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator /. Available signatures: 
-(matrix, matrix) => matrix
 (row_vector, matrix) => row_vector
+(matrix, matrix) => matrix
 
-(matrix, real) => matrix
-(row_vector, real) => row_vector
-(vector, real) => vector
-(real, real) => real
 (int, int) => int
+(real, real) => real
+(vector, real) => vector
+(row_vector, real) => row_vector
+(matrix, real) => matrix
 Instead supplied arguments of incompatible type: int[], matrix.
 
   $ ../../../../install/default/bin/stanc op_divide_right_bad.stan
@@ -1757,14 +1757,14 @@ Semantic error in 'op_divide_right_bad.stan', line 7, column 6 to column 11:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator /. Available signatures: 
-(matrix, matrix) => matrix
 (row_vector, matrix) => row_vector
+(matrix, matrix) => matrix
 
-(matrix, real) => matrix
-(row_vector, real) => row_vector
-(vector, real) => vector
-(real, real) => real
 (int, int) => int
+(real, real) => real
+(vector, real) => vector
+(row_vector, real) => row_vector
+(matrix, real) => matrix
 Instead supplied arguments of incompatible type: int[], matrix.
 
   $ ../../../../install/default/bin/stanc op_elt_divide_bad.stan
@@ -1779,15 +1779,15 @@ Semantic error in 'op_elt_divide_bad.stan', line 7, column 6 to column 12:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator ./. Available signatures: 
-(real, matrix) => matrix
-(real, row_vector) => row_vector
 (real, vector) => vector
-(matrix, real) => matrix
-(row_vector, real) => row_vector
 (vector, real) => vector
-(matrix, matrix) => matrix
-(row_vector, row_vector) => row_vector
 (vector, vector) => vector
+(real, row_vector) => row_vector
+(row_vector, real) => row_vector
+(row_vector, row_vector) => row_vector
+(real, matrix) => matrix
+(matrix, real) => matrix
+(matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: int[], matrix.
 
   $ ../../../../install/default/bin/stanc op_elt_multiply_bad.stan
@@ -1802,9 +1802,9 @@ Semantic error in 'op_elt_multiply_bad.stan', line 7, column 6 to column 12:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator .*. Available signatures: 
-(matrix, matrix) => matrix
-(row_vector, row_vector) => row_vector
 (vector, vector) => vector
+(row_vector, row_vector) => row_vector
+(matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: int[], matrix.
 
   $ ../../../../install/default/bin/stanc op_logical_negation_bad.stan
@@ -1819,8 +1819,8 @@ Semantic error in 'op_logical_negation_bad.stan', line 7, column 6 to column 8:
    -------------------------------------------------
 
 Ill-typed arguments supplied to prefix operator !. Available signatures: 
-(real) => int
 (int) => int
+(real) => int
 Instead supplied argument of incompatible type: int[].
 
   $ ../../../../install/default/bin/stanc op_mdivide_left_bad.stan
@@ -1835,8 +1835,8 @@ Semantic error in 'op_mdivide_left_bad.stan', line 7, column 6 to column 11:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator \. Available signatures: 
-(matrix, matrix) => matrix
 (matrix, vector) => vector
+(matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: int[], matrix.
 
   $ ../../../../install/default/bin/stanc op_minus_bad.stan
@@ -1851,11 +1851,11 @@ Semantic error in 'op_minus_bad.stan', line 7, column 6 to column 8:
    -------------------------------------------------
 
 Ill-typed arguments supplied to prefix operator -. Available signatures: 
-(matrix) => matrix
-(row_vector) => row_vector
-(vector) => vector
-(real) => real
 (int) => int
+(real) => real
+(vector) => vector
+(row_vector) => row_vector
+(matrix) => matrix
 Instead supplied argument of incompatible type: int[].
 
   $ ../../../../install/default/bin/stanc op_modulus_bad.stan
@@ -1885,19 +1885,19 @@ Semantic error in 'op_multiplication_bad.stan', line 7, column 6 to column 11:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator *. Available signatures: 
-(real, matrix) => matrix
-(real, row_vector) => row_vector
-(real, vector) => vector
-(matrix, matrix) => matrix
-(row_vector, matrix) => row_vector
-(matrix, vector) => vector
-(vector, row_vector) => matrix
-(row_vector, vector) => real
-(matrix, real) => matrix
-(row_vector, real) => row_vector
-(vector, real) => vector
-(real, real) => real
 (int, int) => int
+(real, real) => real
+(row_vector, vector) => real
+(real, vector) => vector
+(vector, real) => vector
+(matrix, vector) => vector
+(real, row_vector) => row_vector
+(row_vector, real) => row_vector
+(row_vector, matrix) => row_vector
+(real, matrix) => matrix
+(vector, row_vector) => matrix
+(matrix, real) => matrix
+(matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: int[], matrix.
 
   $ ../../../../install/default/bin/stanc op_subtraction_bad.stan
@@ -1912,17 +1912,17 @@ Semantic error in 'op_subtraction_bad.stan', line 7, column 6 to column 11:
    -------------------------------------------------
 
 Ill-typed arguments supplied to infix operator -. Available signatures: 
-(real, matrix) => matrix
-(real, row_vector) => row_vector
-(real, vector) => vector
-(matrix, real) => matrix
-(row_vector, real) => row_vector
-(vector, real) => vector
-(matrix, matrix) => matrix
-(row_vector, row_vector) => row_vector
-(vector, vector) => vector
-(real, real) => real
 (int, int) => int
+(real, real) => real
+(real, vector) => vector
+(vector, real) => vector
+(vector, vector) => vector
+(real, row_vector) => row_vector
+(row_vector, real) => row_vector
+(row_vector, row_vector) => row_vector
+(real, matrix) => matrix
+(matrix, real) => matrix
+(matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: vector, matrix.
 
   $ ../../../../install/default/bin/stanc op_transpose_bad.stan
@@ -1937,9 +1937,9 @@ Semantic error in 'op_transpose_bad.stan', line 7, column 6 to column 8:
    -------------------------------------------------
 
 Ill-typed arguments supplied to postfix operator '. Available signatures: 
-(matrix) => matrix
 (row_vector) => vector
 (vector) => row_vector
+(matrix) => matrix
 Instead supplied argument of incompatible type: int[].
 
   $ ../../../../install/default/bin/stanc print-void.stan
@@ -2019,70 +2019,70 @@ Semantic error in 'propto-bad1.stan', line 2, column 14 to column 43:
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'normal_propto_lpdf'. Available signatures: 
-(row_vector, row_vector, row_vector) => real
-(row_vector, row_vector, vector) => real
-(row_vector, row_vector, real[]) => real
-(row_vector, row_vector, real) => real
-(row_vector, vector, row_vector) => real
-(row_vector, vector, vector) => real
-(row_vector, vector, real[]) => real
-(row_vector, vector, real) => real
-(row_vector, real[], row_vector) => real
-(row_vector, real[], vector) => real
-(row_vector, real[], real[]) => real
-(row_vector, real[], real) => real
-(row_vector, real, row_vector) => real
-(row_vector, real, vector) => real
-(row_vector, real, real[]) => real
-(row_vector, real, real) => real
-(vector, row_vector, row_vector) => real
-(vector, row_vector, vector) => real
-(vector, row_vector, real[]) => real
-(vector, row_vector, real) => real
-(vector, vector, row_vector) => real
-(vector, vector, vector) => real
-(vector, vector, real[]) => real
-(vector, vector, real) => real
-(vector, real[], row_vector) => real
-(vector, real[], vector) => real
-(vector, real[], real[]) => real
-(vector, real[], real) => real
-(vector, real, row_vector) => real
-(vector, real, vector) => real
-(vector, real, real[]) => real
-(vector, real, real) => real
-(real[], row_vector, row_vector) => real
-(real[], row_vector, vector) => real
-(real[], row_vector, real[]) => real
-(real[], row_vector, real) => real
-(real[], vector, row_vector) => real
-(real[], vector, vector) => real
-(real[], vector, real[]) => real
-(real[], vector, real) => real
-(real[], real[], row_vector) => real
-(real[], real[], vector) => real
-(real[], real[], real[]) => real
-(real[], real[], real) => real
-(real[], real, row_vector) => real
-(real[], real, vector) => real
-(real[], real, real[]) => real
-(real[], real, real) => real
-(real, row_vector, row_vector) => real
-(real, row_vector, vector) => real
-(real, row_vector, real[]) => real
-(real, row_vector, real) => real
-(real, vector, row_vector) => real
-(real, vector, vector) => real
-(real, vector, real[]) => real
-(real, vector, real) => real
-(real, real[], row_vector) => real
-(real, real[], vector) => real
-(real, real[], real[]) => real
-(real, real[], real) => real
-(real, real, row_vector) => real
-(real, real, vector) => real
-(real, real, real[]) => real
 (real, real, real) => real
+(real, real, vector) => real
+(real, real, row_vector) => real
+(real, real, real[]) => real
+(real, vector, real) => real
+(real, vector, vector) => real
+(real, vector, row_vector) => real
+(real, vector, real[]) => real
+(real, row_vector, real) => real
+(real, row_vector, vector) => real
+(real, row_vector, row_vector) => real
+(real, row_vector, real[]) => real
+(real, real[], real) => real
+(real, real[], vector) => real
+(real, real[], row_vector) => real
+(real, real[], real[]) => real
+(vector, real, real) => real
+(vector, real, vector) => real
+(vector, real, row_vector) => real
+(vector, real, real[]) => real
+(vector, vector, real) => real
+(vector, vector, vector) => real
+(vector, vector, row_vector) => real
+(vector, vector, real[]) => real
+(vector, row_vector, real) => real
+(vector, row_vector, vector) => real
+(vector, row_vector, row_vector) => real
+(vector, row_vector, real[]) => real
+(vector, real[], real) => real
+(vector, real[], vector) => real
+(vector, real[], row_vector) => real
+(vector, real[], real[]) => real
+(row_vector, real, real) => real
+(row_vector, real, vector) => real
+(row_vector, real, row_vector) => real
+(row_vector, real, real[]) => real
+(row_vector, vector, real) => real
+(row_vector, vector, vector) => real
+(row_vector, vector, row_vector) => real
+(row_vector, vector, real[]) => real
+(row_vector, row_vector, real) => real
+(row_vector, row_vector, vector) => real
+(row_vector, row_vector, row_vector) => real
+(row_vector, row_vector, real[]) => real
+(row_vector, real[], real) => real
+(row_vector, real[], vector) => real
+(row_vector, real[], row_vector) => real
+(row_vector, real[], real[]) => real
+(real[], real, real) => real
+(real[], real, vector) => real
+(real[], real, row_vector) => real
+(real[], real, real[]) => real
+(real[], vector, real) => real
+(real[], vector, vector) => real
+(real[], vector, row_vector) => real
+(real[], vector, real[]) => real
+(real[], row_vector, real) => real
+(real[], row_vector, vector) => real
+(real[], row_vector, row_vector) => real
+(real[], row_vector, real[]) => real
+(real[], real[], real) => real
+(real[], real[], vector) => real
+(real[], real[], row_vector) => real
+(real[], real[], real[]) => real
 Instead supplied arguments of incompatible type: int, int[], int.
 
   $ ../../../../install/default/bin/stanc real-pdf.stan
@@ -2395,14 +2395,14 @@ Semantic error in 'signature_function_known.stan', line 8, column 21 to column 5
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'bernoulli_logit_log'. Available signatures: 
-(int[], row_vector) => real
-(int[], vector) => real
-(int[], real[]) => real
-(int[], real) => real
-(int, row_vector) => real
-(int, vector) => real
-(int, real[]) => real
 (int, real) => real
+(int, vector) => real
+(int, row_vector) => real
+(int, real[]) => real
+(int[], real) => real
+(int[], vector) => real
+(int[], row_vector) => real
+(int[], real[]) => real
 Instead supplied arguments of incompatible type: vector, vector.
 
   $ ../../../../install/default/bin/stanc signature_function_unknown.stan
@@ -2689,46 +2689,46 @@ Semantic error in 'validate_conditional_op_bad-1.stan', line 5, column 7 to colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to ? : operator. Available signatures: 
-(int, matrix[,,,,,,], matrix[,,,,,,]) => matrix[,,,,,,]
-(int, row_vector[,,,,,,], row_vector[,,,,,,]) => row_vector[,,,,,,]
-(int, vector[,,,,,,], vector[,,,,,,]) => vector[,,,,,,]
-(int, int[,,,,,,], int[,,,,,,]) => int[,,,,,,]
-(int, real[,,,,,,], real[,,,,,,]) => real[,,,,,,]
-(int, matrix[,,,,,], matrix[,,,,,]) => matrix[,,,,,]
-(int, row_vector[,,,,,], row_vector[,,,,,]) => row_vector[,,,,,]
-(int, vector[,,,,,], vector[,,,,,]) => vector[,,,,,]
-(int, int[,,,,,], int[,,,,,]) => int[,,,,,]
-(int, real[,,,,,], real[,,,,,]) => real[,,,,,]
-(int, matrix[,,,,], matrix[,,,,]) => matrix[,,,,]
-(int, row_vector[,,,,], row_vector[,,,,]) => row_vector[,,,,]
-(int, vector[,,,,], vector[,,,,]) => vector[,,,,]
-(int, int[,,,,], int[,,,,]) => int[,,,,]
-(int, real[,,,,], real[,,,,]) => real[,,,,]
-(int, matrix[,,,], matrix[,,,]) => matrix[,,,]
-(int, row_vector[,,,], row_vector[,,,]) => row_vector[,,,]
-(int, vector[,,,], vector[,,,]) => vector[,,,]
-(int, int[,,,], int[,,,]) => int[,,,]
-(int, real[,,,], real[,,,]) => real[,,,]
-(int, matrix[,,], matrix[,,]) => matrix[,,]
-(int, row_vector[,,], row_vector[,,]) => row_vector[,,]
-(int, vector[,,], vector[,,]) => vector[,,]
-(int, int[,,], int[,,]) => int[,,]
-(int, real[,,], real[,,]) => real[,,]
-(int, matrix[,], matrix[,]) => matrix[,]
-(int, row_vector[,], row_vector[,]) => row_vector[,]
-(int, vector[,], vector[,]) => vector[,]
-(int, int[,], int[,]) => int[,]
-(int, real[,], real[,]) => real[,]
-(int, matrix[], matrix[]) => matrix[]
-(int, row_vector[], row_vector[]) => row_vector[]
-(int, vector[], vector[]) => vector[]
-(int, int[], int[]) => int[]
-(int, real[], real[]) => real[]
-(int, matrix, matrix) => matrix
-(int, row_vector, row_vector) => row_vector
-(int, vector, vector) => vector
 (int, int, int) => int
 (int, real, real) => real
+(int, vector, vector) => vector
+(int, row_vector, row_vector) => row_vector
+(int, matrix, matrix) => matrix
+(int, int[], int[]) => int[]
+(int, real[], real[]) => real[]
+(int, vector[], vector[]) => vector[]
+(int, row_vector[], row_vector[]) => row_vector[]
+(int, matrix[], matrix[]) => matrix[]
+(int, int[,], int[,]) => int[,]
+(int, real[,], real[,]) => real[,]
+(int, vector[,], vector[,]) => vector[,]
+(int, row_vector[,], row_vector[,]) => row_vector[,]
+(int, matrix[,], matrix[,]) => matrix[,]
+(int, int[,,], int[,,]) => int[,,]
+(int, real[,,], real[,,]) => real[,,]
+(int, vector[,,], vector[,,]) => vector[,,]
+(int, row_vector[,,], row_vector[,,]) => row_vector[,,]
+(int, matrix[,,], matrix[,,]) => matrix[,,]
+(int, int[,,,], int[,,,]) => int[,,,]
+(int, real[,,,], real[,,,]) => real[,,,]
+(int, vector[,,,], vector[,,,]) => vector[,,,]
+(int, row_vector[,,,], row_vector[,,,]) => row_vector[,,,]
+(int, matrix[,,,], matrix[,,,]) => matrix[,,,]
+(int, int[,,,,], int[,,,,]) => int[,,,,]
+(int, real[,,,,], real[,,,,]) => real[,,,,]
+(int, vector[,,,,], vector[,,,,]) => vector[,,,,]
+(int, row_vector[,,,,], row_vector[,,,,]) => row_vector[,,,,]
+(int, matrix[,,,,], matrix[,,,,]) => matrix[,,,,]
+(int, int[,,,,,], int[,,,,,]) => int[,,,,,]
+(int, real[,,,,,], real[,,,,,]) => real[,,,,,]
+(int, vector[,,,,,], vector[,,,,,]) => vector[,,,,,]
+(int, row_vector[,,,,,], row_vector[,,,,,]) => row_vector[,,,,,]
+(int, matrix[,,,,,], matrix[,,,,,]) => matrix[,,,,,]
+(int, int[,,,,,,], int[,,,,,,]) => int[,,,,,,]
+(int, real[,,,,,,], real[,,,,,,]) => real[,,,,,,]
+(int, vector[,,,,,,], vector[,,,,,,]) => vector[,,,,,,]
+(int, row_vector[,,,,,,], row_vector[,,,,,,]) => row_vector[,,,,,,]
+(int, matrix[,,,,,,], matrix[,,,,,,]) => matrix[,,,,,,]
 Instead supplied arguments of incompatible type: row_vector[,], int, int.
 
   $ ../../../../install/default/bin/stanc validate_conditional_op_bad-2.stan
@@ -2744,46 +2744,46 @@ Semantic error in 'validate_conditional_op_bad-2.stan', line 5, column 7 to colu
    -------------------------------------------------
 
 Ill-typed arguments supplied to ? : operator. Available signatures: 
-(int, matrix[,,,,,,], matrix[,,,,,,]) => matrix[,,,,,,]
-(int, row_vector[,,,,,,], row_vector[,,,,,,]) => row_vector[,,,,,,]
-(int, vector[,,,,,,], vector[,,,,,,]) => vector[,,,,,,]
-(int, int[,,,,,,], int[,,,,,,]) => int[,,,,,,]
-(int, real[,,,,,,], real[,,,,,,]) => real[,,,,,,]
-(int, matrix[,,,,,], matrix[,,,,,]) => matrix[,,,,,]
-(int, row_vector[,,,,,], row_vector[,,,,,]) => row_vector[,,,,,]
-(int, vector[,,,,,], vector[,,,,,]) => vector[,,,,,]
-(int, int[,,,,,], int[,,,,,]) => int[,,,,,]
-(int, real[,,,,,], real[,,,,,]) => real[,,,,,]
-(int, matrix[,,,,], matrix[,,,,]) => matrix[,,,,]
-(int, row_vector[,,,,], row_vector[,,,,]) => row_vector[,,,,]
-(int, vector[,,,,], vector[,,,,]) => vector[,,,,]
-(int, int[,,,,], int[,,,,]) => int[,,,,]
-(int, real[,,,,], real[,,,,]) => real[,,,,]
-(int, matrix[,,,], matrix[,,,]) => matrix[,,,]
-(int, row_vector[,,,], row_vector[,,,]) => row_vector[,,,]
-(int, vector[,,,], vector[,,,]) => vector[,,,]
-(int, int[,,,], int[,,,]) => int[,,,]
-(int, real[,,,], real[,,,]) => real[,,,]
-(int, matrix[,,], matrix[,,]) => matrix[,,]
-(int, row_vector[,,], row_vector[,,]) => row_vector[,,]
-(int, vector[,,], vector[,,]) => vector[,,]
-(int, int[,,], int[,,]) => int[,,]
-(int, real[,,], real[,,]) => real[,,]
-(int, matrix[,], matrix[,]) => matrix[,]
-(int, row_vector[,], row_vector[,]) => row_vector[,]
-(int, vector[,], vector[,]) => vector[,]
-(int, int[,], int[,]) => int[,]
-(int, real[,], real[,]) => real[,]
-(int, matrix[], matrix[]) => matrix[]
-(int, row_vector[], row_vector[]) => row_vector[]
-(int, vector[], vector[]) => vector[]
-(int, int[], int[]) => int[]
-(int, real[], real[]) => real[]
-(int, matrix, matrix) => matrix
-(int, row_vector, row_vector) => row_vector
-(int, vector, vector) => vector
 (int, int, int) => int
 (int, real, real) => real
+(int, vector, vector) => vector
+(int, row_vector, row_vector) => row_vector
+(int, matrix, matrix) => matrix
+(int, int[], int[]) => int[]
+(int, real[], real[]) => real[]
+(int, vector[], vector[]) => vector[]
+(int, row_vector[], row_vector[]) => row_vector[]
+(int, matrix[], matrix[]) => matrix[]
+(int, int[,], int[,]) => int[,]
+(int, real[,], real[,]) => real[,]
+(int, vector[,], vector[,]) => vector[,]
+(int, row_vector[,], row_vector[,]) => row_vector[,]
+(int, matrix[,], matrix[,]) => matrix[,]
+(int, int[,,], int[,,]) => int[,,]
+(int, real[,,], real[,,]) => real[,,]
+(int, vector[,,], vector[,,]) => vector[,,]
+(int, row_vector[,,], row_vector[,,]) => row_vector[,,]
+(int, matrix[,,], matrix[,,]) => matrix[,,]
+(int, int[,,,], int[,,,]) => int[,,,]
+(int, real[,,,], real[,,,]) => real[,,,]
+(int, vector[,,,], vector[,,,]) => vector[,,,]
+(int, row_vector[,,,], row_vector[,,,]) => row_vector[,,,]
+(int, matrix[,,,], matrix[,,,]) => matrix[,,,]
+(int, int[,,,,], int[,,,,]) => int[,,,,]
+(int, real[,,,,], real[,,,,]) => real[,,,,]
+(int, vector[,,,,], vector[,,,,]) => vector[,,,,]
+(int, row_vector[,,,,], row_vector[,,,,]) => row_vector[,,,,]
+(int, matrix[,,,,], matrix[,,,,]) => matrix[,,,,]
+(int, int[,,,,,], int[,,,,,]) => int[,,,,,]
+(int, real[,,,,,], real[,,,,,]) => real[,,,,,]
+(int, vector[,,,,,], vector[,,,,,]) => vector[,,,,,]
+(int, row_vector[,,,,,], row_vector[,,,,,]) => row_vector[,,,,,]
+(int, matrix[,,,,,], matrix[,,,,,]) => matrix[,,,,,]
+(int, int[,,,,,,], int[,,,,,,]) => int[,,,,,,]
+(int, real[,,,,,,], real[,,,,,,]) => real[,,,,,,]
+(int, vector[,,,,,,], vector[,,,,,,]) => vector[,,,,,,]
+(int, row_vector[,,,,,,], row_vector[,,,,,,]) => row_vector[,,,,,,]
+(int, matrix[,,,,,,], matrix[,,,,,,]) => matrix[,,,,,,]
 Instead supplied arguments of incompatible type: int, real, row_vector[,].
 
   $ ../../../../install/default/bin/stanc validate_exponentiation_bad.stan
@@ -2868,8 +2868,8 @@ Semantic error in 'validate_logical_negate_expr_bad.stan', line 3, column 6 to c
    -------------------------------------------------
 
 Ill-typed arguments supplied to prefix operator !. Available signatures: 
-(real) => int
 (int) => int
+(real) => int
 Instead supplied argument of incompatible type: vector.
 
   $ ../../../../install/default/bin/stanc validate_modulus_bad.stan


### PR DESCRIPTION
This means the error messages won't change when the implementation of the signatures dictionary
changes. We also probably shouldn't rely on the ordering in the multi hash table, but not sure.