### PR TITLE
Deal with ints the same way Stan 2 does in function signatures

### DIFF
--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -1617,6 +1617,14 @@ let semantic_check_ostatements_in_block ~cf block stmts_opt =
       |> List.rev |> Validate.sequence
       |> Validate.map ~f:Option.some )
 
+let check_fun_def_body_in_block = function
+  | {stmt= FunDef {body= {stmt= Block _; _}; _}; _}
+   |{stmt= FunDef {body= {stmt= Skip; _}; _}; _} ->
+      Validate.ok ()
+  | {stmt= FunDef {body= {stmt= _; _}; _}; smeta} ->
+      Validate.error @@ Semantic_error.fn_decl_needs_block smeta.loc
+  | _ -> Validate.ok ()
+
 let semantic_check_functions_have_defn function_block_stmts_opt =
   Validate.(
     if
@@ -1628,7 +1636,13 @@ let semantic_check_functions_have_defn function_block_stmts_opt =
           (* TODO: insert better location in the error *)
           error @@ Semantic_error.fn_decl_without_def smeta.loc
       | _ -> fatal_error ~msg:"semantic_check_functions_have_defn" ()
-    else ok ())
+    else
+      match function_block_stmts_opt with
+      | Some [] | None -> ok ()
+      | Some ls ->
+          List.map ~f:check_fun_def_body_in_block ls
+          |> sequence
+          |> map ~f:(fun _ -> ()))
 
 (* The actual semantic checks for all AST nodes! *)
 let semantic_check_program

--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -1621,7 +1621,7 @@ let check_fun_def_body_in_block = function
   | {stmt= FunDef {body= {stmt= Block _; _}; _}; _}
    |{stmt= FunDef {body= {stmt= Skip; _}; _}; _} ->
       Validate.ok ()
-  | {stmt= FunDef {body= {stmt= _; _}; _}; smeta} ->
+  | {stmt= FunDef {body= {stmt= _; smeta}; _}; _} ->
       Validate.error @@ Semantic_error.fn_decl_needs_block smeta.loc
   | _ -> Validate.ok ()
 

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -256,8 +256,10 @@ module StatementError = struct
            of functions with the suffix _lp."
     | InvalidSamplingPDForPMF ->
         Fmt.pf ppf
-          "~-statement expects a distribution name without '_lpdf' or '_lpmf' \
-           suffix."
+          {|
+~ statement should refer to a distribution without its "_lpdf" or "_lpmf" suffix.
+For example, "target += normal_lpdf(y, 0, 1)" should become "y ~ normal(0, 1)."
+|}
     | InvalidSamplingCDForCCDF name ->
         Fmt.pf ppf
           "CDF and CCDF functions may not be used with sampling notation. Use \

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -236,6 +236,7 @@ module StatementError = struct
     | MismatchFunDefDecl of string * unsizedtype option
     | FunDeclExists of string
     | FunDeclNoDefn
+    | FunDeclNeedsBlock
     | NonRealProbFunDef
     | ProbDensityNonRealVariate of unsizedtype option
     | ProbMassNonIntVariate of unsizedtype option
@@ -308,6 +309,8 @@ For example, "target += normal_lpdf(y, 0, 1)" should become "y ~ normal(0, 1)."
           name
     | FunDeclNoDefn ->
         Fmt.pf ppf "Some function is declared without specifying a definition."
+    | FunDeclNeedsBlock ->
+        Fmt.pf ppf "Function definitions must be wrapped in curly braces."
     | NonRealProbFunDef ->
         Fmt.pf ppf
           "Real return type required for probability functions ending in \
@@ -501,6 +504,9 @@ let fn_decl_exists loc name =
   StatementError (loc, StatementError.FunDeclExists name)
 
 let fn_decl_without_def loc = StatementError (loc, StatementError.FunDeclNoDefn)
+
+let fn_decl_needs_block loc =
+  StatementError (loc, StatementError.FunDeclNeedsBlock)
 
 let non_real_prob_fn_def loc =
   StatementError (loc, StatementError.NonRealProbFunDef)

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -72,6 +72,7 @@ val transformed_params_int : location_span -> t
 val mismatched_fn_def_decl : location_span -> string -> unsizedtype option -> t
 val fn_decl_exists : location_span -> string -> t
 val fn_decl_without_def : location_span -> t
+val fn_decl_needs_block : location_span -> t
 val non_real_prob_fn_def : location_span -> t
 val prob_density_non_real_variate : location_span -> unsizedtype option -> t
 val prob_mass_non_int_variate : location_span -> unsizedtype option -> t

--- a/src/middle/Middle.mli
+++ b/src/middle/Middle.mli
@@ -97,6 +97,13 @@ val stan_math_signatures :
 val manual_stan_math_signatures :
   (returntype * (autodifftype * unsizedtype) list) list String.Table.t
 
+val mkfor :
+     mtype_loc_ad with_expr
+  -> (mtype_loc_ad with_expr -> (mtype_loc_ad, location_span) stmt_with)
+  -> mtype_loc_ad with_expr
+  -> location_span
+  -> (mtype_loc_ad, location_span) stmt_with
+
 val for_scalar :
      mtype_loc_ad with_expr sizedtype
   -> (mtype_loc_ad with_expr -> (mtype_loc_ad, location_span) stmt_with)
@@ -107,6 +114,12 @@ val for_scalar :
 val for_scalar_inv :
      mtype_loc_ad with_expr sizedtype
   -> (mtype_loc_ad with_expr -> (mtype_loc_ad, location_span) stmt_with)
+  -> mtype_loc_ad with_expr
+  -> location_span
+  -> (mtype_loc_ad, location_span) stmt_with
+
+val for_each :
+     (mtype_loc_ad with_expr -> (mtype_loc_ad, location_span) stmt_with)
   -> mtype_loc_ad with_expr
   -> location_span
   -> (mtype_loc_ad, location_span) stmt_with
@@ -137,3 +150,4 @@ val stdlib_distribution_name : string -> string
 val distribution_suffices : string list
 val is_distribution_name : ?infix:string -> string -> bool
 val proportional_to_distribution_infix : string
+val infer_type_of_indexed : unsizedtype -> 'a index list -> unsizedtype

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -142,9 +142,6 @@ let pp_fun_def ppf {fdrt; fdname; fdargs; fdbody; _} =
     if not is_dist then (
       text "const static bool propto__ = true;" ;
       text "(void) propto__;" ) ;
-    text
-      "local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());" ;
-    pp_unused ppf "DUMMY_VAR__" ;
     let blocked_fdbody =
       match fdbody.stmt with
       | SList stmts -> {stmt= Block stmts; smeta= fdbody.smeta}
@@ -433,10 +430,8 @@ let pp_log_prob ppf p =
     ; "std::ostream* pstream__ = 0" ]
   in
   let intro =
-    [ "typedef T__ local_scalar_t__;"
-    ; "local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
-    ; strf "%a" pp_unused "DUMMY_VAR__"
-    ; "T__ lp__(0.0);"; "stan::math::accumulator<T__> lp_accum__;"
+    [ "typedef T__ local_scalar_t__;"; "T__ lp__(0.0);"
+    ; "stan::math::accumulator<T__> lp_accum__;"
     ; strf "%a" pp_function__ (p.prog_name, "log_prob")
     ; "stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);" ]
   in

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -356,7 +356,7 @@ let rec contains_eigen = function
 
 let type_needs_fill decl_id ut =
   is_user_ident decl_id
-  && (contains_eigen ut || match ut with UInt | UReal -> true | _ -> false)
+  && (contains_eigen ut || match ut with UReal -> true | _ -> false)
 
 let rec add_fill no_fill_required = function
   | {stmt= Decl {decl_id; decl_type= Sized st; _}; smeta} as decl

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2513,7 +2513,10 @@ Semantic error in 'tilde-bad.stan', line 8, column 8 to column 19:
      9:  }
    -------------------------------------------------
 
-~-statement expects a distribution name without '_lpdf' or '_lpmf' suffix.
+
+~ statement should refer to a distribution without its "_lpdf" or "_lpmf" suffix.
+For example, "target += normal_lpdf(y, 0, 1)" should become "y ~ normal(0, 1)."
+
 
   $ ../../../../install/default/bin/stanc truncation-bad-type1.stan
 

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1053,24 +1053,17 @@ Semantic error in 'experiment.stan', line 12, column 4 to column 11:
 A non-returning function was expected but a returning function 'foo' was supplied.
 
   $ ../../../../install/default/bin/stanc fun-return-typ3.stan
-Uncaught exception:
-  
-  ("Expecting a block or skip, not"
-   (x
-    (((stmt
-       (NRFunApp CompilerInternal FnReject__
-        (((expr (Lit Str ""))
-          (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly)))))))
-      (smeta <opaque>)))))
 
