### PR TITLE
Stan code canonicalizer

### DIFF
--- a/src/frontend/Canonicalize.ml
+++ b/src/frontend/Canonicalize.ml
@@ -229,7 +229,11 @@ let canonicalize_program program : typed_program =
              ; smeta= _ }
              when String.is_suffix ~suffix:"_log" name ->
                let newname =
-                 if Middle.UnsizedType.is_real_type type_ then
+                 if String.is_suffix ~suffix:"_cdf_log" name then
+                   String.drop_suffix name 8 ^ "_lcdf"
+                 else if String.is_suffix ~suffix:"_ccdf_log" name then
+                   String.drop_suffix name 9 ^ "_lccdf"
+                 else if Middle.UnsizedType.is_real_type type_ then
                    String.drop_suffix name 4 ^ "_lpdf"
                  else String.drop_suffix name 4 ^ "_lpmf"
                in

--- a/src/frontend/Canonicalize.ml
+++ b/src/frontend/Canonicalize.ml
@@ -38,6 +38,11 @@ let without_suffix name =
     String.is_suffix ~suffix:"_lpdf" name
     || String.is_suffix ~suffix:"_lpmf" name
   then String.drop_suffix name 5
+  else if
+    is_distribution name && not (is_distribution (name ^ "_log"))
+    (* technically, should also look for user-defined functions
+       but Semantic_check.mli does not export the symbol table *)
+  then String.drop_suffix name 4 (* "_log" *)
   else name
 
 let rec repair_syntax_expr {expr; emeta} =

--- a/src/frontend/Canonicalize.ml
+++ b/src/frontend/Canonicalize.ml
@@ -1,0 +1,119 @@
+open Core_kernel
+open Ast
+
+let deprecated_functions = String.Table.create ()
+let deprecated_distributions = String.Table.create ()
+
+let () =
+  Hashtbl.add_multi deprecated_functions ~key:"multiply_log" ~data:"lmultiply" ;
+  Hashtbl.add_multi deprecated_functions ~key:"binomial_coefficient_log"
+    ~data:"lchoose" ;
+  Hashtbl.add_multi deprecated_functions ~key:"integrate_ode"
+    ~data:"integrate_ode_rk45" ;
+  List.iter Middle.Stan_math_signatures.distributions
+    ~f:(fun (fnkinds, name, _) ->
+      List.iter fnkinds ~f:(function
+        | Lpdf ->
+            Hashtbl.add_multi deprecated_distributions ~key:(name ^ "_log")
+              ~data:(name ^ "_lpdf")
+        | Lpmf ->
+            Hashtbl.add_multi deprecated_distributions ~key:(name ^ "_log")
+              ~data:(name ^ "_lpmf")
+        | Cdf ->
+            Hashtbl.add_multi deprecated_distributions ~key:(name ^ "_cdf_log")
+              ~data:(name ^ "_lcdf")
+        | Ccdf ->
+            Hashtbl.add_multi deprecated_distributions
+              ~key:(name ^ "_ccdf_log") ~data:(name ^ "_lccdf")
+        | Rng | UnaryVectorized -> () ) )
+
+let is_distribution name =
+  Option.is_some (Hashtbl.find deprecated_distributions name)
+
+let rename_distribution name =
+  match Hashtbl.find deprecated_distributions name with
+  | None | Some [] -> name
+  | Some (rename :: _) -> rename
+
+let rename_function name =
+  match Hashtbl.find deprecated_functions name with
+  | None | Some [] -> name
+  | Some (rename :: _) -> rename
+
+let rec replace_deprecated_expr {expr; emeta} =
+  let expr =
+    match expr with
+    | GetLP -> GetTarget
+    | FunApp (f, {name; id_loc}, e) ->
+        if is_distribution name then
+          CondDistApp
+            ( f
+            , {name= rename_distribution name; id_loc}
+            , List.map ~f:replace_deprecated_expr e )
+        else
+          FunApp
+            ( f
+            , {name= rename_function name; id_loc}
+            , List.map ~f:replace_deprecated_expr e )
+    | _ -> map_expression replace_deprecated_expr ident expr
+  in
+  {expr; emeta}
+
+let replace_deprecated_lval = map_lval_with replace_deprecated_expr ident
+
+let without_suffix name =
+  if
+    String.is_suffix ~suffix:"_lpdf" name
+    || String.is_suffix ~suffix:"_lpmf" name
+  then String.drop_suffix name 5
+  else name
+
+let rec replace_deprecated_stmt {stmt; smeta} =
+  let stmt =
+    match stmt with
+    | IncrementLogProb e -> TargetPE (replace_deprecated_expr e)
+    | Assignment {assign_lhs= l; assign_op= ArrowAssign; assign_rhs= e} ->
+        Assignment
+          { assign_lhs= replace_deprecated_lval l
+          ; assign_op= Assign
+          ; assign_rhs= replace_deprecated_expr e }
+    | Tilde {arg; distribution= {name; id_loc}; args; truncation} ->
+        Tilde
+          { arg= replace_deprecated_expr arg
+          ; distribution= {name= without_suffix name; id_loc}
+          ; args= List.map ~f:replace_deprecated_expr args
+          ; truncation= map_truncation replace_deprecated_expr truncation }
+    | stmt ->
+        map_statement replace_deprecated_expr replace_deprecated_stmt
+          replace_deprecated_lval ident stmt
+  in
+  {stmt; smeta}
+
+let rec no_parens {expr; emeta} =
+  match expr with
+  | Paren e -> no_parens e
+  | Variable _ | IntNumeral _ | RealNumeral _ | GetLP | GetTarget ->
+      {expr; emeta}
+  | TernaryIf _ | BinOp _ | PrefixOp _ | PostfixOp _ ->
+      {expr= map_expression keep_parens ident expr; emeta}
+  | Indexed (e, l) ->
+      { expr= Indexed (keep_parens e, List.map ~f:(map_index no_parens) l)
+      ; emeta }
+  | ArrayExpr _ | RowVectorExpr _ | FunApp _ | CondDistApp _ ->
+      {expr= map_expression no_parens ident expr; emeta}
+
+and keep_parens {expr; emeta} =
+  match expr with
+  | Paren {expr= Paren e; _} -> keep_parens e
+  | Paren ({expr= BinOp _; _} as e)
+   |Paren ({expr= PrefixOp _; _} as e)
+   |Paren ({expr= PostfixOp _; _} as e)
+   |Paren ({expr= TernaryIf _; _} as e) ->
+      {expr= Paren (no_parens e); emeta}
+  | _ -> no_parens {expr; emeta}
+
+let parens_lval = map_lval_with no_parens ident
+let parens_stmt = map_statement_with no_parens ident parens_lval ident
+
+let canonicalize_program program : untyped_program =
+  program |> map_program replace_deprecated_stmt |> map_program parens_stmt

