### PR TITLE
Using bijectors to constrain initial values

### DIFF
--- a/test/integration/tfp/stan.py
+++ b/test/integration/tfp/stan.py
@@ -43,7 +43,7 @@ def stan(model, nchain=4, num_main_iters=1000, num_warmup_iters=1000):
   mcmc_trace, pkr = tfp.mcmc.sample_chain(
       num_results = num_main_iters,
       num_burnin_steps = num_warmup_iters,
-      current_state=initial_states,
+      current_state=[bijector.forward(state) for bijector, state in zip(model.parameter_bijectors(),initial_states)],
       kernel=kernel)
 
   return mcmc_trace, pkr

--- a/test/integration/tfp/stan.py
+++ b/test/integration/tfp/stan.py
@@ -21,7 +21,7 @@ def step_size_setter_fn(pkr, new_step_size):
 
 @tf.function(experimental_compile=True)
 def stan(model, nchain=4, num_main_iters=1000, num_warmup_iters=1000):
-  initial_states = [tf.random.uniform(s, 0, 2, dtype, name="initializer") for s in model.parameter_shapes(nchain)]
+  initial_states = [tf.random.uniform(s, -2, 2, dtype, name="initializer") for s in model.parameter_shapes(nchain)]
   step_sizes = [1e-2 * tf.ones_like(i) for i in initial_states]
   kernel = tfp.mcmc.TransformedTransitionKernel(
     tfp.mcmc.nuts.NoUTurnSampler(


### PR DESCRIPTION
NUTS expects initial values to be in the constrained space; passing random(0,2) returns nans for constrained variables outside of this range (for example, <upper=0>).