### PR TITLE
Error on model name that starts with a number or non-underscore symbol

### DIFF
--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -171,7 +171,7 @@ let model_file_err () =
   exit 127
 
 let model_file_start_char_err () =
-  eprintf "%s" "Model name must not start with a number or symbol other than underscore.";
+  eprintf "%s" "Model name must not start with a number or symbol other than underscore.\n";
   exit 127
 
 let add_file filename =
@@ -240,12 +240,12 @@ let main () =
     exit 0 ) ;
   (* Just translate a stan program *)
   if !model_file = "" then model_file_err () ;
-  if not (Str.string_match model_name_check_regex !model_file 0) then
-    model_file_start_char_err () ;
   if !Semantic_check.model_name = "" then
     Semantic_check.model_name :=
       remove_dotstan List.(hd_exn (rev (String.split !model_file ~on:'/')))
       ^ "_model" ;
+  if not (Str.string_match model_name_check_regex !Semantic_check.model_name 0) then
+    model_file_start_char_err () ;
   if !output_file = "" then output_file := remove_dotstan !model_file ^ ".hpp" ;
   use_file !model_file
 

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -170,6 +170,10 @@ let model_file_err () =
   Arg.usage options ("Please specify one model_file.\n\n" ^ usage) ;
   exit 127
 
+let model_file_start_char_err () =
+  eprintf "%s" "Model name must not start with a number or symbol other than underscore.";
+  exit 127
+
 let add_file filename =
   if !model_file = "" then model_file := filename else model_file_err ()
 
@@ -225,6 +229,8 @@ let use_file filename =
 
 let remove_dotstan s = String.drop_suffix s 5
 
+let model_name_check_regex = Str.regexp "^[a-zA-Z_].*$"
+
 let main () =
   (* Parse the arguments. *)
   Arg.parse options add_file usage ;
@@ -234,6 +240,8 @@ let main () =
     exit 0 ) ;
   (* Just translate a stan program *)
   if !model_file = "" then model_file_err () ;
+  if not (Str.string_match model_name_check_regex !model_file 0) then
+    model_file_start_char_err () ;
   if !Semantic_check.model_name = "" then
     Semantic_check.model_name :=
       remove_dotstan List.(hd_exn (rev (String.split !model_file ~on:'/')))

--- a/test/integration/bad/1_starts_with_number.stan
+++ b/test/integration/bad/1_starts_with_number.stan
@@ -1,0 +1,6 @@
+parameters {
+  real y;
+}
+model {
+  y ~ normal(0,1);
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1,3 +1,5 @@
+  $ ../../../../install/default/bin/stanc 1_starts_with_number.stan
+Model name must not start with a number or symbol other than underscore.
   $ ../../../../install/default/bin/stanc assign_real_to_int.stan
 
 Semantic error in 'assign_real_to_int.stan', line 11, column 2 to column 8:


### PR DESCRIPTION
Fixes #506 by outputing the following error message:

```
Model name must not start with a number or symbol other than underscore.
```

Entire cmdstan is then:
```
make examples/eight_schools/8schools

--- Translating Stan model to C++ code ---
bin/stanc  --o=examples/eight_schools/8schools.hpp examples/eight_schools/8schools.stan
Model name must not start with a number or symbol other than underscore.
make: *** No rule to make target 'examples/eight_schools/8schools.hpp', needed by 'examples/eight_schools/8schools'.  Stop.
```