-Raised at file "src/error.ml" (inlined), line 9, characters 14-30
-Called from file "src/error.ml", line 11, characters 19-40
-Called from file "src/frontend/Ast_to_Mir.ml", line 532, characters 12-144
-Called from file "src/list.ml", line 557, characters 34-40
-Called from file "src/frontend/Ast_to_Mir.ml" (inlined), line 561, characters 22-76
-Called from file "src/frontend/Ast_to_Mir.ml", line 653, characters 21-64
-Called from file "src/stanc/stanc.ml", line 208, characters 14-54
-Called from file "src/stanc/stanc.ml", line 257, characters 9-16
+Semantic error in 'fun-return-typ3.stan', line 2, column 13 to column 24:
+   -------------------------------------------------
+     1:  functions {
+     2:    real foo() reject("");
+                      ^
+     3:  }
+   -------------------------------------------------
+
+Function definitions must be wrapped in curly braces.
+
   $ ../../../../install/default/bin/stanc fun-return-type1.stan
 
 Semantic error in 'fun-return-type1.stan', line 2, column 2 to column 72:

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -240,9 +240,6 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
   T__ log_prob(std::vector<T__>& params_r__, std::vector<int>& params_i__,
                std::ostream* pstream__ = 0) const {
     typedef T__ local_scalar_t__;
-    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-    (void) DUMMY_VAR__;  // suppress unused var warning
-
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     static const char* function__ = "optimize_glm_model_namespace::log_prob";

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -981,7 +981,7 @@ foo(const int& n, std::ostream* pstream__) ;
 
 int
 foo(const int& n, std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
   
@@ -1288,7 +1288,7 @@ return unit_normal_lp(u, lp__, lp_accum__, pstream__);
 
 int
 foo_1(const int& a, std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
   
@@ -1507,7 +1507,7 @@ return foo_1(a, pstream__);
 
 int
 foo_2(const int& a, std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
   
@@ -1929,7 +1929,14 @@ f1(const int& a1, const std::vector<int>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
+          T6__,
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   
@@ -1977,7 +1984,14 @@ f2(const int& a1, const std::vector<int>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
+          T6__,
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   
@@ -2025,7 +2039,14 @@ f3(const int& a1, const std::vector<int>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
+          T6__,
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1309,8 +1309,6 @@ foo_1(const int& a, std::ostream* pstream__) {
     while (1) {
       int b;
       
-      current_statement__ = 291;
-      b = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 292;
       b = 5;
       break;
@@ -1348,8 +1346,6 @@ foo_1(const int& a, std::ostream* pstream__) {
       
       int z;
       
-      current_statement__ = 311;
-      z = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 312;
       for (size_t sym2__ = 1; sym2__ <= stan::length(vs); ++sym2__) {
         std::vector<int> v;
@@ -1481,15 +1477,11 @@ foo_1(const int& a, std::ostream* pstream__) {
     while (1) {
       int b;
       
-      current_statement__ = 355;
-      b = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 356;
       b = 5;
       {
         int c;
         
-        current_statement__ = 357;
-        c = std::numeric_limits<double>::quiet_NaN();
         current_statement__ = 358;
         c = 6;
         break;
@@ -1525,8 +1517,6 @@ foo_2(const int& a, std::ostream* pstream__) {
     
     int y;
     
-    current_statement__ = 366;
-    y = std::numeric_limits<double>::quiet_NaN();
     current_statement__ = 367;
     for (size_t sym12__ = 1; sym12__ <= stan::length(vs); ++sym12__) {
       int v;
@@ -2610,8 +2600,6 @@ foo_6(std::ostream* pstream__) {
   try {
     int a;
     
-    current_statement__ = 425;
-    a = std::numeric_limits<double>::quiet_NaN();
     local_scalar_t__ b;
     
     current_statement__ = 426;
@@ -3174,8 +3162,6 @@ class mother_model : public model_base_crtp<mother_model> {
             current_statement__ = 197;
             pos__ = (pos__ + 1);}}}
       
-      current_statement__ = 198;
-      td_int = std::numeric_limits<double>::quiet_NaN();
       td_1d = std::vector<int>(N, 0);
       
       td_1dk = std::vector<int>(M, 0);
@@ -3183,8 +3169,6 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 200;
       assign(td_1dk, nil_index_list(), rep_array(1, M), "assigning variable td_1dk");
       
-      current_statement__ = 201;
-      td_a = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 201;
       td_a = N;
       

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -149,9 +149,6 @@ class eight_schools_ncp_model : public model_base_crtp<eight_schools_ncp_model> 
   T__ log_prob(std::vector<T__>& params_r__, std::vector<int>& params_i__,
                std::ostream* pstream__ = 0) const {
     typedef T__ local_scalar_t__;
-    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-    (void) DUMMY_VAR__;  // suppress unused var warning
-
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     static const char* function__ = "eight_schools_ncp_model_namespace::log_prob";
@@ -987,8 +984,6 @@ foo(const int& n, std::ostream* pstream__) {
   using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 257;
@@ -1032,8 +1027,6 @@ sho(const T0__& t, const std::vector<T1__>& y,
           T2__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     std::vector<local_scalar_t__> dydt;
@@ -1070,8 +1063,6 @@ foo_bar0(std::ostream* pstream__) {
   using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 266;
@@ -1098,8 +1089,6 @@ foo_bar1(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 268;
@@ -1129,8 +1118,6 @@ foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
           T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 270;
@@ -1159,8 +1146,6 @@ typename boost::math::tools::promote_args<T1__>::type
 foo_lpmf(const int& y, const T1__& lambda, T_lp__& lp__,
          T_lp_accum__& lp_accum__, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 272;
@@ -1190,8 +1175,6 @@ foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 274;
@@ -1219,8 +1202,6 @@ foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 276;
@@ -1251,8 +1232,6 @@ foo_rng(RNG& base_rng__, const T0__& mu, const T1__& sigma,
           T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 278;
@@ -1282,8 +1261,6 @@ void
 unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 280;
@@ -1314,8 +1291,6 @@ foo_1(const int& a, std::ostream* pstream__) {
   using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 284;
@@ -1543,8 +1518,6 @@ foo_2(const int& a, std::ostream* pstream__) {
   using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     std::vector<int> vs;
@@ -1585,8 +1558,6 @@ foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 371;
@@ -1614,8 +1585,6 @@ typename boost::math::tools::promote_args<T0__>::type
 foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
        std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 373;
@@ -1645,8 +1614,6 @@ foo_4(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 375;
@@ -1682,8 +1649,6 @@ relative_diff(const T0__& x, const T1__& y, const T2__& max_,
           T3__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     local_scalar_t__ abs_diff;
@@ -1754,8 +1719,6 @@ foo_5(const Eigen::Matrix<T0__, -1, 1>& shared_params,
           T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 387;
@@ -1794,8 +1757,6 @@ foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
           T4__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 389;
@@ -1834,8 +1795,6 @@ foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
           T2__,
           T3__,
           T4__, typename boost::math::tools::promote_args<T5__>::type>::type;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 391;
@@ -1869,8 +1828,6 @@ covsqrt2corsqrt(const Eigen::Matrix<T0__, -1, -1>& mat, const int& invert,
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     Eigen::Matrix<local_scalar_t__, -1, -1> o;
@@ -1934,8 +1891,6 @@ f0(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 399;
@@ -1987,8 +1942,6 @@ f1(const int& a1, const std::vector<int>& a2,
   using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 401;
@@ -2037,8 +1990,6 @@ f2(const int& a1, const std::vector<int>& a2,
   using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 403;
@@ -2087,8 +2038,6 @@ f3(const int& a1, const std::vector<int>& a2,
   using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 405;
@@ -2146,8 +2095,6 @@ f4(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 407;
@@ -2207,8 +2154,6 @@ f5(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 409;
@@ -2268,8 +2213,6 @@ f6(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 411;
@@ -2329,8 +2272,6 @@ f7(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 413;
@@ -2390,8 +2331,6 @@ f8(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 415;
@@ -2451,8 +2390,6 @@ f9(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 417;
@@ -2512,8 +2449,6 @@ f10(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 419;
@@ -2573,8 +2508,6 @@ f11(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 421;
@@ -2634,8 +2567,6 @@ f12(const int& a1, const std::vector<int>& a2,
           T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 423;
@@ -2675,8 +2606,6 @@ foo_6(std::ostream* pstream__) {
   using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     int a;
@@ -2727,8 +2656,6 @@ matfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 431;
@@ -2759,8 +2686,6 @@ vecfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     current_statement__ = 433;
@@ -2787,8 +2712,6 @@ vecmufoo(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     Eigen::Matrix<local_scalar_t__, -1, 1> l;
@@ -2826,8 +2749,6 @@ vecmubar(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     Eigen::Matrix<local_scalar_t__, -1, 1> l;
@@ -2872,8 +2793,6 @@ algebra_system(const Eigen::Matrix<T0__, -1, 1>& x,
           T2__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     Eigen::Matrix<local_scalar_t__, -1, 1> f_x;
@@ -2921,8 +2840,6 @@ binomialf(const Eigen::Matrix<T0__, -1, 1>& phi,
           T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     Eigen::Matrix<local_scalar_t__, -1, 1> lpmf;
@@ -3615,9 +3532,6 @@ class mother_model : public model_base_crtp<mother_model> {
   T__ log_prob(std::vector<T__>& params_r__, std::vector<int>& params_i__,
                std::ostream* pstream__ = 0) const {
     typedef T__ local_scalar_t__;
-    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-    (void) DUMMY_VAR__;  // suppress unused var warning
-
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     static const char* function__ = "mother_model_namespace::log_prob";
@@ -7606,9 +7520,6 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
   T__ log_prob(std::vector<T__>& params_r__, std::vector<int>& params_i__,
                std::ostream* pstream__ = 0) const {
     typedef T__ local_scalar_t__;
-    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-    (void) DUMMY_VAR__;  // suppress unused var warning
-
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     static const char* function__ = "optimize_glm_model_namespace::log_prob";

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1347,36 +1347,44 @@ foo_1(const int& a, std::ostream* pstream__) {
       int z;
       
       current_statement__ = 312;
-      for (size_t sym2__ = 1; sym2__ <= stan::length(vs); ++sym2__) {
-        std::vector<int> v;
-        current_statement__ = 312;
-        v = vs[(sym2__ - 1)];
-        current_statement__ = 313;
-        z = 0;
-        break;}
-      current_statement__ = 315;
-      for (size_t sym3__ = 1; sym3__ <= stan::length(vs); ++sym3__) {
-        std::vector<int> v;
-        current_statement__ = 315;
-        v = vs[(sym3__ - 1)];
-        current_statement__ = 316;
-        z = 0;
-        continue;}
-      current_statement__ = 318;
-      for (size_t sym4__ = 1; sym4__ <= stan::length(vs); ++sym4__) {
-        std::vector<int> v;
-        current_statement__ = 318;
-        v = vs[(sym4__ - 1)];
-        current_statement__ = 319;
-        for (size_t sym5__ = 1; sym5__ <= stan::length(v); ++sym5__) {
-          int vv;
-          current_statement__ = 319;
-          vv = v[(sym5__ - 1)];
-          current_statement__ = 320;
+      for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+        {
+          std::vector<int> v;
+          current_statement__ = 312;
+          assign(v, nil_index_list(), vs[(sym1__ - 1)], "assigning variable v");
+          current_statement__ = 313;
           z = 0;
-          break;}
-        current_statement__ = 322;
-        z = 1;}
+          break;
+        }}
+      current_statement__ = 315;
+      for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+        {
+          std::vector<int> v;
+          current_statement__ = 315;
+          assign(v, nil_index_list(), vs[(sym1__ - 1)], "assigning variable v");
+          current_statement__ = 316;
+          z = 0;
+          continue;
+        }}
+      current_statement__ = 318;
+      for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+        {
+          std::vector<int> v;
+          current_statement__ = 318;
+          assign(v, nil_index_list(), vs[(sym1__ - 1)], "assigning variable v");
+          current_statement__ = 319;
+          for (size_t sym1__ = 1; sym1__ <= stan::length(v); ++sym1__) {
+            {
+              int vv;
+              current_statement__ = 319;
+              vv = v[(sym1__ - 1)];
+              current_statement__ = 320;
+              z = 0;
+              break;
+            }}
+          current_statement__ = 322;
+          z = 1;
+        }}
     }
     current_statement__ = 334;
     while (1) {
@@ -1388,28 +1396,40 @@ foo_1(const int& a, std::ostream* pstream__) {
       vs = Eigen::Matrix<local_scalar_t__, -1, -1>(2, 3);
       
       current_statement__ = 326;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 326;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 326;
-          assign(vs, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(vs, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable vs");}}
       current_statement__ = 327;
-      for (size_t sym6__ = 1; sym6__ <= stan::length(vs); ++sym6__) {
-        double v;
+      for (size_t sym1__ = 1; sym1__ <= rows(vs); ++sym1__) {
         current_statement__ = 327;
-        v = rvalue(vs, cons_list(index_uni(sym6__), nil_index_list()), "vs");
-        current_statement__ = 328;
-        z = 0;
-        break;}
+        for (size_t sym2__ = 1;
+             sym2__ <= stan::length(rvalue(vs, cons_list(index_uni(sym1__), nil_index_list()), "vs"));
+             ++sym2__) {
+          {
+            double v;
+            current_statement__ = 327;
+            v = rvalue(vs, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), "vs");
+            current_statement__ = 328;
+            z = 0;
+            break;
+          }}}
       current_statement__ = 330;
-      for (size_t sym7__ = 1; sym7__ <= stan::length(vs); ++sym7__) {
-        double v;
+      for (size_t sym1__ = 1; sym1__ <= rows(vs); ++sym1__) {
         current_statement__ = 330;
-        v = rvalue(vs, cons_list(index_uni(sym7__), nil_index_list()), "vs");
-        current_statement__ = 331;
-        z = 3.1;
-        continue;}
+        for (size_t sym2__ = 1;
+             sym2__ <= stan::length(rvalue(vs, cons_list(index_uni(sym1__), nil_index_list()), "vs"));
+             ++sym2__) {
+          {
+            double v;
+            current_statement__ = 330;
+            v = rvalue(vs, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), "vs");
+            current_statement__ = 331;
+            z = 3.1;
+            continue;
+          }}}
     }
     current_statement__ = 344;
     while (1) {
@@ -1421,26 +1441,30 @@ foo_1(const int& a, std::ostream* pstream__) {
       vs = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
       
       current_statement__ = 336;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 336;
-        assign(vs, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(vs, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable vs");}
       current_statement__ = 337;
-      for (size_t sym8__ = 1; sym8__ <= stan::length(vs); ++sym8__) {
-        double v;
-        current_statement__ = 337;
-        v = vs[(sym8__ - 1)];
-        current_statement__ = 338;
-        z = 0;
-        break;}
+      for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+        {
+          double v;
+          current_statement__ = 337;
+          v = vs[(sym1__ - 1)];
+          current_statement__ = 338;
+          z = 0;
+          break;
+        }}
       current_statement__ = 340;
-      for (size_t sym9__ = 1; sym9__ <= stan::length(vs); ++sym9__) {
-        double v;
-        current_statement__ = 340;
-        v = vs[(sym9__ - 1)];
-        current_statement__ = 341;
-        z = 3.2;
-        continue;}
+      for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+        {
+          double v;
+          current_statement__ = 340;
+          v = vs[(sym1__ - 1)];
+          current_statement__ = 341;
+          z = 3.2;
+          continue;
+        }}
     }
     current_statement__ = 354;
     while (1) {
@@ -1452,26 +1476,30 @@ foo_1(const int& a, std::ostream* pstream__) {
       vs = Eigen::Matrix<local_scalar_t__, 1, -1>(2);
       
       current_statement__ = 346;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 346;
-        assign(vs, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(vs, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable vs");}
       current_statement__ = 347;
-      for (size_t sym10__ = 1; sym10__ <= stan::length(vs); ++sym10__) {
-        double v;
-        current_statement__ = 347;
-        v = vs[(sym10__ - 1)];
-        current_statement__ = 348;
-        z = 0;
-        break;}
+      for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+        {
+          double v;
+          current_statement__ = 347;
+          v = vs[(sym1__ - 1)];
+          current_statement__ = 348;
+          z = 0;
+          break;
+        }}
       current_statement__ = 350;
-      for (size_t sym11__ = 1; sym11__ <= stan::length(vs); ++sym11__) {
-        double v;
-        current_statement__ = 350;
-        v = vs[(sym11__ - 1)];
-        current_statement__ = 351;
-        z = 3.3;
-        continue;}
+      for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+        {
+          double v;
+          current_statement__ = 350;
+          v = vs[(sym1__ - 1)];
+          current_statement__ = 351;
+          z = 3.3;
+          continue;
+        }}
     }
     current_statement__ = 362;
     while (1) {
@@ -1518,12 +1546,14 @@ foo_2(const int& a, std::ostream* pstream__) {
     int y;
     
     current_statement__ = 367;
-    for (size_t sym12__ = 1; sym12__ <= stan::length(vs); ++sym12__) {
-      int v;
-      current_statement__ = 367;
-      v = vs[(sym12__ - 1)];
-      current_statement__ = 368;
-      y = v;}
+    for (size_t sym1__ = 1; sym1__ <= stan::length(vs); ++sym1__) {
+      {
+        int v;
+        current_statement__ = 367;
+        v = vs[(sym1__ - 1)];
+        current_statement__ = 368;
+        y = v;
+      }}
     current_statement__ = 369;
     return 0;
   } catch (const std::exception& e) {
@@ -1824,11 +1854,11 @@ covsqrt2corsqrt(const Eigen::Matrix<T0__, -1, -1>& mat, const int& invert,
     o = Eigen::Matrix<local_scalar_t__, -1, -1>(rows(mat), cols(mat));
     
     current_statement__ = 393;
-    for (size_t sym13__ = 1; sym13__ <= rows(mat); ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= rows(mat); ++sym1__) {
       current_statement__ = 393;
-      for (size_t sym14__ = 1; sym14__ <= cols(mat); ++sym14__) {
+      for (size_t sym2__ = 1; sym2__ <= cols(mat); ++sym2__) {
         current_statement__ = 393;
-        assign(o, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+        assign(o, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable o");}}
     current_statement__ = 394;
     assign(o, nil_index_list(), mat, "assigning variable o");
@@ -2632,15 +2662,15 @@ foo_6(std::ostream* pstream__) {
     ar_mat = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>>(60, std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>(70, Eigen::Matrix<local_scalar_t__, -1, -1>(40, 50)));
     
     current_statement__ = 428;
-    for (size_t sym13__ = 1; sym13__ <= 60; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 60; ++sym1__) {
       current_statement__ = 428;
-      for (size_t sym14__ = 1; sym14__ <= 70; ++sym14__) {
+      for (size_t sym2__ = 1; sym2__ <= 70; ++sym2__) {
         current_statement__ = 428;
-        for (size_t sym15__ = 1; sym15__ <= 40; ++sym15__) {
+        for (size_t sym3__ = 1; sym3__ <= 40; ++sym3__) {
           current_statement__ = 428;
-          for (size_t sym16__ = 1; sym16__ <= 50; ++sym16__) {
+          for (size_t sym4__ = 1; sym4__ <= 50; ++sym4__) {
             current_statement__ = 428;
-            assign(ar_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+            assign(ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable ar_mat");}}}}
     current_statement__ = 429;
     assign(ar_mat, cons_list(index_uni(1), cons_list(index_uni(1), cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())))), b, "assigning variable ar_mat");
@@ -2727,9 +2757,9 @@ vecmufoo(const T0__& mu, std::ostream* pstream__) {
     l = Eigen::Matrix<local_scalar_t__, -1, 1>(10);
     
     current_statement__ = 435;
-    for (size_t sym13__ = 1; sym13__ <= 10; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 10; ++sym1__) {
       current_statement__ = 435;
-      assign(l, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+      assign(l, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
              ), "assigning variable l");}
     current_statement__ = 435;
     assign(l, nil_index_list(), multiply(mu, vecfoo(pstream__)), "assigning variable l");
@@ -2764,9 +2794,9 @@ vecmubar(const T0__& mu, std::ostream* pstream__) {
     l = Eigen::Matrix<local_scalar_t__, -1, 1>(10);
     
     current_statement__ = 438;
-    for (size_t sym13__ = 1; sym13__ <= 10; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 10; ++sym1__) {
       current_statement__ = 438;
-      assign(l, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+      assign(l, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
              ), "assigning variable l");}
     current_statement__ = 438;
     assign(l, nil_index_list(), multiply(mu, transpose(stan::math::to_row_vector({
@@ -2808,9 +2838,9 @@ algebra_system(const Eigen::Matrix<T0__, -1, 1>& x,
     f_x = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
     
     current_statement__ = 441;
-    for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
       current_statement__ = 441;
-      assign(f_x, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+      assign(f_x, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
              ), "assigning variable f_x");}
     current_statement__ = 442;
     assign(f_x, cons_list(index_uni(1), nil_index_list()), (x[(1 - 1)] - y[(1 - 1)]), "assigning variable f_x");
@@ -2855,9 +2885,9 @@ binomialf(const Eigen::Matrix<T0__, -1, 1>& phi,
     lpmf = Eigen::Matrix<local_scalar_t__, -1, 1>(1);
     
     current_statement__ = 446;
-    for (size_t sym13__ = 1; sym13__ <= 1; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 1; ++sym1__) {
       current_statement__ = 446;
-      assign(lpmf, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+      assign(lpmf, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
              ), "assigning variable lpmf");}
     current_statement__ = 447;
     assign(lpmf, cons_list(index_uni(1), nil_index_list()), 0.0, "assigning variable lpmf");
@@ -2966,9 +2996,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 180;
       pos__ = 1;
       current_statement__ = 180;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 180;
-        assign(d_int_1d_ar, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_i("d_int_1d_ar")[(pos__ - 1)], "assigning variable d_int_1d_ar");
+        assign(d_int_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_i("d_int_1d_ar")[(pos__ - 1)], "assigning variable d_int_1d_ar");
         current_statement__ = 180;
         pos__ = (pos__ + 1);}
       d_int_3d_ar = std::vector<std::vector<std::vector<int>>>(N, std::vector<std::vector<int>>(M, std::vector<int>(K, 0)));
@@ -2976,13 +3006,13 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 181;
       pos__ = 1;
       current_statement__ = 181;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 181;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 181;
-          for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
             current_statement__ = 181;
-            assign(d_int_3d_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), context__.vals_i("d_int_3d_ar")[(pos__ - 1)], "assigning variable d_int_3d_ar");
+            assign(d_int_3d_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), context__.vals_i("d_int_3d_ar")[(pos__ - 1)], "assigning variable d_int_3d_ar");
             current_statement__ = 181;
             pos__ = (pos__ + 1);}}}
       
@@ -2995,9 +3025,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 183;
       pos__ = 1;
       current_statement__ = 183;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 183;
-        assign(d_real_1d_ar, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("d_real_1d_ar")[(pos__ - 1)], "assigning variable d_real_1d_ar");
+        assign(d_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("d_real_1d_ar")[(pos__ - 1)], "assigning variable d_real_1d_ar");
         current_statement__ = 183;
         pos__ = (pos__ + 1);}
       d_real_3d_ar = std::vector<std::vector<std::vector<double>>>(N, std::vector<std::vector<double>>(M, std::vector<double>(K, 0)));
@@ -3005,13 +3035,13 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 184;
       pos__ = 1;
       current_statement__ = 184;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 184;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 184;
-          for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
             current_statement__ = 184;
-            assign(d_real_3d_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), context__.vals_r("d_real_3d_ar")[(pos__ - 1)], "assigning variable d_real_3d_ar");
+            assign(d_real_3d_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), context__.vals_r("d_real_3d_ar")[(pos__ - 1)], "assigning variable d_real_3d_ar");
             current_statement__ = 184;
             pos__ = (pos__ + 1);}}}
       d_vec = Eigen::Matrix<double, -1, 1>(N);
@@ -3019,9 +3049,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 185;
       pos__ = 1;
       current_statement__ = 185;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 185;
-        assign(d_vec, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("d_vec")[(pos__ - 1)], "assigning variable d_vec");
+        assign(d_vec, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("d_vec")[(pos__ - 1)], "assigning variable d_vec");
         current_statement__ = 185;
         pos__ = (pos__ + 1);}
       d_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
@@ -3029,11 +3059,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 186;
       pos__ = 1;
       current_statement__ = 186;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 186;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 186;
-          assign(d_1d_vec, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("d_1d_vec")[(pos__ - 1)], "assigning variable d_1d_vec");
+          assign(d_1d_vec, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("d_1d_vec")[(pos__ - 1)], "assigning variable d_1d_vec");
           current_statement__ = 186;
           pos__ = (pos__ + 1);}}
       d_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
@@ -3041,15 +3071,15 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 187;
       pos__ = 1;
       current_statement__ = 187;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 187;
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           current_statement__ = 187;
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
             current_statement__ = 187;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 187;
-              assign(d_3d_vec, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("d_3d_vec")[(pos__ - 1)], "assigning variable d_3d_vec");
+              assign(d_3d_vec, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("d_3d_vec")[(pos__ - 1)], "assigning variable d_3d_vec");
               current_statement__ = 187;
               pos__ = (pos__ + 1);}}}}
       d_row_vec = Eigen::Matrix<double, 1, -1>(N);
@@ -3057,9 +3087,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 188;
       pos__ = 1;
       current_statement__ = 188;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 188;
-        assign(d_row_vec, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("d_row_vec")[(pos__ - 1)], "assigning variable d_row_vec");
+        assign(d_row_vec, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("d_row_vec")[(pos__ - 1)], "assigning variable d_row_vec");
         current_statement__ = 188;
         pos__ = (pos__ + 1);}
       d_1d_row_vec = std::vector<Eigen::Matrix<double, 1, -1>>(N, Eigen::Matrix<double, 1, -1>(N));
@@ -3067,11 +3097,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 189;
       pos__ = 1;
       current_statement__ = 189;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 189;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 189;
-          assign(d_1d_row_vec, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("d_1d_row_vec")[(pos__ - 1)], "assigning variable d_1d_row_vec");
+          assign(d_1d_row_vec, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("d_1d_row_vec")[(pos__ - 1)], "assigning variable d_1d_row_vec");
           current_statement__ = 189;
           pos__ = (pos__ + 1);}}
       d_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(M, std::vector<Eigen::Matrix<double, 1, -1>>(K, Eigen::Matrix<double, 1, -1>(N))));
@@ -3079,15 +3109,15 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 190;
       pos__ = 1;
       current_statement__ = 190;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 190;
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           current_statement__ = 190;
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
             current_statement__ = 190;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 190;
-              assign(d_3d_row_vec, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("d_3d_row_vec")[(pos__ - 1)], "assigning variable d_3d_row_vec");
+              assign(d_3d_row_vec, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("d_3d_row_vec")[(pos__ - 1)], "assigning variable d_3d_row_vec");
               current_statement__ = 190;
               pos__ = (pos__ + 1);}}}}
       d_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
@@ -3095,15 +3125,15 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 191;
       pos__ = 1;
       current_statement__ = 191;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 191;
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
           current_statement__ = 191;
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
             current_statement__ = 191;
-            for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
               current_statement__ = 191;
-              assign(d_ar_mat, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("d_ar_mat")[(pos__ - 1)], "assigning variable d_ar_mat");
+              assign(d_ar_mat, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("d_ar_mat")[(pos__ - 1)], "assigning variable d_ar_mat");
               current_statement__ = 191;
               pos__ = (pos__ + 1);}}}}
       d_simplex = Eigen::Matrix<double, -1, 1>(N);
@@ -3111,9 +3141,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 192;
       pos__ = 1;
       current_statement__ = 192;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 192;
-        assign(d_simplex, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("d_simplex")[(pos__ - 1)], "assigning variable d_simplex");
+        assign(d_simplex, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("d_simplex")[(pos__ - 1)], "assigning variable d_simplex");
         current_statement__ = 192;
         pos__ = (pos__ + 1);}
       d_1d_simplex = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
@@ -3121,11 +3151,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 193;
       pos__ = 1;
       current_statement__ = 193;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 193;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 193;
-          assign(d_1d_simplex, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("d_1d_simplex")[(pos__ - 1)], "assigning variable d_1d_simplex");
+          assign(d_1d_simplex, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("d_1d_simplex")[(pos__ - 1)], "assigning variable d_1d_simplex");
           current_statement__ = 193;
           pos__ = (pos__ + 1);}}
       d_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
@@ -3133,15 +3163,15 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 194;
       pos__ = 1;
       current_statement__ = 194;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 194;
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           current_statement__ = 194;
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
             current_statement__ = 194;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 194;
-              assign(d_3d_simplex, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("d_3d_simplex")[(pos__ - 1)], "assigning variable d_3d_simplex");
+              assign(d_3d_simplex, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("d_3d_simplex")[(pos__ - 1)], "assigning variable d_3d_simplex");
               current_statement__ = 194;
               pos__ = (pos__ + 1);}}}}
       d_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 4);
@@ -3149,11 +3179,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 195;
       pos__ = 1;
       current_statement__ = 195;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 195;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 195;
-          assign(d_cfcov_54, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("d_cfcov_54")[(pos__ - 1)], "assigning variable d_cfcov_54");
+          assign(d_cfcov_54, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("d_cfcov_54")[(pos__ - 1)], "assigning variable d_cfcov_54");
           current_statement__ = 195;
           pos__ = (pos__ + 1);}}
       d_cfcov_33 = Eigen::Matrix<double, -1, -1>(3, 3);
@@ -3161,11 +3191,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 196;
       pos__ = 1;
       current_statement__ = 196;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 196;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 196;
-          assign(d_cfcov_33, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("d_cfcov_33")[(pos__ - 1)], "assigning variable d_cfcov_33");
+          assign(d_cfcov_33, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("d_cfcov_33")[(pos__ - 1)], "assigning variable d_cfcov_33");
           current_statement__ = 196;
           pos__ = (pos__ + 1);}}
       d_cfcov_33_ar = std::vector<Eigen::Matrix<double, -1, -1>>(K, Eigen::Matrix<double, -1, -1>(3, 3));
@@ -3173,13 +3203,13 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 197;
       pos__ = 1;
       current_statement__ = 197;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 197;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 197;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 197;
-            assign(d_cfcov_33_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), context__.vals_r("d_cfcov_33_ar")[(pos__ - 1)], "assigning variable d_cfcov_33_ar");
+            assign(d_cfcov_33_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), context__.vals_r("d_cfcov_33_ar")[(pos__ - 1)], "assigning variable d_cfcov_33_ar");
             current_statement__ = 197;
             pos__ = (pos__ + 1);}}}
       
@@ -3205,76 +3235,76 @@ class mother_model : public model_base_crtp<mother_model> {
       td_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
       
       current_statement__ = 204;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 204;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 204;
-          for (size_t sym15__ = 1; sym15__ <= 2; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 2; ++sym3__) {
             current_statement__ = 204;
-            for (size_t sym16__ = 1; sym16__ <= 3; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= 3; ++sym4__) {
               current_statement__ = 204;
-              assign(td_ar_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(td_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable td_ar_mat");}}}}
       td_simplex = Eigen::Matrix<double, -1, 1>(N);
       
       current_statement__ = 205;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 205;
-        assign(td_simplex, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(td_simplex, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable td_simplex");}
       td_1d_simplex = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       
       current_statement__ = 206;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 206;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 206;
-          assign(td_1d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(td_1d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable td_1d_simplex");}}
       td_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       
       current_statement__ = 207;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 207;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 207;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 207;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 207;
-              assign(td_3d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(td_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable td_3d_simplex");}}}}
       td_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 5);
       
       current_statement__ = 208;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 208;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 208;
-          assign(td_cfcov_54, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(td_cfcov_54, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable td_cfcov_54");}}
       td_cfcov_33 = Eigen::Matrix<double, -1, -1>(3, 3);
       
       current_statement__ = 209;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 209;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 209;
-          assign(td_cfcov_33, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(td_cfcov_33, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable td_cfcov_33");}}
       x = Eigen::Matrix<double, -1, 1>(2);
       
       current_statement__ = 210;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 210;
-        assign(x, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(x, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable x");}
       y = Eigen::Matrix<double, -1, 1>(2);
       
       current_statement__ = 211;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 211;
-        assign(y, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(y, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable y");}
       dat = std::vector<double>(0, 0);
       
@@ -3322,11 +3352,11 @@ class mother_model : public model_base_crtp<mother_model> {
           l_mat = Eigen::Matrix<double, -1, -1>(2, 3);
           
           current_statement__ = 238;
-          for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+          for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
             current_statement__ = 238;
-            for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+            for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
               current_statement__ = 238;
-              assign(l_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+              assign(l_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable l_mat");}}
           current_statement__ = 238;
           assign(l_mat, nil_index_list(), d_ar_mat[(i - 1)][(j - 1)], "assigning variable l_mat");
@@ -3357,18 +3387,20 @@ class mother_model : public model_base_crtp<mother_model> {
         blocked_tdata_vs = Eigen::Matrix<double, 1, -1>(2);
         
         current_statement__ = 247;
-        for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+        for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
           current_statement__ = 247;
-          assign(blocked_tdata_vs, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+          assign(blocked_tdata_vs, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable blocked_tdata_vs");}
         current_statement__ = 248;
         for (size_t sym1__ = 1; sym1__ <= stan::length(blocked_tdata_vs);
              ++sym1__) {
-          double v;
-          current_statement__ = 248;
-          v = blocked_tdata_vs[(sym1__ - 1)];
-          current_statement__ = 249;
-          z = 0;}
+          {
+            double v;
+            current_statement__ = 248;
+            v = blocked_tdata_vs[(sym1__ - 1)];
+            current_statement__ = 249;
+            z = 0;
+          }}
       }
       current_statement__ = 251;
       assign(td_1dk, nil_index_list(), rvalue(td_1d, cons_list(index_multi(stan::model::deep_copy(
@@ -3553,70 +3585,70 @@ class mother_model : public model_base_crtp<mother_model> {
       offset_multiplier = std::vector<local_scalar_t__>(5, 0);
       
       current_statement__ = 2;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 2;
-        assign(offset_multiplier, cons_list(index_uni(sym13__), nil_index_list()), in__.scalar(
+        assign(offset_multiplier, cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(
                ), "assigning variable offset_multiplier");}
       current_statement__ = 2;
-      for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 2;
         if (jacobian__) {
           current_statement__ = 2;
-          assign(offset_multiplier, cons_list(index_uni(sym2__), nil_index_list()), offset_multiplier_constrain(
-                 offset_multiplier[(sym2__ - 1)], 1, 2, lp__), "assigning variable offset_multiplier");
+          assign(offset_multiplier, cons_list(index_uni(sym1__), nil_index_list()), offset_multiplier_constrain(
+                 offset_multiplier[(sym1__ - 1)], 1, 2, lp__), "assigning variable offset_multiplier");
         } else {
           current_statement__ = 2;
-          assign(offset_multiplier, cons_list(index_uni(sym2__), nil_index_list()), offset_multiplier_constrain(
-                 offset_multiplier[(sym2__ - 1)], 1, 2), "assigning variable offset_multiplier");
+          assign(offset_multiplier, cons_list(index_uni(sym1__), nil_index_list()), offset_multiplier_constrain(
+                 offset_multiplier[(sym1__ - 1)], 1, 2), "assigning variable offset_multiplier");
         }}
       std::vector<local_scalar_t__> p_real_1d_ar;
       p_real_1d_ar = std::vector<local_scalar_t__>(N, 0);
       
       current_statement__ = 3;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 3;
-        assign(p_real_1d_ar, cons_list(index_uni(sym13__), nil_index_list()), in__.scalar(
+        assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(
                ), "assigning variable p_real_1d_ar");}
       current_statement__ = 3;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 3;
         if (jacobian__) {
           current_statement__ = 3;
-          assign(p_real_1d_ar, cons_list(index_uni(sym2__), nil_index_list()), lb_constrain(
-                 p_real_1d_ar[(sym2__ - 1)], 0, lp__), "assigning variable p_real_1d_ar");
+          assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), lb_constrain(
+                 p_real_1d_ar[(sym1__ - 1)], 0, lp__), "assigning variable p_real_1d_ar");
         } else {
           current_statement__ = 3;
-          assign(p_real_1d_ar, cons_list(index_uni(sym2__), nil_index_list()), lb_constrain(
-                 p_real_1d_ar[(sym2__ - 1)], 0), "assigning variable p_real_1d_ar");
+          assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), lb_constrain(
+                 p_real_1d_ar[(sym1__ - 1)], 0), "assigning variable p_real_1d_ar");
         }}
       std::vector<std::vector<std::vector<local_scalar_t__>>> p_real_3d_ar;
       p_real_3d_ar = std::vector<std::vector<std::vector<local_scalar_t__>>>(N, std::vector<std::vector<local_scalar_t__>>(M, std::vector<local_scalar_t__>(K, 0)));
       
       current_statement__ = 4;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 4;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 4;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 4;
-            assign(p_real_3d_ar, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.scalar(
+            assign(p_real_3d_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.scalar(
                    ), "assigning variable p_real_3d_ar");}}}
       current_statement__ = 4;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 4;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 4;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 4;
             if (jacobian__) {
               current_statement__ = 4;
-              assign(p_real_3d_ar, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), lb_constrain(
-                     p_real_3d_ar[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)],
+              assign(p_real_3d_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), lb_constrain(
+                     p_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                      0, lp__), "assigning variable p_real_3d_ar");
             } else {
               current_statement__ = 4;
-              assign(p_real_3d_ar, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), lb_constrain(
-                     p_real_3d_ar[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)],
+              assign(p_real_3d_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), lb_constrain(
+                     p_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                      0), "assigning variable p_real_3d_ar");
             }}}}
       Eigen::Matrix<local_scalar_t__, -1, 1> p_vec;
@@ -3625,36 +3657,36 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 5;
       p_vec = in__.vector(N);
       current_statement__ = 5;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 5;
         if (jacobian__) {
           current_statement__ = 5;
-          assign(p_vec, cons_list(index_uni(sym2__), nil_index_list()), lb_constrain(
-                 p_vec[(sym2__ - 1)], 0, lp__), "assigning variable p_vec");
+          assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()), lb_constrain(
+                 p_vec[(sym1__ - 1)], 0, lp__), "assigning variable p_vec");
         } else {
           current_statement__ = 5;
-          assign(p_vec, cons_list(index_uni(sym2__), nil_index_list()), lb_constrain(
-                 p_vec[(sym2__ - 1)], 0), "assigning variable p_vec");
+          assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()), lb_constrain(
+                 p_vec[(sym1__ - 1)], 0), "assigning variable p_vec");
         }}
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> p_1d_vec;
       p_1d_vec = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(N, Eigen::Matrix<local_scalar_t__, -1, 1>(N));
       
       current_statement__ = 6;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 6;
-        assign(p_1d_vec, cons_list(index_uni(sym13__), nil_index_list()), in__.vector(
+        assign(p_1d_vec, cons_list(index_uni(sym1__), nil_index_list()), in__.vector(
                N), "assigning variable p_1d_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>> p_3d_vec;
       p_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(N))));
       
       current_statement__ = 7;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 7;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 7;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 7;
-            assign(p_3d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.vector(
+            assign(p_3d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.vector(
                    N), "assigning variable p_3d_vec");}}}
       Eigen::Matrix<local_scalar_t__, 1, -1> p_row_vec;
       p_row_vec = Eigen::Matrix<local_scalar_t__, 1, -1>(N);
@@ -3665,50 +3697,50 @@ class mother_model : public model_base_crtp<mother_model> {
       p_1d_row_vec = std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(N, Eigen::Matrix<local_scalar_t__, 1, -1>(N));
       
       current_statement__ = 9;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 9;
-        assign(p_1d_row_vec, cons_list(index_uni(sym13__), nil_index_list()), in__.row_vector(
+        assign(p_1d_row_vec, cons_list(index_uni(sym1__), nil_index_list()), in__.row_vector(
                N), "assigning variable p_1d_row_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>> p_3d_row_vec;
       p_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(K, Eigen::Matrix<local_scalar_t__, 1, -1>(N))));
       
       current_statement__ = 10;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 10;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 10;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 10;
-            assign(p_3d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.row_vector(
+            assign(p_3d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.row_vector(
                    N), "assigning variable p_3d_row_vec");}}}
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>> p_ar_mat;
       p_ar_mat = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>>(4, std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>(5, Eigen::Matrix<local_scalar_t__, -1, -1>(2, 3)));
       
       current_statement__ = 11;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 11;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 11;
-          assign(p_ar_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), in__.matrix(
+          assign(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), in__.matrix(
                  2, 3), "assigning variable p_ar_mat");}}
       current_statement__ = 11;
-      for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 11;
-        for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 11;
-          for (size_t sym4__ = 1; sym4__ <= 2; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= 2; ++sym3__) {
             current_statement__ = 11;
-            for (size_t sym5__ = 1; sym5__ <= 3; ++sym5__) {
+            for (size_t sym4__ = 1; sym4__ <= 3; ++sym4__) {
               current_statement__ = 11;
               if (jacobian__) {
                 current_statement__ = 11;
-                assign(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), lub_constrain(
-                       rvalue(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), "p_ar_mat"),
+                assign(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), lub_constrain(
+                       rvalue(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), "p_ar_mat"),
                        0, 1, lp__), "assigning variable p_ar_mat");
               } else {
                 current_statement__ = 11;
-                assign(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), lub_constrain(
-                       rvalue(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), "p_ar_mat"),
+                assign(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), lub_constrain(
+                       rvalue(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), "p_ar_mat"),
                        0, 1), "assigning variable p_ar_mat");
               }}}}}
       Eigen::Matrix<local_scalar_t__, -1, 1> p_simplex;
@@ -3735,21 +3767,21 @@ class mother_model : public model_base_crtp<mother_model> {
       p_1d_simplex_in__ = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(N, Eigen::Matrix<local_scalar_t__, -1, 1>((N - 1)));
       
       current_statement__ = 13;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 13;
-        assign(p_1d_simplex_in__, cons_list(index_uni(sym13__), nil_index_list()), in__.vector(
+        assign(p_1d_simplex_in__, cons_list(index_uni(sym1__), nil_index_list()), in__.vector(
                (N - 1)), "assigning variable p_1d_simplex_in__");}
       current_statement__ = 13;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 13;
         if (jacobian__) {
           current_statement__ = 13;
-          assign(p_1d_simplex, cons_list(index_uni(sym2__), nil_index_list()), simplex_constrain(
-                 p_1d_simplex_in__[(sym2__ - 1)], lp__), "assigning variable p_1d_simplex");
+          assign(p_1d_simplex, cons_list(index_uni(sym1__), nil_index_list()), simplex_constrain(
+                 p_1d_simplex_in__[(sym1__ - 1)], lp__), "assigning variable p_1d_simplex");
         } else {
           current_statement__ = 13;
-          assign(p_1d_simplex, cons_list(index_uni(sym2__), nil_index_list()), simplex_constrain(
-                 p_1d_simplex_in__[(sym2__ - 1)]), "assigning variable p_1d_simplex");
+          assign(p_1d_simplex, cons_list(index_uni(sym1__), nil_index_list()), simplex_constrain(
+                 p_1d_simplex_in__[(sym1__ - 1)]), "assigning variable p_1d_simplex");
         }}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>> p_3d_simplex;
       p_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(N))));
@@ -3758,30 +3790,30 @@ class mother_model : public model_base_crtp<mother_model> {
       p_3d_simplex_in__ = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>((N - 1)))));
       
       current_statement__ = 14;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 14;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 14;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 14;
-            assign(p_3d_simplex_in__, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.vector(
+            assign(p_3d_simplex_in__, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.vector(
                    (N - 1)), "assigning variable p_3d_simplex_in__");}}}
       current_statement__ = 14;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 14;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 14;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 14;
             if (jacobian__) {
               current_statement__ = 14;
-              assign(p_3d_simplex, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), simplex_constrain(
-                     p_3d_simplex_in__[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)],
+              assign(p_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), simplex_constrain(
+                     p_3d_simplex_in__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                      lp__), "assigning variable p_3d_simplex");
             } else {
               current_statement__ = 14;
-              assign(p_3d_simplex, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), simplex_constrain(
-                     p_3d_simplex_in__[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)]), "assigning variable p_3d_simplex");
+              assign(p_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), simplex_constrain(
+                     p_3d_simplex_in__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]), "assigning variable p_3d_simplex");
             }}}}
       Eigen::Matrix<local_scalar_t__, -1, -1> p_cfcov_54;
       p_cfcov_54 = Eigen::Matrix<local_scalar_t__, -1, -1>(5, 4);
@@ -3826,22 +3858,22 @@ class mother_model : public model_base_crtp<mother_model> {
       p_cfcov_33_ar_in__ = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))));
       
       current_statement__ = 17;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 17;
-        assign(p_cfcov_33_ar_in__, cons_list(index_uni(sym13__), nil_index_list()), in__.vector(
+        assign(p_cfcov_33_ar_in__, cons_list(index_uni(sym1__), nil_index_list()), in__.vector(
                ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))), "assigning variable p_cfcov_33_ar_in__");
       }
       current_statement__ = 17;
-      for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 17;
         if (jacobian__) {
           current_statement__ = 17;
-          assign(p_cfcov_33_ar, cons_list(index_uni(sym2__), nil_index_list()), cholesky_factor_constrain(
-                 p_cfcov_33_ar_in__[(sym2__ - 1)], 3, 3, lp__), "assigning variable p_cfcov_33_ar");
+          assign(p_cfcov_33_ar, cons_list(index_uni(sym1__), nil_index_list()), cholesky_factor_constrain(
+                 p_cfcov_33_ar_in__[(sym1__ - 1)], 3, 3, lp__), "assigning variable p_cfcov_33_ar");
         } else {
           current_statement__ = 17;
-          assign(p_cfcov_33_ar, cons_list(index_uni(sym2__), nil_index_list()), cholesky_factor_constrain(
-                 p_cfcov_33_ar_in__[(sym2__ - 1)], 3, 3), "assigning variable p_cfcov_33_ar");
+          assign(p_cfcov_33_ar, cons_list(index_uni(sym1__), nil_index_list()), cholesky_factor_constrain(
+                 p_cfcov_33_ar_in__[(sym1__ - 1)], 3, 3), "assigning variable p_cfcov_33_ar");
         }}
       Eigen::Matrix<local_scalar_t__, -1, 1> x_p;
       x_p = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
@@ -3863,151 +3895,151 @@ class mother_model : public model_base_crtp<mother_model> {
       tp_vec = Eigen::Matrix<local_scalar_t__, -1, 1>(N);
       
       current_statement__ = 22;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 22;
-        assign(tp_vec, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(tp_vec, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable tp_vec");}
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> tp_1d_vec;
       tp_1d_vec = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(N, Eigen::Matrix<local_scalar_t__, -1, 1>(N));
       
       current_statement__ = 23;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 23;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 23;
-          assign(tp_1d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_1d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_1d_vec");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>> tp_3d_vec;
       tp_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(N))));
       
       current_statement__ = 24;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 24;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 24;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 24;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 24;
-              assign(tp_3d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_3d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_3d_vec");}}}}
       Eigen::Matrix<local_scalar_t__, 1, -1> tp_row_vec;
       tp_row_vec = Eigen::Matrix<local_scalar_t__, 1, -1>(N);
       
       current_statement__ = 25;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 25;
-        assign(tp_row_vec, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(tp_row_vec, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable tp_row_vec");}
       std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>> tp_1d_row_vec;
       tp_1d_row_vec = std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(N, Eigen::Matrix<local_scalar_t__, 1, -1>(N));
       
       current_statement__ = 26;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 26;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 26;
-          assign(tp_1d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_1d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_1d_row_vec");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>> tp_3d_row_vec;
       tp_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(K, Eigen::Matrix<local_scalar_t__, 1, -1>(N))));
       
       current_statement__ = 27;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 27;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 27;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 27;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 27;
-              assign(tp_3d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_3d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_3d_row_vec");}}}}
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>> tp_ar_mat;
       tp_ar_mat = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>>(4, std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>(5, Eigen::Matrix<local_scalar_t__, -1, -1>(2, 3)));
       
       current_statement__ = 28;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 28;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 28;
-          for (size_t sym15__ = 1; sym15__ <= 2; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 2; ++sym3__) {
             current_statement__ = 28;
-            for (size_t sym16__ = 1; sym16__ <= 3; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= 3; ++sym4__) {
               current_statement__ = 28;
-              assign(tp_ar_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_ar_mat");}}}}
       Eigen::Matrix<local_scalar_t__, -1, 1> tp_simplex;
       tp_simplex = Eigen::Matrix<local_scalar_t__, -1, 1>(N);
       
       current_statement__ = 29;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 29;
-        assign(tp_simplex, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(tp_simplex, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable tp_simplex");}
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> tp_1d_simplex;
       tp_1d_simplex = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(N, Eigen::Matrix<local_scalar_t__, -1, 1>(N));
       
       current_statement__ = 30;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 30;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 30;
-          assign(tp_1d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_1d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_1d_simplex");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>> tp_3d_simplex;
       tp_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(N))));
       
       current_statement__ = 31;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 31;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 31;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 31;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 31;
-              assign(tp_3d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_3d_simplex");}}}}
       Eigen::Matrix<local_scalar_t__, -1, -1> tp_cfcov_54;
       tp_cfcov_54 = Eigen::Matrix<local_scalar_t__, -1, -1>(5, 4);
       
       current_statement__ = 32;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 32;
-        for (size_t sym14__ = 1; sym14__ <= 4; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
           current_statement__ = 32;
-          assign(tp_cfcov_54, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_cfcov_54, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_cfcov_54");}}
       Eigen::Matrix<local_scalar_t__, -1, -1> tp_cfcov_33;
       tp_cfcov_33 = Eigen::Matrix<local_scalar_t__, -1, -1>(3, 3);
       
       current_statement__ = 33;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 33;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 33;
-          assign(tp_cfcov_33, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_cfcov_33, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_cfcov_33");}}
       std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>> tp_cfcov_33_ar;
       tp_cfcov_33_ar = std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>(K, Eigen::Matrix<local_scalar_t__, -1, -1>(3, 3));
       
       current_statement__ = 34;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 34;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 34;
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
             current_statement__ = 34;
-            assign(tp_cfcov_33_ar, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(tp_cfcov_33_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable tp_cfcov_33_ar");}}}
       Eigen::Matrix<local_scalar_t__, -1, 1> theta_p;
       theta_p = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
       
       current_statement__ = 35;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 35;
-        assign(theta_p, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(theta_p, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable theta_p");}
       current_statement__ = 36;
       assign(tp_real_1d_ar, nil_index_list(), p_real_1d_ar, "assigning variable tp_real_1d_ar");
@@ -4084,62 +4116,62 @@ class mother_model : public model_base_crtp<mother_model> {
                                                        dat_int, pstream__,
                                                        0.01, 0.01, 10), "assigning variable theta_p");
       current_statement__ = 20;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 20;
         current_statement__ = 20;
-        check_greater_or_equal(function__, "tp_real_1d_ar[sym2__]",
-                               tp_real_1d_ar[(sym2__ - 1)], 0);}
+        check_greater_or_equal(function__, "tp_real_1d_ar[sym1__]",
+                               tp_real_1d_ar[(sym1__ - 1)], 0);}
       current_statement__ = 21;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 21;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 21;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 21;
             current_statement__ = 21;
             check_greater_or_equal(function__,
-                                   "tp_real_3d_ar[sym2__, sym3__, sym4__]",
-                                   tp_real_3d_ar[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)],
+                                   "tp_real_3d_ar[sym1__, sym2__, sym3__]",
+                                   tp_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                                    0);}}}
       current_statement__ = 22;
       current_statement__ = 22;
       check_less_or_equal(function__, "tp_vec", tp_vec, 0);
       current_statement__ = 28;
-      for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 28;
-        for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 28;
           current_statement__ = 28;
-          check_greater_or_equal(function__, "tp_ar_mat[sym2__, sym3__]",
-                                 tp_ar_mat[(sym2__ - 1)][(sym3__ - 1)], 0);}}
+          check_greater_or_equal(function__, "tp_ar_mat[sym1__, sym2__]",
+                                 tp_ar_mat[(sym1__ - 1)][(sym2__ - 1)], 0);}}
       current_statement__ = 28;
-      for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 28;
-        for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 28;
           current_statement__ = 28;
-          check_less_or_equal(function__, "tp_ar_mat[sym2__, sym3__]",
-                              tp_ar_mat[(sym2__ - 1)][(sym3__ - 1)], 1);}}
+          check_less_or_equal(function__, "tp_ar_mat[sym1__, sym2__]",
+                              tp_ar_mat[(sym1__ - 1)][(sym2__ - 1)], 1);}}
       current_statement__ = 29;
       current_statement__ = 29;
       check_simplex(function__, "tp_simplex", tp_simplex);
       current_statement__ = 30;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 30;
         current_statement__ = 30;
-        check_simplex(function__, "tp_1d_simplex[sym2__]",
-                      tp_1d_simplex[(sym2__ - 1)]);}
+        check_simplex(function__, "tp_1d_simplex[sym1__]",
+                      tp_1d_simplex[(sym1__ - 1)]);}
       current_statement__ = 31;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 31;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 31;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 31;
             current_statement__ = 31;
             check_simplex(function__,
-                          "tp_3d_simplex[sym2__, sym3__, sym4__]",
-                          tp_3d_simplex[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)]);
+                          "tp_3d_simplex[sym1__, sym2__, sym3__]",
+                          tp_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);
           }}}
       current_statement__ = 32;
       current_statement__ = 32;
@@ -4148,29 +4180,29 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 33;
       check_cholesky_factor(function__, "tp_cfcov_33", tp_cfcov_33);
       current_statement__ = 34;
-      for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 34;
         current_statement__ = 34;
-        check_cholesky_factor(function__, "tp_cfcov_33_ar[sym2__]",
-                              tp_cfcov_33_ar[(sym2__ - 1)]);}
+        check_cholesky_factor(function__, "tp_cfcov_33_ar[sym1__]",
+                              tp_cfcov_33_ar[(sym1__ - 1)]);}
       {
         Eigen::Matrix<local_scalar_t__, -1, 1> tmp;
         tmp = Eigen::Matrix<local_scalar_t__, -1, 1>(0);
         
         current_statement__ = 143;
-        for (size_t sym13__ = 1; sym13__ <= 0; ++sym13__) {
+        for (size_t sym1__ = 1; sym1__ <= 0; ++sym1__) {
           current_statement__ = 143;
-          assign(tmp, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+          assign(tmp, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tmp");}
         std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> tmp2;
         tmp2 = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(0, Eigen::Matrix<local_scalar_t__, -1, 1>(0));
         
         current_statement__ = 144;
-        for (size_t sym13__ = 1; sym13__ <= 0; ++sym13__) {
+        for (size_t sym1__ = 1; sym1__ <= 0; ++sym1__) {
           current_statement__ = 144;
-          for (size_t sym14__ = 1; sym14__ <= 0; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 0; ++sym2__) {
             current_statement__ = 144;
-            assign(tmp2, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+            assign(tmp2, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable tmp2");}}
         local_scalar_t__ r1;
         
@@ -4283,51 +4315,51 @@ class mother_model : public model_base_crtp<mother_model> {
       offset_multiplier = std::vector<double>(5, 0);
       
       current_statement__ = 2;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 2;
-        assign(offset_multiplier, cons_list(index_uni(sym13__), nil_index_list()), in__.scalar(
+        assign(offset_multiplier, cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(
                ), "assigning variable offset_multiplier");}
       current_statement__ = 2;
-      for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 2;
-        assign(offset_multiplier, cons_list(index_uni(sym2__), nil_index_list()), offset_multiplier_constrain(
-               offset_multiplier[(sym2__ - 1)], 1, 2), "assigning variable offset_multiplier");
+        assign(offset_multiplier, cons_list(index_uni(sym1__), nil_index_list()), offset_multiplier_constrain(
+               offset_multiplier[(sym1__ - 1)], 1, 2), "assigning variable offset_multiplier");
       }
       std::vector<double> p_real_1d_ar;
       p_real_1d_ar = std::vector<double>(N, 0);
       
       current_statement__ = 3;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 3;
-        assign(p_real_1d_ar, cons_list(index_uni(sym13__), nil_index_list()), in__.scalar(
+        assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(
                ), "assigning variable p_real_1d_ar");}
       current_statement__ = 3;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 3;
-        assign(p_real_1d_ar, cons_list(index_uni(sym2__), nil_index_list()), lb_constrain(
-               p_real_1d_ar[(sym2__ - 1)], 0), "assigning variable p_real_1d_ar");
+        assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), lb_constrain(
+               p_real_1d_ar[(sym1__ - 1)], 0), "assigning variable p_real_1d_ar");
       }
       std::vector<std::vector<std::vector<double>>> p_real_3d_ar;
       p_real_3d_ar = std::vector<std::vector<std::vector<double>>>(N, std::vector<std::vector<double>>(M, std::vector<double>(K, 0)));
       
       current_statement__ = 4;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 4;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 4;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 4;
-            assign(p_real_3d_ar, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.scalar(
+            assign(p_real_3d_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.scalar(
                    ), "assigning variable p_real_3d_ar");}}}
       current_statement__ = 4;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 4;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 4;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 4;
-            assign(p_real_3d_ar, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), lb_constrain(
-                   p_real_3d_ar[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)], 0), "assigning variable p_real_3d_ar");
+            assign(p_real_3d_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), lb_constrain(
+                   p_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)], 0), "assigning variable p_real_3d_ar");
           }}}
       Eigen::Matrix<double, -1, 1> p_vec;
       p_vec = Eigen::Matrix<double, -1, 1>(N);
@@ -4335,29 +4367,29 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 5;
       p_vec = in__.vector(N);
       current_statement__ = 5;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 5;
-        assign(p_vec, cons_list(index_uni(sym2__), nil_index_list()), lb_constrain(
-               p_vec[(sym2__ - 1)], 0), "assigning variable p_vec");}
+        assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()), lb_constrain(
+               p_vec[(sym1__ - 1)], 0), "assigning variable p_vec");}
       std::vector<Eigen::Matrix<double, -1, 1>> p_1d_vec;
       p_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       
       current_statement__ = 6;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 6;
