### PR TITLE
added support for empty datablock

### DIFF
--- a/src/tfp_backend/Code_gen.ml
+++ b/src/tfp_backend/Code_gen.ml
@@ -97,9 +97,9 @@ let pp_init ppf p =
     pf ppf "self.%s = %a" name (pp_cast "") (name, st)
   in
   let ppbody ppf =
-    if not (List.is_empty p.Program.input_vars) then
-      (list ~sep:cut pp_save_data) ppf p.Program.input_vars
-    else pf ppf "pass;"
+    match p.Program.input_vars with
+    | [] -> pf ppf "pass"
+    | _ -> (list ~sep:cut pp_save_data) ppf p.Program.input_vars
   in
   pp_method ppf "__init__" ("self" :: List.map ~f:fst p.input_vars) [] ppbody
 

--- a/src/tfp_backend/Code_gen.ml
+++ b/src/tfp_backend/Code_gen.ml
@@ -96,7 +96,11 @@ let pp_init ppf p =
   let pp_save_data ppf (name, st) =
     pf ppf "self.%s = %a" name (pp_cast "") (name, st)
   in
-  let ppbody ppf = (list ~sep:cut pp_save_data) ppf p.Program.input_vars in
+  let ppbody ppf =
+    if not (List.is_empty p.Program.input_vars) then
+      (list ~sep:cut pp_save_data) ppf p.Program.input_vars
+    else pf ppf "pass;"
+  in
   pp_method ppf "__init__" ("self" :: List.map ~f:fst p.input_vars) [] ppbody
 
 let pp_extract_data ppf p =

--- a/test/integration/tfp/test_empty_data_block.stan
+++ b/test/integration/tfp/test_empty_data_block.stan
@@ -1,0 +1,6 @@
+parameters {
+  real p;
+}
+model {
+  p ~ normal(0,1);
+}


### PR DESCRIPTION
At the moment, a Stan program without a data block creates an empty `__init__` function which raises an indentation error in `def log_prob_one_chain`. This adds a simple `pass;` statement to avoid this.