--- a/test/integration/canonicalize/canonical.expected
+++ b/test/integration/canonicalize/canonical.expected
@@ -6,6 +6,9 @@ functions {
     dydt[2] = -y[1] - theta[1] * y[2];
     return dydt;
   }
+  real normal_log_log(real a, real b, real c) {
+    return (a - b) / c;
+  }
 }
 transformed data {
   int a = -12;
@@ -24,8 +27,17 @@ model {
   target += lchoose(10, 10);
   c ~ poisson(3.0);
   c ~ poisson_log(3.0);
-  x ~ normal(0, 1);
-  target += std_normal_lpdf(x| );
+  c ~ poisson_log(3.0);
+  if (a) {
+    x ~ normal(0, 1);
+    x ~ normal_log(0, 1);
+    x ~ normal_log(0, 1);
+    target += std_normal_lpdf(x| );
+  }
+  else {
+    x ~ exponential(1);
+    x ~ exponential(1);
+  }
   target += normal_lpdf(x| 0, 1) + normal_lcdf(2| 0, 1)
             + normal_lccdf(3| 0, 1);
   print("target: ", target());

--- a/test/integration/canonicalize/canonical.expected
+++ b/test/integration/canonicalize/canonical.expected
@@ -1,0 +1,57 @@
+  $ ../../../../install/default/bin/stanc --print-canonical deprecated.stan
+functions {
+  real[] sho(real t, real[] y, real[] theta, real[] x, int[] x_int) {
+    real dydt[2];
+    dydt[1] = y[2];
+    dydt[2] = -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+transformed data {
+  int a = -12;
+  real b = 1.5;
+  int c = abs(a);
+  real d = fabs(b);
+  int x_i[0];
+  real x_r[0];
+}
+parameters {
+  real x;
+  real theta[3];
+}
+model {
+  real k = (b < 0) ? lmultiply(1, d) : 0;
+  target += lchoose(10, 10);
+  c ~ poisson(3.0);
+  c ~ poisson_log(3.0);
+  x ~ normal(0, 1);
+  target += std_normal_lpdf(x| );
+  target += normal_lpdf(x| 0, 1) + normal_lcdf(2| 0, 1)
+            + normal_lccdf(3| 0, 1);
+  print("target: ", target());
+}
+generated quantities {
+  real y0[2] = {1.0, 2.0};
+  real ts[3] = {0.5, 1.0, 2.0};
+  real y_hat[3, 2] = integrate_ode_rk45(sho, y0, 0.0, ts, theta, x_r, x_i);
+}
+
+  $ ../../../../install/default/bin/stanc --print-canonical parenthesize.stan
+transformed data {
+  int N = 12;
+  real b = 1.5;
+}
+parameters {
+  real<lower=((b > 3) ? 1.0 : b - 2)> x;
+  matrix[N, N] m;
+}
+model {
+  matrix[N - 3, 4] n;
+  row_vector[N] v = ((1.0 + m)')[1];
+  for (i in 1 : (N - 3)) {
+    n[i] = m[i : (i + 3), i]';
+  }
+  if ((b < x) && (x < 1)) 
+    x + 4 ~ normal(0, 1 + 1) T[0, 8];
+}
+

--- a/test/integration/canonicalize/canonical.expected
+++ b/test/integration/canonicalize/canonical.expected
@@ -6,7 +6,7 @@ functions {
     dydt[2] = -y[1] - theta[1] * y[2];
     return dydt;
   }
-  real normal_log_log(real a, real b, real c) {
+  real normal_log_lpdf(real a, real b, real c) {
     return (a - b) / c;
   }
 }
@@ -32,6 +32,7 @@ model {
     x ~ normal(0, 1);
     x ~ normal_log(0, 1);
     x ~ normal_log(0, 1);
+    target += normal_log_lpdf(x| 1, 2);
     target += std_normal_lpdf(x| );
   }
   else {

--- a/test/integration/canonicalize/canonical.expected
+++ b/test/integration/canonicalize/canonical.expected
@@ -9,6 +9,9 @@ functions {
   real normal_log_lpdf(real a, real b, real c) {
     return (a - b) / c;
   }
+  real foo_lcdf(real x, real y) {
+    return x / y;
+  }
 }
 transformed data {
   int a = -12;
@@ -38,6 +41,7 @@ model {
   else {
     x ~ exponential(1);
     x ~ exponential(1);
+    target += foo_lcdf(x| 1);
   }
   target += normal_lpdf(x| 0, 1) + normal_lcdf(2| 0, 1)
             + normal_lccdf(3| 0, 1);

--- a/test/integration/canonicalize/deprecated.stan
+++ b/test/integration/canonicalize/deprecated.stan
@@ -32,6 +32,7 @@ model {
     x ~ normal(0, 1);
     x ~ normal_log(0, 1);
     x ~ normal_log_log(0, 1);
+    target += normal_log_log(x,1,2);
     increment_log_prob(std_normal_lpdf(x));
   } else {
     x ~ exponential(1);
@@ -41,6 +42,7 @@ model {
   target += normal_log(x, 0, 1)
     + normal_cdf_log(2, 0, 1)
     + normal_ccdf_log(3, 0, 1);
+
 
   print("target: ", get_lp());
 }

--- a/test/integration/canonicalize/deprecated.stan
+++ b/test/integration/canonicalize/deprecated.stan
@@ -1,0 +1,40 @@
+functions {
+  real[] sho(real t,real[] y, real[] theta, real[] x, int[] x_int) {
+    real dydt[2];
+    dydt[1] <- y[2];
+    dydt[2] <- -y[1] - theta[1] * y[2];
+    return dydt;
+  }
+}
+transformed data {
+  int a = -12;
+  real b = 1.5;
+  int c = abs(a);
+  real d = abs(b);
+  int x_i[0];
+  real x_r[0];
+}
+parameters {
+  real x;
+  real theta[3];
+}
+model {
+  real k = if_else(b<0, multiply_log(1, d), 0);
+  target += binomial_coefficient_log(10, 10);
+
+  c ~ poisson_lpmf(3.0);
+  c ~ poisson_log(3.0);
+  x ~ normal_log(0, 1);
+  increment_log_prob(std_normal_lpdf(x));
+
+  target += normal_log(x, 0, 1)
+    + normal_cdf_log(2, 0, 1)
+    + normal_ccdf_log(3, 0, 1);
+
+  print("target: ", get_lp());
+}
+generated quantities {
+  real y0[2] = {1.0, 2.0};
+  real ts[3] = {0.5, 1.0, 2.0};
+  real y_hat[3,2] = integrate_ode(sho, y0, 0.0, ts, theta, x_r, x_i );
+}

--- a/test/integration/canonicalize/deprecated.stan
+++ b/test/integration/canonicalize/deprecated.stan
@@ -5,6 +5,9 @@ functions {
     dydt[2] <- -y[1] - theta[1] * y[2];
     return dydt;
   }
+  real normal_log_log(real a, real b, real c) {
+    return (a-b)/c;
+  }
 }
 transformed data {
   int a = -12;
@@ -24,8 +27,16 @@ model {
 
   c ~ poisson_lpmf(3.0);
   c ~ poisson_log(3.0);
-  x ~ normal_log(0, 1);
-  increment_log_prob(std_normal_lpdf(x));
+  c ~ poisson_log_log(3.0);
+  if (a) {
+    x ~ normal(0, 1);
+    x ~ normal_log(0, 1);
+    x ~ normal_log_log(0, 1);
+    increment_log_prob(std_normal_lpdf(x));
+  } else {
+    x ~ exponential(1);
+    x ~ exponential_log(1);
+  }
 
   target += normal_log(x, 0, 1)
     + normal_cdf_log(2, 0, 1)

--- a/test/integration/canonicalize/deprecated.stan
+++ b/test/integration/canonicalize/deprecated.stan
@@ -8,6 +8,9 @@ functions {
   real normal_log_log(real a, real b, real c) {
     return (a-b)/c;
   }
+  real foo_cdf_log(real x, real y) {
+    return x/y;
+  }
 }
 transformed data {
   int a = -12;
@@ -37,12 +40,12 @@ model {
   } else {
     x ~ exponential(1);
     x ~ exponential_log(1);
+    increment_log_prob(foo_cdf_log(x, 1));
   }
 
   target += normal_log(x, 0, 1)
     + normal_cdf_log(2, 0, 1)
     + normal_ccdf_log(3, 0, 1);
-
 
   print("target: ", get_lp());
 }

--- a/test/integration/canonicalize/dune
+++ b/test/integration/canonicalize/dune
@@ -1,0 +1,10 @@
+(rule
+ (targets canonical.output)
+ (deps (package stanc) (:stanfiles (glob_files *.stan)))
+ (action
+  (with-stdout-to %{targets}
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --print-canonical" %{stanfiles}))))
+
+(alias
+ (name runtest)
+ (action (diff canonical.expected canonical.output)))

--- a/test/integration/canonicalize/parenthesize.stan
+++ b/test/integration/canonicalize/parenthesize.stan
@@ -1,0 +1,17 @@
+transformed data {
+  int N = 12;
+  real b = 1.5;
+}
+parameters {
+  real<lower=if_else(b > 3, 1.0, b-2)> x;
+  matrix[N,N] m;
+}
+model {
+  matrix[N-3,4] n;
+  row_vector[N] v = (((1.0)+(m))')[1];
+  for (i in (1):(N-3)) {
+    n[i] = (m[i:(i+3),(((i)))]');
+  }
+  if (((b<x) && (x<1)))
+    (x+4) ~ normal(0, (1+1)) T[0, (8)];
+}


### PR DESCRIPTION
Based on issue #262.

A new command line option that removes deprecated syntax from Stan code and pretty prints the result. No attempt is made to infer priors.

I still need to figure out what tests are required. The pretty printer seems to have nothing but a `pretty.expected` file in every subdirectory of `test/integration/good`. How are those generated?