### PR TITLE
improve ternary-if typechecking

### DIFF
--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -343,16 +343,16 @@ let semantic_check_ternary_if loc (pe, te, fe) =
       Semantic_error.illtyped_ternary_if loc pe.emeta.type_ te.emeta.type_
         fe.emeta.type_
     in
-    [pe; te; fe] |> List.map ~f:arg_type
-    |> Stan_math_signatures.stan_math_returntype "if_else"
-    |> Option.value_map ~default:(error err) ~f:(function
-         | UnsizedType.ReturnType type_ ->
-             mk_typed_expression
-               ~expr:(TernaryIf (pe, te, fe))
-               ~ad_level:(lub_ad_e [pe; te; fe])
-               ~type_ ~loc
-             |> ok
-         | Void -> error err ))
+    if pe.emeta.type_ = UInt then
+      match UnsizedType.common_type (te.emeta.type_, fe.emeta.type_) with
+      | Some type_ ->
+          mk_typed_expression
+            ~expr:(TernaryIf (pe, te, fe))
+            ~ad_level:(lub_ad_e [pe; te; fe])
+            ~type_ ~loc
+          |> ok
+      | None -> error err
+    else error err)
 
 (* -- Binary (Infix) Operators ---------------------------------------------- *)
 

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -79,17 +79,15 @@ module TypeError = struct
            type %a and rhs has type %a"
           (Pretty_printing.pretty_print_assignmentoperator assignop)
           UnsizedType.pp lt UnsizedType.pp rt
-    | IllTypedTernaryIf (ut1, ut2, ut3) ->
-        if ut1 = UnsizedType.UInt then
-          Fmt.pf ppf
-            "Type mismatch in ternary expression, expression when true is: \
-             %a; expression when false is: %a"
-            UnsizedType.pp ut2 UnsizedType.pp ut3
-        else
-          Fmt.pf ppf
-            "Condition in ternary expression must be primitive int; found \
-             type=%a"
-            UnsizedType.pp ut1
+    | IllTypedTernaryIf (UInt, ut2, ut3) ->
+        Fmt.pf ppf
+          "Type mismatch in ternary expression, expression when true is: %a; \
+           expression when false is: %a"
+          UnsizedType.pp ut2 UnsizedType.pp ut3
+    | IllTypedTernaryIf (ut1, _, _) ->
+        Fmt.pf ppf
+          "Condition in ternary expression must be primitive int; found type=%a"
+          UnsizedType.pp ut1
     | NotIndexable ut ->
         Fmt.pf ppf
           "Only expressions of array, matrix, row_vector and vector type may \

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -80,12 +80,16 @@ module TypeError = struct
           (Pretty_printing.pretty_print_assignmentoperator assignop)
           UnsizedType.pp lt UnsizedType.pp rt
     | IllTypedTernaryIf (ut1, ut2, ut3) ->
-        Fmt.pf ppf
-          "Ill-typed arguments supplied to ? : operator. Available \
-           signatures: %s\n\
-           Instead supplied arguments of incompatible type: %a, %a, %a."
-          (Stan_math_signatures.pretty_print_math_sigs "if_else")
-          UnsizedType.pp ut1 UnsizedType.pp ut2 UnsizedType.pp ut3
+        if ut1 = UnsizedType.UInt then
+          Fmt.pf ppf
+            "Type mismatch in ternary expression, expression when true is: \
+             %a; expression when false is: %a"
+            UnsizedType.pp ut2 UnsizedType.pp ut3
+        else
+          Fmt.pf ppf
+            "Condition in ternary expression must be primitive int; found \
+             type=%a"
+            UnsizedType.pp ut1
     | NotIndexable ut ->
         Fmt.pf ppf
           "Only expressions of array, matrix, row_vector and vector type may \

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -87,6 +87,13 @@ let check_compatible_arguments_mod_conv name args1 args2 =
             && autodifftype_can_convert (fst sign1) (fst sign2) )
           args1 args2)
 
+let rec common_type = function
+  | UReal, UInt | UInt, UReal -> Some UReal
+  | UArray t1, UArray t2 ->
+      common_type (t1, t2) |> Option.map ~f:(fun t -> UArray t)
+  | t1, t2 when t1 = t2 -> Some t1
+  | _, _ -> None
+
 (* -- Helpers -- *)
 let is_real_type = function
   | UReal | UVector | URowVector | UMatrix

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -87,6 +87,7 @@ let check_compatible_arguments_mod_conv name args1 args2 =
             && autodifftype_can_convert (fst sign1) (fst sign2) )
           args1 args2)
 
