### PR TITLE
Move transformations (bijectors) to MIR and include in Mir.prog.

### DIFF
--- a/src/analysis_and_optimization/Dependence_analysis.ml
+++ b/src/analysis_and_optimization/Dependence_analysis.ml
@@ -212,11 +212,17 @@ let mir_uninitialized_variables (mir : typed_prog) :
       (Set.Poly.of_list flag_variables)
       (Set.Poly.singleton "target")
   in
-  let parameters = Set.Poly.of_list (List.map ~f:fst
-    (List.filter ~f:(fun (_, {out_block; _}) -> out_block = Parameters) mir.output_vars))
+  let parameters =
+    Set.Poly.of_list
+      (List.map ~f:fst
+         (List.filter
+            ~f:(fun (_, {out_block; _}) -> out_block = Parameters)
+            mir.output_vars))
   in
   let globals_data = Set.Poly.union globals data_vars in
-  let globals_data_prep = Set.Poly.union_list [globals_data; prep_vars; parameters] in
+  let globals_data_prep =
+    Set.Poly.union_list [globals_data; prep_vars; parameters]
+  in
   Set.Poly.union_list
     [ (* prepare_data scope: data *)
       stmt_uninitialized_variables globals_data

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -97,25 +97,6 @@ type 'e truncation =
 type 'e printable = PString of string | PExpr of 'e
 [@@deriving sexp, compare, map, hash]
 
-(** Transformations (constraints) for global variable declarations *)
-type 'e transformation =
-  | Identity
-  | Lower of 'e
-  | Upper of 'e
-  | LowerUpper of 'e * 'e
-  | Offset of 'e
-  | Multiplier of 'e
-  | OffsetMultiplier of 'e * 'e
-  | Ordered
-  | PositiveOrdered
-  | Simplex
-  | UnitVector
-  | CholeskyCorr
-  | CholeskyCov
-  | Correlation
-  | Covariance
-[@@deriving sexp, compare, map, hash]
-
 type ('l, 'e) lvalue =
   | LVariable of identifier
   | LIndexed of 'l * 'e index list
@@ -165,7 +146,7 @@ type ('e, 's, 'l, 'f) statement =
   | Block of 's list
   | VarDecl of
       { decl_type: 'e Middle.possiblysizedtype
-      ; transformation: 'e transformation
+      ; transformation: 'e Middle.transformation
       ; identifier: identifier
       ; initial_value: 'e option
       ; is_global: bool }

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -194,7 +194,7 @@ and pp_sizedtype ppf = function
   | Middle.SArray _ -> raise (Errors.FatalError "This should never happen.")
 
 and pp_transformation ppf = function
-  | Identity -> Fmt.pf ppf ""
+  | Middle.Identity -> Fmt.pf ppf ""
   | Lower e -> Fmt.pf ppf "<lower=%a>" pp_expression e
   | Upper e -> Fmt.pf ppf "<upper=%a>" pp_expression e
   | LowerUpper (e1, e2) ->
@@ -249,7 +249,7 @@ and pp_transformed_type ppf (pst, trans) =
     | _ -> Fmt.nop
   in
   match trans with
-  | Identity -> Fmt.pf ppf "%a%a" unsizedtype_fmt () sizes_fmt ()
+  | Middle.Identity -> Fmt.pf ppf "%a%a" unsizedtype_fmt () sizes_fmt ()
   | Lower _ | Upper _ | LowerUpper _ | Offset _ | Multiplier _
    |OffsetMultiplier _ ->
       Fmt.pf ppf "%a%a%a" unsizedtype_fmt () pp_transformation trans sizes_fmt

--- a/src/middle/Mir.ml
+++ b/src/middle/Mir.ml
@@ -141,10 +141,30 @@ type ('e, 's) statement =
 type io_block = Parameters | TransformedParameters | GeneratedQuantities
 [@@deriving sexp, hash]
 
+(** Transformations (constraints) for global variable declarations *)
+type 'e transformation =
+  | Identity
+  | Lower of 'e
+  | Upper of 'e
+  | LowerUpper of 'e * 'e
+  | Offset of 'e
+  | Multiplier of 'e
+  | OffsetMultiplier of 'e * 'e
+  | Ordered
+  | PositiveOrdered
+  | Simplex
+  | UnitVector
+  | CholeskyCorr
+  | CholeskyCov
+  | Correlation
+  | Covariance
+[@@deriving sexp, compare, map, hash]
+
 type 'e outvar =
   { out_unconstrained_st: 'e sizedtype
   ; out_constrained_st: 'e sizedtype
-  ; out_block: io_block }
+  ; out_block: io_block
+  ; out_trans: 'e transformation }
 [@@deriving sexp, map, hash]
 
 type ('e, 's) prog =

--- a/src/middle/Mir_pretty_printer.ml
+++ b/src/middle/Mir_pretty_printer.ml
@@ -196,7 +196,7 @@ let pp_io_block ppf = function
   | GeneratedQuantities -> Fmt.string ppf "generated_quantities"
 
 let pp_output_var pp_e ppf
-    (name, {out_unconstrained_st; out_constrained_st; out_block}) =
+    (name, {out_unconstrained_st; out_constrained_st; out_block; _}) =
   Fmt.pf ppf "@[<h>%a %a %s; //%a@]" pp_io_block out_block (pp_sizedtype pp_e)
     out_constrained_st name (pp_sizedtype pp_e) out_unconstrained_st
 

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -50,8 +50,8 @@ let rec base_ut_to_string = function
         [%message "Another place where it's weird to get " (t : unsizedtype)]
 
 let param_read smeta
-    (decl_id, {out_constrained_st= cst; out_unconstrained_st= ucst; out_block})
-    =
+    ( decl_id
+    , {out_constrained_st= cst; out_unconstrained_st= ucst; out_block; _} ) =
   if not (out_block = Parameters) then []
   else
     let decl_id, decl =
@@ -159,7 +159,7 @@ let rec contains_var_expr is_vident accum {expr; _} =
 *)
 let constrain_in_params outvars stmts =
   let is_target_var = function
