### PR TITLE
Fix map_rect

### DIFF
--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -99,6 +99,11 @@ let fn_renames =
     ; (FnNaN, "std::numeric_limits<double>::quiet_NaN") ]
   |> String.Map.of_alist_exn
 
+(* code smell - not sure how to refactor this. I was thinking ideally there'd be a stringly typed
+   hash map of metadata available for each expression that we could put something like this in.
+*)
+let map_rect_counter = ref 0
+
 let rec pp_index ppf = function
   | All -> pf ppf "index_omni()"
   | Single e -> pf ppf "index_uni(%a)" pp_expr e
@@ -205,7 +210,7 @@ and read_data ut ppf es =
   pf ppf "context__.vals_%s(%a)" i_or_r pp_expr (List.hd_exn es)
 
 (* assumes everything well formed from parser checks *)
-and gen_fun_app ppf f es =
+and gen_fun_app ppf fname es =
   let default ppf es =
     let to_var s = {expr= Var s; emeta= internal_meta} in
     let convert_hof_vars = function
@@ -214,7 +219,7 @@ and gen_fun_app ppf f es =
       | e -> e
     in
     let converted_es = List.map ~f:convert_hof_vars es in
-    let extra = suffix_args f |> List.map ~f:to_var in
+    let extra = suffix_args fname |> List.map ~f:to_var in
     let is_hof_call = not (converted_es = es) in
     let msgs = "pstream__" |> to_var in
     (* Here, because these signatures are written in C++ such that they
@@ -225,10 +230,10 @@ and gen_fun_app ppf f es =
        developer please don't add more of these - just add the
        overloads.
     *)
-    let args =
-      match (is_hof_call, f, converted_es @ extra) with
+    let fname, args =
+      match (is_hof_call, fname, converted_es @ extra) with
       | true, "algebra_solver", f :: x :: y :: dat :: datint :: tl ->
-          f :: x :: y :: dat :: datint :: msgs :: tl
+          (fname, f :: x :: y :: dat :: datint :: msgs :: tl)
       | ( true
         , "integrate_ode_bdf"
         , f :: y0 :: t0 :: ts :: theta :: x :: x_int :: tl )
@@ -238,16 +243,19 @@ and gen_fun_app ppf f es =
        |( true
         , "integrate_ode_rk45"
         , f :: y0 :: t0 :: ts :: theta :: x :: x_int :: tl ) ->
-          f :: y0 :: t0 :: ts :: theta :: x :: x_int :: msgs :: tl
-      | true, _, args -> args @ [msgs]
-      | false, _, args -> args
+          (fname, f :: y0 :: t0 :: ts :: theta :: x :: x_int :: msgs :: tl)
+      | true, "map_rect", {expr= FunApp (_, f, _); _} :: tl ->
+          incr map_rect_counter ;
+          (strf "%s<%d, %s>" fname !map_rect_counter f, tl)
+      | true, _, args -> (fname, args @ [msgs])
+      | false, _, args -> (fname, args)
     in
-    let f = stan_namespace_qualify f |> demangle_propto_name false in
-    pp_call ppf (f, pp_expr, args)
+    let fname = stan_namespace_qualify fname |> demangle_propto_name false in
+    pp_call ppf (fname, pp_expr, args)
   in
   let pp =
-    [ Option.map ~f:gen_operator_app (operator_of_string f)
-    ; gen_misc_special_math_app f ]
+    [ Option.map ~f:gen_operator_app (operator_of_string fname)
+    ; gen_misc_special_math_app fname ]
     |> List.filter_opt |> List.hd |> Option.value ~default
   in
   pp ppf es

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -51,13 +51,10 @@ let%expect_test "arg types templated correctly" =
 let promoted_arg_type ppf argtypetemplates =
   match argtypetemplates with
   | [] -> pf ppf "double"
-  | [a] -> pf ppf "%s" a
   | a ->
       let rec promote_args_chunked ppf args =
         let go ppf tl =
