### PR TITLE
Remove second scoped definition of `sexp_of_expr_typed_located` and `sexp_of_stmt_loc`

### DIFF
--- a/src/middle/Middle.mli
+++ b/src/middle/Middle.mli
@@ -23,8 +23,6 @@ val loop_bottom : Mir.mtype_loc_ad Mir.with_expr
 val remove_size : 'a Mir.sizedtype -> Mir.unsizedtype
 val zero : Mir.mtype_loc_ad Mir.with_expr
 val remove_possible_size : 'a possiblysizedtype -> unsizedtype
-val sexp_of_expr_typed_located : 'a Mir.with_expr -> Sexp.t
-val sexp_of_stmt_loc : ('a, 'b) Mir.stmt_with -> Sexp.t
 val gensym : unit -> string
 val gensym_enter : unit -> string * (unit -> unit)
 val gensym_reset_danger_use_cautiously : unit -> unit

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1056,7 +1056,12 @@ A non-returning function was expected but a returning function 'foo' was supplie
 Uncaught exception:
   
   ("Expecting a block or skip, not"
-   (x ((NRFunApp CompilerInternal FnReject__ ((Lit Str ""))))))
+   (x
+    (((stmt
+       (NRFunApp CompilerInternal FnReject__
+        (((expr (Lit Str ""))
+          (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly)))))))
+      (smeta <opaque>)))))
 
 Raised at file "src/error.ml" (inlined), line 9, characters 14-30
 Called from file "src/error.ml", line 11, characters 19-40

