### PR TITLE
Bugfix/issue 504 spurious integer warning

### DIFF
--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -599,7 +599,7 @@ and semantic_check_expression cf ({emeta; expr} : Ast.untyped_expression) :
               "@[<hov>Info: Found int division at %s:@   @[<hov 2>%a\n@]%s@.@]"
               (Location_span.to_string x.emeta.loc)
               Pretty_printing.pp_expression {expr; emeta}
-              "Values will be rounded to zero." ;
+              "Values will be rounded towards zero." ;
             (x, y)
         | _ -> (x, y)
       in

--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -594,13 +594,12 @@ and semantic_check_expression cf ({emeta; expr} : Ast.untyped_expression) :
       and re = semantic_check_expression cf e2
       and warn_int_division (x, y) =
         match (x.emeta.type_, y.emeta.type_, op) with
-        | UInt, UReal, Divide | UInt, UInt, Divide ->
+        | UInt, UInt, Divide ->
             Fmt.pr
-              "@[<hov>Info: Found int division at %s:@   @[<hov 2>%a@]@,%s@,@]"
+              "@[<hov>Info: Found int division at %s:@   @[<hov 2>%a\n@]%s@.@]"
               (Location_span.to_string x.emeta.loc)
               Pretty_printing.pp_expression {expr; emeta}
-              "Positive values rounded down, negative values rounded up or \
-               down in platform-dependent way." ;
+              "Values will be rounded to zero." ;
             (x, y)
         | _ -> (x, y)
       in

--- a/test/integration/example-models/ARM/Ch.17/pretty.expected
+++ b/test/integration/example-models/ARM/Ch.17/pretty.expected
@@ -769,6 +769,3 @@ model {
   }
 }
 
-Info: Found int division at 'robit_17.7.stan', line 79, column 7 to column 8:
-  1 / df_inv
-Positive values rounded down, negative values rounded up or down in platform-dependent way.

--- a/test/integration/example-models/bugs_examples/vol1/dyes/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/dyes/pretty.expected
@@ -31,18 +31,6 @@ generated quantities {
   sigmasq_within <- 1 / tau_within;
 }
 
-Info: Found int division at 'dyes.stan', line 21, column 19 to column 20:
-  1 / sqrt(tau_between)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'dyes.stan', line 22, column 18 to column 19:
-  1 / sqrt(tau_within)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'dyes.stan', line 39, column 21 to column 22:
-  1 / tau_between
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'dyes.stan', line 40, column 20 to column 21:
-  1 / tau_within
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'dyes.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol1/equiv/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/equiv/pretty.expected
@@ -49,7 +49,7 @@ generated quantities {
 
 Info: Found int division at 'equiv.stan', line 16, column 16 to column 44:
   (group[n] * (2 * p - 3) + 3) / 2
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded towards zero.
 
 Warning: deprecated language construct used in 'equiv.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol1/kidney/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/kidney/pretty.expected
@@ -67,9 +67,6 @@ generated quantities {
 
 }
 
-Info: Found int division at 'kidney.stan', line 39, column 16 to column 17:
-  1 / tau
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'kidney.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol1/leukfr/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/leukfr/pretty.expected
@@ -50,9 +50,6 @@ model {
   }
 }
 
-Info: Found int division at 'leukfr.stan', line 46, column 11 to column 12:
-  1 / sqrt(tau)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'leukfr.stan', line 31, column 15:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol1/litter/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/litter/pretty.expected
@@ -31,9 +31,6 @@ generated quantities {
     theta[g] <- 1 / (a[g] + b[g]);
 }
 
-Info: Found int division at 'litter.stan', line 30, column 16 to column 17:
-  1 / (a[g] + b[g])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'litter.stan', line 15, column 5:
    -------------------------------------------------
@@ -103,9 +100,6 @@ generated quantities {
     theta[g] <- 1 / (a[g] + b[g]);
 }
 
-Info: Found int division at 'litter_old_param.stan', line 28, column 16 to column 17:
-  1 / (a[g] + b[g])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'litter_old_param.stan', line 26, column 11:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol1/magnesium/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/magnesium/pretty.expected
@@ -61,12 +61,6 @@ generated quantities {
   }
 }
 