-          match tl with
-          | _ :: _ -> pf ppf ", %a" promote_args_chunked tl
-          | _ -> ()
+          match tl with [] -> () | _ -> pf ppf ", %a" promote_args_chunked tl
         in
         pf ppf "typename boost::math::tools::promote_args<%a%a>::type"
           (list ~sep:comma string) (List.hd_exn args) go (List.tl_exn args)

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -969,13 +969,13 @@ static const std::vector<string> locations_array__ = {" (found before start of p
                                                       " (in 'mother.stan', line 302, column 39 to line 307, column 3)"};
 
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 foo(const T0__& n, std::ostream* pstream__) ;
 
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 foo(const T0__& n, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -1001,7 +1001,7 @@ foo(const T0__& n, std::ostream* pstream__) {
 
 struct foo_functor__ {
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 operator()(const T0__& n, std::ostream* pstream__)  const 
 {
 return foo(n, pstream__);
@@ -1096,9 +1096,9 @@ return foo_bar0(pstream__);
 };
 
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 foo_bar1(const T0__& x, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -1119,7 +1119,7 @@ foo_bar1(const T0__& x, std::ostream* pstream__) {
 
 struct foo_bar1_functor__ {
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 operator()(const T0__& x, std::ostream* pstream__)  const 
 {
 return foo_bar1(x, pstream__);
@@ -1305,7 +1305,7 @@ typename T_lp_accum__>
 void
 unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1336,9 +1336,9 @@ return unit_normal_lp(u, lp__, lp_accum__, pstream__);
 };
 
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 foo_1(const T0__& a, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -1530,7 +1530,7 @@ foo_1(const T0__& a, std::ostream* pstream__) {
 
 struct foo_1_functor__ {
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 operator()(const T0__& a, std::ostream* pstream__)  const 
 {
 return foo_1(a, pstream__);
@@ -1538,9 +1538,9 @@ return foo_1(a, pstream__);
 };
 
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 foo_2(const T0__& a, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -1573,7 +1573,7 @@ foo_2(const T0__& a, std::ostream* pstream__) {
 
 struct foo_2_functor__ {
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 operator()(const T0__& a, std::ostream* pstream__)  const 
 {
 return foo_2(a, pstream__);
@@ -1616,10 +1616,10 @@ return foo_3(t, n, pstream__);
 
 template <bool propto__, typename T0__, typename T_lp__,
 typename T_lp_accum__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
        std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1639,7 +1639,7 @@ foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
 struct foo_lp_functor__ {
 template <bool propto__, typename T0__, typename T_lp__,
 typename T_lp_accum__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 operator()(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
            std::ostream* pstream__)  const 
 {
@@ -1650,7 +1650,7 @@ return foo_lp(x, lp__, lp_accum__, pstream__);
 template <typename T0__>
 void
 foo_4(const T0__& x, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -2922,9 +2922,9 @@ return vecfoo(pstream__);
 };
 
 template <typename T0__>
-Eigen::Matrix<T0__, -1, 1>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, 1>
 vecmufoo(const T0__& mu, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -2950,7 +2950,7 @@ vecmufoo(const T0__& mu, std::ostream* pstream__) {
 
 struct vecmufoo_functor__ {
 template <typename T0__>
-Eigen::Matrix<T0__, -1, 1>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, 1>
 operator()(const T0__& mu, std::ostream* pstream__)  const 
 {
 return vecmufoo(mu, pstream__);
@@ -2958,9 +2958,9 @@ return vecmufoo(mu, pstream__);
 };
 
 template <typename T0__>
-Eigen::Matrix<T0__, -1, 1>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, 1>
 vecmubar(const T0__& mu, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -2987,7 +2987,7 @@ vecmubar(const T0__& mu, std::ostream* pstream__) {
 
 struct vecmubar_functor__ {
 template <typename T0__>
-Eigen::Matrix<T0__, -1, 1>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, 1>
 operator()(const T0__& mu, std::ostream* pstream__)  const 
 {
 return vecmubar(mu, pstream__);

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -193,9 +193,9 @@ return nrfun_lp(x, y, lp__, lp_accum__, pstream__);
 };
 
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 rfun(const T0__& y, std::ostream* pstream__) {
-  using local_scalar_t__ = T0__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
@@ -226,7 +226,7 @@ rfun(const T0__& y, std::ostream* pstream__) {
 
 struct rfun_functor__ {
 template <typename T0__>
-T0__
+typename boost::math::tools::promote_args<T0__>::type
 operator()(const T0__& y, std::ostream* pstream__)  const 
 {
 return rfun(y, pstream__);


### PR DESCRIPTION
* remove the first argument from calls to map_rect even though all other HOFs have the first argument as the function and don't require explicit template arguments
* add a call_id integer that just increments every time we emit a call to map_rect. I think this was a hack that went in before because we didn't want to modify the old compiler too much; now I'm reproducing that hack in the new compiler in lieu of fixing it because it would require nontrivial changes to Math.