### PR TITLE
Fix parenthesis in TFP code gen

### DIFF
--- a/src/tfp_backend/Code_gen.ml
+++ b/src/tfp_backend/Code_gen.ml
@@ -28,15 +28,16 @@ let rec pp_expr ppf {Expr.Fixed.pattern; _} =
       ( Operator.of_string_opt f |> Option.value_exn |> pystring_of_operator
       , args )
     with
-    | op, [lhs; rhs] -> pf ppf "%a %s %a" pp_expr lhs op pp_expr rhs
-    | op, [unary] -> pf ppf "(%s%a)" op pp_expr unary
+    | op, [lhs; rhs] -> pf ppf "%a %s %a" pp_paren lhs op pp_paren rhs
+    | op, [unary] -> pf ppf "%s%a" op pp_paren unary
     | op, args ->
         raise_s [%message "Need to implement" op (args : Expr.Typed.t list)] )
   | FunApp (_, fname, args) -> pp_call ppf (fname, pp_expr, args)
   | TernaryIf (cond, iftrue, iffalse) ->
-      pf ppf "%a if %a else %a" pp_expr cond pp_expr iftrue pp_expr iffalse
-  | EAnd (a, b) -> pf ppf "%a and %a" pp_expr a pp_expr b
-  | EOr (a, b) -> pf ppf "%a or %a" pp_expr a pp_expr b
+      pf ppf "%a if %a else %a" pp_paren iftrue pp_paren cond pp_paren
+        iffalse
+  | EAnd (a, b) -> pf ppf "%a and %a" pp_paren a pp_paren b
+  | EOr (a, b) -> pf ppf "%a or %a" pp_paren a pp_paren b
   | Indexed (_, indices) when List.exists ~f:is_multi_index indices ->
       (*
        TF indexing options:
@@ -52,6 +53,13 @@ let rec pp_expr ppf {Expr.Fixed.pattern; _} =
         | indices -> pf ppf "[%a]" (list ~sep:comma (Index.pp pp_expr)) indices
       in
       pf ppf "%a%a" pp_expr obj pp_indexed indices
+
+and pp_paren ppf expr =
+  match expr.Expr.Fixed.pattern with
+  | TernaryIf _ | EAnd _ | EOr _ -> pf ppf "(%a)" pp_expr expr
+  | FunApp (StanLib, f, _) when Operator.of_string_opt f |> Option.is_some ->
+      pf ppf "(%a)" pp_expr expr
+  | _ -> pp_expr ppf expr
 
 let rec pp_stmt ppf s =
   let fake_expr pattern = {Expr.Fixed.pattern; meta= Expr.Typed.Meta.empty} in

--- a/test/integration/tfp/dune
+++ b/test/integration/tfp/dune
@@ -9,7 +9,7 @@
  (name runtest)
  (action (diff eight_schools.py eight_schools.py.output)))
 
- (rule
+(rule
  (targets normal_lub.py.output)
  (deps (package stanc) (:stanfiles normal_lub.stan))
  (action
@@ -19,3 +19,14 @@
 (alias
  (name runtest)
  (action (diff normal_lub.py normal_lub.py.output)))
+
+(rule
+ (targets nested_expr.py.output)
+ (deps (package stanc) (:stanfiles nested_expr.stan))
+ (action
+  (with-stdout-to %{targets}
+   (run %{bin:stan2tfp} %{stanfiles}))))
+
+(alias
+ (name runtest)
+ (action (diff nested_expr.py nested_expr.py.output)))

--- a/test/integration/tfp/eight_schools.py
+++ b/test/integration/tfp/eight_schools.py
@@ -22,7 +22,7 @@ class eight_schools_ncp_model(tfd__.Distribution):
     mu = tf__.cast(params[0], tf__.float64)
     tau = tf__.cast(params[1], tf__.float64)
     theta_tilde = tf__.cast(params[2], tf__.float64)
-    theta = mu + tau * theta_tilde
+    theta = mu + (tau * theta_tilde)
     target += tf__.reduce_sum(tfd__.Normal(tf__.cast(0, tf__.float64),
                                            tf__.cast(5, tf__.float64)).log_prob(mu))
     target += tf__.reduce_sum(tfd__.Normal(tf__.cast(0, tf__.float64),

--- a/test/integration/tfp/nested_expr.py
+++ b/test/integration/tfp/nested_expr.py
@@ -1,0 +1,44 @@
+
+import numpy as np__
+import tensorflow as tf__
+import tensorflow_probability as tfp__
+tfd__ = tfp__.distributions
+tfb__ = tfp__.bijectors
+from tensorflow.python.ops.parallel_for import pfor as pfor__
+
+class nested_expr_model(tfd__.Distribution):
+
+  def __init__(self, x, y):
+    self.x = tf__.cast(x, tf__.float64)
+    self.y = tf__.cast(y, tf__.float64)
+     
+  
+  def log_prob_one_chain(self, params):
+    target = 0
+    x = self.x
+    y = self.y
+    s = tf__.cast(params[0], tf__.float64)
+    z = x if (y < x) else (y if (tf__.cast(1, tf__.float64) < y) else tf__.cast(1, tf__.float64))
+    v = z * (z + (x ^ tf__.cast(2, tf__.float64)))
+    u = ((y < tf__.cast(1, tf__.float64)) and (x < tf__.cast(1, tf__.float64))) * (-x)
+    target += tf__.reduce_sum(tfd__.Normal(u, v).log_prob(s))
+    return target
+     
+  def log_prob(self, params):
+    return tf__.vectorized_map(self.log_prob_one_chain, params)
+    
+     
+  def parameter_shapes(self, nchains__):
+    x = self.x
+    y = self.y
+    return [(nchains__, )]
+     
+  def parameter_bijectors(self):
+    x = self.x
+    y = self.y
+    return [tfb__.Identity()]
+     
+  def parameter_names(self):
+    return ["s"]
+     
+model = nested_expr_model

--- a/test/integration/tfp/nested_expr.stan
+++ b/test/integration/tfp/nested_expr.stan
@@ -1,0 +1,13 @@
+data {
+    real x;
+    real y;
+}
+parameters {
+    real s;
+}
+model {
+    real z = (y < x) ? x : (1 < y ? y : 1);
+    real v = z*(z+x^2);
+    real u = (y < 1 && x < 1) * -x;
+    s ~ normal(u,v);
+}

--- a/test/integration/tfp/normal_lub.py
+++ b/test/integration/tfp/normal_lub.py
@@ -50,7 +50,7 @@ class normal_lub_model(tfd__.Distribution):
     y_lub = self.y_lub
     y_ub = self.y_ub
     y_lb = self.y_lb
-    return [tfb__.Chain([tfb__.Shift((-tf__.cast(3, tf__.float64))),
+    return [tfb__.Chain([tfb__.Shift(-tf__.cast(3, tf__.float64)),
                          tfb__.Scale(tf__.cast(3, tf__.float64) - (-tf__.cast(3, tf__.float64))),
                          tfb__.Sigmoid()]),
             tfb__.Chain([tfb__.Shift(tf__.cast(1, tf__.float64)),


### PR DESCRIPTION
TFP backend generates code with binary ops but when nested they need parenthesis to ensure the correct order of operations. This PR adds parens to all nested binary ops.