-Info: Found int division at 'magnesium.stan', line 25, column 14 to column 15:
-  1 / sqrt(Phi(0.75) / s0_sq)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'magnesium.stan', line 43, column 12 to column 13:
-  1 / sqrt(inv_tau_sq_1)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'magnesium.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol1/mice/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/mice/pretty.expected
@@ -37,9 +37,6 @@ generated quantities {
   pos_control <- beta[4] - beta[1];
 }
 
-Info: Found int division at 'mice.stan', line 43, column 45 to column 46:
-  1 / r
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'mice.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol2/cervix/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol2/cervix/pretty.expected
@@ -42,12 +42,6 @@ generated quantities {
                + (1 + exp(-beta0C - beta)) / (1 + exp(-beta0C)) * (1 - q) / q);
 }
 
-Info: Found int division at 'cervix2.stan', line 57, column 12 to column 13:
-  1 / (1 + (1 + exp(beta0C + beta)) / (1 + exp(beta0C)) * (1 - q) / q)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'cervix2.stan', line 58, column 12 to column 13:
-  1 / (1 + (1 + exp(-beta0C - beta)) / (1 + exp(-beta0C)) * (1 - q) / q)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'cervix2.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol2/dugongs/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol2/dugongs/pretty.expected
@@ -27,9 +27,6 @@ model {
   tau ~ gamma(.0001, .0001);
 }
 
-Info: Found int division at 'dugongs.stan', line 25, column 11 to column 12:
-  1 / sqrt(tau)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'dugongs.stan', line 25, column 9:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol2/orange/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol2/orange/pretty.expected
@@ -39,12 +39,6 @@ model {
   }
 }
 
-Info: Found int division at 'orange.stan', line 30, column 16 to column 17:
-  1 / sqrt(tau[j])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'orange.stan', line 31, column 13 to column 14:
-  1 / sqrt(tau_C)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'orange.stan', line 4, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol2/pines/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol2/pines/pretty.expected
@@ -193,9 +193,6 @@ generated quantities {
   lambda = softmax(log_py)[1];
 }
 
-Info: Found int division at 'pines-3.stan', line 23, column 15 to column 16:
-  1 / sqrt(tau[i])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
   $ ../../../../../../../install/default/bin/stanc --auto-format pines-4.stan
 data {
   int<lower=0> N;
@@ -239,9 +236,6 @@ model {
   target += log_sum_exp(log_p);
 }
 
-Info: Found int division at 'pines-4.stan', line 28, column 16 to column 17:
-  1 / sqrt(tau[i])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'pines-4.stan', line 12, column 9:
    -------------------------------------------------
@@ -474,21 +468,6 @@ generated quantities {
   pM2 <- bernoulli_rng(softmax(log_py)[2]);
 }
 
-Info: Found int division at 'pines.stan', line 29, column 16 to column 17:
-  1 / sqrt(tau[i])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'pines.stan', line 37, column 32 to column 33:
-  1 / 400.0
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'pines.stan', line 38, column 32 to column 33:
-  1 / 400.0
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'pines.stan', line 48, column 32 to column 33:
-  1 / 256.0
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'pines.stan', line 49, column 31 to column 32:
-  1 / 256.0
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'pines.stan', line 12, column 9:
    -------------------------------------------------

--- a/test/integration/example-models/bugs_examples/vol3/data_cloning/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol3/data_cloning/pretty.expected
@@ -38,9 +38,6 @@ model {
   }
 }
 
-Info: Found int division at 'seeds.stan', line 40, column 13 to column 14:
-  1 / sqrt(tau)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'seeds.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/knitr/chapter2/pretty.expected
+++ b/test/integration/example-models/knitr/chapter2/pretty.expected
@@ -93,9 +93,6 @@ generated quantities {
   sigma_degrees = (180 / pi()) * sigma;
 }
 
