### PR TITLE
Jenkinsfile test binaries

### DIFF
--- a/Jenkinsfile-test-binaries
+++ b/Jenkinsfile-test-binaries
@@ -45,7 +45,7 @@ pipeline {
                     dune build @install
                 """)
                 sh "mkdir -p bin && mv _build/default/src/stanc/stanc.exe bin/stanc"
-                stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
+
                 archiveArtifacts 'bin/*'
             }
             post { always { runShell("rm -rf ./*") }}
@@ -73,7 +73,6 @@ pipeline {
                         sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/mac-stanc"
                         sh "mv _build/default/src/stan2tfp/stan2tfp.exe bin/mac-stan2tfp"
 
-                        stash name:'mac-exe', includes:'bin/*'
                         archiveArtifacts 'bin/*'
                     }
                     post { always { runShell("rm -rf ./*") }}
@@ -96,7 +95,7 @@ pipeline {
 
                         sh "mkdir -p bin && mv `find _build -name stancjs.bc.js` bin/stanc.js"
                         sh "mv `find _build -name index.html` bin/load_stanc.html"
-                        stash name:'js-exe', includes:'bin/*'
+
                         archiveArtifacts 'bin/*'
                     }
                     post {always { runShell("rm -rf ./*")}}
@@ -125,7 +124,6 @@ pipeline {
                         sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/linux-stanc"
                         sh "mv `find _build -name stan2tfp.exe` bin/linux-stan2tfp"
 
-                        stash name:'linux-exe', includes:'bin/*'
                         archiveArtifacts 'bin/*'
                     }
                     post {always { runShell("rm -rf ./*")}}
@@ -140,7 +138,7 @@ pipeline {
                         bat "bash -cl \"eval \$(opam env) make clean; dune subst; dune build -x windows; dune runtest --verbose\""
                         bat """bash -cl "rm -rf bin/*; mkdir -p bin; mv _build/default.windows/src/stanc/stanc.exe bin/windows-stanc" """
                         bat "bash -cl \"mv _build/default.windows/src/stan2tfp/stan2tfp.exe bin/windows-stan2tfp\""
-                        stash name:'windows-exe', includes:'bin/*'
+                        archiveArtifacts 'bin/*'
                     }
                 }
             }

--- a/Jenkinsfile-test-binaries
+++ b/Jenkinsfile-test-binaries
@@ -46,6 +46,7 @@ pipeline {
                 """)
                 sh "mkdir -p bin && mv _build/default/src/stanc/stanc.exe bin/stanc"
                 stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
+                archiveArtifacts 'bin/*'
             }
             post { always { runShell("rm -rf ./*") }}
         }

