### PR TITLE
Refactor easy+clean distributions into more structured form

### DIFF
--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -745,6 +745,7 @@ let rec simplify_index_expr = function
 
 let remove_trailing_alls_expr = function
   | Indexed (obj, indices) ->
+      (* a[2][:] -> a[2] *)
       let rec remove_trailing_alls indices =
         match List.rev indices with
         | All :: tl -> remove_trailing_alls (List.rev tl)

--- a/src/middle/Middle.mli
+++ b/src/middle/Middle.mli
@@ -92,3 +92,6 @@ val mock_for :
   -> (mtype_loc_ad, location_span) stmt_with
 
 val is_indexing_matrix : unsizedtype * 'e index list -> bool
+
+val stan_math_signatures :
+  (returntype * (autodifftype * unsizedtype) list) list String.Table.t


### PR DESCRIPTION
Putting up an initial version to hopefully get some comments :) 

There really are a lot of special cases in here! But my thinking is we can possibly encode the semantics (e.g. "this is the CDF of this LPDF" or "this takes Stan's 'reals' type") and then list out the explicit exceptions to this rule in a way that 1) is way less code but also 2) is useful for other structured uses of the data, like generating explicit template instantiations 😅