### PR TITLE
Small fix to warn-uninitialized

### DIFF
--- a/src/analysis_and_optimization/Dependence_analysis.ml
+++ b/src/analysis_and_optimization/Dependence_analysis.ml
@@ -212,8 +212,11 @@ let mir_uninitialized_variables (mir : typed_prog) :
       (Set.Poly.of_list flag_variables)
       (Set.Poly.singleton "target")
   in
+  let parameters = Set.Poly.of_list (List.map ~f:fst
+    (List.filter ~f:(fun (_, {out_block; _}) -> out_block = Parameters) mir.output_vars))
+  in
   let globals_data = Set.Poly.union globals data_vars in
-  let globals_data_prep = Set.Poly.union globals_data prep_vars in
+  let globals_data_prep = Set.Poly.union_list [globals_data; prep_vars; parameters] in
   Set.Poly.union_list
     [ (* prepare_data scope: data *)
       stmt_uninitialized_variables globals_data

--- a/test/unit/Dependence_analysis.ml
+++ b/test/unit/Dependence_analysis.ml
@@ -195,11 +195,6 @@ let%expect_test "Uninitialized variables example" =
           ((filename string) (line_num 26) (col_num 17) (included_from ()))))
         i)
        (((begin_loc
-          ((filename string) (line_num 28) (col_num 16) (included_from ())))
-         (end_loc
-          ((filename string) (line_num 28) (col_num 17) (included_from ()))))
-        x)
-       (((begin_loc
           ((filename string) (line_num 32) (col_num 16) (included_from ())))
          (end_loc
           ((filename string) (line_num 32) (col_num 17) (included_from ()))))


### PR DESCRIPTION
Fixed issue with parameters not being included correctly in the scope of the model or generated quantities blocks. See changed test case.