--- a/Jenkinsfile-test-binaries
+++ b/Jenkinsfile-test-binaries
@@ -1,0 +1,148 @@
+@Library('StanUtils')
+import org.stan.Utils
+
+def utils = new org.stan.Utils()
+
+/* Functions that runs a sh command and returns the stdout */
+def runShell(String command){
+    def output = sh (returnStdout: true, script: "${command}").trim()
+    return "${output}"
+}
+
+def tagName() {
+    if (env.TAG_NAME) {
+        env.TAG_NAME
+    } else if (env.BRANCH_NAME == 'master') {
+        'nightly'
+    } else {
+        'unknown-tag'
+    }
+}
+pipeline {
+    agent none
+    parameters {
+        string(defaultValue: 'master', name: 'git_branch',
+               description: "Please specify a git branch ( develop ), git hash ( aace72b6ccecbb750431c46f418879b325416c7d ), pull request ( PR-123 ), pull request from fork ( PR-123 )")
+    }
+    environment {
+        GITHUB_TOKEN = credentials('6e7c1e8f-ca2c-4b11-a70e-d934d3f6b681')
+    }
+    options {parallelsAlwaysFailFast()}
+    stages {
+        stage("Build") {
+            agent {
+                dockerfile {
+                    filename 'docker/debian/Dockerfile'
+                    //Forces image to ignore entrypoint
+                    args "-u root --entrypoint=\'\'"
+                }
+            }
+            steps {
+                sh 'echo Hellow'
+                sh 'printenv'
+                runShell("""
+                    eval \$(opam env)
+                    dune build @install
+                """)
+                sh "mkdir -p bin && mv _build/default/src/stanc/stanc.exe bin/stanc"
+                stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
+            }
+            post { always { runShell("rm -rf ./*") }}
+        }
+        stage("Build and test static release binaries") {
+            failFast true
+            parallel {
+                stage("Build & test Mac OS X binary") {
+                    agent { label "osx && ocaml" }
+                    steps {
+
+                        runShell("""
+                            eval \$(opam env)
+                            opam update || true
+                            bash -x scripts/install_build_deps.sh
+                            dune subst
+                            dune build @install
+                        """)
+
+                        echo runShell("""
+                            eval \$(opam env)
+                            time dune runtest --verbose
+                        """)
+
+                        sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/mac-stanc"
+                        sh "mv _build/default/src/stan2tfp/stan2tfp.exe bin/mac-stan2tfp"
+
+                        stash name:'mac-exe', includes:'bin/*'
+                        archiveArtifacts 'bin/*'
+                    }
+                    post { always { runShell("rm -rf ./*") }}
+                }
+                stage("Build stanc.js") {
+                    agent {
+                        dockerfile {
+                            filename 'docker/debian/Dockerfile'
+                            //Forces image to ignore entrypoint
+                            args "-u root --entrypoint=\'\'"
+                        }
+                    }
+                    steps {
+
+                        runShell("""
+                            eval \$(opam env)
+                            dune subst
+                            dune build --profile release src/stancjs
+                        """)
+
+                        sh "mkdir -p bin && mv `find _build -name stancjs.bc.js` bin/stanc.js"
+                        sh "mv `find _build -name index.html` bin/load_stanc.html"
+                        stash name:'js-exe', includes:'bin/*'
+                        archiveArtifacts 'bin/*'
+                    }
+                    post {always { runShell("rm -rf ./*")}}
+                }
+                stage("Build & test a static Linux binary") {
+                    agent {
+                        dockerfile {
+                            filename 'docker/static/Dockerfile'
+                            //Forces image to ignore entrypoint
+                            args "-u 1000 --entrypoint=\'\'"
+                        }
+                    }
+                    steps {
+
+                        runShell("""
+                            eval \$(opam env)
+                            dune subst
+                            dune build @install --profile static
+                        """)
+
+                        echo runShell("""
+                            eval \$(opam env)
+                            time dune runtest --profile static --verbose
+                        """)
+
+                        sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/linux-stanc"
+                        sh "mv `find _build -name stan2tfp.exe` bin/linux-stan2tfp"
+
+                        stash name:'linux-exe', includes:'bin/*'
+                        archiveArtifacts 'bin/*'
+                    }
+                    post {always { runShell("rm -rf ./*")}}
+                }
+                stage("Build & test static Windows binary") {
+                    agent { label "WSL" }
+                    steps {
+
+                        bat "bash -cl \"cd test/integration\""
+                        bat "bash -cl \"find . -type f -name \"*.expected\" -print0 | xargs -0 dos2unix\""
+                        bat "bash -cl \"cd ..\""
+                        bat "bash -cl \"eval \$(opam env) make clean; dune subst; dune build -x windows; dune runtest --verbose\""
+                        bat """bash -cl "rm -rf bin/*; mkdir -p bin; mv _build/default.windows/src/stanc/stanc.exe bin/windows-stanc" """
+                        bat "bash -cl \"mv _build/default.windows/src/stan2tfp/stan2tfp.exe bin/windows-stan2tfp\""
+                        stash name:'windows-exe', includes:'bin/*'
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a Jenkinsfile which will be used in the [test-binaries](https://jenkins.mc-stan.org/job/stanc3-test-binaries/) Jenkins job to build stanc3 binaries on-demand as requested in https://github.com/stan-dev/stanc3/pull/434