-        assign(p_1d_vec, cons_list(index_uni(sym13__), nil_index_list()), in__.vector(
+        assign(p_1d_vec, cons_list(index_uni(sym1__), nil_index_list()), in__.vector(
                N), "assigning variable p_1d_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_vec;
       p_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       
       current_statement__ = 7;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 7;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 7;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 7;
-            assign(p_3d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.vector(
+            assign(p_3d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.vector(
                    N), "assigning variable p_3d_vec");}}}
       Eigen::Matrix<double, 1, -1> p_row_vec;
       p_row_vec = Eigen::Matrix<double, 1, -1>(N);
@@ -4368,43 +4400,43 @@ class mother_model : public model_base_crtp<mother_model> {
       p_1d_row_vec = std::vector<Eigen::Matrix<double, 1, -1>>(N, Eigen::Matrix<double, 1, -1>(N));
       
       current_statement__ = 9;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 9;
-        assign(p_1d_row_vec, cons_list(index_uni(sym13__), nil_index_list()), in__.row_vector(
+        assign(p_1d_row_vec, cons_list(index_uni(sym1__), nil_index_list()), in__.row_vector(
                N), "assigning variable p_1d_row_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>> p_3d_row_vec;
       p_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(M, std::vector<Eigen::Matrix<double, 1, -1>>(K, Eigen::Matrix<double, 1, -1>(N))));
       
       current_statement__ = 10;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 10;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 10;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 10;
-            assign(p_3d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.row_vector(
+            assign(p_3d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.row_vector(
                    N), "assigning variable p_3d_row_vec");}}}
       std::vector<std::vector<Eigen::Matrix<double, -1, -1>>> p_ar_mat;
       p_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
       
       current_statement__ = 11;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 11;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 11;
-          assign(p_ar_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), in__.matrix(
+          assign(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), in__.matrix(
                  2, 3), "assigning variable p_ar_mat");}}
       current_statement__ = 11;
-      for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 11;
-        for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 11;
-          for (size_t sym4__ = 1; sym4__ <= 2; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= 2; ++sym3__) {
             current_statement__ = 11;
-            for (size_t sym5__ = 1; sym5__ <= 3; ++sym5__) {
+            for (size_t sym4__ = 1; sym4__ <= 3; ++sym4__) {
               current_statement__ = 11;
-              assign(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), lub_constrain(
-                     rvalue(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), "p_ar_mat"),
+              assign(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), lub_constrain(
+                     rvalue(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), "p_ar_mat"),
                      0, 1), "assigning variable p_ar_mat");}}}}
       Eigen::Matrix<double, -1, 1> p_simplex;
       p_simplex = Eigen::Matrix<double, -1, 1>(N);
@@ -4423,15 +4455,15 @@ class mother_model : public model_base_crtp<mother_model> {
       p_1d_simplex_in__ = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(N, Eigen::Matrix<local_scalar_t__, -1, 1>((N - 1)));
       
       current_statement__ = 13;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 13;
-        assign(p_1d_simplex_in__, cons_list(index_uni(sym13__), nil_index_list()), in__.vector(
+        assign(p_1d_simplex_in__, cons_list(index_uni(sym1__), nil_index_list()), in__.vector(
                (N - 1)), "assigning variable p_1d_simplex_in__");}
       current_statement__ = 13;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 13;
-        assign(p_1d_simplex, cons_list(index_uni(sym2__), nil_index_list()), simplex_constrain(
-               p_1d_simplex_in__[(sym2__ - 1)]), "assigning variable p_1d_simplex");
+        assign(p_1d_simplex, cons_list(index_uni(sym1__), nil_index_list()), simplex_constrain(
+               p_1d_simplex_in__[(sym1__ - 1)]), "assigning variable p_1d_simplex");
       }
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_simplex;
       p_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
@@ -4440,23 +4472,23 @@ class mother_model : public model_base_crtp<mother_model> {
       p_3d_simplex_in__ = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>((N - 1)))));
       
       current_statement__ = 14;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 14;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 14;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 14;
-            assign(p_3d_simplex_in__, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), in__.vector(
+            assign(p_3d_simplex_in__, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), in__.vector(
                    (N - 1)), "assigning variable p_3d_simplex_in__");}}}
       current_statement__ = 14;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 14;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 14;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 14;
-            assign(p_3d_simplex, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), simplex_constrain(
-                   p_3d_simplex_in__[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)]), "assigning variable p_3d_simplex");
+            assign(p_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), simplex_constrain(
+                   p_3d_simplex_in__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]), "assigning variable p_3d_simplex");
           }}}
       Eigen::Matrix<double, -1, -1> p_cfcov_54;
       p_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 4);
@@ -4487,16 +4519,16 @@ class mother_model : public model_base_crtp<mother_model> {
       p_cfcov_33_ar_in__ = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))));
       
       current_statement__ = 17;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 17;
-        assign(p_cfcov_33_ar_in__, cons_list(index_uni(sym13__), nil_index_list()), in__.vector(
+        assign(p_cfcov_33_ar_in__, cons_list(index_uni(sym1__), nil_index_list()), in__.vector(
                ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))), "assigning variable p_cfcov_33_ar_in__");
       }
       current_statement__ = 17;
-      for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 17;
-        assign(p_cfcov_33_ar, cons_list(index_uni(sym2__), nil_index_list()), cholesky_factor_constrain(
-               p_cfcov_33_ar_in__[(sym2__ - 1)], 3, 3), "assigning variable p_cfcov_33_ar");
+        assign(p_cfcov_33_ar, cons_list(index_uni(sym1__), nil_index_list()), cholesky_factor_constrain(
+               p_cfcov_33_ar_in__[(sym1__ - 1)], 3, 3), "assigning variable p_cfcov_33_ar");
       }
       Eigen::Matrix<double, -1, 1> x_p;
       x_p = Eigen::Matrix<double, -1, 1>(2);