-Info: Found int division at 'golf1.stan', line 21, column 19 to column 22:
-  180 / pi()
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
   $ ../../../../../../install/default/bin/stanc --auto-format golf_logistic.stan
 data {
   int J;

--- a/test/integration/example-models/knitr/golf/pretty.expected
+++ b/test/integration/example-models/knitr/golf/pretty.expected
@@ -22,9 +22,6 @@ generated quantities {
   sigma_degrees = (180 / pi()) * sigma;
 }
 
-Info: Found int division at 'golf1.stan', line 21, column 19 to column 22:
-  180 / pi()
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
   $ ../../../../../../install/default/bin/stanc --auto-format golf_logistic.stan
 data {
   int J;

--- a/test/integration/example-models/knitr/irt/pretty.expected
+++ b/test/integration/example-models/knitr/irt/pretty.expected
@@ -198,9 +198,6 @@ generated quantities {
   }
 }
 
-Info: Found int division at 'irt_1pl_fit_predict.stan', line 21, column 20 to column 28:
-  (j - 20) / 4.0
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'irt_1pl_fit_predict.stan', line 1, column 0:
    -------------------------------------------------
@@ -359,9 +356,6 @@ generated quantities {
   }
 }
 
-Info: Found int division at 'irt_1pl_predict.stan', line 21, column 20 to column 28:
-  (j - 20) / 4.0
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'irt_1pl_predict.stan', line 1, column 0:
    -------------------------------------------------
@@ -523,9 +517,6 @@ generated quantities {
   }
 }
 
-Info: Found int division at 'irt_2pl_power.stan', line 13, column 20 to column 28:
-  (j - 50) / 10.0
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'irt_2pl_power.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/example-models/knitr/pool-binary-trials/pretty.expected
+++ b/test/integration/example-models/knitr/pool-binary-trials/pretty.expected
@@ -115,9 +115,6 @@ generated quantities {
   p_sd <- (sd_y_rep >= sd_y);
 }
 
-Info: Found int division at 'hier-logit.stan', line 70, column 23 to column 36:
-  (y[n] + z[n]) / (0.0 + K[n] + K_new[n])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'hier-logit.stan', line 15, column 9:
    -------------------------------------------------
@@ -508,9 +505,6 @@ generated quantities {
   p_sd <- (sd_y_rep >= sd_y);
 }
 
-Info: Found int division at 'hier.stan', line 64, column 23 to column 36:
-  (y[n] + z[n]) / (0.0 + K[n] + K_new[n])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'hier.stan', line 15, column 9:
    -------------------------------------------------
@@ -880,9 +874,6 @@ generated quantities {
   p_sd <- (sd_y_rep >= sd_y);
 }
 
-Info: Found int division at 'no-pool.stan', line 59, column 23 to column 36:
-  (y[n] + z[n]) / (0.0 + K[n] + K_new[n])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'no-pool.stan', line 15, column 9:
    -------------------------------------------------
@@ -1231,9 +1222,6 @@ generated quantities {
   p_sd <- (sd_y_rep >= sd_y);
 }
 
-Info: Found int division at 'pool.stan', line 60, column 23 to column 36:
-  (y[n] + z[n]) / (0.0 + K[n] + K_new[n])
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'pool.stan', line 15, column 9:
    -------------------------------------------------

--- a/test/integration/example-models/misc/ecology/mark-recapture/pretty.expected
+++ b/test/integration/example-models/misc/ecology/mark-recapture/pretty.expected
@@ -63,9 +63,6 @@ generated quantities {
     pop_hat[k] <- n_captured[k] / p[k];
 }
 
-Info: Found int division at 'cjs-K.stan', line 76, column 18 to column 31:
-  n_captured[k] / p[k]
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'cjs-K.stan', line 18, column 9:
    -------------------------------------------------
@@ -453,9 +450,6 @@ generated quantities {
   N <- M / theta;
 }
 
-Info: Found int division at 'mark-recapture-2.stan', line 19, column 7 to column 8:
-  M / theta
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'mark-recapture-2.stan', line 8, column 13:
    -------------------------------------------------
@@ -518,9 +512,6 @@ model {
   R ~ binomial(C, theta);
 }
 
-Info: Found int division at 'mark-recapture-3.stan', line 34, column 11 to column 12:
-  M / N
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 
 Warning: deprecated language construct used in 'mark-recapture-3.stan', line 26, column 13:
    -------------------------------------------------
@@ -586,6 +577,3 @@ model {
   R ~ binomial(C, M / N);
 }
 