-    | name, {out_unconstrained_st; out_constrained_st; out_block= Parameters}
+    | name, {out_unconstrained_st; out_constrained_st; out_block= Parameters; _}
       when not (out_unconstrained_st = out_constrained_st) ->
         Some name
     | _ -> None

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -9067,7 +9067,7 @@
  (output_vars
   ((p_real
     ((out_unconstrained_st SReal) (out_constrained_st SReal)
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Identity)))
    (offset_multiplier
     ((out_unconstrained_st
       (SArray SReal
@@ -9077,7 +9077,13 @@
       (SArray SReal
        ((expr (Lit Int 5))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters)
+     (out_trans
+      (OffsetMultiplier
+       ((expr (Lit Int 1))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+       ((expr (Lit Int 2))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (p_real_1d_ar
     ((out_unconstrained_st
       (SArray SReal
@@ -9087,7 +9093,11 @@
       (SArray SReal
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters)
+     (out_trans
+      (Lower
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (p_real_3d_ar
     ((out_unconstrained_st
       (SArray
@@ -9109,7 +9119,11 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters)
+     (out_trans
+      (Lower
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (p_vec
     ((out_unconstrained_st
       (SVector
@@ -9119,7 +9133,11 @@
       (SVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters)
+     (out_trans
+      (Lower
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (p_1d_vec
     ((out_unconstrained_st
       (SArray
@@ -9135,7 +9153,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Identity)))
    (p_3d_vec
     ((out_unconstrained_st
       (SArray
@@ -9163,7 +9181,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Identity)))
    (p_row_vec
     ((out_unconstrained_st
       (SRowVector
@@ -9173,7 +9191,7 @@
       (SRowVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Identity)))
    (p_1d_row_vec
     ((out_unconstrained_st
       (SArray
@@ -9189,7 +9207,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Identity)))
    (p_3d_row_vec
     ((out_unconstrained_st
       (SArray
@@ -9217,7 +9235,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Identity)))
    (p_ar_mat
     ((out_unconstrained_st
       (SArray
@@ -9243,7 +9261,13 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 4))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters)
+     (out_trans
+      (LowerUpper
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+       ((expr (Lit Int 1))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (p_simplex
     ((out_unconstrained_st
       (SVector
@@ -9258,7 +9282,7 @@
       (SVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Simplex)))
    (p_1d_simplex
     ((out_unconstrained_st
       (SArray
@@ -9279,7 +9303,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Simplex)))
    (p_3d_simplex
     ((out_unconstrained_st
       (SArray
@@ -9312,7 +9336,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans Simplex)))
    (p_cfcov_54
     ((out_unconstrained_st
       (SVector
@@ -9369,7 +9393,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
        ((expr (Lit Int 4))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans CholeskyCov)))
    (p_cfcov_33
     ((out_unconstrained_st
       (SVector
@@ -9426,7 +9450,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans CholeskyCov)))
    (p_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
@@ -9489,7 +9513,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var K))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block Parameters)))
+     (out_block Parameters) (out_trans CholeskyCov)))
    (tp_real_1d_ar
     ((out_unconstrained_st
       (SArray SReal
@@ -9499,7 +9523,11 @@
       (SArray SReal
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters)
+     (out_trans
+      (Lower
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (tp_real_3d_ar
     ((out_unconstrained_st
       (SArray
@@ -9521,7 +9549,11 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters)
+     (out_trans
+      (Lower
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (tp_vec
     ((out_unconstrained_st
       (SVector
@@ -9531,7 +9563,11 @@
       (SVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters)
+     (out_trans
+      (Upper
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (tp_1d_vec
     ((out_unconstrained_st
       (SArray
@@ -9547,7 +9583,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Identity)))
    (tp_3d_vec
     ((out_unconstrained_st
       (SArray
@@ -9575,7 +9611,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Identity)))
    (tp_row_vec
     ((out_unconstrained_st
       (SRowVector
@@ -9585,7 +9621,7 @@
       (SRowVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Identity)))
    (tp_1d_row_vec
     ((out_unconstrained_st
       (SArray
@@ -9601,7 +9637,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Identity)))
    (tp_3d_row_vec
     ((out_unconstrained_st
       (SArray
@@ -9629,7 +9665,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Identity)))
    (tp_ar_mat
     ((out_unconstrained_st
       (SArray
@@ -9655,7 +9691,13 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 4))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters)
+     (out_trans
+      (LowerUpper
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+       ((expr (Lit Int 1))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (tp_simplex
     ((out_unconstrained_st
       (SVector
@@ -9670,7 +9712,7 @@
       (SVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Simplex)))
    (tp_1d_simplex
     ((out_unconstrained_st
       (SArray
@@ -9691,7 +9733,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Simplex)))
    (tp_3d_simplex
     ((out_unconstrained_st
       (SArray
@@ -9724,7 +9766,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans Simplex)))
    (tp_cfcov_54
     ((out_unconstrained_st
       (SVector
@@ -9781,7 +9823,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
        ((expr (Lit Int 4))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans CholeskyCov)))
    (tp_cfcov_33
     ((out_unconstrained_st
       (SVector
@@ -9838,7 +9880,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans CholeskyCov)))
    (tp_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
@@ -9901,13 +9943,13 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var K))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block TransformedParameters)))
+     (out_block TransformedParameters) (out_trans CholeskyCov)))
    (gq_r1
     ((out_unconstrained_st SReal) (out_constrained_st SReal)
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_r2
     ((out_unconstrained_st SReal) (out_constrained_st SReal)
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_real_1d_ar
     ((out_unconstrained_st
       (SArray SReal
@@ -9917,7 +9959,11 @@
       (SArray SReal
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities)
+     (out_trans
+      (Lower
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (gq_real_3d_ar
     ((out_unconstrained_st
       (SArray
@@ -9939,7 +9985,11 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities)
+     (out_trans
+      (Lower
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (gq_vec
     ((out_unconstrained_st
       (SVector
@@ -9949,7 +9999,11 @@
       (SVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities)
+     (out_trans
+      (Upper
+       ((expr (Lit Int 1))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (gq_1d_vec
     ((out_unconstrained_st
       (SArray
@@ -9965,7 +10019,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_3d_vec
     ((out_unconstrained_st
       (SArray
@@ -9993,7 +10047,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_row_vec
     ((out_unconstrained_st
       (SRowVector
@@ -10003,7 +10057,7 @@
       (SRowVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_1d_row_vec
     ((out_unconstrained_st
       (SArray
@@ -10019,7 +10073,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_3d_row_vec
     ((out_unconstrained_st
       (SArray
@@ -10047,7 +10101,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_ar_mat
     ((out_unconstrained_st
       (SArray
@@ -10073,7 +10127,13 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 4))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities)
+     (out_trans
+      (LowerUpper
+       ((expr (Lit Int 0))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+       ((expr (Lit Int 1))
+        (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
    (gq_simplex
     ((out_unconstrained_st
       (SVector
@@ -10088,7 +10148,7 @@
       (SVector
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Simplex)))
    (gq_1d_simplex
     ((out_unconstrained_st
       (SArray
@@ -10109,7 +10169,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Simplex)))
    (gq_3d_simplex
     ((out_unconstrained_st
       (SArray
@@ -10142,7 +10202,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var N))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Simplex)))
    (gq_cfcov_54
     ((out_unconstrained_st
       (SVector
@@ -10199,7 +10259,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
        ((expr (Lit Int 4))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans CholeskyCov)))
    (gq_cfcov_33
     ((out_unconstrained_st
       (SVector
@@ -10256,7 +10316,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans CholeskyCov)))
    (gq_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
@@ -10319,7 +10379,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Var K))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans CholeskyCov)))
    (indices
     ((out_unconstrained_st
       (SArray SInt
@@ -10329,7 +10389,7 @@
       (SArray SInt
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (indexing_mat
     ((out_unconstrained_st
       (SArray
@@ -10349,7 +10409,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 5))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res1
     ((out_unconstrained_st
       (SArray
@@ -10369,7 +10429,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res2
     ((out_unconstrained_st
       (SArray
@@ -10389,7 +10449,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 5))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res3
     ((out_unconstrained_st
       (SArray
@@ -10409,7 +10469,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res11
     ((out_unconstrained_st
       (SArray
@@ -10429,7 +10489,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res21
     ((out_unconstrained_st
       (SArray
@@ -10449,7 +10509,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 5))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res31
     ((out_unconstrained_st
       (SArray
@@ -10469,7 +10529,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res4
     ((out_unconstrained_st
       (SArray
@@ -10485,7 +10545,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 3))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))
+     (out_block GeneratedQuantities) (out_trans Identity)))
    (idx_res5
     ((out_unconstrained_st
       (SArray
@@ -10501,7 +10561,7 @@
          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
        ((expr (Lit Int 2))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-     (out_block GeneratedQuantities)))))
+     (out_block GeneratedQuantities) (out_trans Identity)))))
  (prog_name mother_model) (prog_path mother.stan))
 
 Warning: deprecated language construct used in 'mother.stan', line 60, column 21:


### PR DESCRIPTION
We need this so that we can allow the Stan C++ model to expose this metadata (ref: https://discourse.mc-stan.org/t/interface-roadmap-last-draft-before-ratification-vote/10955/10)

Also helps with TFP backend - better to compile these to TFP bijectors than to imperative numerical code accomplishing hopefully the same thing.