@@ -4518,218 +4550,218 @@ class mother_model : public model_base_crtp<mother_model> {
       tp_vec = Eigen::Matrix<double, -1, 1>(N);
       
       current_statement__ = 22;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 22;
-        assign(tp_vec, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(tp_vec, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable tp_vec");}
       std::vector<Eigen::Matrix<double, -1, 1>> tp_1d_vec;
       tp_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       
       current_statement__ = 23;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 23;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 23;
-          assign(tp_1d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_1d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_1d_vec");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> tp_3d_vec;
       tp_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       
       current_statement__ = 24;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 24;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 24;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 24;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 24;
-              assign(tp_3d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_3d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_3d_vec");}}}}
       Eigen::Matrix<double, 1, -1> tp_row_vec;
       tp_row_vec = Eigen::Matrix<double, 1, -1>(N);
       
       current_statement__ = 25;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 25;
-        assign(tp_row_vec, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(tp_row_vec, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable tp_row_vec");}
       std::vector<Eigen::Matrix<double, 1, -1>> tp_1d_row_vec;
       tp_1d_row_vec = std::vector<Eigen::Matrix<double, 1, -1>>(N, Eigen::Matrix<double, 1, -1>(N));
       
       current_statement__ = 26;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 26;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 26;
-          assign(tp_1d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_1d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_1d_row_vec");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>> tp_3d_row_vec;
       tp_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(M, std::vector<Eigen::Matrix<double, 1, -1>>(K, Eigen::Matrix<double, 1, -1>(N))));
       
       current_statement__ = 27;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 27;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 27;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 27;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 27;
-              assign(tp_3d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_3d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_3d_row_vec");}}}}
       std::vector<std::vector<Eigen::Matrix<double, -1, -1>>> tp_ar_mat;
       tp_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
       
       current_statement__ = 28;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 28;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 28;
-          for (size_t sym15__ = 1; sym15__ <= 2; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 2; ++sym3__) {
             current_statement__ = 28;
-            for (size_t sym16__ = 1; sym16__ <= 3; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= 3; ++sym4__) {
               current_statement__ = 28;
-              assign(tp_ar_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_ar_mat");}}}}
       Eigen::Matrix<double, -1, 1> tp_simplex;
       tp_simplex = Eigen::Matrix<double, -1, 1>(N);
       
       current_statement__ = 29;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 29;
-        assign(tp_simplex, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(tp_simplex, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable tp_simplex");}
       std::vector<Eigen::Matrix<double, -1, 1>> tp_1d_simplex;
       tp_1d_simplex = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       
       current_statement__ = 30;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 30;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 30;
-          assign(tp_1d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_1d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_1d_simplex");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> tp_3d_simplex;
       tp_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       
       current_statement__ = 31;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 31;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 31;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 31;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 31;
-              assign(tp_3d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(tp_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable tp_3d_simplex");}}}}
       Eigen::Matrix<double, -1, -1> tp_cfcov_54;
       tp_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 4);
       
       current_statement__ = 32;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 32;
-        for (size_t sym14__ = 1; sym14__ <= 4; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
           current_statement__ = 32;
-          assign(tp_cfcov_54, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_cfcov_54, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_cfcov_54");}}
       Eigen::Matrix<double, -1, -1> tp_cfcov_33;
       tp_cfcov_33 = Eigen::Matrix<double, -1, -1>(3, 3);
       
       current_statement__ = 33;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 33;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 33;
-          assign(tp_cfcov_33, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(tp_cfcov_33, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable tp_cfcov_33");}}
       std::vector<Eigen::Matrix<double, -1, -1>> tp_cfcov_33_ar;
       tp_cfcov_33_ar = std::vector<Eigen::Matrix<double, -1, -1>>(K, Eigen::Matrix<double, -1, -1>(3, 3));
       
       current_statement__ = 34;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 34;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 34;
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
             current_statement__ = 34;
-            assign(tp_cfcov_33_ar, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(tp_cfcov_33_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable tp_cfcov_33_ar");}}}
       Eigen::Matrix<double, -1, 1> theta_p;
       theta_p = Eigen::Matrix<double, -1, 1>(2);
       
       current_statement__ = 35;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 35;
-        assign(theta_p, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(theta_p, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable theta_p");}
       vars__.push_back(p_real);
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
-        vars__.push_back(offset_multiplier[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_real_1d_ar[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
-            vars__.push_back(p_real_3d_ar[(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
+        vars__.push_back(offset_multiplier[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_real_1d_ar[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
+            vars__.push_back(p_real_3d_ar[(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
           }}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(p_1d_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(p_3d_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(p_1d_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(p_3d_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_row_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(p_1d_row_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(p_3d_row_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_row_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(p_1d_row_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(p_3d_row_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
-              vars__.push_back(rvalue(p_ar_mat, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), "p_ar_mat"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
+              vars__.push_back(rvalue(p_ar_mat, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), "p_ar_mat"));
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_simplex[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(p_1d_simplex[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(p_3d_simplex[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_simplex[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(p_1d_simplex[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(p_3d_simplex[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
-          vars__.push_back(rvalue(p_cfcov_54, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "p_cfcov_54"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
+          vars__.push_back(rvalue(p_cfcov_54, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "p_cfcov_54"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          vars__.push_back(rvalue(p_cfcov_33, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "p_cfcov_33"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          vars__.push_back(rvalue(p_cfcov_33, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "p_cfcov_33"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
-            vars__.push_back(rvalue(p_cfcov_33_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "p_cfcov_33_ar"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
+            vars__.push_back(rvalue(p_cfcov_33_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "p_cfcov_33_ar"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
-        vars__.push_back(x_p[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
-        vars__.push_back(y_p[(sym13__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        vars__.push_back(x_p[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        vars__.push_back(y_p[(sym1__ - 1)]);}
       if (logical_negation((primitive_value(emit_transformed_parameters__) || primitive_value(emit_generated_quantities__)))) {
         return ;
       } 
@@ -4807,67 +4839,67 @@ class mother_model : public model_base_crtp<mother_model> {
                                                        ), x_p, y_p, dat,
                                                        dat_int, pstream__,
                                                        0.01, 0.01, 10), "assigning variable theta_p");
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(tp_real_1d_ar[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
-            vars__.push_back(tp_real_3d_ar[(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(tp_real_1d_ar[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
+            vars__.push_back(tp_real_3d_ar[(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
           }}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(tp_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(tp_1d_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(tp_3d_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(tp_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(tp_1d_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(tp_3d_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(tp_row_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(tp_1d_row_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(tp_3d_row_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(tp_row_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(tp_1d_row_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(tp_3d_row_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
-              vars__.push_back(rvalue(tp_ar_mat, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), "tp_ar_mat"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
+              vars__.push_back(rvalue(tp_ar_mat, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), "tp_ar_mat"));
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(tp_simplex[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(tp_1d_simplex[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(tp_3d_simplex[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(tp_simplex[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(tp_1d_simplex[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(tp_3d_simplex[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
-          vars__.push_back(rvalue(tp_cfcov_54, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "tp_cfcov_54"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
+          vars__.push_back(rvalue(tp_cfcov_54, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "tp_cfcov_54"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          vars__.push_back(rvalue(tp_cfcov_33, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "tp_cfcov_33"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          vars__.push_back(rvalue(tp_cfcov_33, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "tp_cfcov_33"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
-            vars__.push_back(rvalue(tp_cfcov_33_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "tp_cfcov_33_ar"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
+            vars__.push_back(rvalue(tp_cfcov_33_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "tp_cfcov_33_ar"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
-        vars__.push_back(theta_p[(sym13__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        vars__.push_back(theta_p[(sym1__ - 1)]);}
       if (logical_negation(emit_generated_quantities__)) {
         return ;
       } 
@@ -4893,143 +4925,143 @@ class mother_model : public model_base_crtp<mother_model> {
       gq_vec = Eigen::Matrix<double, -1, 1>(N);
       
       current_statement__ = 71;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 71;
-        assign(gq_vec, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(gq_vec, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable gq_vec");}
       std::vector<Eigen::Matrix<double, -1, 1>> gq_1d_vec;
       gq_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       
       current_statement__ = 72;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 72;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 72;
-          assign(gq_1d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(gq_1d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable gq_1d_vec");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> gq_3d_vec;
       gq_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       
       current_statement__ = 73;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 73;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 73;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 73;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 73;
-              assign(gq_3d_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(gq_3d_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable gq_3d_vec");}}}}
       Eigen::Matrix<double, 1, -1> gq_row_vec;
       gq_row_vec = Eigen::Matrix<double, 1, -1>(N);
       
       current_statement__ = 74;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 74;
-        assign(gq_row_vec, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(gq_row_vec, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable gq_row_vec");}
       std::vector<Eigen::Matrix<double, 1, -1>> gq_1d_row_vec;
       gq_1d_row_vec = std::vector<Eigen::Matrix<double, 1, -1>>(N, Eigen::Matrix<double, 1, -1>(N));
       
       current_statement__ = 75;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 75;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 75;
-          assign(gq_1d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(gq_1d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable gq_1d_row_vec");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>> gq_3d_row_vec;
       gq_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(M, std::vector<Eigen::Matrix<double, 1, -1>>(K, Eigen::Matrix<double, 1, -1>(N))));
       
       current_statement__ = 76;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 76;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 76;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 76;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 76;
-              assign(gq_3d_row_vec, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(gq_3d_row_vec, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable gq_3d_row_vec");}}}}
       std::vector<std::vector<Eigen::Matrix<double, -1, -1>>> gq_ar_mat;
       gq_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
       
       current_statement__ = 77;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 77;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 77;
-          for (size_t sym15__ = 1; sym15__ <= 2; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 2; ++sym3__) {
             current_statement__ = 77;
-            for (size_t sym16__ = 1; sym16__ <= 3; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= 3; ++sym4__) {
               current_statement__ = 77;
-              assign(gq_ar_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(gq_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable gq_ar_mat");}}}}
       Eigen::Matrix<double, -1, 1> gq_simplex;
       gq_simplex = Eigen::Matrix<double, -1, 1>(N);
       
       current_statement__ = 78;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 78;
-        assign(gq_simplex, cons_list(index_uni(sym13__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
+        assign(gq_simplex, cons_list(index_uni(sym1__), nil_index_list()), std::numeric_limits<double>::quiet_NaN(
                ), "assigning variable gq_simplex");}
       std::vector<Eigen::Matrix<double, -1, 1>> gq_1d_simplex;
       gq_1d_simplex = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       
       current_statement__ = 79;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 79;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 79;
-          assign(gq_1d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(gq_1d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable gq_1d_simplex");}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> gq_3d_simplex;
       gq_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       
       current_statement__ = 80;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 80;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 80;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 80;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 80;
-              assign(gq_3d_simplex, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), cons_list(index_uni(sym16__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
+              assign(gq_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), std::numeric_limits<double>::quiet_NaN(
                      ), "assigning variable gq_3d_simplex");}}}}
       Eigen::Matrix<double, -1, -1> gq_cfcov_54;
       gq_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 4);
       
       current_statement__ = 81;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 81;
-        for (size_t sym14__ = 1; sym14__ <= 4; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
           current_statement__ = 81;
-          assign(gq_cfcov_54, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(gq_cfcov_54, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable gq_cfcov_54");}}
       Eigen::Matrix<double, -1, -1> gq_cfcov_33;
       gq_cfcov_33 = Eigen::Matrix<double, -1, -1>(3, 3);
       
       current_statement__ = 82;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 82;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 82;
-          assign(gq_cfcov_33, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(gq_cfcov_33, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable gq_cfcov_33");}}
       std::vector<Eigen::Matrix<double, -1, -1>> gq_cfcov_33_ar;
       gq_cfcov_33_ar = std::vector<Eigen::Matrix<double, -1, -1>>(K, Eigen::Matrix<double, -1, -1>(3, 3));
       
       current_statement__ = 83;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 83;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 83;
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
             current_statement__ = 83;
-            assign(gq_cfcov_33_ar, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(gq_cfcov_33_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable gq_cfcov_33_ar");}}}
       std::vector<int> indices;
       indices = std::vector<int>(3, 0);
@@ -5040,105 +5072,105 @@ class mother_model : public model_base_crtp<mother_model> {
       indexing_mat = std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(3, 4));
       
       current_statement__ = 85;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 85;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 85;
-          for (size_t sym15__ = 1; sym15__ <= 4; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 4; ++sym3__) {
             current_statement__ = 85;
-            assign(indexing_mat, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(indexing_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable indexing_mat");}}}
       std::vector<Eigen::Matrix<double, -1, -1>> idx_res1;
       idx_res1 = std::vector<Eigen::Matrix<double, -1, -1>>(3, Eigen::Matrix<double, -1, -1>(3, 4));
       
       current_statement__ = 86;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 86;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 86;
-          for (size_t sym15__ = 1; sym15__ <= 4; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 4; ++sym3__) {
             current_statement__ = 86;
-            assign(idx_res1, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(idx_res1, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable idx_res1");}}}
       std::vector<Eigen::Matrix<double, -1, -1>> idx_res2;
       idx_res2 = std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(3, 4));
       
       current_statement__ = 87;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 87;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 87;
-          for (size_t sym15__ = 1; sym15__ <= 4; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 4; ++sym3__) {
             current_statement__ = 87;
-            assign(idx_res2, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(idx_res2, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable idx_res2");}}}
       std::vector<Eigen::Matrix<double, -1, -1>> idx_res3;
       idx_res3 = std::vector<Eigen::Matrix<double, -1, -1>>(3, Eigen::Matrix<double, -1, -1>(3, 3));
       
       current_statement__ = 88;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 88;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 88;
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
             current_statement__ = 88;
-            assign(idx_res3, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(idx_res3, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable idx_res3");}}}
       std::vector<Eigen::Matrix<double, -1, -1>> idx_res11;
       idx_res11 = std::vector<Eigen::Matrix<double, -1, -1>>(3, Eigen::Matrix<double, -1, -1>(3, 4));
       
       current_statement__ = 89;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 89;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 89;
-          for (size_t sym15__ = 1; sym15__ <= 4; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 4; ++sym3__) {
             current_statement__ = 89;
-            assign(idx_res11, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(idx_res11, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable idx_res11");}}}
       std::vector<Eigen::Matrix<double, -1, -1>> idx_res21;
       idx_res21 = std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(3, 4));
       
       current_statement__ = 90;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 90;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 90;
-          for (size_t sym15__ = 1; sym15__ <= 4; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 4; ++sym3__) {
             current_statement__ = 90;
-            assign(idx_res21, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(idx_res21, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable idx_res21");}}}
       std::vector<Eigen::Matrix<double, -1, -1>> idx_res31;
       idx_res31 = std::vector<Eigen::Matrix<double, -1, -1>>(3, Eigen::Matrix<double, -1, -1>(3, 3));
       
       current_statement__ = 91;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 91;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 91;
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
             current_statement__ = 91;
-            assign(idx_res31, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), cons_list(index_uni(sym15__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
+            assign(idx_res31, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), std::numeric_limits<double>::quiet_NaN(
                    ), "assigning variable idx_res31");}}}
       std::vector<Eigen::Matrix<double, 1, -1>> idx_res4;
       idx_res4 = std::vector<Eigen::Matrix<double, 1, -1>>(3, Eigen::Matrix<double, 1, -1>(4));
       
       current_statement__ = 92;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 92;
-        for (size_t sym14__ = 1; sym14__ <= 4; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
           current_statement__ = 92;
-          assign(idx_res4, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(idx_res4, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable idx_res4");}}
       std::vector<Eigen::Matrix<double, -1, 1>> idx_res5;
       idx_res5 = std::vector<Eigen::Matrix<double, -1, 1>>(2, Eigen::Matrix<double, -1, 1>(2));
       
       current_statement__ = 93;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 93;
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
           current_statement__ = 93;
-          assign(idx_res5, cons_list(index_uni(sym13__), cons_list(index_uni(sym14__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
+          assign(idx_res5, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), nil_index_list())), std::numeric_limits<double>::quiet_NaN(
                  ), "assigning variable idx_res5");}}
       current_statement__ = 94;
       assign(gq_real_1d_ar, nil_index_list(), rvalue(p_1d_simplex, cons_list(index_omni(), cons_list(index_uni(1), nil_index_list())), "p_1d_simplex"), "assigning variable gq_real_1d_ar");
@@ -5246,62 +5278,62 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 142;
       assign(idx_res5, nil_index_list(), rvalue(indexing_mat, cons_list(index_min(4), cons_list(index_min_max(2, 3), cons_list(index_uni(1), nil_index_list()))), "indexing_mat"), "assigning variable idx_res5");
       current_statement__ = 69;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 69;
         current_statement__ = 69;
-        check_greater_or_equal(function__, "gq_real_1d_ar[sym2__]",
-                               gq_real_1d_ar[(sym2__ - 1)], 0);}
+        check_greater_or_equal(function__, "gq_real_1d_ar[sym1__]",
+                               gq_real_1d_ar[(sym1__ - 1)], 0);}
       current_statement__ = 70;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 70;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 70;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 70;
             current_statement__ = 70;
             check_greater_or_equal(function__,
-                                   "gq_real_3d_ar[sym2__, sym3__, sym4__]",
-                                   gq_real_3d_ar[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)],
+                                   "gq_real_3d_ar[sym1__, sym2__, sym3__]",
+                                   gq_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                                    0);}}}
       current_statement__ = 71;
       current_statement__ = 71;
       check_less_or_equal(function__, "gq_vec", gq_vec, 1);
       current_statement__ = 77;
-      for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 77;
-        for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 77;
           current_statement__ = 77;
-          check_greater_or_equal(function__, "gq_ar_mat[sym2__, sym3__]",
-                                 gq_ar_mat[(sym2__ - 1)][(sym3__ - 1)], 0);}}
+          check_greater_or_equal(function__, "gq_ar_mat[sym1__, sym2__]",
+                                 gq_ar_mat[(sym1__ - 1)][(sym2__ - 1)], 0);}}
       current_statement__ = 77;
-      for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 77;
-        for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 77;
           current_statement__ = 77;
-          check_less_or_equal(function__, "gq_ar_mat[sym2__, sym3__]",
-                              gq_ar_mat[(sym2__ - 1)][(sym3__ - 1)], 1);}}
+          check_less_or_equal(function__, "gq_ar_mat[sym1__, sym2__]",
+                              gq_ar_mat[(sym1__ - 1)][(sym2__ - 1)], 1);}}
       current_statement__ = 78;
       current_statement__ = 78;
       check_simplex(function__, "gq_simplex", gq_simplex);
       current_statement__ = 79;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 79;
         current_statement__ = 79;
-        check_simplex(function__, "gq_1d_simplex[sym2__]",
-                      gq_1d_simplex[(sym2__ - 1)]);}
+        check_simplex(function__, "gq_1d_simplex[sym1__]",
+                      gq_1d_simplex[(sym1__ - 1)]);}
       current_statement__ = 80;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 80;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 80;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 80;
             current_statement__ = 80;
             check_simplex(function__,
-                          "gq_3d_simplex[sym2__, sym3__, sym4__]",
-                          gq_3d_simplex[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)]);
+                          "gq_3d_simplex[sym1__, sym2__, sym3__]",
+                          gq_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);
           }}}
       current_statement__ = 81;
       current_statement__ = 81;
@@ -5310,115 +5342,115 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 82;
       check_cholesky_factor(function__, "gq_cfcov_33", gq_cfcov_33);
       current_statement__ = 83;
-      for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 83;
         current_statement__ = 83;
-        check_cholesky_factor(function__, "gq_cfcov_33_ar[sym2__]",
-                              gq_cfcov_33_ar[(sym2__ - 1)]);}
+        check_cholesky_factor(function__, "gq_cfcov_33_ar[sym1__]",
+                              gq_cfcov_33_ar[(sym1__ - 1)]);}
       vars__.push_back(gq_r1);
       vars__.push_back(gq_r2);
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(gq_real_1d_ar[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
-            vars__.push_back(gq_real_3d_ar[(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(gq_real_1d_ar[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
+            vars__.push_back(gq_real_3d_ar[(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
           }}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(gq_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(gq_1d_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(gq_3d_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(gq_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(gq_1d_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(gq_3d_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(gq_row_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(gq_1d_row_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(gq_3d_row_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(gq_row_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(gq_1d_row_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(gq_3d_row_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
-              vars__.push_back(rvalue(gq_ar_mat, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), "gq_ar_mat"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
+              vars__.push_back(rvalue(gq_ar_mat, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), "gq_ar_mat"));
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(gq_simplex[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(gq_1d_simplex[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(gq_3d_simplex[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(gq_simplex[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(gq_1d_simplex[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(gq_3d_simplex[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
-          vars__.push_back(rvalue(gq_cfcov_54, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "gq_cfcov_54"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
+          vars__.push_back(rvalue(gq_cfcov_54, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "gq_cfcov_54"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          vars__.push_back(rvalue(gq_cfcov_33, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "gq_cfcov_33"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          vars__.push_back(rvalue(gq_cfcov_33, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "gq_cfcov_33"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
-            vars__.push_back(rvalue(gq_cfcov_33_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "gq_cfcov_33_ar"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
+            vars__.push_back(rvalue(gq_cfcov_33_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "gq_cfcov_33_ar"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        vars__.push_back(indices[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
-            vars__.push_back(rvalue(indexing_mat, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "indexing_mat"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        vars__.push_back(indices[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            vars__.push_back(rvalue(indexing_mat, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "indexing_mat"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
-            vars__.push_back(rvalue(idx_res1, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "idx_res1"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
+            vars__.push_back(rvalue(idx_res1, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "idx_res1"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
-            vars__.push_back(rvalue(idx_res2, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "idx_res2"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            vars__.push_back(rvalue(idx_res2, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "idx_res2"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
-            vars__.push_back(rvalue(idx_res3, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "idx_res3"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
+            vars__.push_back(rvalue(idx_res3, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "idx_res3"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
-            vars__.push_back(rvalue(idx_res11, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "idx_res11"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
+            vars__.push_back(rvalue(idx_res11, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "idx_res11"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
-            vars__.push_back(rvalue(idx_res21, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "idx_res21"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            vars__.push_back(rvalue(idx_res21, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "idx_res21"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
-            vars__.push_back(rvalue(idx_res31, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "idx_res31"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
+            vars__.push_back(rvalue(idx_res31, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "idx_res31"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          vars__.push_back(idx_res4[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
-          vars__.push_back(idx_res5[(sym14__ - 1)][(sym13__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          vars__.push_back(idx_res4[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
+          vars__.push_back(idx_res5[(sym2__ - 1)][(sym1__ - 1)]);}}
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -5449,16 +5481,16 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 2;
       pos__ = 1;
       current_statement__ = 2;
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 2;
-        assign(offset_multiplier, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("offset_multiplier")[(pos__ - 1)], "assigning variable offset_multiplier");
+        assign(offset_multiplier, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("offset_multiplier")[(pos__ - 1)], "assigning variable offset_multiplier");
         current_statement__ = 2;
         pos__ = (pos__ + 1);}
       current_statement__ = 2;
-      for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 2;
-        assign(offset_multiplier, cons_list(index_uni(sym2__), nil_index_list()), offset_multiplier_free(
-               offset_multiplier[(sym2__ - 1)], 1, 2), "assigning variable offset_multiplier");
+        assign(offset_multiplier, cons_list(index_uni(sym1__), nil_index_list()), offset_multiplier_free(
+               offset_multiplier[(sym1__ - 1)], 1, 2), "assigning variable offset_multiplier");
       }
       std::vector<double> p_real_1d_ar;
       p_real_1d_ar = std::vector<double>(N, 0);
@@ -5466,16 +5498,16 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 3;
       pos__ = 1;
       current_statement__ = 3;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 3;
-        assign(p_real_1d_ar, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("p_real_1d_ar")[(pos__ - 1)], "assigning variable p_real_1d_ar");
+        assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("p_real_1d_ar")[(pos__ - 1)], "assigning variable p_real_1d_ar");
         current_statement__ = 3;
         pos__ = (pos__ + 1);}
       current_statement__ = 3;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 3;
-        assign(p_real_1d_ar, cons_list(index_uni(sym2__), nil_index_list()), lb_free(
-               p_real_1d_ar[(sym2__ - 1)], 0), "assigning variable p_real_1d_ar");
+        assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()), lb_free(
+               p_real_1d_ar[(sym1__ - 1)], 0), "assigning variable p_real_1d_ar");
       }
       std::vector<std::vector<std::vector<double>>> p_real_3d_ar;
       p_real_3d_ar = std::vector<std::vector<std::vector<double>>>(N, std::vector<std::vector<double>>(M, std::vector<double>(K, 0)));
@@ -5483,24 +5515,24 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 4;
       pos__ = 1;
       current_statement__ = 4;
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 4;
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 4;
-          for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
             current_statement__ = 4;
-            assign(p_real_3d_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), context__.vals_r("p_real_3d_ar")[(pos__ - 1)], "assigning variable p_real_3d_ar");
+            assign(p_real_3d_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), context__.vals_r("p_real_3d_ar")[(pos__ - 1)], "assigning variable p_real_3d_ar");
             current_statement__ = 4;
             pos__ = (pos__ + 1);}}}
       current_statement__ = 4;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 4;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 4;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 4;
-            assign(p_real_3d_ar, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), lb_free(
-                   p_real_3d_ar[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)], 0), "assigning variable p_real_3d_ar");
+            assign(p_real_3d_ar, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), lb_free(
+                   p_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)], 0), "assigning variable p_real_3d_ar");
           }}}
       Eigen::Matrix<double, -1, 1> p_vec;
       p_vec = Eigen::Matrix<double, -1, 1>(N);
@@ -5508,27 +5540,27 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 5;
       pos__ = 1;
       current_statement__ = 5;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 5;
-        assign(p_vec, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("p_vec")[(pos__ - 1)], "assigning variable p_vec");
+        assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("p_vec")[(pos__ - 1)], "assigning variable p_vec");
         current_statement__ = 5;
         pos__ = (pos__ + 1);}
       current_statement__ = 5;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 5;
-        assign(p_vec, cons_list(index_uni(sym2__), nil_index_list()), lb_free(
-               p_vec[(sym2__ - 1)], 0), "assigning variable p_vec");}
+        assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()), lb_free(
+               p_vec[(sym1__ - 1)], 0), "assigning variable p_vec");}
       std::vector<Eigen::Matrix<double, -1, 1>> p_1d_vec;
       p_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       
       current_statement__ = 6;
       pos__ = 1;
       current_statement__ = 6;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 6;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 6;
-          assign(p_1d_vec, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("p_1d_vec")[(pos__ - 1)], "assigning variable p_1d_vec");
+          assign(p_1d_vec, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("p_1d_vec")[(pos__ - 1)], "assigning variable p_1d_vec");
           current_statement__ = 6;
           pos__ = (pos__ + 1);}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_vec;
@@ -5537,15 +5569,15 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 7;
       pos__ = 1;
       current_statement__ = 7;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 7;
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           current_statement__ = 7;
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
             current_statement__ = 7;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 7;
-              assign(p_3d_vec, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("p_3d_vec")[(pos__ - 1)], "assigning variable p_3d_vec");
+              assign(p_3d_vec, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("p_3d_vec")[(pos__ - 1)], "assigning variable p_3d_vec");
               current_statement__ = 7;
               pos__ = (pos__ + 1);}}}}
       Eigen::Matrix<double, 1, -1> p_row_vec;
@@ -5554,9 +5586,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 8;
       pos__ = 1;
       current_statement__ = 8;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 8;
-        assign(p_row_vec, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("p_row_vec")[(pos__ - 1)], "assigning variable p_row_vec");
+        assign(p_row_vec, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("p_row_vec")[(pos__ - 1)], "assigning variable p_row_vec");
         current_statement__ = 8;
         pos__ = (pos__ + 1);}
       std::vector<Eigen::Matrix<double, 1, -1>> p_1d_row_vec;
@@ -5565,11 +5597,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 9;
       pos__ = 1;
       current_statement__ = 9;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 9;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 9;
-          assign(p_1d_row_vec, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("p_1d_row_vec")[(pos__ - 1)], "assigning variable p_1d_row_vec");
+          assign(p_1d_row_vec, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("p_1d_row_vec")[(pos__ - 1)], "assigning variable p_1d_row_vec");
           current_statement__ = 9;
           pos__ = (pos__ + 1);}}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>> p_3d_row_vec;
@@ -5578,15 +5610,15 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 10;
       pos__ = 1;
       current_statement__ = 10;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 10;
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           current_statement__ = 10;
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
             current_statement__ = 10;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 10;
-              assign(p_3d_row_vec, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("p_3d_row_vec")[(pos__ - 1)], "assigning variable p_3d_row_vec");
+              assign(p_3d_row_vec, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("p_3d_row_vec")[(pos__ - 1)], "assigning variable p_3d_row_vec");
               current_statement__ = 10;
               pos__ = (pos__ + 1);}}}}
       std::vector<std::vector<Eigen::Matrix<double, -1, -1>>> p_ar_mat;
@@ -5595,28 +5627,28 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 11;
       pos__ = 1;
       current_statement__ = 11;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 11;
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
           current_statement__ = 11;
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
             current_statement__ = 11;
-            for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
               current_statement__ = 11;
-              assign(p_ar_mat, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("p_ar_mat")[(pos__ - 1)], "assigning variable p_ar_mat");
+              assign(p_ar_mat, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("p_ar_mat")[(pos__ - 1)], "assigning variable p_ar_mat");
               current_statement__ = 11;
               pos__ = (pos__ + 1);}}}}
       current_statement__ = 11;
-      for (size_t sym2__ = 1; sym2__ <= 4; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 11;
-        for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 11;
-          for (size_t sym4__ = 1; sym4__ <= 2; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= 2; ++sym3__) {
             current_statement__ = 11;
-            for (size_t sym5__ = 1; sym5__ <= 3; ++sym5__) {
+            for (size_t sym4__ = 1; sym4__ <= 3; ++sym4__) {
               current_statement__ = 11;
-              assign(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), lub_free(
-                     rvalue(p_ar_mat, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), cons_list(index_uni(sym5__), nil_index_list())))), "p_ar_mat"),
+              assign(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), lub_free(
+                     rvalue(p_ar_mat, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list())))), "p_ar_mat"),
                      0, 1), "assigning variable p_ar_mat");}}}}
       Eigen::Matrix<double, -1, 1> p_simplex;
       p_simplex = Eigen::Matrix<double, -1, 1>(N);
@@ -5624,9 +5656,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 12;
       pos__ = 1;
       current_statement__ = 12;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 12;
-        assign(p_simplex, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("p_simplex")[(pos__ - 1)], "assigning variable p_simplex");
+        assign(p_simplex, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("p_simplex")[(pos__ - 1)], "assigning variable p_simplex");
         current_statement__ = 12;
         pos__ = (pos__ + 1);}
       current_statement__ = 12;
@@ -5637,18 +5669,18 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 13;
       pos__ = 1;
       current_statement__ = 13;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 13;
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           current_statement__ = 13;
-          assign(p_1d_simplex, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("p_1d_simplex")[(pos__ - 1)], "assigning variable p_1d_simplex");
+          assign(p_1d_simplex, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("p_1d_simplex")[(pos__ - 1)], "assigning variable p_1d_simplex");
           current_statement__ = 13;
           pos__ = (pos__ + 1);}}
       current_statement__ = 13;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 13;
-        assign(p_1d_simplex, cons_list(index_uni(sym2__), nil_index_list()), simplex_free(
-               p_1d_simplex[(sym2__ - 1)]), "assigning variable p_1d_simplex");
+        assign(p_1d_simplex, cons_list(index_uni(sym1__), nil_index_list()), simplex_free(
+               p_1d_simplex[(sym1__ - 1)]), "assigning variable p_1d_simplex");
       }
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_simplex;
       p_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
@@ -5656,26 +5688,26 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 14;
       pos__ = 1;
       current_statement__ = 14;
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 14;
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           current_statement__ = 14;
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
             current_statement__ = 14;
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
               current_statement__ = 14;
-              assign(p_3d_simplex, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), context__.vals_r("p_3d_simplex")[(pos__ - 1)], "assigning variable p_3d_simplex");
+              assign(p_3d_simplex, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), context__.vals_r("p_3d_simplex")[(pos__ - 1)], "assigning variable p_3d_simplex");
               current_statement__ = 14;
               pos__ = (pos__ + 1);}}}}
       current_statement__ = 14;
-      for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 14;
-        for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           current_statement__ = 14;
-          for (size_t sym4__ = 1; sym4__ <= K; ++sym4__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 14;
-            assign(p_3d_simplex, cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), cons_list(index_uni(sym4__), nil_index_list()))), simplex_free(
-                   p_3d_simplex[(sym2__ - 1)][(sym3__ - 1)][(sym4__ - 1)]), "assigning variable p_3d_simplex");
+            assign(p_3d_simplex, cons_list(index_uni(sym1__), cons_list(index_uni(sym2__), cons_list(index_uni(sym3__), nil_index_list()))), simplex_free(
+                   p_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]), "assigning variable p_3d_simplex");
           }}}
       Eigen::Matrix<double, -1, -1> p_cfcov_54;
       p_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 4);
@@ -5683,11 +5715,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 15;
       pos__ = 1;
       current_statement__ = 15;
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         current_statement__ = 15;
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           current_statement__ = 15;
-          assign(p_cfcov_54, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("p_cfcov_54")[(pos__ - 1)], "assigning variable p_cfcov_54");
+          assign(p_cfcov_54, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("p_cfcov_54")[(pos__ - 1)], "assigning variable p_cfcov_54");
           current_statement__ = 15;
           pos__ = (pos__ + 1);}}
       current_statement__ = 15;
@@ -5698,11 +5730,11 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 16;
       pos__ = 1;
       current_statement__ = 16;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 16;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 16;
-          assign(p_cfcov_33, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), context__.vals_r("p_cfcov_33")[(pos__ - 1)], "assigning variable p_cfcov_33");
+          assign(p_cfcov_33, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), context__.vals_r("p_cfcov_33")[(pos__ - 1)], "assigning variable p_cfcov_33");
           current_statement__ = 16;
           pos__ = (pos__ + 1);}}
       current_statement__ = 16;
@@ -5713,20 +5745,20 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 17;
       pos__ = 1;
       current_statement__ = 17;
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         current_statement__ = 17;
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           current_statement__ = 17;
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
             current_statement__ = 17;
-            assign(p_cfcov_33_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), context__.vals_r("p_cfcov_33_ar")[(pos__ - 1)], "assigning variable p_cfcov_33_ar");
+            assign(p_cfcov_33_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), context__.vals_r("p_cfcov_33_ar")[(pos__ - 1)], "assigning variable p_cfcov_33_ar");
             current_statement__ = 17;
             pos__ = (pos__ + 1);}}}
       current_statement__ = 17;
-      for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         current_statement__ = 17;
-        assign(p_cfcov_33_ar, cons_list(index_uni(sym2__), nil_index_list()), cholesky_factor_free(
-               p_cfcov_33_ar[(sym2__ - 1)]), "assigning variable p_cfcov_33_ar");
+        assign(p_cfcov_33_ar, cons_list(index_uni(sym1__), nil_index_list()), cholesky_factor_free(
+               p_cfcov_33_ar[(sym1__ - 1)]), "assigning variable p_cfcov_33_ar");
       }
       Eigen::Matrix<double, -1, 1> x_p;
       x_p = Eigen::Matrix<double, -1, 1>(2);
@@ -5734,9 +5766,9 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 18;
       pos__ = 1;
       current_statement__ = 18;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 18;
-        assign(x_p, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("x_p")[(pos__ - 1)], "assigning variable x_p");
+        assign(x_p, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("x_p")[(pos__ - 1)], "assigning variable x_p");
         current_statement__ = 18;
         pos__ = (pos__ + 1);}
       Eigen::Matrix<double, -1, 1> y_p;
@@ -5745,77 +5777,77 @@ class mother_model : public model_base_crtp<mother_model> {
       current_statement__ = 19;
       pos__ = 1;
       current_statement__ = 19;
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 19;
-        assign(y_p, cons_list(index_uni(sym13__), nil_index_list()), context__.vals_r("y_p")[(pos__ - 1)], "assigning variable y_p");
+        assign(y_p, cons_list(index_uni(sym1__), nil_index_list()), context__.vals_r("y_p")[(pos__ - 1)], "assigning variable y_p");
         current_statement__ = 19;
         pos__ = (pos__ + 1);}
       vars__.push_back(p_real);
-      for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
-        vars__.push_back(offset_multiplier[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_real_1d_ar[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
-            vars__.push_back(p_real_3d_ar[(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
+        vars__.push_back(offset_multiplier[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_real_1d_ar[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
+            vars__.push_back(p_real_3d_ar[(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
           }}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(p_1d_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(p_3d_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(p_1d_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(p_3d_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_row_vec[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(p_1d_row_vec[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(p_3d_row_vec[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_row_vec[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(p_1d_row_vec[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(p_3d_row_vec[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
-              vars__.push_back(rvalue(p_ar_mat, cons_list(index_uni(sym16__), cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())))), "p_ar_mat"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
+              vars__.push_back(rvalue(p_ar_mat, cons_list(index_uni(sym4__), cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())))), "p_ar_mat"));
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        vars__.push_back(p_simplex[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
-          vars__.push_back(p_1d_simplex[(sym14__ - 1)][(sym13__ - 1)]);}}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
-            for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
-              vars__.push_back(p_3d_simplex[(sym16__ - 1)][(sym15__ - 1)][(sym14__ - 1)][(sym13__ - 1)]);
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        vars__.push_back(p_simplex[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
+          vars__.push_back(p_1d_simplex[(sym2__ - 1)][(sym1__ - 1)]);}}
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
+              vars__.push_back(p_3d_simplex[(sym4__ - 1)][(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);
             }}}}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
-          vars__.push_back(rvalue(p_cfcov_54, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "p_cfcov_54"));
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
+          vars__.push_back(rvalue(p_cfcov_54, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "p_cfcov_54"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          vars__.push_back(rvalue(p_cfcov_33, cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list())), "p_cfcov_33"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          vars__.push_back(rvalue(p_cfcov_33, cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list())), "p_cfcov_33"));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
-          for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
-            vars__.push_back(rvalue(p_cfcov_33_ar, cons_list(index_uni(sym15__), cons_list(index_uni(sym14__), cons_list(index_uni(sym13__), nil_index_list()))), "p_cfcov_33_ar"));
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
+            vars__.push_back(rvalue(p_cfcov_33_ar, cons_list(index_uni(sym3__), cons_list(index_uni(sym2__), cons_list(index_uni(sym1__), nil_index_list()))), "p_cfcov_33_ar"));
           }}}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
-        vars__.push_back(x_p[(sym13__ - 1)]);}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
-        vars__.push_back(y_p[(sym13__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        vars__.push_back(x_p[(sym1__ - 1)]);}
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        vars__.push_back(y_p[(sym1__ - 1)]);}
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -6242,483 +6274,483 @@ class mother_model : public model_base_crtp<mother_model> {
                                bool emit_generated_quantities__ = true) const {
     
     param_names__.push_back(std::string() + "p_real");
-    for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "offset_multiplier" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "offset_multiplier" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_real_1d_ar" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_real_1d_ar" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
               {
-                param_names__.push_back(std::string() + "p_real_3d_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                param_names__.push_back(std::string() + "p_real_3d_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_vec" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_vec" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_1d_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_1d_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_3d_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_3d_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_row_vec" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_row_vec" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_1d_row_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_1d_row_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_3d_row_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_3d_row_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_ar_mat" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_ar_mat" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_simplex" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_simplex" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_1d_simplex" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_1d_simplex" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_3d_simplex" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_3d_simplex" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_cfcov_54" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_cfcov_54" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_cfcov_33" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_cfcov_33" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
               {
-                param_names__.push_back(std::string() + "p_cfcov_33_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                param_names__.push_back(std::string() + "p_cfcov_33_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "x_p" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "x_p" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "y_p" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "y_p" + '.' + std::to_string(sym1__));
       }}
     if (emit_transformed_parameters__) {
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_real_1d_ar" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_real_1d_ar" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "tp_real_3d_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "tp_real_3d_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_1d_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_1d_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_3d_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_3d_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_row_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_row_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_1d_row_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_1d_row_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_3d_row_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_3d_row_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_ar_mat" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_ar_mat" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_simplex" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_simplex" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_1d_simplex" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_1d_simplex" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_3d_simplex" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_3d_simplex" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_cfcov_54" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_cfcov_54" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_cfcov_33" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_cfcov_33" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "tp_cfcov_33_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "tp_cfcov_33_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "theta_p" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "theta_p" + '.' + std::to_string(sym1__));
         }}
     }
     
     if (emit_generated_quantities__) {
       param_names__.push_back(std::string() + "gq_r1");
       param_names__.push_back(std::string() + "gq_r2");
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_real_1d_ar" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_real_1d_ar" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "gq_real_3d_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "gq_real_3d_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_1d_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_1d_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_3d_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_3d_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_row_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_row_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_1d_row_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_1d_row_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_3d_row_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_3d_row_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_ar_mat" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_ar_mat" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_simplex" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_simplex" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_1d_simplex" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_1d_simplex" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_3d_simplex" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_3d_simplex" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 5; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 5; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_cfcov_54" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_cfcov_54" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_cfcov_33" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_cfcov_33" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= K; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= K; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "gq_cfcov_33_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "gq_cfcov_33_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "indices" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "indices" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "indexing_mat" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "indexing_mat" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res1" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res1" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res2" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res2" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res3" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res3" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res11" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res11" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res21" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res21" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res31" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res31" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "idx_res4" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "idx_res4" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "idx_res5" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "idx_res5" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
     }
@@ -6730,465 +6762,465 @@ class mother_model : public model_base_crtp<mother_model> {
                                  bool emit_generated_quantities__ = true) const {
     
     param_names__.push_back(std::string() + "p_real");
-    for (size_t sym13__ = 1; sym13__ <= 5; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 5; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "offset_multiplier" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "offset_multiplier" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_real_1d_ar" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_real_1d_ar" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
               {
-                param_names__.push_back(std::string() + "p_real_3d_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                param_names__.push_back(std::string() + "p_real_3d_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_vec" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_vec" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_1d_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_1d_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_3d_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_3d_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_row_vec" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_row_vec" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_1d_row_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_1d_row_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_3d_row_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_3d_row_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_ar_mat" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_ar_mat" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_simplex" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_simplex" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_1d_simplex" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_1d_simplex" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           {
-            for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+            for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
               {
-                for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                   {
-                    param_names__.push_back(std::string() + "p_3d_simplex" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                    param_names__.push_back(std::string() + "p_3d_simplex" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                   }}
               }}
           }}
       }}
-    for (size_t sym13__ = 1;
-         sym13__ <= ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)); ++sym13__) {
+    for (size_t sym1__ = 1;
+         sym1__ <= ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)); ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_cfcov_54" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_cfcov_54" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1;
-         sym13__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym13__) {
+    for (size_t sym1__ = 1;
+         sym1__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym1__) {
       {
-        param_names__.push_back(std::string() + "p_cfcov_33" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "p_cfcov_33" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1;
-         sym13__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym13__) {
+    for (size_t sym1__ = 1;
+         sym1__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym1__) {
       {
-        for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+        for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
           {
-            param_names__.push_back(std::string() + "p_cfcov_33_ar" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+            param_names__.push_back(std::string() + "p_cfcov_33_ar" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
           }}
       }}
-    for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "x_p" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "x_p" + '.' + std::to_string(sym1__));
       }}
-    for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
       {
-        param_names__.push_back(std::string() + "y_p" + '.' + std::to_string(sym13__));
+        param_names__.push_back(std::string() + "y_p" + '.' + std::to_string(sym1__));
       }}
     if (emit_transformed_parameters__) {
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_real_1d_ar" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_real_1d_ar" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "tp_real_3d_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "tp_real_3d_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_1d_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_1d_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_3d_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_3d_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_row_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_row_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_1d_row_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_1d_row_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_3d_row_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_3d_row_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_ar_mat" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_ar_mat" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_simplex" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_simplex" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_1d_simplex" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_1d_simplex" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "tp_3d_simplex" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "tp_3d_simplex" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1;
-           sym13__ <= ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)); ++sym13__) {
+      for (size_t sym1__ = 1;
+           sym1__ <= ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)); ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_cfcov_54" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_cfcov_54" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1;
-           sym13__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym13__) {
+      for (size_t sym1__ = 1;
+           sym1__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym1__) {
         {
-          param_names__.push_back(std::string() + "tp_cfcov_33" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "tp_cfcov_33" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1;
-           sym13__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym13__) {
+      for (size_t sym1__ = 1;
+           sym1__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "tp_cfcov_33_ar" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "tp_cfcov_33_ar" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "theta_p" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "theta_p" + '.' + std::to_string(sym1__));
         }}
     }
     
     if (emit_generated_quantities__) {
       param_names__.push_back(std::string() + "gq_r1");
       param_names__.push_back(std::string() + "gq_r2");
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_real_1d_ar" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_real_1d_ar" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= K; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= K; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= M; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= M; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= N; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= N; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "gq_real_3d_ar" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "gq_real_3d_ar" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_1d_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_1d_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_3d_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_3d_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_row_vec" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_row_vec" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_1d_row_vec" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_1d_row_vec" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= N; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_3d_row_vec" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_3d_row_vec" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= 4; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= 4; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_ar_mat" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_ar_mat" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_simplex" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_simplex" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= N; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= N; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_1d_simplex" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_1d_simplex" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= (N - 1); ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= M; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= M; ++sym3__) {
                 {
-                  for (size_t sym16__ = 1; sym16__ <= N; ++sym16__) {
+                  for (size_t sym4__ = 1; sym4__ <= N; ++sym4__) {
                     {
-                      param_names__.push_back(std::string() + "gq_3d_simplex" + '.' + std::to_string(sym16__) + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                      param_names__.push_back(std::string() + "gq_3d_simplex" + '.' + std::to_string(sym4__) + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                     }}
                 }}
             }}
         }}
-      for (size_t sym13__ = 1;
-           sym13__ <= ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)); ++sym13__) {
+      for (size_t sym1__ = 1;
+           sym1__ <= ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)); ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_cfcov_54" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_cfcov_54" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1;
-           sym13__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym13__) {
+      for (size_t sym1__ = 1;
+           sym1__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym1__) {
         {
-          param_names__.push_back(std::string() + "gq_cfcov_33" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "gq_cfcov_33" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1;
-           sym13__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym13__) {
+      for (size_t sym1__ = 1;
+           sym1__ <= ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)); ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= K; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= K; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "gq_cfcov_33_ar" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "gq_cfcov_33_ar" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          param_names__.push_back(std::string() + "indices" + '.' + std::to_string(sym13__));
+          param_names__.push_back(std::string() + "indices" + '.' + std::to_string(sym1__));
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "indexing_mat" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "indexing_mat" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res1" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res1" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res2" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res2" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res3" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res3" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res11" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res11" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 5; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 5; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res21" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res21" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 3; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 3; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              for (size_t sym15__ = 1; sym15__ <= 3; ++sym15__) {
+              for (size_t sym3__ = 1; sym3__ <= 3; ++sym3__) {
                 {
-                  param_names__.push_back(std::string() + "idx_res31" + '.' + std::to_string(sym15__) + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+                  param_names__.push_back(std::string() + "idx_res31" + '.' + std::to_string(sym3__) + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
                 }}
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 4; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 4; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 3; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 3; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "idx_res4" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "idx_res4" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
-      for (size_t sym13__ = 1; sym13__ <= 2; ++sym13__) {
+      for (size_t sym1__ = 1; sym1__ <= 2; ++sym1__) {
         {
-          for (size_t sym14__ = 1; sym14__ <= 2; ++sym14__) {
+          for (size_t sym2__ = 1; sym2__ <= 2; ++sym2__) {
             {
-              param_names__.push_back(std::string() + "idx_res5" + '.' + std::to_string(sym14__) + '.' + std::to_string(sym13__));
+              param_names__.push_back(std::string() + "idx_res5" + '.' + std::to_string(sym2__) + '.' + std::to_string(sym1__));
             }}
         }}
     }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -979,15 +979,12 @@ static const std::vector<string> locations_array__ = {" (found before start of p
                                                       " (in 'mother.stan', line 312, column 4 to column 16)",
                                                       " (in 'mother.stan', line 309, column 78 to line 313, column 3)"};
 
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-foo(const T0__& n, std::ostream* pstream__) ;
+int
+foo(const int& n, std::ostream* pstream__) ;
 
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-foo(const T0__& n, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+int
+foo(const int& n, std::ostream* pstream__) {
+  using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1010,35 +1007,29 @@ foo(const T0__& n, std::ostream* pstream__) {
 }
 
 struct foo_functor__ {
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-operator()(const T0__& n, std::ostream* pstream__)  const 
+int
+operator()(const int& n, std::ostream* pstream__)  const 
 {
 return foo(n, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__>
+template <typename T0__, typename T1__, typename T2__>
 std::vector<typename boost::math::tools::promote_args<T0__, T1__,
 T2__>::type>
 sho(const T0__& t, const std::vector<T1__>& y,
-    const std::vector<T2__>& theta, const std::vector<T3__>& x,
-    const std::vector<T4__>& x_int, std::ostream* pstream__) ;
+    const std::vector<T2__>& theta, const std::vector<double>& x,
+    const std::vector<int>& x_int, std::ostream* pstream__) ;
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__>
+template <typename T0__, typename T1__, typename T2__>
 std::vector<typename boost::math::tools::promote_args<T0__, T1__,
 T2__>::type>
 sho(const T0__& t, const std::vector<T1__>& y,
-    const std::vector<T2__>& theta, const std::vector<T3__>& x,
-    const std::vector<T4__>& x_int, std::ostream* pstream__) {
+    const std::vector<T2__>& theta, const std::vector<double>& x,
+    const std::vector<int>& x_int, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
           T1__,
-          T2__,
-          T3__,
-          T4__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T2__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1063,13 +1054,12 @@ sho(const T0__& t, const std::vector<T1__>& y,
 }
 
 struct sho_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__>
+template <typename T0__, typename T1__, typename T2__>
 std::vector<typename boost::math::tools::promote_args<T0__, T1__,
 T2__>::type>
 operator()(const T0__& t, const std::vector<T1__>& y,
-           const std::vector<T2__>& theta, const std::vector<T3__>& x,
-           const std::vector<T4__>& x_int, std::ostream* pstream__)  const 
+           const std::vector<T2__>& theta, const std::vector<double>& x,
+           const std::vector<int>& x_int, std::ostream* pstream__)  const 
 {
 return sho(t, y, theta, x, x_int, pstream__);
 }
@@ -1078,7 +1068,6 @@ return sho(t, y, theta, x, x_int, pstream__);
 double
 foo_bar0(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1107,7 +1096,6 @@ template <typename T0__>
 typename boost::math::tools::promote_args<T0__>::type
 foo_bar1(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1139,7 +1127,6 @@ T1__>::type
 foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
           T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1166,15 +1153,12 @@ return foo_bar2(x, y, pstream__);
 }
 };
 
-template <bool propto__, typename T0__, typename T1__, typename T_lp__,
+template <bool propto__, typename T1__, typename T_lp__,
 typename T_lp_accum__>
-typename boost::math::tools::promote_args<T0__,
-T1__>::type
-foo_lpmf(const T0__& y, const T1__& lambda, T_lp__& lp__,
+typename boost::math::tools::promote_args<T1__>::type
+foo_lpmf(const int& y, const T1__& lambda, T_lp__& lp__,
          T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   
@@ -1190,24 +1174,20 @@ foo_lpmf(const T0__& y, const T1__& lambda, T_lp__& lp__,
 }
 
 struct foo_lpmf_functor__ {
-template <bool propto__, typename T0__, typename T1__, typename T_lp__,
+template <bool propto__, typename T1__, typename T_lp__,
 typename T_lp_accum__>
-typename boost::math::tools::promote_args<T0__,
-T1__>::type
-operator()(const T0__& y, const T1__& lambda, T_lp__& lp__,
+typename boost::math::tools::promote_args<T1__>::type
+operator()(const int& y, const T1__& lambda, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__)  const 
 {
 return foo_lpmf(y, lambda, lp__, lp_accum__, pstream__);
 }
 };
 
-template <typename T0__, typename T1__>
-typename boost::math::tools::promote_args<T0__,
-T1__>::type
-foo_lcdf(const T0__& y, const T1__& lambda, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+template <typename T1__>
+typename boost::math::tools::promote_args<T1__>::type
+foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1225,22 +1205,18 @@ foo_lcdf(const T0__& y, const T1__& lambda, std::ostream* pstream__) {
 }
 
 struct foo_lcdf_functor__ {
-template <typename T0__, typename T1__>
-typename boost::math::tools::promote_args<T0__,
-T1__>::type
-operator()(const T0__& y, const T1__& lambda, std::ostream* pstream__)  const 
+template <typename T1__>
+typename boost::math::tools::promote_args<T1__>::type
+operator()(const int& y, const T1__& lambda, std::ostream* pstream__)  const 
 {
 return foo_lcdf(y, lambda, pstream__);
 }
 };
 
-template <typename T0__, typename T1__>
-typename boost::math::tools::promote_args<T0__,
-T1__>::type
-foo_lccdf(const T0__& y, const T1__& lambda, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+template <typename T1__>
+typename boost::math::tools::promote_args<T1__>::type
+foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1258,10 +1234,9 @@ foo_lccdf(const T0__& y, const T1__& lambda, std::ostream* pstream__) {
 }
 
 struct foo_lccdf_functor__ {
-template <typename T0__, typename T1__>
-typename boost::math::tools::promote_args<T0__,
-T1__>::type
-operator()(const T0__& y, const T1__& lambda, std::ostream* pstream__)  const 
+template <typename T1__>
+typename boost::math::tools::promote_args<T1__>::type
+operator()(const int& y, const T1__& lambda, std::ostream* pstream__)  const 
 {
 return foo_lccdf(y, lambda, pstream__);
 }
@@ -1274,7 +1249,6 @@ foo_rng(RNG& base_rng__, const T0__& mu, const T1__& sigma,
         std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
           T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1308,7 +1282,6 @@ void
 unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   
@@ -1336,11 +1309,9 @@ return unit_normal_lp(u, lp__, lp_accum__, pstream__);
 }
 };
 
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-foo_1(const T0__& a, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+int
+foo_1(const int& a, std::ostream* pstream__) {
+  using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1560,19 +1531,16 @@ foo_1(const T0__& a, std::ostream* pstream__) {
 }
 
 struct foo_1_functor__ {
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-operator()(const T0__& a, std::ostream* pstream__)  const 
+int
+operator()(const int& a, std::ostream* pstream__)  const 
 {
 return foo_1(a, pstream__);
 }
 };
 
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-foo_2(const T0__& a, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+int
+foo_2(const int& a, std::ostream* pstream__) {
+  using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1604,21 +1572,17 @@ foo_2(const T0__& a, std::ostream* pstream__) {
 }
 
 struct foo_2_functor__ {
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-operator()(const T0__& a, std::ostream* pstream__)  const 
+int
+operator()(const int& a, std::ostream* pstream__)  const 
 {
 return foo_2(a, pstream__);
 }
 };
 
-template <typename T0__, typename T1__>
-std::vector<typename boost::math::tools::promote_args<T0__,
-T1__>::type>
-foo_3(const T0__& t, const T1__& n, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+template <typename T0__>
+std::vector<typename boost::math::tools::promote_args<T0__>::type>
+foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1636,10 +1600,9 @@ foo_3(const T0__& t, const T1__& n, std::ostream* pstream__) {
 }
 
 struct foo_3_functor__ {
-template <typename T0__, typename T1__>
-std::vector<typename boost::math::tools::promote_args<T0__,
-T1__>::type>
-operator()(const T0__& t, const T1__& n, std::ostream* pstream__)  const 
+template <typename T0__>
+std::vector<typename boost::math::tools::promote_args<T0__>::type>
+operator()(const T0__& t, const int& n, std::ostream* pstream__)  const 
 {
 return foo_3(t, n, pstream__);
 }
@@ -1651,7 +1614,6 @@ typename boost::math::tools::promote_args<T0__>::type
 foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
        std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   
@@ -1681,7 +1643,6 @@ template <typename T0__>
 void
 foo_4(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1719,7 +1680,6 @@ relative_diff(const T0__& x, const T1__& y, const T2__& max_,
           T1__,
           T2__,
           T3__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1783,18 +1743,15 @@ return relative_diff(x, y, max_, min_, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__>
 Eigen::Matrix<typename boost::math::tools::promote_args<T0__,
 T1__>::type, -1, 1>
 foo_5(const Eigen::Matrix<T0__, -1, 1>& shared_params,
       const Eigen::Matrix<T1__, -1, 1>& job_params,
-      const std::vector<T2__>& data_r, const std::vector<T3__>& data_i,
+      const std::vector<double>& data_r, const std::vector<int>& data_i,
       std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1812,12 +1769,12 @@ foo_5(const Eigen::Matrix<T0__, -1, 1>& shared_params,
 }
 
 struct foo_5_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__>
 Eigen::Matrix<typename boost::math::tools::promote_args<T0__,
 T1__>::type, -1, 1>
 operator()(const Eigen::Matrix<T0__, -1, 1>& shared_params,
            const Eigen::Matrix<T1__, -1, 1>& job_params,
-           const std::vector<T2__>& data_r, const std::vector<T3__>& data_i,
+           const std::vector<double>& data_r, const std::vector<int>& data_i,
            std::ostream* pstream__)  const 
 {
 return foo_5(shared_params, job_params, data_r, data_i, pstream__);
@@ -1835,7 +1792,6 @@ foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
           T2__,
           T3__,
           T4__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1878,7 +1834,6 @@ foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
           T2__,
           T3__,
           T4__, typename boost::math::tools::promote_args<T5__>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   
@@ -1907,14 +1862,11 @@ return foo_five_args_lp(x1, x2, x3, x4, x5, x6, lp__, lp_accum__, pstream__);
 }
 };
 
-template <typename T0__, typename T1__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__,
-T1__>::type, -1, -1>
-covsqrt2corsqrt(const Eigen::Matrix<T0__, -1, -1>& mat, const T1__& invert,
+template <typename T0__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, -1>
+covsqrt2corsqrt(const Eigen::Matrix<T0__, -1, -1>& mat, const int& invert,
                 std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1950,22 +1902,20 @@ covsqrt2corsqrt(const Eigen::Matrix<T0__, -1, -1>& mat, const T1__& invert,
 }
 
 struct covsqrt2corsqrt_functor__ {
-template <typename T0__, typename T1__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__,
-T1__>::type, -1, -1>
-operator()(const Eigen::Matrix<T0__, -1, -1>& mat, const T1__& invert,
+template <typename T0__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, -1>
+operator()(const Eigen::Matrix<T0__, -1, -1>& mat, const int& invert,
            std::ostream* pstream__)  const 
 {
 return covsqrt2corsqrt(mat, invert, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
 void
-f0(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+f0(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -1974,17 +1924,14 @@ f0(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2005,12 +1952,11 @@ f0(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f0_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
 void
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2025,15 +1971,11 @@ return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type
-f1(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+int
+f1(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2042,17 +1984,7 @@ f1(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
-          T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+  using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2070,15 +2002,11 @@ f1(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f1_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+int
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2093,15 +2021,11 @@ return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>
-f2(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<int>
+f2(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2110,17 +2034,7 @@ f2(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
-          T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+  using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2138,15 +2052,11 @@ f2(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f2_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<int>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2161,15 +2071,11 @@ return f2(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>>
-f3(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<int>>
+f3(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2178,17 +2084,7 @@ f3(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
-          T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+  using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2206,15 +2102,11 @@ f3(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f3_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<int>>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2229,15 +2121,13 @@ return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type
-f4(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type
+f4(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2246,17 +2136,14 @@ f4(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2274,15 +2161,13 @@ f4(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f4_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2297,15 +2182,13 @@ return f4(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>
-f5(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type>
+f5(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2314,17 +2197,14 @@ f5(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2342,15 +2222,13 @@ f5(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f5_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2365,15 +2243,13 @@ return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>>
-f6(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type>>
+f6(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2382,17 +2258,14 @@ f6(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2410,15 +2283,13 @@ f6(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f6_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type>>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type>>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2433,15 +2304,13 @@ return f6(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, 1>
-f7(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, 1>
+f7(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2450,17 +2319,14 @@ f7(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2478,15 +2344,13 @@ f7(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f7_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, 1>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, 1>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2501,15 +2365,13 @@ return f7(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, 1>>
-f8(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, 1>>
+f8(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2518,17 +2380,14 @@ f8(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2546,15 +2405,13 @@ f8(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f8_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, 1>>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, 1>>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2569,15 +2426,13 @@ return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, 1>>>
-f9(const T0__& a1, const std::vector<T1__>& a2,
-   const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, 1>>>
+f9(const int& a1, const std::vector<int>& a2,
+   const std::vector<std::vector<int>>& a3, const T3__& a4,
    const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
    const Eigen::Matrix<T6__, -1, 1>& a7,
    const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2586,17 +2441,14 @@ f9(const T0__& a1, const std::vector<T1__>& a2,
    const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
    const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
    std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2614,15 +2466,13 @@ f9(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f9_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, 1>>>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, 1>>>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2637,15 +2487,13 @@ return f9(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, -1>
-f10(const T0__& a1, const std::vector<T1__>& a2,
-    const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, -1>
+f10(const int& a1, const std::vector<int>& a2,
+    const std::vector<std::vector<int>>& a3, const T3__& a4,
     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
     const Eigen::Matrix<T6__, -1, 1>& a7,
     const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2654,17 +2502,14 @@ f10(const T0__& a1, const std::vector<T1__>& a2,
     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
     std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2682,15 +2527,13 @@ f10(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f10_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, -1>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, -1>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2705,15 +2548,13 @@ return f10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, -1>>
-f11(const T0__& a1, const std::vector<T1__>& a2,
-    const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, -1>>
+f11(const int& a1, const std::vector<int>& a2,
+    const std::vector<std::vector<int>>& a3, const T3__& a4,
     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
     const Eigen::Matrix<T6__, -1, 1>& a7,
     const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2722,17 +2563,14 @@ f11(const T0__& a1, const std::vector<T1__>& a2,
     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
     std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2750,15 +2588,13 @@ f11(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f11_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, -1>>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, -1>>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2773,15 +2609,13 @@ return f11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, -1>>>
-f12(const T0__& a1, const std::vector<T1__>& a2,
-    const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, -1>>>
+f12(const int& a1, const std::vector<int>& a2,
+    const std::vector<std::vector<int>>& a3, const T3__& a4,
     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
     const Eigen::Matrix<T6__, -1, 1>& a7,
     const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
@@ -2790,17 +2624,14 @@ f12(const T0__& a1, const std::vector<T1__>& a2,
     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
     std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__,
-          T4__, typename boost::math::tools::promote_args<T5__,
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T3__,
+          T4__,
+          T5__,
           T6__,
-          T7__,
-          T8__,
-          T9__, typename boost::math::tools::promote_args<T10__,
-          T11__>::type>::type>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T7__, typename boost::math::tools::promote_args<T8__,
+          T9__,
+          T10__,
+          T11__>::type>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2818,15 +2649,13 @@ f12(const T0__& a1, const std::vector<T1__>& a2,
 }
 
 struct f12_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-typename T4__, typename T5__, typename T6__, typename T7__, typename T8__,
-typename T9__, typename T10__, typename T11__>
-std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__, T3__,
-T4__, typename boost::math::tools::promote_args<T5__, T6__, T7__, T8__,
-T9__, typename boost::math::tools::promote_args<T10__,
-T11__>::type>::type>::type, -1, -1>>>
-operator()(const T0__& a1, const std::vector<T1__>& a2,
-           const std::vector<std::vector<T2__>>& a3, const T3__& a4,
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+std::vector<std::vector<Eigen::Matrix<typename boost::math::tools::promote_args<T3__, T4__, T5__, T6__,
+T7__, typename boost::math::tools::promote_args<T8__, T9__, T10__,
+T11__>::type>::type, -1, -1>>>
+operator()(const int& a1, const std::vector<int>& a2,
+           const std::vector<std::vector<int>>& a3, const T3__& a4,
            const std::vector<T4__>& a5,
            const std::vector<std::vector<T5__>>& a6,
            const Eigen::Matrix<T6__, -1, 1>& a7,
@@ -2844,7 +2673,6 @@ return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 void
 foo_6(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2897,7 +2725,6 @@ return foo_6(pstream__);
 Eigen::Matrix<double, -1, -1>
 matfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2930,7 +2757,6 @@ return matfoo(pstream__);
 Eigen::Matrix<double, -1, 1>
 vecfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2959,7 +2785,6 @@ template <typename T0__>
 Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, 1>
 vecmufoo(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2999,7 +2824,6 @@ template <typename T0__>
 Eigen::Matrix<typename boost::math::tools::promote_args<T0__>::type, -1, 1>
 vecmubar(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3036,18 +2860,16 @@ return vecmubar(mu, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__,
-T3__>::type, -1, 1>
+template <typename T0__, typename T1__, typename T2__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__,
+T2__>::type, -1, 1>
 algebra_system(const Eigen::Matrix<T0__, -1, 1>& x,
                const Eigen::Matrix<T1__, -1, 1>& y,
-               const std::vector<T2__>& dat,
-               const std::vector<T3__>& dat_int, std::ostream* pstream__) {
+               const std::vector<T2__>& dat, const std::vector<int>& dat_int,
+               std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
           T1__,
-          T2__,
-          T3__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T2__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3077,29 +2899,26 @@ algebra_system(const Eigen::Matrix<T0__, -1, 1>& x,
 }
 
 struct algebra_system_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__>
-Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__, T2__,
-T3__>::type, -1, 1>
+template <typename T0__, typename T1__, typename T2__>
+Eigen::Matrix<typename boost::math::tools::promote_args<T0__, T1__,
+T2__>::type, -1, 1>
 operator()(const Eigen::Matrix<T0__, -1, 1>& x,
            const Eigen::Matrix<T1__, -1, 1>& y, const std::vector<T2__>& dat,
-           const std::vector<T3__>& dat_int, std::ostream* pstream__)  const 
+           const std::vector<int>& dat_int, std::ostream* pstream__)  const 
 {
 return algebra_system(x, y, dat, dat_int, pstream__);
 }
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__>
 Eigen::Matrix<typename boost::math::tools::promote_args<T0__,
 T1__>::type, -1, 1>
 binomialf(const Eigen::Matrix<T0__, -1, 1>& phi,
           const Eigen::Matrix<T1__, -1, 1>& theta,
-          const std::vector<T2__>& x_r, const std::vector<T3__>& x_i,
+          const std::vector<double>& x_r, const std::vector<int>& x_i,
           std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__,
-          T2__,
-          T3__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+          T1__>::type;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3127,12 +2946,12 @@ binomialf(const Eigen::Matrix<T0__, -1, 1>& phi,
 }
 
 struct binomialf_functor__ {
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__>
 Eigen::Matrix<typename boost::math::tools::promote_args<T0__,
 T1__>::type, -1, 1>
 operator()(const Eigen::Matrix<T0__, -1, 1>& phi,
            const Eigen::Matrix<T1__, -1, 1>& theta,
-           const std::vector<T2__>& x_r, const std::vector<T3__>& x_i,
+           const std::vector<double>& x_r, const std::vector<int>& x_i,
            std::ostream* pstream__)  const 
 {
 return binomialf(phi, theta, x_r, x_i, pstream__);

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -410,14 +410,14 @@
                    (decl_type (Sized SInt))))
                  (smeta <opaque>))
                 ((stmt
-                  (For (loopvar sym2__)
+                  (For (loopvar sym1__)
                    (lower
                     ((expr (Lit Int 1))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
                    (upper
                     ((expr
-                      (FunApp StanLib FnLength__
+                      (FunApp CompilerInternal FnLength__
                        (((expr (Var vs))
                          (emeta
                           ((mtype (UArray (UArray UInt))) (mloc <opaque>)
@@ -428,181 +428,196 @@
                     ((stmt
                       (Block
                        (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized (UArray UInt)))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype (UArray (UArray UInt)))
-                                 (mloc <opaque>) (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym2__))
-                                 (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UInt ())
-                           ((expr (Lit Int 0))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Break) (smeta <opaque>)))))
-                     (smeta <opaque>)))))
-                 (smeta <opaque>))
-                ((stmt
-                  (For (loopvar sym3__)
-                   (lower
-                    ((expr (Lit Int 1))
-                     (emeta
-                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
-                   (upper
-                    ((expr
-                      (FunApp StanLib FnLength__
-                       (((expr (Var vs))
-                         (emeta
-                          ((mtype (UArray (UArray UInt))) (mloc <opaque>)
-                           (madlevel DataOnly)))))))
-                     (emeta
-                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
-                   (body
-                    ((stmt
-                      (Block
-                       (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized (UArray UInt)))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype (UArray (UArray UInt)))
-                                 (mloc <opaque>) (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym3__))
-                                 (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UInt ())
-                           ((expr (Lit Int 0))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Continue) (smeta <opaque>)))))
-                     (smeta <opaque>)))))
-                 (smeta <opaque>))
-                ((stmt
-                  (For (loopvar sym4__)
-                   (lower
-                    ((expr (Lit Int 1))
-                     (emeta
-                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
-                   (upper
-                    ((expr
-                      (FunApp StanLib FnLength__
-                       (((expr (Var vs))
-                         (emeta
-                          ((mtype (UArray (UArray UInt))) (mloc <opaque>)
-                           (madlevel DataOnly)))))))
-                     (emeta
-                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
-                   (body
-                    ((stmt
-                      (Block
-                       (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized (UArray UInt)))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype (UArray (UArray UInt)))
-                                 (mloc <opaque>) (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym4__))
-                                 (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (For (loopvar sym5__)
-                           (lower
-                            ((expr (Lit Int 1))
-                             (emeta
-                              ((mtype UInt) (mloc <opaque>)
-                               (madlevel DataOnly)))))
-                           (upper
-                            ((expr
-                              (FunApp StanLib FnLength__
-                               (((expr (Var v))
-                                 (emeta
-                                  ((mtype (UArray UInt)) (mloc <opaque>)
-                                   (madlevel DataOnly)))))))
-                             (emeta
-                              ((mtype UInt) (mloc <opaque>)
-                               (madlevel DataOnly)))))
-                           (body
+                          (Block
+                           (((stmt
+                              (Decl (decl_adtype DataOnly) (decl_id v)
+                               (decl_type (Unsized (UArray UInt)))))
+                             (smeta <opaque>))
                             ((stmt
-                              (Block
-                               (((stmt
-                                  (Decl (decl_adtype DataOnly) (decl_id vv)
-                                   (decl_type (Unsized UInt))))
-                                 (smeta <opaque>))
+                              (Assignment (v (UArray UInt) ())
+                               ((expr
+                                 (Indexed
+                                  ((expr (Var vs))
+                                   (emeta
+                                    ((mtype (UArray (UArray UInt)))
+                                     (mloc <opaque>) (madlevel DataOnly))))
+                                  ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly))))))))
+                                (emeta
+                                 ((mtype (UArray UInt)) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (z UInt ())
+                               ((expr (Lit Int 0))
+                                (emeta
+                                 ((mtype UInt) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt Break) (smeta <opaque>)))))
+                         (smeta <opaque>)))))
+                     (smeta <opaque>)))))
+                 (smeta <opaque>))
+                ((stmt
+                  (For (loopvar sym1__)
+                   (lower
+                    ((expr (Lit Int 1))
+                     (emeta
+                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                   (upper
+                    ((expr
+                      (FunApp CompilerInternal FnLength__
+                       (((expr (Var vs))
+                         (emeta
+                          ((mtype (UArray (UArray UInt))) (mloc <opaque>)
+                           (madlevel DataOnly)))))))
+                     (emeta
+                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                   (body
+                    ((stmt
+                      (Block
+                       (((stmt
+                          (Block
+                           (((stmt
+                              (Decl (decl_adtype DataOnly) (decl_id v)
+                               (decl_type (Unsized (UArray UInt)))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (v (UArray UInt) ())
+                               ((expr
+                                 (Indexed
+                                  ((expr (Var vs))
+                                   (emeta
+                                    ((mtype (UArray (UArray UInt)))
+                                     (mloc <opaque>) (madlevel DataOnly))))
+                                  ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly))))))))
+                                (emeta
+                                 ((mtype (UArray UInt)) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (z UInt ())
+                               ((expr (Lit Int 0))
+                                (emeta
+                                 ((mtype UInt) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt Continue) (smeta <opaque>)))))
+                         (smeta <opaque>)))))
+                     (smeta <opaque>)))))
+                 (smeta <opaque>))
+                ((stmt
+                  (For (loopvar sym1__)
+                   (lower
+                    ((expr (Lit Int 1))
+                     (emeta
+                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                   (upper
+                    ((expr
+                      (FunApp CompilerInternal FnLength__
+                       (((expr (Var vs))
+                         (emeta
+                          ((mtype (UArray (UArray UInt))) (mloc <opaque>)
+                           (madlevel DataOnly)))))))
+                     (emeta
+                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
+                   (body
+                    ((stmt
+                      (Block
+                       (((stmt
+                          (Block
+                           (((stmt
+                              (Decl (decl_adtype DataOnly) (decl_id v)
+                               (decl_type (Unsized (UArray UInt)))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (v (UArray UInt) ())
+                               ((expr
+                                 (Indexed
+                                  ((expr (Var vs))
+                                   (emeta
+                                    ((mtype (UArray (UArray UInt)))
+                                     (mloc <opaque>) (madlevel DataOnly))))
+                                  ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly))))))))
+                                (emeta
+                                 ((mtype (UArray UInt)) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (For (loopvar sym1__)
+                               (lower
+                                ((expr (Lit Int 1))
+                                 (emeta
+                                  ((mtype UInt) (mloc <opaque>)
+                                   (madlevel DataOnly)))))
+                               (upper
+                                ((expr
+                                  (FunApp CompilerInternal FnLength__
+                                   (((expr (Var v))
+                                     (emeta
+                                      ((mtype (UArray UInt)) (mloc <opaque>)
+                                       (madlevel DataOnly)))))))
+                                 (emeta
+                                  ((mtype UInt) (mloc <opaque>)
+                                   (madlevel DataOnly)))))
+                               (body
                                 ((stmt
-                                  (Assignment (vv UInt ())
-                                   ((expr
-                                     (Indexed
-                                      ((expr (Var v))
-                                       (emeta
-                                        ((mtype (UArray UInt))
-                                         (mloc <opaque>) (madlevel DataOnly))))
-                                      ((Single
-                                        ((expr (Var sym5__))
-                                         (emeta
-                                          ((mtype UInt) (mloc <opaque>)
-                                           (madlevel DataOnly))))))))
-                                    (emeta
-                                     ((mtype UInt) (mloc <opaque>)
-                                      (madlevel DataOnly))))))
-                                 (smeta <opaque>))
-                                ((stmt
-                                  (Assignment (z UInt ())
-                                   ((expr (Lit Int 0))
-                                    (emeta
-                                     ((mtype UInt) (mloc <opaque>)
-                                      (madlevel DataOnly))))))
-                                 (smeta <opaque>))
-                                ((stmt Break) (smeta <opaque>)))))
+                                  (Block
+                                   (((stmt
+                                      (Block
+                                       (((stmt
+                                          (Decl (decl_adtype DataOnly)
+                                           (decl_id vv)
+                                           (decl_type (Unsized UInt))))
+                                         (smeta <opaque>))
+                                        ((stmt
+                                          (Assignment (vv UInt ())
+                                           ((expr
+                                             (Indexed
+                                              ((expr (Var v))
+                                               (emeta
+                                                ((mtype (UArray UInt))
+                                                 (mloc <opaque>)
+                                                 (madlevel DataOnly))))
+                                              ((Single
+                                                ((expr (Var sym1__))
+                                                 (emeta
+                                                  ((mtype UInt)
+                                                   (mloc <opaque>)
+                                                   (madlevel DataOnly))))))))
+                                            (emeta
+                                             ((mtype UInt) (mloc <opaque>)
+                                              (madlevel DataOnly))))))
+                                         (smeta <opaque>))
+                                        ((stmt
+                                          (Assignment (z UInt ())
+                                           ((expr (Lit Int 0))
+                                            (emeta
+                                             ((mtype UInt) (mloc <opaque>)
+                                              (madlevel DataOnly))))))
+                                         (smeta <opaque>))
+                                        ((stmt Break) (smeta <opaque>)))))
+                                     (smeta <opaque>)))))
+                                 (smeta <opaque>)))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (z UInt ())
+                               ((expr (Lit Int 1))
+                                (emeta
+                                 ((mtype UInt) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
                              (smeta <opaque>)))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UInt ())
-                           ((expr (Lit Int 1))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
                          (smeta <opaque>)))))
                      (smeta <opaque>)))))
                  (smeta <opaque>)))))
@@ -631,14 +646,14 @@
                         ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
                  (smeta <opaque>))
                 ((stmt
-                  (For (loopvar sym6__)
+                  (For (loopvar sym1__)
                    (lower
                     ((expr (Lit Int 1))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
                    (upper
                     ((expr
-                      (FunApp StanLib FnLength__
+                      (FunApp StanLib rows
                        (((expr (Var vs))
                          (emeta
                           ((mtype UMatrix) (mloc <opaque>)
@@ -649,45 +664,86 @@
                     ((stmt
                       (Block
                        (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized UReal))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype UMatrix) (mloc <opaque>)
-                                 (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym6__))
+                          (For (loopvar sym2__)
+                           (lower
+                            ((expr (Lit Int 1))
+                             (emeta
+                              ((mtype UInt) (mloc <opaque>)
+                               (madlevel DataOnly)))))
+                           (upper
+                            ((expr
+                              (FunApp CompilerInternal FnLength__
+                               (((expr
+                                  (Indexed
+                                   ((expr (Var vs))
+                                    (emeta
+                                     ((mtype UMatrix) (mloc <opaque>)
+                                      (madlevel DataOnly))))
+                                   ((Single
+                                     ((expr (Var sym1__))
+                                      (emeta
+                                       ((mtype UInt) (mloc <opaque>)
+                                        (madlevel DataOnly))))))))
                                  (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UReal ())
-                           ((expr (Lit Int 0))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Break) (smeta <opaque>)))))
+                                  ((mtype URowVector) (mloc <opaque>)
+                                   (madlevel DataOnly)))))))
+                             (emeta
+                              ((mtype UInt) (mloc <opaque>)
+                               (madlevel DataOnly)))))
+                           (body
+                            ((stmt
+                              (Block
+                               (((stmt
+                                  (Block
+                                   (((stmt
+                                      (Decl (decl_adtype DataOnly)
+                                       (decl_id v)
+                                       (decl_type (Unsized UReal))))
+                                     (smeta <opaque>))
+                                    ((stmt
+                                      (Assignment (v UReal ())
+                                       ((expr
+                                         (Indexed
+                                          ((expr (Var vs))
+                                           (emeta
+                                            ((mtype UMatrix) (mloc <opaque>)
+                                             (madlevel DataOnly))))
+                                          ((Single
+                                            ((expr (Var sym1__))
+                                             (emeta
+                                              ((mtype UInt) (mloc <opaque>)
+                                               (madlevel DataOnly)))))
+                                           (Single
+                                            ((expr (Var sym2__))
+                                             (emeta
+                                              ((mtype UInt) (mloc <opaque>)
+                                               (madlevel DataOnly))))))))
+                                        (emeta
+                                         ((mtype UReal) (mloc <opaque>)
+                                          (madlevel DataOnly))))))
+                                     (smeta <opaque>))
+                                    ((stmt
+                                      (Assignment (z UReal ())
+                                       ((expr (Lit Int 0))
+                                        (emeta
+                                         ((mtype UInt) (mloc <opaque>)
+                                          (madlevel DataOnly))))))
+                                     (smeta <opaque>))
+                                    ((stmt Break) (smeta <opaque>)))))
+                                 (smeta <opaque>)))))
+                             (smeta <opaque>)))))
+                         (smeta <opaque>)))))
                      (smeta <opaque>)))))
                  (smeta <opaque>))
                 ((stmt
-                  (For (loopvar sym7__)
+                  (For (loopvar sym1__)
                    (lower
                     ((expr (Lit Int 1))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
                    (upper
                     ((expr
-                      (FunApp StanLib FnLength__
+                      (FunApp StanLib rows
                        (((expr (Var vs))
                          (emeta
                           ((mtype UMatrix) (mloc <opaque>)
@@ -698,34 +754,75 @@
                     ((stmt
                       (Block
                        (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized UReal))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype UMatrix) (mloc <opaque>)
-                                 (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym7__))
+                          (For (loopvar sym2__)
+                           (lower
+                            ((expr (Lit Int 1))
+                             (emeta
+                              ((mtype UInt) (mloc <opaque>)
+                               (madlevel DataOnly)))))
+                           (upper
+                            ((expr
+                              (FunApp CompilerInternal FnLength__
+                               (((expr
+                                  (Indexed
+                                   ((expr (Var vs))
+                                    (emeta
+                                     ((mtype UMatrix) (mloc <opaque>)
+                                      (madlevel DataOnly))))
+                                   ((Single
+                                     ((expr (Var sym1__))
+                                      (emeta
+                                       ((mtype UInt) (mloc <opaque>)
+                                        (madlevel DataOnly))))))))
                                  (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UReal ())
-                           ((expr (Lit Real 3.1))
-                            (emeta
-                             ((mtype UReal) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Continue) (smeta <opaque>)))))
+                                  ((mtype URowVector) (mloc <opaque>)
+                                   (madlevel DataOnly)))))))
+                             (emeta
+                              ((mtype UInt) (mloc <opaque>)
+                               (madlevel DataOnly)))))
+                           (body
+                            ((stmt
+                              (Block
+                               (((stmt
+                                  (Block
+                                   (((stmt
+                                      (Decl (decl_adtype DataOnly)
+                                       (decl_id v)
+                                       (decl_type (Unsized UReal))))
+                                     (smeta <opaque>))
+                                    ((stmt
+                                      (Assignment (v UReal ())
+                                       ((expr
+                                         (Indexed
+                                          ((expr (Var vs))
+                                           (emeta
+                                            ((mtype UMatrix) (mloc <opaque>)
+                                             (madlevel DataOnly))))
+                                          ((Single
+                                            ((expr (Var sym1__))
+                                             (emeta
+                                              ((mtype UInt) (mloc <opaque>)
+                                               (madlevel DataOnly)))))
+                                           (Single
+                                            ((expr (Var sym2__))
+                                             (emeta
+                                              ((mtype UInt) (mloc <opaque>)
+                                               (madlevel DataOnly))))))))
+                                        (emeta
+                                         ((mtype UReal) (mloc <opaque>)
+                                          (madlevel DataOnly))))))
+                                     (smeta <opaque>))
+                                    ((stmt
+                                      (Assignment (z UReal ())
+                                       ((expr (Lit Real 3.1))
+                                        (emeta
+                                         ((mtype UReal) (mloc <opaque>)
+                                          (madlevel DataOnly))))))
+                                     (smeta <opaque>))
+                                    ((stmt Continue) (smeta <opaque>)))))
+                                 (smeta <opaque>)))))
+                             (smeta <opaque>)))))
+                         (smeta <opaque>)))))
                      (smeta <opaque>)))))
                  (smeta <opaque>)))))
              (smeta <opaque>))))
@@ -750,14 +847,14 @@
                         ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
                  (smeta <opaque>))
                 ((stmt
-                  (For (loopvar sym8__)
+                  (For (loopvar sym1__)
                    (lower
                     ((expr (Lit Int 1))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
                    (upper
                     ((expr
-                      (FunApp StanLib FnLength__
+                      (FunApp CompilerInternal FnLength__
                        (((expr (Var vs))
                          (emeta
                           ((mtype UVector) (mloc <opaque>)
@@ -768,45 +865,48 @@
                     ((stmt
                       (Block
                        (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized UReal))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype UVector) (mloc <opaque>)
-                                 (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym8__))
-                                 (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UReal ())
-                           ((expr (Lit Int 0))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Break) (smeta <opaque>)))))
+                          (Block
+                           (((stmt
+                              (Decl (decl_adtype DataOnly) (decl_id v)
+                               (decl_type (Unsized UReal))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (v UReal ())
+                               ((expr
+                                 (Indexed
+                                  ((expr (Var vs))
+                                   (emeta
+                                    ((mtype UVector) (mloc <opaque>)
+                                     (madlevel DataOnly))))
+                                  ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly))))))))
+                                (emeta
+                                 ((mtype UReal) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (z UReal ())
+                               ((expr (Lit Int 0))
+                                (emeta
+                                 ((mtype UInt) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt Break) (smeta <opaque>)))))
+                         (smeta <opaque>)))))
                      (smeta <opaque>)))))
                  (smeta <opaque>))
                 ((stmt
-                  (For (loopvar sym9__)
+                  (For (loopvar sym1__)
                    (lower
                     ((expr (Lit Int 1))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
                    (upper
                     ((expr
-                      (FunApp StanLib FnLength__
+                      (FunApp CompilerInternal FnLength__
                        (((expr (Var vs))
                          (emeta
                           ((mtype UVector) (mloc <opaque>)
@@ -817,34 +917,37 @@
                     ((stmt
                       (Block
                        (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized UReal))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype UVector) (mloc <opaque>)
-                                 (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym9__))
-                                 (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UReal ())
-                           ((expr (Lit Real 3.2))
-                            (emeta
-                             ((mtype UReal) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Continue) (smeta <opaque>)))))
+                          (Block
+                           (((stmt
+                              (Decl (decl_adtype DataOnly) (decl_id v)
+                               (decl_type (Unsized UReal))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (v UReal ())
+                               ((expr
+                                 (Indexed
+                                  ((expr (Var vs))
+                                   (emeta
+                                    ((mtype UVector) (mloc <opaque>)
+                                     (madlevel DataOnly))))
+                                  ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly))))))))
+                                (emeta
+                                 ((mtype UReal) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (z UReal ())
+                               ((expr (Lit Real 3.2))
+                                (emeta
+                                 ((mtype UReal) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt Continue) (smeta <opaque>)))))
+                         (smeta <opaque>)))))
                      (smeta <opaque>)))))
                  (smeta <opaque>)))))
              (smeta <opaque>))))
@@ -869,14 +972,14 @@
                         ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
                  (smeta <opaque>))
                 ((stmt
-                  (For (loopvar sym10__)
+                  (For (loopvar sym1__)
                    (lower
                     ((expr (Lit Int 1))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
                    (upper
                     ((expr
-                      (FunApp StanLib FnLength__
+                      (FunApp CompilerInternal FnLength__
                        (((expr (Var vs))
                          (emeta
                           ((mtype URowVector) (mloc <opaque>)
@@ -887,45 +990,48 @@
                     ((stmt
                       (Block
                        (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized UReal))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype URowVector) (mloc <opaque>)
-                                 (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym10__))
-                                 (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UReal ())
-                           ((expr (Lit Int 0))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Break) (smeta <opaque>)))))
+                          (Block
+                           (((stmt
+                              (Decl (decl_adtype DataOnly) (decl_id v)
+                               (decl_type (Unsized UReal))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (v UReal ())
+                               ((expr
+                                 (Indexed
+                                  ((expr (Var vs))
+                                   (emeta
+                                    ((mtype URowVector) (mloc <opaque>)
+                                     (madlevel DataOnly))))
+                                  ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly))))))))
+                                (emeta
+                                 ((mtype UReal) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (z UReal ())
+                               ((expr (Lit Int 0))
+                                (emeta
+                                 ((mtype UInt) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt Break) (smeta <opaque>)))))
+                         (smeta <opaque>)))))
                      (smeta <opaque>)))))
                  (smeta <opaque>))
                 ((stmt
-                  (For (loopvar sym11__)
+                  (For (loopvar sym1__)
                    (lower
                     ((expr (Lit Int 1))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
                    (upper
                     ((expr
-                      (FunApp StanLib FnLength__
+                      (FunApp CompilerInternal FnLength__
                        (((expr (Var vs))
                          (emeta
                           ((mtype URowVector) (mloc <opaque>)
@@ -936,34 +1042,37 @@
                     ((stmt
                       (Block
                        (((stmt
-                          (Decl (decl_adtype DataOnly) (decl_id v)
-                           (decl_type (Unsized UReal))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (v UInt ())
-                           ((expr
-                             (Indexed
-                              ((expr (Var vs))
-                               (emeta
-                                ((mtype URowVector) (mloc <opaque>)
-                                 (madlevel DataOnly))))
-                              ((Single
-                                ((expr (Var sym11__))
-                                 (emeta
-                                  ((mtype UInt) (mloc <opaque>)
-                                   (madlevel DataOnly))))))))
-                            (emeta
-                             ((mtype UInt) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt
-                          (Assignment (z UReal ())
-                           ((expr (Lit Real 3.3))
-                            (emeta
-                             ((mtype UReal) (mloc <opaque>)
-                              (madlevel DataOnly))))))
-                         (smeta <opaque>))
-                        ((stmt Continue) (smeta <opaque>)))))
+                          (Block
+                           (((stmt
+                              (Decl (decl_adtype DataOnly) (decl_id v)
+                               (decl_type (Unsized UReal))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (v UReal ())
+                               ((expr
+                                 (Indexed
+                                  ((expr (Var vs))
+                                   (emeta
+                                    ((mtype URowVector) (mloc <opaque>)
+                                     (madlevel DataOnly))))
+                                  ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly))))))))
+                                (emeta
+                                 ((mtype UReal) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt
+                              (Assignment (z UReal ())
+                               ((expr (Lit Real 3.3))
+                                (emeta
+                                 ((mtype UReal) (mloc <opaque>)
+                                  (madlevel DataOnly))))))
+                             (smeta <opaque>))
+                            ((stmt Continue) (smeta <opaque>)))))
+                         (smeta <opaque>)))))
                      (smeta <opaque>)))))
                  (smeta <opaque>)))))
              (smeta <opaque>))))
@@ -1024,13 +1133,13 @@
             (decl_type (Sized SInt))))
           (smeta <opaque>))
          ((stmt
-           (For (loopvar sym12__)
+           (For (loopvar sym1__)
             (lower
              ((expr (Lit Int 1))
               (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
             (upper
              ((expr
-               (FunApp StanLib FnLength__
+               (FunApp CompilerInternal FnLength__
                 (((expr (Var vs))
                   (emeta
                    ((mtype (UArray UInt)) (mloc <opaque>)
@@ -1040,29 +1149,33 @@
              ((stmt
                (Block
                 (((stmt
-                   (Decl (decl_adtype DataOnly) (decl_id v)
-                    (decl_type (Unsized UInt))))
-                  (smeta <opaque>))
-                 ((stmt
-                   (Assignment (v UInt ())
-                    ((expr
-                      (Indexed
-                       ((expr (Var vs))
-                        (emeta
-                         ((mtype (UArray UInt)) (mloc <opaque>)
-                          (madlevel DataOnly))))
-                       ((Single
-                         ((expr (Var sym12__))
-                          (emeta
-                           ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
-                     (emeta
-                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-                  (smeta <opaque>))
-                 ((stmt
-                   (Assignment (y UInt ())
-                    ((expr (Var v))
-                     (emeta
-                      ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+                   (Block
+                    (((stmt
+                       (Decl (decl_adtype DataOnly) (decl_id v)
+                        (decl_type (Unsized UInt))))
+                      (smeta <opaque>))
+                     ((stmt
+                       (Assignment (v UInt ())
+                        ((expr
+                          (Indexed
+                           ((expr (Var vs))
+                            (emeta
+                             ((mtype (UArray UInt)) (mloc <opaque>)
+                              (madlevel DataOnly))))
+                           ((Single
+                             ((expr (Var sym1__))
+                              (emeta
+                               ((mtype UInt) (mloc <opaque>)
+                                (madlevel DataOnly))))))))
+                         (emeta
+                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+                      (smeta <opaque>))
+                     ((stmt
+                       (Assignment (y UInt ())
+                        ((expr (Var v))
+                         (emeta
+                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+                      (smeta <opaque>)))))
                   (smeta <opaque>)))))
               (smeta <opaque>)))))
           (smeta <opaque>))
@@ -3053,7 +3166,7 @@
             (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
           (upper
            ((expr
-             (FunApp StanLib FnLength__
+             (FunApp CompilerInternal FnLength__
               (((expr (Var blocked_tdata_vs))
                 (emeta
                  ((mtype URowVector) (mloc <opaque>) (madlevel DataOnly)))))))
@@ -3062,27 +3175,33 @@
            ((stmt
              (Block
               (((stmt
-                 (Decl (decl_adtype DataOnly) (decl_id v)
-                  (decl_type (Unsized UReal))))
-                (smeta <opaque>))
-               ((stmt
-                 (Assignment (v UInt ())
-                  ((expr
-                    (Indexed
-                     ((expr (Var blocked_tdata_vs))
-                      (emeta
-                       ((mtype URowVector) (mloc <opaque>)
-                        (madlevel DataOnly))))
-                     ((Single
-                       ((expr (Var sym1__))
-                        (emeta
-                         ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
-                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
-                (smeta <opaque>))
-               ((stmt
-                 (Assignment (z UReal ())
-                  ((expr (Lit Int 0))
-                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+                 (Block
+                  (((stmt
+                     (Decl (decl_adtype DataOnly) (decl_id v)
+                      (decl_type (Unsized UReal))))
+                    (smeta <opaque>))
+                   ((stmt
+                     (Assignment (v UReal ())
+                      ((expr
+                        (Indexed
+                         ((expr (Var blocked_tdata_vs))
+                          (emeta
+                           ((mtype URowVector) (mloc <opaque>)
+                            (madlevel DataOnly))))
+                         ((Single
+                           ((expr (Var sym1__))
+                            (emeta
+                             ((mtype UInt) (mloc <opaque>)
+                              (madlevel DataOnly))))))))
+                       (emeta
+                        ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))))
+                    (smeta <opaque>))
+                   ((stmt
+                     (Assignment (z UReal ())
+                      ((expr (Lit Int 0))
+                       (emeta
+                        ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))
+                    (smeta <opaque>)))))
                 (smeta <opaque>)))))
             (smeta <opaque>)))))
         (smeta <opaque>)))))
@@ -3878,7 +3997,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -3892,7 +4011,7 @@
              (Assignment
               (offset_multiplier (UArray UReal)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -3903,7 +4022,7 @@
                        ((mtype (UArray UReal)) (mloc <opaque>)
                         (madlevel AutoDiffable))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -3929,7 +4048,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -3943,7 +4062,7 @@
              (Assignment
               (p_real_1d_ar (UArray UReal)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -3954,7 +4073,7 @@
                        ((mtype (UArray UReal)) (mloc <opaque>)
                         (madlevel AutoDiffable))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -3984,7 +4103,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -3995,7 +4114,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4006,7 +4125,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -4022,17 +4141,17 @@
                              (Assignment
                               (p_real_3d_ar (UArray (UArray (UArray UReal)))
                                ((Single
+                                 ((expr (Var sym1__))
+                                  (emeta
+                                   ((mtype UInt) (mloc <opaque>)
+                                    (madlevel DataOnly)))))
+                                (Single
                                  ((expr (Var sym2__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))
                                 (Single
                                  ((expr (Var sym3__))
-                                  (emeta
-                                   ((mtype UInt) (mloc <opaque>)
-                                    (madlevel DataOnly)))))
-                                (Single
-                                 ((expr (Var sym4__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))))
@@ -4047,17 +4166,17 @@
                                         (mloc <opaque>)
                                         (madlevel AutoDiffable))))
                                      ((Single
+                                       ((expr (Var sym1__))
+                                        (emeta
+                                         ((mtype UInt) (mloc <opaque>)
+                                          (madlevel DataOnly)))))
+                                      (Single
                                        ((expr (Var sym2__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly)))))
                                       (Single
                                        ((expr (Var sym3__))
-                                        (emeta
-                                         ((mtype UInt) (mloc <opaque>)
-                                          (madlevel DataOnly)))))
-                                      (Single
-                                       ((expr (Var sym4__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly))))))))
@@ -4091,7 +4210,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4105,7 +4224,7 @@
              (Assignment
               (p_vec UVector
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -4116,7 +4235,7 @@
                        ((mtype UVector) (mloc <opaque>)
                         (madlevel AutoDiffable))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -4212,7 +4331,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4223,7 +4342,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4234,7 +4353,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -4247,7 +4366,7 @@
                        ((stmt
                          (Block
                           (((stmt
-                             (For (loopvar sym5__)
+                             (For (loopvar sym4__)
                               (lower
                                ((expr (Lit Int 1))
                                 (emeta
@@ -4265,6 +4384,11 @@
                                      (Assignment
                                       (p_ar_mat (UArray (UArray UMatrix))
                                        ((Single
+                                         ((expr (Var sym1__))
+                                          (emeta
+                                           ((mtype UInt) (mloc <opaque>)
+                                            (madlevel DataOnly)))))
+                                        (Single
                                          ((expr (Var sym2__))
                                           (emeta
                                            ((mtype UInt) (mloc <opaque>)
@@ -4276,11 +4400,6 @@
                                             (madlevel DataOnly)))))
                                         (Single
                                          ((expr (Var sym4__))
-                                          (emeta
-                                           ((mtype UInt) (mloc <opaque>)
-                                            (madlevel DataOnly)))))
-                                        (Single
-                                         ((expr (Var sym5__))
                                           (emeta
                                            ((mtype UInt) (mloc <opaque>)
                                             (madlevel DataOnly)))))))
@@ -4296,6 +4415,12 @@
                                                 (mloc <opaque>)
                                                 (madlevel AutoDiffable))))
                                              ((Single
+                                               ((expr (Var sym1__))
+                                                (emeta
+                                                 ((mtype UInt)
+                                                  (mloc <opaque>)
+                                                  (madlevel DataOnly)))))
+                                              (Single
                                                ((expr (Var sym2__))
                                                 (emeta
                                                  ((mtype UInt)
@@ -4309,12 +4434,6 @@
                                                   (madlevel DataOnly)))))
                                               (Single
                                                ((expr (Var sym4__))
-                                                (emeta
-                                                 ((mtype UInt)
-                                                  (mloc <opaque>)
-                                                  (madlevel DataOnly)))))
-                                              (Single
-                                               ((expr (Var sym5__))
                                                 (emeta
                                                  ((mtype UInt)
                                                   (mloc <opaque>)
@@ -4376,7 +4495,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4390,7 +4509,7 @@
              (Assignment
               (p_1d_simplex (UArray UVector)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -4401,7 +4520,7 @@
                        ((mtype (UArray UVector)) (mloc <opaque>)
                         (madlevel AutoDiffable))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -4432,7 +4551,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4443,7 +4562,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4454,7 +4573,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -4471,17 +4590,17 @@
                               (p_3d_simplex
                                (UArray (UArray (UArray UVector)))
                                ((Single
+                                 ((expr (Var sym1__))
+                                  (emeta
+                                   ((mtype UInt) (mloc <opaque>)
+                                    (madlevel DataOnly)))))
+                                (Single
                                  ((expr (Var sym2__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))
                                 (Single
                                  ((expr (Var sym3__))
-                                  (emeta
-                                   ((mtype UInt) (mloc <opaque>)
-                                    (madlevel DataOnly)))))
-                                (Single
-                                 ((expr (Var sym4__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))))
@@ -4496,17 +4615,17 @@
                                         (mloc <opaque>)
                                         (madlevel AutoDiffable))))
                                      ((Single
+                                       ((expr (Var sym1__))
+                                        (emeta
+                                         ((mtype UInt) (mloc <opaque>)
+                                          (madlevel DataOnly)))))
+                                      (Single
                                        ((expr (Var sym2__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly)))))
                                       (Single
                                        ((expr (Var sym3__))
-                                        (emeta
-                                         ((mtype UInt) (mloc <opaque>)
-                                          (madlevel DataOnly)))))
-                                      (Single
-                                       ((expr (Var sym4__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly))))))))
@@ -4589,7 +4708,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -4603,7 +4722,7 @@
              (Assignment
               (p_cfcov_33_ar (UArray UMatrix)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -4614,7 +4733,7 @@
                        ((mtype (UArray UMatrix)) (mloc <opaque>)
                         (madlevel AutoDiffable))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -5245,7 +5364,7 @@
        (emeta ((mtype UVector) (mloc <opaque>) (madlevel AutoDiffable))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5259,7 +5378,7 @@
              (NRFunApp CompilerInternal FnCheck__
               (((expr (Lit Str greater_or_equal))
                 (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-               ((expr (Lit Str tp_real_1d_ar[sym2__]))
+               ((expr (Lit Str tp_real_1d_ar[sym1__]))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                ((expr
                  (Indexed
@@ -5268,7 +5387,7 @@
                     ((mtype (UArray UReal)) (mloc <opaque>)
                      (madlevel AutoDiffable))))
                   ((Single
-                    ((expr (Var sym2__))
+                    ((expr (Var sym1__))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                 (emeta
@@ -5279,7 +5398,7 @@
         (smeta <opaque>)))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5290,7 +5409,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5301,7 +5420,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -5321,7 +5440,7 @@
                                   (madlevel DataOnly))))
                                ((expr
                                  (Lit Str
-                                  "tp_real_3d_ar[sym2__, sym3__, sym4__]"))
+                                  "tp_real_3d_ar[sym1__, sym2__, sym3__]"))
                                 (emeta
                                  ((mtype UInt) (mloc <opaque>)
                                   (madlevel DataOnly))))
@@ -5332,17 +5451,17 @@
                                     ((mtype (UArray (UArray (UArray UReal))))
                                      (mloc <opaque>) (madlevel AutoDiffable))))
                                   ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly)))))
+                                   (Single
                                     ((expr (Var sym2__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly)))))
                                    (Single
                                     ((expr (Var sym3__))
-                                     (emeta
-                                      ((mtype UInt) (mloc <opaque>)
-                                       (madlevel DataOnly)))))
-                                   (Single
-                                    ((expr (Var sym4__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly))))))))
@@ -5372,7 +5491,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5383,7 +5502,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5398,7 +5517,7 @@
                       (((expr (Lit Str greater_or_equal))
                         (emeta
                          ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-                       ((expr (Lit Str "tp_ar_mat[sym2__, sym3__]"))
+                       ((expr (Lit Str "tp_ar_mat[sym1__, sym2__]"))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                        ((expr
@@ -5408,12 +5527,12 @@
                             ((mtype (UArray (UArray UMatrix)))
                              (mloc <opaque>) (madlevel AutoDiffable))))
                           ((Single
-                            ((expr (Var sym2__))
+                            ((expr (Var sym1__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly)))))
                            (Single
-                            ((expr (Var sym3__))
+                            ((expr (Var sym2__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly))))))))
@@ -5429,7 +5548,7 @@
         (smeta <opaque>)))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5440,7 +5559,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5455,7 +5574,7 @@
                       (((expr (Lit Str less_or_equal))
                         (emeta
                          ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-                       ((expr (Lit Str "tp_ar_mat[sym2__, sym3__]"))
+                       ((expr (Lit Str "tp_ar_mat[sym1__, sym2__]"))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                        ((expr
@@ -5465,12 +5584,12 @@
                             ((mtype (UArray (UArray UMatrix)))
                              (mloc <opaque>) (madlevel AutoDiffable))))
                           ((Single
-                            ((expr (Var sym2__))
+                            ((expr (Var sym1__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly)))))
                            (Single
-                            ((expr (Var sym3__))
+                            ((expr (Var sym2__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly))))))))
@@ -5495,7 +5614,7 @@
         (emeta ((mtype UVector) (mloc <opaque>) (madlevel AutoDiffable)))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5509,7 +5628,7 @@
              (NRFunApp CompilerInternal FnCheck__
               (((expr (Lit Str simplex))
                 (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-               ((expr (Lit Str tp_1d_simplex[sym2__]))
+               ((expr (Lit Str tp_1d_simplex[sym1__]))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                ((expr
                  (Indexed
@@ -5518,7 +5637,7 @@
                     ((mtype (UArray UVector)) (mloc <opaque>)
                      (madlevel AutoDiffable))))
                   ((Single
-                    ((expr (Var sym2__))
+                    ((expr (Var sym1__))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                 (emeta
@@ -5527,7 +5646,7 @@
         (smeta <opaque>)))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5538,7 +5657,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5549,7 +5668,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -5569,7 +5688,7 @@
                                   (madlevel DataOnly))))
                                ((expr
                                  (Lit Str
-                                  "tp_3d_simplex[sym2__, sym3__, sym4__]"))
+                                  "tp_3d_simplex[sym1__, sym2__, sym3__]"))
                                 (emeta
                                  ((mtype UInt) (mloc <opaque>)
                                   (madlevel DataOnly))))
@@ -5581,17 +5700,17 @@
                                       (UArray (UArray (UArray UVector))))
                                      (mloc <opaque>) (madlevel AutoDiffable))))
                                   ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly)))))
+                                   (Single
                                     ((expr (Var sym2__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly)))))
                                    (Single
                                     ((expr (Var sym3__))
-                                     (emeta
-                                      ((mtype UInt) (mloc <opaque>)
-                                       (madlevel DataOnly)))))
-                                   (Single
-                                    ((expr (Var sym4__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly))))))))
@@ -5624,7 +5743,7 @@
         (emeta ((mtype UMatrix) (mloc <opaque>) (madlevel AutoDiffable)))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -5638,7 +5757,7 @@
              (NRFunApp CompilerInternal FnCheck__
               (((expr (Lit Str cholesky_factor))
                 (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-               ((expr (Lit Str tp_cfcov_33_ar[sym2__]))
+               ((expr (Lit Str tp_cfcov_33_ar[sym1__]))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                ((expr
                  (Indexed
@@ -5647,7 +5766,7 @@
                     ((mtype (UArray UMatrix)) (mloc <opaque>)
                      (madlevel AutoDiffable))))
                   ((Single
-                    ((expr (Var sym2__))
+                    ((expr (Var sym1__))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                 (emeta
@@ -6418,7 +6537,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6432,7 +6551,7 @@
              (Assignment
               (offset_multiplier (UArray UReal)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -6443,7 +6562,7 @@
                        ((mtype (UArray UReal)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -6468,7 +6587,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6482,7 +6601,7 @@
              (Assignment
               (p_real_1d_ar (UArray UReal)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -6493,7 +6612,7 @@
                        ((mtype (UArray UReal)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -6522,7 +6641,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6533,7 +6652,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6544,7 +6663,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -6560,17 +6679,17 @@
                              (Assignment
                               (p_real_3d_ar (UArray (UArray (UArray UReal)))
                                ((Single
+                                 ((expr (Var sym1__))
+                                  (emeta
+                                   ((mtype UInt) (mloc <opaque>)
+                                    (madlevel DataOnly)))))
+                                (Single
                                  ((expr (Var sym2__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))
                                 (Single
                                  ((expr (Var sym3__))
-                                  (emeta
-                                   ((mtype UInt) (mloc <opaque>)
-                                    (madlevel DataOnly)))))
-                                (Single
-                                 ((expr (Var sym4__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))))
@@ -6584,17 +6703,17 @@
                                          (UArray (UArray (UArray UReal))))
                                         (mloc <opaque>) (madlevel DataOnly))))
                                      ((Single
+                                       ((expr (Var sym1__))
+                                        (emeta
+                                         ((mtype UInt) (mloc <opaque>)
+                                          (madlevel DataOnly)))))
+                                      (Single
                                        ((expr (Var sym2__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly)))))
                                       (Single
                                        ((expr (Var sym3__))
-                                        (emeta
-                                         ((mtype UInt) (mloc <opaque>)
-                                          (madlevel DataOnly)))))
-                                      (Single
-                                       ((expr (Var sym4__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly))))))))
@@ -6628,7 +6747,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6642,7 +6761,7 @@
              (Assignment
               (p_vec UVector
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -6652,7 +6771,7 @@
                       (emeta
                        ((mtype UVector) (mloc <opaque>) (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -6747,7 +6866,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6758,7 +6877,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6769,7 +6888,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -6782,7 +6901,7 @@
                        ((stmt
                          (Block
                           (((stmt
-                             (For (loopvar sym5__)
+                             (For (loopvar sym4__)
                               (lower
                                ((expr (Lit Int 1))
                                 (emeta
@@ -6800,6 +6919,11 @@
                                      (Assignment
                                       (p_ar_mat (UArray (UArray UMatrix))
                                        ((Single
+                                         ((expr (Var sym1__))
+                                          (emeta
+                                           ((mtype UInt) (mloc <opaque>)
+                                            (madlevel DataOnly)))))
+                                        (Single
                                          ((expr (Var sym2__))
                                           (emeta
                                            ((mtype UInt) (mloc <opaque>)
@@ -6811,11 +6935,6 @@
                                             (madlevel DataOnly)))))
                                         (Single
                                          ((expr (Var sym4__))
-                                          (emeta
-                                           ((mtype UInt) (mloc <opaque>)
-                                            (madlevel DataOnly)))))
-                                        (Single
-                                         ((expr (Var sym5__))
                                           (emeta
                                            ((mtype UInt) (mloc <opaque>)
                                             (madlevel DataOnly)))))))
@@ -6831,6 +6950,12 @@
                                                 (mloc <opaque>)
                                                 (madlevel DataOnly))))
                                              ((Single
+                                               ((expr (Var sym1__))
+                                                (emeta
+                                                 ((mtype UInt)
+                                                  (mloc <opaque>)
+                                                  (madlevel DataOnly)))))
+                                              (Single
                                                ((expr (Var sym2__))
                                                 (emeta
                                                  ((mtype UInt)
@@ -6844,12 +6969,6 @@
                                                   (madlevel DataOnly)))))
                                               (Single
                                                ((expr (Var sym4__))
-                                                (emeta
-                                                 ((mtype UInt)
-                                                  (mloc <opaque>)
-                                                  (madlevel DataOnly)))))
-                                              (Single
-                                               ((expr (Var sym5__))
                                                 (emeta
                                                  ((mtype UInt)
                                                   (mloc <opaque>)
@@ -6911,7 +7030,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6925,7 +7044,7 @@
              (Assignment
               (p_1d_simplex (UArray UVector)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -6936,7 +7055,7 @@
                        ((mtype (UArray UVector)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -6966,7 +7085,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6977,7 +7096,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -6988,7 +7107,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -7005,17 +7124,17 @@
                               (p_3d_simplex
                                (UArray (UArray (UArray UVector)))
                                ((Single
+                                 ((expr (Var sym1__))
+                                  (emeta
+                                   ((mtype UInt) (mloc <opaque>)
+                                    (madlevel DataOnly)))))
+                                (Single
                                  ((expr (Var sym2__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))
                                 (Single
                                  ((expr (Var sym3__))
-                                  (emeta
-                                   ((mtype UInt) (mloc <opaque>)
-                                    (madlevel DataOnly)))))
-                                (Single
-                                 ((expr (Var sym4__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))))
@@ -7029,17 +7148,17 @@
                                          (UArray (UArray (UArray UVector))))
                                         (mloc <opaque>) (madlevel DataOnly))))
                                      ((Single
+                                       ((expr (Var sym1__))
+                                        (emeta
+                                         ((mtype UInt) (mloc <opaque>)
+                                          (madlevel DataOnly)))))
+                                      (Single
                                        ((expr (Var sym2__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly)))))
                                       (Single
                                        ((expr (Var sym3__))
-                                        (emeta
-                                         ((mtype UInt) (mloc <opaque>)
-                                          (madlevel DataOnly)))))
-                                      (Single
-                                       ((expr (Var sym4__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly))))))))
@@ -7122,7 +7241,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -7136,7 +7255,7 @@
              (Assignment
               (p_cfcov_33_ar (UArray UMatrix)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnConstrain__
@@ -7147,7 +7266,7 @@
                        ((mtype (UArray UMatrix)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -8961,7 +9080,7 @@
        (emeta ((mtype (UArray UVector)) (mloc <opaque>) (madlevel DataOnly))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -8975,7 +9094,7 @@
              (NRFunApp CompilerInternal FnCheck__
               (((expr (Lit Str greater_or_equal))
                 (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-               ((expr (Lit Str gq_real_1d_ar[sym2__]))
+               ((expr (Lit Str gq_real_1d_ar[sym1__]))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                ((expr
                  (Indexed
@@ -8984,7 +9103,7 @@
                     ((mtype (UArray UReal)) (mloc <opaque>)
                      (madlevel DataOnly))))
                   ((Single
-                    ((expr (Var sym2__))
+                    ((expr (Var sym1__))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                 (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
@@ -8994,7 +9113,7 @@
         (smeta <opaque>)))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9005,7 +9124,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9016,7 +9135,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -9036,7 +9155,7 @@
                                   (madlevel DataOnly))))
                                ((expr
                                  (Lit Str
-                                  "gq_real_3d_ar[sym2__, sym3__, sym4__]"))
+                                  "gq_real_3d_ar[sym1__, sym2__, sym3__]"))
                                 (emeta
                                  ((mtype UInt) (mloc <opaque>)
                                   (madlevel DataOnly))))
@@ -9047,17 +9166,17 @@
                                     ((mtype (UArray (UArray (UArray UReal))))
                                      (mloc <opaque>) (madlevel DataOnly))))
                                   ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly)))))
+                                   (Single
                                     ((expr (Var sym2__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly)))))
                                    (Single
                                     ((expr (Var sym3__))
-                                     (emeta
-                                      ((mtype UInt) (mloc <opaque>)
-                                       (madlevel DataOnly)))))
-                                   (Single
-                                    ((expr (Var sym4__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly))))))))
@@ -9087,7 +9206,7 @@
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9098,7 +9217,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9113,7 +9232,7 @@
                       (((expr (Lit Str greater_or_equal))
                         (emeta
                          ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-                       ((expr (Lit Str "gq_ar_mat[sym2__, sym3__]"))
+                       ((expr (Lit Str "gq_ar_mat[sym1__, sym2__]"))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                        ((expr
@@ -9123,12 +9242,12 @@
                             ((mtype (UArray (UArray UMatrix)))
                              (mloc <opaque>) (madlevel DataOnly))))
                           ((Single
-                            ((expr (Var sym2__))
+                            ((expr (Var sym1__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly)))))
                            (Single
-                            ((expr (Var sym3__))
+                            ((expr (Var sym2__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly))))))))
@@ -9144,7 +9263,7 @@
         (smeta <opaque>)))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9155,7 +9274,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9170,7 +9289,7 @@
                       (((expr (Lit Str less_or_equal))
                         (emeta
                          ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-                       ((expr (Lit Str "gq_ar_mat[sym2__, sym3__]"))
+                       ((expr (Lit Str "gq_ar_mat[sym1__, sym2__]"))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                        ((expr
@@ -9180,12 +9299,12 @@
                             ((mtype (UArray (UArray UMatrix)))
                              (mloc <opaque>) (madlevel DataOnly))))
                           ((Single
-                            ((expr (Var sym2__))
+                            ((expr (Var sym1__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly)))))
                            (Single
-                            ((expr (Var sym3__))
+                            ((expr (Var sym2__))
                              (emeta
                               ((mtype UInt) (mloc <opaque>)
                                (madlevel DataOnly))))))))
@@ -9210,7 +9329,7 @@
         (emeta ((mtype UVector) (mloc <opaque>) (madlevel DataOnly)))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9224,7 +9343,7 @@
              (NRFunApp CompilerInternal FnCheck__
               (((expr (Lit Str simplex))
                 (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-               ((expr (Lit Str gq_1d_simplex[sym2__]))
+               ((expr (Lit Str gq_1d_simplex[sym1__]))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                ((expr
                  (Indexed
@@ -9233,7 +9352,7 @@
                     ((mtype (UArray UVector)) (mloc <opaque>)
                      (madlevel DataOnly))))
                   ((Single
-                    ((expr (Var sym2__))
+                    ((expr (Var sym1__))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                 (emeta ((mtype UVector) (mloc <opaque>) (madlevel DataOnly)))))))
@@ -9241,7 +9360,7 @@
         (smeta <opaque>)))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9252,7 +9371,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9263,7 +9382,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -9283,7 +9402,7 @@
                                   (madlevel DataOnly))))
                                ((expr
                                  (Lit Str
-                                  "gq_3d_simplex[sym2__, sym3__, sym4__]"))
+                                  "gq_3d_simplex[sym1__, sym2__, sym3__]"))
                                 (emeta
                                  ((mtype UInt) (mloc <opaque>)
                                   (madlevel DataOnly))))
@@ -9295,17 +9414,17 @@
                                       (UArray (UArray (UArray UVector))))
                                      (mloc <opaque>) (madlevel DataOnly))))
                                   ((Single
+                                    ((expr (Var sym1__))
+                                     (emeta
+                                      ((mtype UInt) (mloc <opaque>)
+                                       (madlevel DataOnly)))))
+                                   (Single
                                     ((expr (Var sym2__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly)))))
                                    (Single
                                     ((expr (Var sym3__))
-                                     (emeta
-                                      ((mtype UInt) (mloc <opaque>)
-                                       (madlevel DataOnly)))))
-                                   (Single
-                                    ((expr (Var sym4__))
                                      (emeta
                                       ((mtype UInt) (mloc <opaque>)
                                        (madlevel DataOnly))))))))
@@ -9338,7 +9457,7 @@
         (emeta ((mtype UMatrix) (mloc <opaque>) (madlevel DataOnly)))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9352,7 +9471,7 @@
              (NRFunApp CompilerInternal FnCheck__
               (((expr (Lit Str cholesky_factor))
                 (emeta ((mtype UReal) (mloc <opaque>) (madlevel DataOnly))))
-               ((expr (Lit Str gq_cfcov_33_ar[sym2__]))
+               ((expr (Lit Str gq_cfcov_33_ar[sym1__]))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))
                ((expr
                  (Indexed
@@ -9361,7 +9480,7 @@
                     ((mtype (UArray UMatrix)) (mloc <opaque>)
                      (madlevel DataOnly))))
                   ((Single
-                    ((expr (Var sym2__))
+                    ((expr (Var sym1__))
                      (emeta
                       ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                 (emeta ((mtype UMatrix) (mloc <opaque>) (madlevel DataOnly)))))))
@@ -9381,7 +9500,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9395,7 +9514,7 @@
              (Assignment
               (offset_multiplier (UArray UReal)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnUnconstrain__
@@ -9406,7 +9525,7 @@
                        ((mtype (UArray UReal)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -9431,7 +9550,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9445,7 +9564,7 @@
              (Assignment
               (p_real_1d_ar (UArray UReal)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnUnconstrain__
@@ -9456,7 +9575,7 @@
                        ((mtype (UArray UReal)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -9485,7 +9604,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9496,7 +9615,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9507,7 +9626,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -9523,17 +9642,17 @@
                              (Assignment
                               (p_real_3d_ar (UArray (UArray (UArray UReal)))
                                ((Single
+                                 ((expr (Var sym1__))
+                                  (emeta
+                                   ((mtype UInt) (mloc <opaque>)
+                                    (madlevel DataOnly)))))
+                                (Single
                                  ((expr (Var sym2__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))
                                 (Single
                                  ((expr (Var sym3__))
-                                  (emeta
-                                   ((mtype UInt) (mloc <opaque>)
-                                    (madlevel DataOnly)))))
-                                (Single
-                                 ((expr (Var sym4__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))))
@@ -9547,17 +9666,17 @@
                                          (UArray (UArray (UArray UReal))))
                                         (mloc <opaque>) (madlevel DataOnly))))
                                      ((Single
+                                       ((expr (Var sym1__))
+                                        (emeta
+                                         ((mtype UInt) (mloc <opaque>)
+                                          (madlevel DataOnly)))))
+                                      (Single
                                        ((expr (Var sym2__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly)))))
                                       (Single
                                        ((expr (Var sym3__))
-                                        (emeta
-                                         ((mtype UInt) (mloc <opaque>)
-                                          (madlevel DataOnly)))))
-                                      (Single
-                                       ((expr (Var sym4__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly))))))))
@@ -9591,7 +9710,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9605,7 +9724,7 @@
              (Assignment
               (p_vec UVector
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnUnconstrain__
@@ -9615,7 +9734,7 @@
                       (emeta
                        ((mtype UVector) (mloc <opaque>) (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -9710,7 +9829,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9721,7 +9840,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9732,7 +9851,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -9745,7 +9864,7 @@
                        ((stmt
                          (Block
                           (((stmt
-                             (For (loopvar sym5__)
+                             (For (loopvar sym4__)
                               (lower
                                ((expr (Lit Int 1))
                                 (emeta
@@ -9763,6 +9882,11 @@
                                      (Assignment
                                       (p_ar_mat (UArray (UArray UMatrix))
                                        ((Single
+                                         ((expr (Var sym1__))
+                                          (emeta
+                                           ((mtype UInt) (mloc <opaque>)
+                                            (madlevel DataOnly)))))
+                                        (Single
                                          ((expr (Var sym2__))
                                           (emeta
                                            ((mtype UInt) (mloc <opaque>)
@@ -9774,11 +9898,6 @@
                                             (madlevel DataOnly)))))
                                         (Single
                                          ((expr (Var sym4__))
-                                          (emeta
-                                           ((mtype UInt) (mloc <opaque>)
-                                            (madlevel DataOnly)))))
-                                        (Single
-                                         ((expr (Var sym5__))
                                           (emeta
                                            ((mtype UInt) (mloc <opaque>)
                                             (madlevel DataOnly)))))))
@@ -9794,6 +9913,12 @@
                                                 (mloc <opaque>)
                                                 (madlevel DataOnly))))
                                              ((Single
+                                               ((expr (Var sym1__))
+                                                (emeta
+                                                 ((mtype UInt)
+                                                  (mloc <opaque>)
+                                                  (madlevel DataOnly)))))
+                                              (Single
                                                ((expr (Var sym2__))
                                                 (emeta
                                                  ((mtype UInt)
@@ -9807,12 +9932,6 @@
                                                   (madlevel DataOnly)))))
                                               (Single
                                                ((expr (Var sym4__))
-                                                (emeta
-                                                 ((mtype UInt)
-                                                  (mloc <opaque>)
-                                                  (madlevel DataOnly)))))
-                                              (Single
-                                               ((expr (Var sym5__))
                                                 (emeta
                                                  ((mtype UInt)
                                                   (mloc <opaque>)
@@ -9874,7 +9993,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9888,7 +10007,7 @@
              (Assignment
               (p_1d_simplex (UArray UVector)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnUnconstrain__
@@ -9899,7 +10018,7 @@
                        ((mtype (UArray UVector)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta
@@ -9929,7 +10048,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9940,7 +10059,7 @@
        ((stmt
          (Block
           (((stmt
-             (For (loopvar sym3__)
+             (For (loopvar sym2__)
               (lower
                ((expr (Lit Int 1))
                 (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -9951,7 +10070,7 @@
                ((stmt
                  (Block
                   (((stmt
-                     (For (loopvar sym4__)
+                     (For (loopvar sym3__)
                       (lower
                        ((expr (Lit Int 1))
                         (emeta
@@ -9968,17 +10087,17 @@
                               (p_3d_simplex
                                (UArray (UArray (UArray UVector)))
                                ((Single
+                                 ((expr (Var sym1__))
+                                  (emeta
+                                   ((mtype UInt) (mloc <opaque>)
+                                    (madlevel DataOnly)))))
+                                (Single
                                  ((expr (Var sym2__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))
                                 (Single
                                  ((expr (Var sym3__))
-                                  (emeta
-                                   ((mtype UInt) (mloc <opaque>)
-                                    (madlevel DataOnly)))))
-                                (Single
-                                 ((expr (Var sym4__))
                                   (emeta
                                    ((mtype UInt) (mloc <opaque>)
                                     (madlevel DataOnly)))))))
@@ -9992,17 +10111,17 @@
                                          (UArray (UArray (UArray UVector))))
                                         (mloc <opaque>) (madlevel DataOnly))))
                                      ((Single
+                                       ((expr (Var sym1__))
+                                        (emeta
+                                         ((mtype UInt) (mloc <opaque>)
+                                          (madlevel DataOnly)))))
+                                      (Single
                                        ((expr (Var sym2__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly)))))
                                       (Single
                                        ((expr (Var sym3__))
-                                        (emeta
-                                         ((mtype UInt) (mloc <opaque>)
-                                          (madlevel DataOnly)))))
-                                      (Single
-                                       ((expr (Var sym4__))
                                         (emeta
                                          ((mtype UInt) (mloc <opaque>)
                                           (madlevel DataOnly))))))))
@@ -10077,7 +10196,7 @@
           (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))))
     (smeta <opaque>))
    ((stmt
-     (For (loopvar sym2__)
+     (For (loopvar sym1__)
       (lower
        ((expr (Lit Int 1))
         (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))
@@ -10091,7 +10210,7 @@
              (Assignment
               (p_cfcov_33_ar (UArray UMatrix)
                ((Single
-                 ((expr (Var sym2__))
+                 ((expr (Var sym1__))
                   (emeta ((mtype UInt) (mloc <opaque>) (madlevel DataOnly)))))))
               ((expr
                 (FunApp CompilerInternal FnUnconstrain__
@@ -10102,7 +10221,7 @@
                        ((mtype (UArray UMatrix)) (mloc <opaque>)
                         (madlevel DataOnly))))
                      ((Single
-                       ((expr (Var sym2__))
+                       ((expr (Var sym1__))
                         (emeta
                          ((mtype UInt) (mloc <opaque>) (madlevel DataOnly))))))))
                    (emeta

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -155,8 +155,6 @@ void
 nrfun_lp(const T0__& x, const int& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     int sym34__;
@@ -196,8 +194,6 @@ rfun(const int& y, std::ostream* pstream__) {
   using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     int sym37__;
@@ -234,8 +230,6 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__>
 int
 rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
   using local_scalar_t__ = int;
-  local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-  (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
     {
@@ -300,9 +294,6 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
   T__ log_prob(std::vector<T__>& params_r__, std::vector<int>& params_i__,
                std::ostream* pstream__ = 0) const {
     typedef T__ local_scalar_t__;
-    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-    (void) DUMMY_VAR__;  // suppress unused var warning
-
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     static const char* function__ = "optimizations_model_namespace::log_prob";

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -191,7 +191,7 @@ return nrfun_lp(x, y, lp__, lp_accum__, pstream__);
 
 int
 rfun(const int& y, std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = double;
   const static bool propto__ = true;
   (void) propto__;
   
@@ -229,7 +229,7 @@ return rfun(y, pstream__);
 template <bool propto__, typename T_lp__, typename T_lp_accum__>
 int
 rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-  using local_scalar_t__ = int;
+  using local_scalar_t__ = double;
   
   try {
     {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -149,14 +149,12 @@ static const std::vector<string> locations_array__ = {" (found before start of p
                                                       " (in 'optimizations.stan', line 11, column 8 to column 21)",
                                                       " (in 'optimizations.stan', line 16, column 8 to column 18)"};
 
-template <bool propto__, typename T0__, typename T1__, typename T_lp__,
+template <bool propto__, typename T0__, typename T_lp__,
 typename T_lp_accum__>
 void
-nrfun_lp(const T0__& x, const T1__& y, T_lp__& lp__,
-         T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-          T1__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+nrfun_lp(const T0__& x, const int& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
+         std::ostream* pstream__) {
+  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   
@@ -183,21 +181,19 @@ nrfun_lp(const T0__& x, const T1__& y, T_lp__& lp__,
 }
 
 struct nrfun_lp_functor__ {
-template <bool propto__, typename T0__, typename T1__, typename T_lp__,
+template <bool propto__, typename T0__, typename T_lp__,
 typename T_lp_accum__>
 void
-operator()(const T0__& x, const T1__& y, T_lp__& lp__,
+operator()(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__)  const 
 {
 return nrfun_lp(x, y, lp__, lp_accum__, pstream__);
 }
 };
 
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-rfun(const T0__& y, std::ostream* pstream__) {
-  using local_scalar_t__ = typename boost::math::tools::promote_args<T0__>::type;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+int
+rfun(const int& y, std::ostream* pstream__) {
+  using local_scalar_t__ = int;
   const static bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -227,19 +223,17 @@ rfun(const T0__& y, std::ostream* pstream__) {
 }
 
 struct rfun_functor__ {
-template <typename T0__>
-typename boost::math::tools::promote_args<T0__>::type
-operator()(const T0__& y, std::ostream* pstream__)  const 
+int
+operator()(const int& y, std::ostream* pstream__)  const 
 {
 return rfun(y, pstream__);
 }
 };
 
 template <bool propto__, typename T_lp__, typename T_lp_accum__>
-double
+int
 rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-  using local_scalar_t__ = double;
-  typedef local_scalar_t__ fun_return_scalar_t__;
+  using local_scalar_t__ = int;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   
@@ -260,7 +254,7 @@ rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
 
 struct rfun_lp_functor__ {
 template <bool propto__, typename T_lp__, typename T_lp_accum__>
-double
+int
 operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__)  const 
 {
 return rfun_lp(lp__, lp_accum__, pstream__);

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -19,13 +19,11 @@ let%expect_test "udf" =
   |> strf "@[<v>%a" pp_fun_def |> print_endline ;
   [%expect
     {|
-    template <typename T0__, typename T1__>
+    template <typename T1__>
     void
-    sars(const Eigen::Matrix<T0__, -1, -1>& x,
+    sars(const Eigen::Matrix<double, -1, -1>& x,
          const Eigen::Matrix<T1__, 1, -1>& y, std::ostream* pstream__) {
-      using local_scalar_t__ = typename boost::math::tools::promote_args<T0__,
-              T1__>::type;
-      typedef local_scalar_t__ fun_return_scalar_t__;
+      using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
       const static bool propto__ = true;
       (void) propto__;
       local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -42,9 +40,9 @@ let%expect_test "udf" =
     }
 
     struct sars_functor__ {
-    template <typename T0__, typename T1__>
+    template <typename T1__>
     void
-    operator()(const Eigen::Matrix<T0__, -1, -1>& x,
+    operator()(const Eigen::Matrix<double, -1, -1>& x,
                const Eigen::Matrix<T1__, 1, -1>& y, std::ostream* pstream__)  const
     {
     return sars(x, y, pstream__);

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -26,8 +26,6 @@ let%expect_test "udf" =
       using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
       const static bool propto__ = true;
       (void) propto__;
-      local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-      (void) DUMMY_VAR__;  // suppress unused var warning
 
       try {
         return add(x, 1);


### PR DESCRIPTION
Assumes we'll never want to autodiff something declared as an integer, which might make sense. I wasn't able to see a decent quick way of enabling autodiff over ints while preserving the old behavior. Also doesn't fill ints with NaN now. 

Fixes #343 