--- a/test/unit/Ast_to_Mir_tests.ml
+++ b/test/unit/Ast_to_Mir_tests.ml
@@ -43,47 +43,167 @@ let%expect_test "Prefix-Op-Example" =
   (* Perhaps this is producing too many nested lists. XXX*)
   [%expect
     {|
-      ((Block
-        ((Decl (decl_adtype AutoDiffable) (decl_id i) (decl_type (Sized SInt)))
-         (IfElse
-          (FunApp StanLib Less__ ((Var i) (FunApp StanLib PMinus__ ((Lit Int 1)))))
-          (NRFunApp CompilerInternal FnPrint__ ((Lit Str Badger))) ())))) |}]
+      (((stmt
+         (Block
+          (((stmt
+             (Decl (decl_adtype AutoDiffable) (decl_id i) (decl_type (Sized SInt))))
+            (smeta <opaque>))
+           ((stmt
+             (IfElse
+              ((expr
+                (FunApp StanLib Less__
+                 (((expr (Var i))
+                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+                  ((expr
+                    (FunApp StanLib PMinus__
+                     (((expr (Lit Int 1))
+                       (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+               (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+              ((stmt
+                (NRFunApp CompilerInternal FnPrint__
+                 (((expr (Lit Str Badger))
+                   (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly)))))))
+               (smeta <opaque>))
+              ()))
+            (smeta <opaque>)))))
+        (smeta <opaque>))) |}]
 
 let%expect_test "read data" =
   let m = mir_from_string "data { matrix[10, 20] mat[5]; }" in
   print_s [%sexp (m.prepare_data : stmt_loc list)] ;
   [%expect
     {|
-    ((Decl (decl_adtype DataOnly) (decl_id mat)
-      (decl_type
-       (Sized (SArray (SMatrix (Lit Int 10) (Lit Int 20)) (Lit Int 5)))))) |}]
+    (((stmt
+       (Decl (decl_adtype DataOnly) (decl_id mat)
+        (decl_type
+         (Sized
+          (SArray
+           (SMatrix
+            ((expr (Lit Int 10))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+            ((expr (Lit Int 20))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+           ((expr (Lit Int 5))
+            (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
+      (smeta <opaque>))) |}]
 
 let%expect_test "read param" =
   let m = mir_from_string "parameters { matrix<lower=0>[10, 20] mat[5]; }" in
   print_s [%sexp (m.log_prob : stmt_loc list)] ;
   [%expect
     {|
-    ((Decl (decl_adtype AutoDiffable) (decl_id mat)
-      (decl_type
-       (Sized (SArray (SMatrix (Lit Int 10) (Lit Int 20)) (Lit Int 5)))))
-     (For (loopvar sym1__) (lower (Lit Int 1)) (upper (Lit Int 5))
-      (body
-       (Block
-        ((For (loopvar sym2__) (lower (Lit Int 1)) (upper (Lit Int 10))
-          (body
+    (((stmt
+       (Decl (decl_adtype AutoDiffable) (decl_id mat)
+        (decl_type
+         (Sized
+          (SArray
+           (SMatrix
+            ((expr (Lit Int 10))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+            ((expr (Lit Int 20))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+           ((expr (Lit Int 5))
+            (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
+      (smeta <opaque>))
+     ((stmt
+       (For (loopvar sym1__)
+        (lower
+         ((expr (Lit Int 1))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+        (upper
+         ((expr (Lit Int 5))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+        (body
+         ((stmt
            (Block
-            ((For (loopvar sym3__) (lower (Lit Int 1)) (upper (Lit Int 20))
-              (body
-               (Block
-                ((Assignment
-                  (mat (UArray UMatrix)
-                   ((Single (Var sym1__)) (Single (Var sym2__))
-                    (Single (Var sym3__))))
-                  (FunApp CompilerInternal FnConstrain__
-                   ((Indexed (Var mat)
-                     ((Single (Var sym1__)) (Single (Var sym2__))
-                      (Single (Var sym3__))))
-                    (Lit Str lb) (Lit Int 0))))))))))))))))) |}]
+            (((stmt
+               (For (loopvar sym2__)
+                (lower
+                 ((expr (Lit Int 1))
+                  (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                (upper
+                 ((expr (Lit Int 10))
+                  (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                (body
+                 ((stmt
+                   (Block
+                    (((stmt
+                       (For (loopvar sym3__)
+                        (lower
+                         ((expr (Lit Int 1))
+                          (emeta
+                           ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                        (upper
+                         ((expr (Lit Int 20))
+                          (emeta
+                           ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                        (body
+                         ((stmt
+                           (Block
+                            (((stmt
+                               (Assignment
+                                (mat (UArray UMatrix)
+                                 ((Single
+                                   ((expr (Var sym1__))
+                                    (emeta
+                                     ((mtype UInt) (mloc <opaque>)
+                                      (madlevel DataOnly)))))
+                                  (Single
+                                   ((expr (Var sym2__))
+                                    (emeta
+                                     ((mtype UInt) (mloc <opaque>)
+                                      (madlevel DataOnly)))))
+                                  (Single
+                                   ((expr (Var sym3__))
+                                    (emeta
+                                     ((mtype UInt) (mloc <opaque>)
+                                      (madlevel DataOnly)))))))
+                                ((expr
+                                  (FunApp CompilerInternal FnConstrain__
+                                   (((expr
+                                      (Indexed
+                                       ((expr (Var mat))
+                                        (emeta
+                                         ((mtype (UArray UMatrix))
+                                          (mloc <opaque>)
+                                          (madlevel AutoDiffable))))
+                                       ((Single
+                                         ((expr (Var sym1__))
+                                          (emeta
+                                           ((mtype UInt) (mloc <opaque>)
+                                            (madlevel DataOnly)))))
+                                        (Single
+                                         ((expr (Var sym2__))
+                                          (emeta
+                                           ((mtype UInt) (mloc <opaque>)
+                                            (madlevel DataOnly)))))
+                                        (Single
+                                         ((expr (Var sym3__))
+                                          (emeta
+                                           ((mtype UInt) (mloc <opaque>)
+                                            (madlevel DataOnly))))))))
+                                     (emeta
+                                      ((mtype UReal) (mloc <opaque>)
+                                       (madlevel AutoDiffable))))
+                                    ((expr (Lit Str lb))
+                                     (emeta
+                                      ((mtype UReal) (mloc <opaque>)
+                                       (madlevel DataOnly))))
+                                    ((expr (Lit Int 0))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly)))))))
+                                 (emeta
+                                  ((mtype UReal) (mloc <opaque>)
+                                   (madlevel AutoDiffable))))))
+                              (smeta <opaque>)))))
+                          (smeta <opaque>)))))
+                      (smeta <opaque>)))))
+                  (smeta <opaque>)))))
+              (smeta <opaque>)))))
+          (smeta <opaque>)))))
+      (smeta <opaque>))) |}]
 
 let%expect_test "gen quant" =
   let m =
@@ -92,19 +212,71 @@ let%expect_test "gen quant" =
   print_s [%sexp (m.generate_quantities : stmt_loc list)] ;
   [%expect
     {|
-    ((IfElse
-      (FunApp StanLib PNot__
-       ((EOr (Var emit_transformed_parameters__)
-         (Var emit_generated_quantities__))))
-      (Return ()) ())
-     (IfElse (FunApp StanLib PNot__ ((Var emit_generated_quantities__)))
-      (Return ()) ())
-     (Decl (decl_adtype DataOnly) (decl_id mat)
-      (decl_type
-       (Sized (SArray (SMatrix (Lit Int 10) (Lit Int 20)) (Lit Int 5)))))
-     (For (loopvar sym1__) (lower (Lit Int 1)) (upper (Lit Int 5))
-      (body
-       (Block
-        ((NRFunApp CompilerInternal FnCheck__
-          ((Lit Str greater_or_equal) (Lit Str mat[sym1__])
-           (Indexed (Var mat) ((Single (Var sym1__)))) (Lit Int 0)))))))) |}]
+    (((stmt
+       (IfElse
+        ((expr
+          (FunApp StanLib PNot__
+           (((expr
+              (EOr
+               ((expr (Var emit_transformed_parameters__))
+                (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+               ((expr (Var emit_generated_quantities__))
+                (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+        ((stmt (Return ())) (smeta <opaque>)) ()))
+      (smeta <opaque>))
+     ((stmt
+       (IfElse
+        ((expr
+          (FunApp StanLib PNot__
+           (((expr (Var emit_generated_quantities__))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+        ((stmt (Return ())) (smeta <opaque>)) ()))
+      (smeta <opaque>))
+     ((stmt
+       (Decl (decl_adtype DataOnly) (decl_id mat)
+        (decl_type
+         (Sized
+          (SArray
+           (SMatrix
+            ((expr (Lit Int 10))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+            ((expr (Lit Int 20))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+           ((expr (Lit Int 5))
+            (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
+      (smeta <opaque>))
+     ((stmt
+       (For (loopvar sym1__)
+        (lower
+         ((expr (Lit Int 1))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+        (upper
+         ((expr (Lit Int 5))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+        (body
+         ((stmt
+           (Block
+            (((stmt
+               (NRFunApp CompilerInternal FnCheck__
+                (((expr (Lit Str greater_or_equal))
+                  (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
+                 ((expr (Lit Str mat[sym1__]))
+                  (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+                 ((expr
+                   (Indexed
+                    ((expr (Var mat))
+                     (emeta
+                      ((mtype (UArray UMatrix)) (mloc <opaque>)
+                       (madlevel DataOnly))))
+                    ((Single
+                      ((expr (Var sym1__))
+                       (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
+                  (emeta ((mtype UMatrix) (mloc <opaque>) (madlevel DataOnly))))
+                 ((expr (Lit Int 0))
+                  (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+              (smeta <opaque>)))))
+          (smeta <opaque>)))))
+      (smeta <opaque>))) |}]

--- a/test/unit/Dataflow_utils.ml
+++ b/test/unit/Dataflow_utils.ml
@@ -184,26 +184,97 @@ let%expect_test "Statement label map example" =
     {|
       ((1 (Block (2))) (2 (Block (3 4 5)))
        (3 (Decl (decl_adtype AutoDiffable) (decl_id i) (decl_type (Sized SInt))))
-       (4 (Assignment (i UInt ()) (Lit Int 0)))
-       (5 (IfElse (FunApp StanLib Less__ ((Var i) (Lit Int 0))) 6 (8)))
-       (6 (Block (7))) (7 (NRFunApp CompilerInternal FnPrint__ ((Var i))))
+       (4
+        (Assignment (i UInt ())
+         ((expr (Lit Int 0))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+       (5
+        (IfElse
+         ((expr
+           (FunApp StanLib Less__
+            (((expr (Var i))
+              (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+             ((expr (Lit Int 0))
+              (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+         6 (8)))
+       (6 (Block (7)))
+       (7
+        (NRFunApp CompilerInternal FnPrint__
+         (((expr (Var i))
+           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
        (8 (Block (9)))
-       (9 (For (loopvar j) (lower (Lit Int 1)) (upper (Lit Int 10)) (body 10)))
+       (9
+        (For (loopvar j)
+         (lower
+          ((expr (Lit Int 1))
+           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+         (upper
+          ((expr (Lit Int 10))
+           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+         (body 10)))
        (10 (Block (11 14 17 22)))
-       (11 (IfElse (FunApp StanLib Greater__ ((Var j) (Lit Int 9))) 12 ()))
+       (11
+        (IfElse
+         ((expr
+           (FunApp StanLib Greater__
+            (((expr (Var j))
+              (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+             ((expr (Lit Int 9))
+              (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+         12 ()))
        (12 (Block (13))) (13 Break)
        (14
         (IfElse
-         (EAnd (FunApp StanLib Greater__ ((Var j) (Lit Int 8)))
-          (FunApp StanLib Less__ ((Var i) (FunApp StanLib PMinus__ ((Lit Int 1))))))
+         ((expr
+           (EAnd
+            ((expr
+              (FunApp StanLib Greater__
+               (((expr (Var j))
+                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+                ((expr (Lit Int 8))
+                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+            ((expr
+              (FunApp StanLib Less__
+               (((expr (Var i))
+                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+                ((expr
+                  (FunApp StanLib PMinus__
+                   (((expr (Lit Int 1))
+                     (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
          15 ()))
        (15 (Block (16))) (16 Continue)
-       (17 (IfElse (FunApp StanLib Greater__ ((Var j) (Lit Int 5))) 18 (20)))
+       (17
+        (IfElse
+         ((expr
+           (FunApp StanLib Greater__
+            (((expr (Var j))
+              (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+             ((expr (Lit Int 5))
+              (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+         18 (20)))
        (18 (Block (19))) (19 Continue) (20 (Block (21)))
        (21
         (NRFunApp CompilerInternal FnPrint__
-         ((Lit Str Badger) (FunApp StanLib Plus__ ((Var i) (Var j))))))
-       (22 (NRFunApp CompilerInternal FnPrint__ ((Lit Str Fin)))))
+         (((expr (Lit Str Badger))
+           (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
+          ((expr
+            (FunApp StanLib Plus__
+             (((expr (Var i))
+               (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+              ((expr (Var j))
+               (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
+       (22
+        (NRFunApp CompilerInternal FnPrint__
+         (((expr (Lit Str Fin))
+           (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))))))
     |}]
 
 let%expect_test "Predecessor graph example" =
@@ -281,7 +352,10 @@ let%expect_test "Statement label map example 3" =
           (end_loc
            ((filename string) (line_num 3) (col_num 19) (included_from ()))))))
        (4
-        ((While (Lit Int 42) 5)
+        ((While
+          ((expr (Lit Int 42))
+           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
+          5)
          ((begin_loc
            ((filename string) (line_num 3) (col_num 8) (included_from ())))
           (end_loc
@@ -293,7 +367,9 @@ let%expect_test "Statement label map example 3" =
           (end_loc
            ((filename string) (line_num 3) (col_num 19) (included_from ()))))))
        (6
-        ((NRFunApp CompilerInternal FnPrint__ ((Lit Str exit)))
+        ((NRFunApp CompilerInternal FnPrint__
+          (((expr (Lit Str exit))
+            (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))))
          ((begin_loc
            ((filename string) (line_num 4) (col_num 8) (included_from ())))
           (end_loc
@@ -365,7 +441,14 @@ let%expect_test "Statement label map example 4" =
            ((filename string) (line_num 3) (col_num 8) (included_from ())))
           (end_loc ((filename string) (line_num 6) (col_num 9) (included_from ()))))))
        (4
-        ((For (loopvar i) (lower (Lit Int 1)) (upper (Lit Int 6)) (body 5))
+        ((For (loopvar i)
+          (lower
+           ((expr (Lit Int 1))
+            (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+          (upper
+           ((expr (Lit Int 6))
+            (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+          (body 5))
          ((begin_loc
            ((filename string) (line_num 3) (col_num 8) (included_from ())))
           (end_loc ((filename string) (line_num 6) (col_num 9) (included_from ()))))))
@@ -456,7 +539,14 @@ let%expect_test "Statement label map example 5" =
            ((filename string) (line_num 3) (col_num 8) (included_from ())))
           (end_loc ((filename string) (line_num 6) (col_num 9) (included_from ()))))))
        (4
-        ((For (loopvar i) (lower (Lit Int 1)) (upper (Lit Int 6)) (body 5))
+        ((For (loopvar i)
+          (lower
+           ((expr (Lit Int 1))
+            (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+          (upper
+           ((expr (Lit Int 6))
+            (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+          (body 5))
          ((begin_loc
            ((filename string) (line_num 3) (col_num 8) (included_from ())))
           (end_loc ((filename string) (line_num 6) (col_num 9) (included_from ()))))))

--- a/test/unit/Factor_graph.ml
+++ b/test/unit/Factor_graph.ml
@@ -54,6 +54,14 @@ let%expect_test "Variable dependency example" =
   [%expect
     {|
       ((19 Reject ((VVar i) (VVar j)))
-       (21 (TargetTerm (Lit Int 1)) ((VVar i) (VVar j)))
-       (21 (TargetTerm (Lit Int 1)) ((VVar i) (VVar j))))
+       (21
+        (TargetTerm
+         ((expr (Lit Int 1))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+        ((VVar i) (VVar j)))
+       (21
+        (TargetTerm
+         ((expr (Lit Int 1))
+          (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+        ((VVar i) (VVar j))))
     |}]


### PR DESCRIPTION
At the moment `sexp_of_expr_typed_located` and `sexp_of_stmt_loc` are both defined twice, once by the deriving annotation on the type definition and then, again, in `Middle.ml`. Since the implementations are different the pretty printed s-expression of the type differs depending on whether the implementations in `Middle.ml` are in scope.

This PR removes the second definition so we have consistent s-expressions and updates tests to this format.