-Info: Found int division at 'mark-recapture.stan', line 11, column 18 to column 19:
-  M / N
-Positive values rounded down, negative values rounded up or down in platform-dependent way.

--- a/test/integration/good/function-signatures/math/functions/pretty.expected
+++ b/test/integration/good/function-signatures/math/functions/pretty.expected
@@ -2076,10 +2076,10 @@ model {
 
 Info: Found int division at 'operators_int.stan', line 10, column 25 to column 30:
   d_int / d_int
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
 Info: Found int division at 'operators_int.stan', line 24, column 27 to column 32:
   d_int / d_int
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../../../../install/default/bin/stanc --auto-format operators_real.stan
 data {
   int d_int;
@@ -2161,21 +2161,12 @@ model {
   y_p ~ normal(0, 1);
 }
 
-Info: Found int division at 'operators_real.stan', line 21, column 26 to column 31:
-  d_int / d_real
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 Info: Found int division at 'operators_real.stan', line 23, column 26 to column 31:
   d_int / d_int
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'operators_real.stan', line 66, column 27 to column 32:
-  d_int / d_real
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
 Info: Found int division at 'operators_real.stan', line 67, column 27 to column 32:
   d_int / d_int
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'operators_real.stan', line 71, column 27 to column 32:
-  d_int / p_real
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../../../../install/default/bin/stanc --auto-format owens_t.stan
 data {
   int d_int;

--- a/test/integration/good/function-signatures/math/functions/pretty.expected
+++ b/test/integration/good/function-signatures/math/functions/pretty.expected
@@ -2076,10 +2076,10 @@ model {
 
 Info: Found int division at 'operators_int.stan', line 10, column 25 to column 30:
   d_int / d_int
-Values will be rounded to zero.
+Values will be rounded towards zero.
 Info: Found int division at 'operators_int.stan', line 24, column 27 to column 32:
   d_int / d_int
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../../../../install/default/bin/stanc --auto-format operators_real.stan
 data {
   int d_int;
@@ -2163,10 +2163,10 @@ model {
 
 Info: Found int division at 'operators_real.stan', line 23, column 26 to column 31:
   d_int / d_int
-Values will be rounded to zero.
+Values will be rounded towards zero.
 Info: Found int division at 'operators_real.stan', line 67, column 27 to column 32:
   d_int / d_int
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../../../../install/default/bin/stanc --auto-format owens_t.stan
 data {
   int d_int;

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -958,7 +958,7 @@ model {
 
 Info: Found int division at 'bernoulli_logit_glm_old_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format bernoulli_logit_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -989,7 +989,7 @@ model {
 
 Info: Found int division at 'bernoulli_logit_glm_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format break-continue.stan
 functions {
   int foo(int a) {
@@ -3581,7 +3581,7 @@ model {
 
 Info: Found int division at 'int_div_user.stan', line 7, column 6 to column 10:
   a[1] / b[2]
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format int_fun.stan
 functions {
   int foo(int x) {
@@ -4143,7 +4143,7 @@ model {
 
 Info: Found int division at 'neg_binomial_2_log_glm_old_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format neg_binomial_2_log_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4175,7 +4175,7 @@ model {
 
 Info: Found int division at 'neg_binomial_2_log_glm_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format new-prob-fun-suffixes.stan
 parameters {
   real y;
@@ -4221,7 +4221,7 @@ model {
 
 Info: Found int division at 'normal_id_glm_old_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format normal_id_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4253,7 +4253,7 @@ model {
 
 Info: Found int division at 'normal_id_glm_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format nullary-unconflicted.stan
 parameters {
   real e;
@@ -4419,7 +4419,7 @@ model {
 
 Info: Found int division at 'poisson_log_glm_old_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format poisson_log_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4450,7 +4450,7 @@ model {
 
 Info: Found int division at 'poisson_log_glm_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format pound-comment-deprecated.stan
 data {
   int N;
@@ -5113,7 +5113,7 @@ model {
 
 Info: Found int division at 'validate_division_good.stan', line 19, column 7 to column 8:
   2 / 3
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format validate_division_int_warning.stan
 transformed data {
   real u;
@@ -5132,7 +5132,7 @@ model {
 
 Info: Found int division at 'validate_division_int_warning.stan', line 7, column 6 to column 7:
   j / k
-Values will be rounded to zero.
+Values will be rounded towards zero.
   $ ../../../../install/default/bin/stanc --auto-format validate_elt_division_good.stan
 transformed data {
   matrix[3, 3] m;

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -958,7 +958,7 @@ model {
 
 Info: Found int division at 'bernoulli_logit_glm_old_performance.stan', line 10, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format bernoulli_logit_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -989,7 +989,7 @@ model {
 
 Info: Found int division at 'bernoulli_logit_glm_performance.stan', line 10, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format break-continue.stan
 functions {
   int foo(int a) {
@@ -3581,7 +3581,7 @@ model {
 
 Info: Found int division at 'int_div_user.stan', line 7, column 6 to column 10:
   a[1] / b[2]
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format int_fun.stan
 functions {
   int foo(int x) {
@@ -4143,7 +4143,7 @@ model {
 
 Info: Found int division at 'neg_binomial_2_log_glm_old_performance.stan', line 11, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format neg_binomial_2_log_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4175,7 +4175,7 @@ model {
 
 Info: Found int division at 'neg_binomial_2_log_glm_performance.stan', line 11, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format new-prob-fun-suffixes.stan
 parameters {
   real y;
@@ -4221,7 +4221,7 @@ model {
 
 Info: Found int division at 'normal_id_glm_old_performance.stan', line 11, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format normal_id_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4253,7 +4253,7 @@ model {
 
 Info: Found int division at 'normal_id_glm_performance.stan', line 11, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format nullary-unconflicted.stan
 parameters {
   real e;
@@ -4419,7 +4419,7 @@ model {
 
 Info: Found int division at 'poisson_log_glm_old_performance.stan', line 10, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format poisson_log_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4450,7 +4450,7 @@ model {
 
 Info: Found int division at 'poisson_log_glm_performance.stan', line 10, column 19 to column 20:
   j / M
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format pound-comment-deprecated.stan
 data {
   int N;
@@ -5111,15 +5111,9 @@ model {
   y ~ normal(0, 1);
 }
 
-Info: Found int division at 'validate_division_good.stan', line 6, column 6 to column 7:
-  2 / 3.1
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
 Info: Found int division at 'validate_division_good.stan', line 19, column 7 to column 8:
   2 / 3
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'validate_division_good.stan', line 21, column 7 to column 8:
-  2 / 3.1
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format validate_division_int_warning.stan
 transformed data {
   real u;
@@ -5138,7 +5132,7 @@ model {
 
 Info: Found int division at 'validate_division_int_warning.stan', line 7, column 6 to column 7:
   j / k
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
+Values will be rounded to zero.
   $ ../../../../install/default/bin/stanc --auto-format validate_elt_division_good.stan
 transformed data {
   matrix[3, 3] m;
@@ -5410,12 +5404,6 @@ model {
   (-y) ~ normal(0, 1);
 }
 
-Info: Found int division at 'validate_jacobian_warning_good.stan', line 57, column 7 to column 8:
-  1 / z
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
-Info: Found int division at 'validate_jacobian_warning_good.stan', line 57, column 2 to column 3:
-  1 / (1 / z)
-Positive values rounded down, negative values rounded up or down in platform-dependent way.
   $ ../../../../install/default/bin/stanc --auto-format validate_jacobian_warning_user.stan
 parameters {
   vector[1] y;

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -2192,10 +2192,8 @@ model {
     {|
       Info: Found int division at 'string', line 27, column 14 to column 15:
         i / j
-      Positive values rounded down, negative values rounded up or down in platform-dependent way.
-      Info: Found int division at 'string', line 99, column 25 to column 26:
-        1 / 2.
-      Positive values rounded down, negative values rounded up or down in platform-dependent way.
+      Values will be rounded towards zero.
+
 
 
       log_prob {


### PR DESCRIPTION
Fixes #504 
Removed int/real from int warning.

The new error message will be:
```
Info: Found int division at 'operators_int.stan', line 10, column 25 to column 30:
  d_int / d_int
Values will be rounded towards zero.
```