### PR TITLE
remove  lp__ argument from _lpmf functions

### DIFF
--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -102,7 +102,7 @@ let pp_unsizedtype_local ppf (adtype, ut) =
 let pp_expr_type ppf e =
   pp_unsizedtype_local ppf Expr.Typed.(adlevel_of e, type_of e)
 
-let user_dist_suffices = ["_lp"; "_lpdf"; "_lpmf"; "_log"]
+let user_dist_suffices = ["_lpdf"; "_lpmf"; "_log"]
 
 let ends_with_any suffices s =
   List.exists ~f:(fun suffix -> String.is_suffix ~suffix s) suffices
@@ -111,14 +111,16 @@ let is_user_dist s =
   ends_with_any user_dist_suffices s
   && not (ends_with_any ["_cdf_log"; "_ccdf_log"] s)
 
+let is_user_lp s = String.is_suffix ~suffix:"_lp" s
 let suffix_args f = if ends_with "_rng" f then ["base_rng__"] else []
 
 let demangle_propto_name udf f =
   if f = "multiply_log" || f = "binomial_coefficient_log" then f
   else if Utils.is_propto_distribution f then
     Utils.stdlib_distribution_name f ^ "<propto__>"
-  else if Utils.is_distribution_name f || (udf && is_user_dist f) then
-    f ^ "<false>"
+  else if
+    Utils.is_distribution_name f || (udf && (is_user_dist f || is_user_lp f))
+  then f ^ "<false>"
   else f
 
 let fn_renames =
@@ -315,7 +317,7 @@ and pp_constrain_funapp constrain_or_un_str ppf = function
 and pp_user_defined_fun ppf (f, es) =
   let extra_args =
     suffix_args f
-    @ (if is_user_dist f then ["lp__"; "lp_accum__"] else [])
+    @ (if is_user_lp f then ["lp__"; "lp_accum__"] else [])
     @ ["pstream__"]
   in
   let sep = if List.is_empty es then "" else ", " in

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1165,11 +1165,9 @@ return foo_bar2(x, y, pstream__);
 }
 };
 
-template <bool propto__, typename T1__, typename T_lp__,
-typename T_lp_accum__>
+template <bool propto__, typename T1__>
 typename boost::math::tools::promote_args<T1__>::type
-foo_lpmf(const int& y, const T1__& lambda, T_lp__& lp__,
-         T_lp_accum__& lp_accum__, std::ostream* pstream__) {
+foo_lpmf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = typename boost::math::tools::promote_args<T1__>::type;
   
   try {
@@ -1184,13 +1182,11 @@ foo_lpmf(const int& y, const T1__& lambda, T_lp__& lp__,
 }
 
 struct foo_lpmf_functor__ {
-template <bool propto__, typename T1__, typename T_lp__,
-typename T_lp_accum__>
+template <bool propto__, typename T1__>
 typename boost::math::tools::promote_args<T1__>::type
-operator()(const int& y, const T1__& lambda, T_lp__& lp__,
-           T_lp_accum__& lp_accum__, std::ostream* pstream__)  const 
+operator()(const int& y, const T1__& lambda, std::ostream* pstream__)  const 
 {
-return foo_lpmf(y, lambda, lp__, lp_accum__, pstream__);
+return foo_lpmf(y, lambda, pstream__);
 }
 };
 


### PR DESCRIPTION
A quick fix for issue #335

See my comment on the issue for reasons why I chose this approach rather than the one suggested by the issue title.