+(** Given two types find the minimal type both can convert to *)
 let rec common_type = function
   | UReal, UInt | UInt, UReal -> Some UReal
   | UArray t1, UArray t2 ->

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2675,48 +2675,7 @@ Semantic error in 'validate_conditional_op_bad-1.stan', line 5, column 7 to colu
      7:  parameters {
    -------------------------------------------------
 
-Ill-typed arguments supplied to ? : operator. Available signatures: 
-(int, int, int) => int
-(int, real, real) => real
-(int, vector, vector) => vector
-(int, row_vector, row_vector) => row_vector
-(int, matrix, matrix) => matrix
-(int, int[], int[]) => int[]
-(int, real[], real[]) => real[]
-(int, vector[], vector[]) => vector[]
-(int, row_vector[], row_vector[]) => row_vector[]
-(int, matrix[], matrix[]) => matrix[]
-(int, int[,], int[,]) => int[,]
-(int, real[,], real[,]) => real[,]
-(int, vector[,], vector[,]) => vector[,]
-(int, row_vector[,], row_vector[,]) => row_vector[,]
-(int, matrix[,], matrix[,]) => matrix[,]
-(int, int[,,], int[,,]) => int[,,]
-(int, real[,,], real[,,]) => real[,,]
-(int, vector[,,], vector[,,]) => vector[,,]
-(int, row_vector[,,], row_vector[,,]) => row_vector[,,]
-(int, matrix[,,], matrix[,,]) => matrix[,,]
-(int, int[,,,], int[,,,]) => int[,,,]
-(int, real[,,,], real[,,,]) => real[,,,]
-(int, vector[,,,], vector[,,,]) => vector[,,,]
-(int, row_vector[,,,], row_vector[,,,]) => row_vector[,,,]
-(int, matrix[,,,], matrix[,,,]) => matrix[,,,]
-(int, int[,,,,], int[,,,,]) => int[,,,,]
-(int, real[,,,,], real[,,,,]) => real[,,,,]
-(int, vector[,,,,], vector[,,,,]) => vector[,,,,]
-(int, row_vector[,,,,], row_vector[,,,,]) => row_vector[,,,,]
-(int, matrix[,,,,], matrix[,,,,]) => matrix[,,,,]
-(int, int[,,,,,], int[,,,,,]) => int[,,,,,]
-(int, real[,,,,,], real[,,,,,]) => real[,,,,,]
-(int, vector[,,,,,], vector[,,,,,]) => vector[,,,,,]
-(int, row_vector[,,,,,], row_vector[,,,,,]) => row_vector[,,,,,]
-(int, matrix[,,,,,], matrix[,,,,,]) => matrix[,,,,,]
-(int, int[,,,,,,], int[,,,,,,]) => int[,,,,,,]
-(int, real[,,,,,,], real[,,,,,,]) => real[,,,,,,]
-(int, vector[,,,,,,], vector[,,,,,,]) => vector[,,,,,,]
-(int, row_vector[,,,,,,], row_vector[,,,,,,]) => row_vector[,,,,,,]
-(int, matrix[,,,,,,], matrix[,,,,,,]) => matrix[,,,,,,]
-Instead supplied arguments of incompatible type: row_vector[,], int, int.
+Condition in ternary expression must be primitive int; found type=row_vector[,]
 
   $ ../../../../install/default/bin/stanc validate_conditional_op_bad-2.stan
 
@@ -2730,48 +2689,7 @@ Semantic error in 'validate_conditional_op_bad-2.stan', line 5, column 7 to colu
      7:  parameters {
    -------------------------------------------------
 
-Ill-typed arguments supplied to ? : operator. Available signatures: 
-(int, int, int) => int
-(int, real, real) => real
-(int, vector, vector) => vector
-(int, row_vector, row_vector) => row_vector
-(int, matrix, matrix) => matrix
-(int, int[], int[]) => int[]
-(int, real[], real[]) => real[]
-(int, vector[], vector[]) => vector[]
-(int, row_vector[], row_vector[]) => row_vector[]
-(int, matrix[], matrix[]) => matrix[]
-(int, int[,], int[,]) => int[,]
-(int, real[,], real[,]) => real[,]
-(int, vector[,], vector[,]) => vector[,]
-(int, row_vector[,], row_vector[,]) => row_vector[,]
-(int, matrix[,], matrix[,]) => matrix[,]
-(int, int[,,], int[,,]) => int[,,]
-(int, real[,,], real[,,]) => real[,,]
-(int, vector[,,], vector[,,]) => vector[,,]
-(int, row_vector[,,], row_vector[,,]) => row_vector[,,]
-(int, matrix[,,], matrix[,,]) => matrix[,,]
-(int, int[,,,], int[,,,]) => int[,,,]
-(int, real[,,,], real[,,,]) => real[,,,]
-(int, vector[,,,], vector[,,,]) => vector[,,,]
-(int, row_vector[,,,], row_vector[,,,]) => row_vector[,,,]
-(int, matrix[,,,], matrix[,,,]) => matrix[,,,]
-(int, int[,,,,], int[,,,,]) => int[,,,,]
-(int, real[,,,,], real[,,,,]) => real[,,,,]
-(int, vector[,,,,], vector[,,,,]) => vector[,,,,]
-(int, row_vector[,,,,], row_vector[,,,,]) => row_vector[,,,,]
-(int, matrix[,,,,], matrix[,,,,]) => matrix[,,,,]
-(int, int[,,,,,], int[,,,,,]) => int[,,,,,]
-(int, real[,,,,,], real[,,,,,]) => real[,,,,,]
-(int, vector[,,,,,], vector[,,,,,]) => vector[,,,,,]
-(int, row_vector[,,,,,], row_vector[,,,,,]) => row_vector[,,,,,]
-(int, matrix[,,,,,], matrix[,,,,,]) => matrix[,,,,,]
-(int, int[,,,,,,], int[,,,,,,]) => int[,,,,,,]
-(int, real[,,,,,,], real[,,,,,,]) => real[,,,,,,]
-(int, vector[,,,,,,], vector[,,,,,,]) => vector[,,,,,,]
-(int, row_vector[,,,,,,], row_vector[,,,,,,]) => row_vector[,,,,,,]
-(int, matrix[,,,,,,], matrix[,,,,,,]) => matrix[,,,,,,]
-Instead supplied arguments of incompatible type: int, real, row_vector[,].
+Type mismatch in ternary expression, expression when true is: real; expression when false is: row_vector[,]
 
   $ ../../../../install/default/bin/stanc validate_exponentiation_bad.stan
 


### PR DESCRIPTION
Copy Stanc2 error messages for ill-typed ternary operator `? :` expression.