### PR TITLE
Organize .gitignore and add a few more patterns to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,33 @@
+# rust
 /rust/target
 /bindgen_test/target
 **/*.rs.bk
 Cargo.lock
 math_iface/gen/*
-
-*.swp
 *.a
-*.merlin
-test/*.log
-_build
+
+# ocaml
 _opam
-.#*
+_build
+*.merlin
+
+# js
 node_modules/*
+
+# python
+*.pyc
+
+# tests
+test/*.log
+
+# Visual Studio settings
 .vscode/**
 
-*.pyc
+# temporary editor files
+*~
+\#*#
+.#*
+.*.swp
+
+# Mac OS X hidden files
+*.DS_Store


### PR DESCRIPTION
This adds the following patterns to `.gitignore`:
- `.DS_Store`
- `*~` 
- `\#*#`

and reorganizes it a bit.

I don't know if the convention here is to open an issue for each PR, given the triviality of this I'm sending this PR directly.
