### PR TITLE
Check for out-of-bounds array access

### DIFF
--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -56,6 +56,11 @@ let minus_one e =
 
 let is_single_index = function Index.Single _ -> true | _ -> false
 
+let dont_need_range_check = function
+  | Index.Single Expr.Fixed.({pattern= Var id; _}) ->
+      not (Utils.is_user_ident id)
+  | _ -> false
+
 let promote_adtype =
   List.fold
     ~f:(fun accum expr ->
@@ -426,7 +431,7 @@ and pp_expr ppf Expr.Fixed.({pattern; meta} as e) =
       when Some Internal_fun.FnReadData = Internal_fun.of_string_opt f ->
         pp_indexed_simple ppf (strf "%a" pp_expr e, idx)
     | _
-      when List.for_all ~f:is_single_index idx
+      when List.for_all ~f:dont_need_range_check idx
            && not (UnsizedType.is_indexing_matrix (Expr.Typed.type_of e, idx))
       ->
         pp_indexed_simple ppf (strf "%a" pp_expr e, idx)

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1128,11 +1128,14 @@ sho(const T0__& t, const std::vector<T1__>& y,
     dydt = std::vector<local_scalar_t__>(2, 0);
     
     current_statement__ = 268;
-    assign(dydt, cons_list(index_uni(1), nil_index_list()), y[(2 - 1)],
+    assign(dydt, cons_list(index_uni(1), nil_index_list()),
+      rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"),
       "assigning variable dydt");
     current_statement__ = 269;
     assign(dydt, cons_list(index_uni(2), nil_index_list()),
-      (-y[(1 - 1)] - (theta[(1 - 1)] * y[(2 - 1)])),
+      (-rvalue(y, cons_list(index_uni(1), nil_index_list()), "y") -
+        (rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta") *
+          rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"))),
       "assigning variable dydt");
     current_statement__ = 270;
     return dydt;
@@ -3019,10 +3022,14 @@ algebra_system(const Eigen::Matrix<T0__, -1, 1>& x,
         std::numeric_limits<double>::quiet_NaN(), "assigning variable f_x");}
     current_statement__ = 448;
     assign(f_x, cons_list(index_uni(1), nil_index_list()),
-      (x[(1 - 1)] - y[(1 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(1), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 449;
     assign(f_x, cons_list(index_uni(2), nil_index_list()),
-      (x[(2 - 1)] - y[(2 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(2), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(2), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 450;
     return f_x;
   } catch (const std::exception& e) {
@@ -3894,7 +3901,10 @@ class mother_model : public model_base_crtp<mother_model> {
                 std::numeric_limits<double>::quiet_NaN(),
                 "assigning variable l_mat");}}
           current_statement__ = 238;
-          assign(l_mat, nil_index_list(), d_ar_mat[(i - 1)][(j - 1)],
+          assign(l_mat, nil_index_list(),
+            rvalue(d_ar_mat,
+              cons_list(index_uni(i),
+                cons_list(index_uni(j), nil_index_list())), "d_ar_mat"),
             "assigning variable l_mat");
           current_statement__ = 239;
           if (pstream__) {
@@ -5074,10 +5084,14 @@ class mother_model : public model_base_crtp<mother_model> {
       for (size_t i = 1; i <= N; ++i) {
         current_statement__ = 55;
         assign(tp_vec, cons_list(index_uni(i), nil_index_list()),
-          (-1.0 * p_vec[(i - 1)]), "assigning variable tp_vec");}
+          (-1.0 *
+            rvalue(p_vec, cons_list(index_uni(i), nil_index_list()), "p_vec")),
+          "assigning variable tp_vec");}
       current_statement__ = 57;
-      assign(tp_row_vec, nil_index_list(), transpose(tp_1d_vec[(1 - 1)]),
-        "assigning variable tp_row_vec");
+      assign(tp_row_vec, nil_index_list(),
+        transpose(
+          rvalue(tp_1d_vec, cons_list(index_uni(1), nil_index_list()),
+            "tp_1d_vec")), "assigning variable tp_row_vec");
       current_statement__ = 58;
       assign(tp_1d_row_vec, nil_index_list(), p_1d_row_vec,
         "assigning variable tp_1d_row_vec");
@@ -5233,13 +5247,24 @@ class mother_model : public model_base_crtp<mother_model> {
         for (size_t n = 1; n <= N; ++n) {
           current_statement__ = 150;
           lp_accum__.add(
-            normal_log<propto__>(to_vector(p_1d_vec[(n - 1)]), 0, 1));
+            normal_log<propto__>(
+              to_vector(
+                rvalue(p_1d_vec, cons_list(index_uni(n), nil_index_list()),
+                  "p_1d_vec")), 0, 1));
           current_statement__ = 151;
           lp_accum__.add(
-            normal_log<propto__>(to_vector(p_1d_row_vec[(n - 1)]), 0, 1));
+            normal_log<propto__>(
+              to_vector(
+                rvalue(p_1d_row_vec,
+                  cons_list(index_uni(n), nil_index_list()), "p_1d_row_vec")),
+              0, 1));
           current_statement__ = 152;
           lp_accum__.add(
-            normal_log<propto__>(to_vector(p_1d_simplex[(n - 1)]), 0, 1));
+            normal_log<propto__>(
+              to_vector(
+                rvalue(p_1d_simplex,
+                  cons_list(index_uni(n), nil_index_list()), "p_1d_simplex")),
+              0, 1));
           current_statement__ = 160;
           for (size_t m = 1; m <= M; ++m) {
             current_statement__ = 158;
@@ -5247,35 +5272,79 @@ class mother_model : public model_base_crtp<mother_model> {
               current_statement__ = 153;
               lp_accum__.add(
                 normal_log<propto__>(
-                  to_vector(p_3d_vec[(n - 1)][(m - 1)][(k - 1)]),
-                  d_3d_vec[(n - 1)][(m - 1)][(k - 1)], 1));
+                  to_vector(
+                    rvalue(p_3d_vec,
+                      cons_list(index_uni(n),
+                        cons_list(index_uni(m),
+                          cons_list(index_uni(k), nil_index_list()))),
+                      "p_3d_vec")),
+                  rvalue(d_3d_vec,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "d_3d_vec"), 1));
               current_statement__ = 154;
               lp_accum__.add(
                 normal_log<propto__>(
-                  to_vector(p_3d_row_vec[(n - 1)][(m - 1)][(k - 1)]),
-                  d_3d_row_vec[(n - 1)][(m - 1)][(k - 1)], 1));
+                  to_vector(
+                    rvalue(p_3d_row_vec,
+                      cons_list(index_uni(n),
+                        cons_list(index_uni(m),
+                          cons_list(index_uni(k), nil_index_list()))),
+                      "p_3d_row_vec")),
+                  rvalue(d_3d_row_vec,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "d_3d_row_vec"), 1));
               current_statement__ = 155;
               lp_accum__.add(
                 normal_log<propto__>(
-                  to_vector(p_3d_simplex[(n - 1)][(m - 1)][(k - 1)]),
-                  d_3d_simplex[(n - 1)][(m - 1)][(k - 1)], 1));
+                  to_vector(
+                    rvalue(p_3d_simplex,
+                      cons_list(index_uni(n),
+                        cons_list(index_uni(m),
+                          cons_list(index_uni(k), nil_index_list()))),
+                      "p_3d_simplex")),
+                  rvalue(d_3d_simplex,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "d_3d_simplex"), 1));
               current_statement__ = 156;
               lp_accum__.add(
-                normal_log<propto__>(p_real_3d_ar[(n - 1)][(m - 1)][(k - 1)],
-                  p_real_3d_ar[(n - 1)][(m - 1)][(k - 1)], 1));}}}
+                normal_log<propto__>(
+                  rvalue(p_real_3d_ar,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "p_real_3d_ar"),
+                  rvalue(p_real_3d_ar,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "p_real_3d_ar"), 1));}}}
         current_statement__ = 167;
         for (size_t i = 1; i <= 4; ++i) {
           current_statement__ = 165;
           for (size_t j = 1; j <= 5; ++j) {
             current_statement__ = 163;
             lp_accum__.add(
-              normal_log<propto__>(to_vector(p_ar_mat[(i - 1)][(j - 1)]), 0,
-                1));}}
+              normal_log<propto__>(
+                to_vector(
+                  rvalue(p_ar_mat,
+                    cons_list(index_uni(i),
+                      cons_list(index_uni(j), nil_index_list())), "p_ar_mat")),
+                0, 1));}}
         current_statement__ = 170;
         for (size_t k = 1; k <= K; ++k) {
           current_statement__ = 168;
           lp_accum__.add(
-            normal_log<propto__>(to_vector(p_cfcov_33_ar[(k - 1)]), 0, 1));}
+            normal_log<propto__>(
+              to_vector(
+                rvalue(p_cfcov_33_ar,
+                  cons_list(index_uni(k), nil_index_list()), "p_cfcov_33_ar")),
+              0, 1));}
         current_statement__ = 171;
         lp_accum__.add(normal_log<propto__>(to_vector(p_vec), d_vec, 1));
         current_statement__ = 172;
@@ -6103,10 +6172,14 @@ class mother_model : public model_base_crtp<mother_model> {
       for (size_t i = 1; i <= N; ++i) {
         current_statement__ = 55;
         assign(tp_vec, cons_list(index_uni(i), nil_index_list()),
-          (-1.0 * p_vec[(i - 1)]), "assigning variable tp_vec");}
+          (-1.0 *
+            rvalue(p_vec, cons_list(index_uni(i), nil_index_list()), "p_vec")),
+          "assigning variable tp_vec");}
       current_statement__ = 57;
-      assign(tp_row_vec, nil_index_list(), transpose(tp_1d_vec[(1 - 1)]),
-        "assigning variable tp_row_vec");
+      assign(tp_row_vec, nil_index_list(),
+        transpose(
+          rvalue(tp_1d_vec, cons_list(index_uni(1), nil_index_list()),
+            "tp_1d_vec")), "assigning variable tp_row_vec");
       current_statement__ = 58;
       assign(tp_1d_row_vec, nil_index_list(), p_1d_row_vec,
         "assigning variable tp_1d_row_vec");
@@ -6756,7 +6829,9 @@ class mother_model : public model_base_crtp<mother_model> {
       for (size_t i = 1; i <= N; ++i) {
         current_statement__ = 116;
         assign(gq_vec, cons_list(index_uni(i), nil_index_list()),
-          (-1.0 * p_vec[(i - 1)]), "assigning variable gq_vec");}
+          (-1.0 *
+            rvalue(p_vec, cons_list(index_uni(i), nil_index_list()), "p_vec")),
+          "assigning variable gq_vec");}
       current_statement__ = 121;
       for (size_t i = 1; i <= 3; ++i) {
         current_statement__ = 120;
@@ -6779,8 +6854,14 @@ class mother_model : public model_base_crtp<mother_model> {
             cons_list(index_uni(i),
               cons_list(index_uni(j), nil_index_list())),
             rvalue(indexing_mat,
-              cons_list(index_uni(indices[(i - 1)]),
-                cons_list(index_uni(indices[(j - 1)]), nil_index_list())),
+              cons_list(
+                index_uni(rvalue(indices,
+                            cons_list(index_uni(i), nil_index_list()),
+                            "indices")),
+                cons_list(
+                  index_uni(rvalue(indices,
+                              cons_list(index_uni(j), nil_index_list()),
+                              "indices")), nil_index_list())),
               "indexing_mat"), "assigning variable idx_res1");}}
       current_statement__ = 125;
       assign(idx_res11, nil_index_list(),
@@ -6817,7 +6898,10 @@ class mother_model : public model_base_crtp<mother_model> {
               cons_list(index_uni(j), nil_index_list())),
             rvalue(indexing_mat,
               cons_list(index_uni(i),
-                cons_list(index_uni(indices[(j - 1)]), nil_index_list())),
+                cons_list(
+                  index_uni(rvalue(indices,
+                              cons_list(index_uni(j), nil_index_list()),
+                              "indices")), nil_index_list())),
               "indexing_mat"), "assigning variable idx_res2");}}
       current_statement__ = 131;
       assign(idx_res21, nil_index_list(),
@@ -6856,9 +6940,15 @@ class mother_model : public model_base_crtp<mother_model> {
                 cons_list(index_uni(j),
                   cons_list(index_uni(k), nil_index_list()))),
               rvalue(indexing_mat,
-                cons_list(index_uni(indices[(i - 1)]),
+                cons_list(
+                  index_uni(rvalue(indices,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "indices")),
                   cons_list(index_uni(j),
-                    cons_list(index_uni(indices[(k - 1)]), nil_index_list()))),
+                    cons_list(
+                      index_uni(rvalue(indices,
+                                  cons_list(index_uni(k), nil_index_list()),
+                                  "indices")), nil_index_list()))),
                 "indexing_mat"), "assigning variable idx_res3");}}}
       current_statement__ = 138;
       assign(idx_res31, nil_index_list(),
@@ -9531,11 +9621,14 @@ sho(const T0__& t, const std::vector<T1__>& y,
     dydt = std::vector<local_scalar_t__>(2, 0);
     
     current_statement__ = 113;
-    assign(dydt, cons_list(index_uni(1), nil_index_list()), y[(2 - 1)],
+    assign(dydt, cons_list(index_uni(1), nil_index_list()),
+      rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"),
       "assigning variable dydt");
     current_statement__ = 114;
     assign(dydt, cons_list(index_uni(2), nil_index_list()),
-      (-y[(1 - 1)] - (theta[(1 - 1)] * y[(2 - 1)])),
+      (-rvalue(y, cons_list(index_uni(1), nil_index_list()), "y") -
+        (rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta") *
+          rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"))),
       "assigning variable dydt");
     current_statement__ = 115;
     return dydt;
@@ -9686,10 +9779,14 @@ algebra_system(const Eigen::Matrix<T0__, -1, 1>& x,
         std::numeric_limits<double>::quiet_NaN(), "assigning variable f_x");}
     current_statement__ = 124;
     assign(f_x, cons_list(index_uni(1), nil_index_list()),
-      (x[(1 - 1)] - y[(1 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(1), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 125;
     assign(f_x, cons_list(index_uni(2), nil_index_list()),
-      (x[(2 - 1)] - y[(2 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(2), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(2), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 126;
     return f_x;
   } catch (const std::exception& e) {
@@ -13850,7 +13947,11 @@ g2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice, const int& start,
     current_statement__ = 40;
     for (size_t n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 38;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(y_slice[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(y_slice,
+                       cons_list(index_uni(n), nil_index_list()), "y_slice"),
+                     0, 1));}
     current_statement__ = 41;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -13900,7 +14001,11 @@ g3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice, const int& start,
     current_statement__ = 46;
     for (size_t n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 44;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(y_slice[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(y_slice,
+                       cons_list(index_uni(n), nil_index_list()), "y_slice"),
+                     0, 1));}
     current_statement__ = 47;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -13951,7 +14056,11 @@ g4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice, const int& start,
     for (size_t n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 50;
       sum_lpdf = (sum_lpdf +
-                   normal_lpdf<false>(to_vector(y_slice[(n - 1)]), 0, 1));}
+                   normal_lpdf<false>(
+                     to_vector(
+                       rvalue(y_slice,
+                         cons_list(index_uni(n), nil_index_list()),
+                         "y_slice")), 0, 1));}
     current_statement__ = 53;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14001,10 +14110,17 @@ g5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
     current_statement__ = 60;
     for (size_t n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 58;
-      for (size_t m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 56;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(y_slice[(n - 1)][(m - 1)], 0, 1));}}
+                     normal_lpdf<false>(
+                       rvalue(y_slice,
+                         cons_list(index_uni(n),
+                           cons_list(index_uni(m), nil_index_list())),
+                         "y_slice"), 0, 1));}}
     current_statement__ = 61;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14054,11 +14170,18 @@ g6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
     current_statement__ = 68;
     for (size_t n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 66;
-      for (size_t m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 64;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(y_slice[(n - 1)][(m - 1)]),
-                       0, 1));}}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(y_slice,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())),
+                           "y_slice")), 0, 1));}}
     current_statement__ = 69;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14108,11 +14231,18 @@ g7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
     current_statement__ = 76;
     for (size_t n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 74;
-      for (size_t m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 72;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(y_slice[(n - 1)][(m - 1)]),
-                       0, 1));}}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(y_slice,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())),
+                           "y_slice")), 0, 1));}}
     current_statement__ = 77;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14162,11 +14292,18 @@ g8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
     current_statement__ = 84;
     for (size_t n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 82;
-      for (size_t m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 80;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(y_slice[(n - 1)][(m - 1)]),
-                       0, 1));}}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(y_slice,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())),
+                           "y_slice")), 0, 1));}}
     current_statement__ = 85;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14265,7 +14402,10 @@ h2(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 92;
     for (size_t n = start; n <= end; ++n) {
       current_statement__ = 90;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(a[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(a, cons_list(index_uni(n), nil_index_list()),
+                       "a"), 0, 1));}
     current_statement__ = 93;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14321,7 +14461,10 @@ h3(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 98;
     for (size_t n = start; n <= end; ++n) {
       current_statement__ = 96;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(a[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(a, cons_list(index_uni(n), nil_index_list()),
+                       "a"), 0, 1));}
     current_statement__ = 99;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14377,8 +14520,11 @@ h4(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 104;
     for (size_t n = start; n <= end; ++n) {
       current_statement__ = 102;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(to_vector(a[(n - 1)]), 0, 1));
-    }
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     to_vector(
+                       rvalue(a, cons_list(index_uni(n), nil_index_list()),
+                         "a")), 0, 1));}
     current_statement__ = 105;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14434,10 +14580,17 @@ h5(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 112;
     for (size_t n = start; n <= end; ++n) {
       current_statement__ = 110;
-      for (size_t m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 108;
-        sum_lpdf = (sum_lpdf + normal_lpdf<false>(a[(n - 1)][(m - 1)], 0, 1));
-      }}
+        sum_lpdf = (sum_lpdf +
+                     normal_lpdf<false>(
+                       rvalue(a,
+                         cons_list(index_uni(n),
+                           cons_list(index_uni(m), nil_index_list())), "a"),
+                       0, 1));}}
     current_statement__ = 113;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14492,11 +14645,18 @@ h6(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 120;
     for (size_t n = start; n <= end; ++n) {
       current_statement__ = 118;
-      for (size_t m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 116;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(a[(n - 1)][(m - 1)]), 0, 1));
-      }}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(a,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())), "a")),
+                       0, 1));}}
     current_statement__ = 121;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14553,11 +14713,18 @@ h7(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 128;
     for (size_t n = start; n <= end; ++n) {
       current_statement__ = 126;
-      for (size_t m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 124;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(a[(n - 1)][(m - 1)]), 0, 1));
-      }}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(a,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())), "a")),
+                       0, 1));}}
     current_statement__ = 129;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -14614,11 +14781,18 @@ h8(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 136;
     for (size_t n = start; n <= end; ++n) {
       current_statement__ = 134;
-      for (size_t m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (size_t m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 132;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(a[(n - 1)][(m - 1)]), 0, 1));
-      }}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(a,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())), "a")),
+                       0, 1));}}
     current_statement__ = 137;
     return sum_lpdf;
   } catch (const std::exception& e) {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -1208,11 +1208,15 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
       {
         {
           {
-            vars__.push_back(x_vector[(1 - 1)]);
+            vars__.push_back(
+              rvalue(x_vector, cons_list(index_uni(1), nil_index_list()),
+                "x_vector"));
           }
           {
             {
-              vars__.push_back(x_vector[(2 - 1)]);
+              vars__.push_back(
+                rvalue(x_vector, cons_list(index_uni(2), nil_index_list()),
+                  "x_vector"));
             }
           }
         }
@@ -1344,7 +1348,9 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
                     assign(x_matrix,
                       cons_list(index_uni(1),
                         cons_list(index_uni(1), nil_index_list())),
-                      sym42__[(1 - 1)], "assigning variable x_matrix");
+                      rvalue(sym42__,
+                        cons_list(index_uni(1), nil_index_list()), "sym42__"),
+                      "assigning variable x_matrix");
                     current_statement__ = 3;
                     pos__ = 2;
                   }
@@ -1426,7 +1432,8 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
             {
               current_statement__ = 4;
               assign(x_vector, cons_list(index_uni(1), nil_index_list()),
-                sym43__[(1 - 1)], "assigning variable x_vector");
+                rvalue(sym43__, cons_list(index_uni(1), nil_index_list()),
+                  "sym43__"), "assigning variable x_vector");
               current_statement__ = 4;
               pos__ = 2;
             }
@@ -1461,7 +1468,9 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
                     assign(x_cov,
                       cons_list(index_uni(1),
                         cons_list(index_uni(1), nil_index_list())),
-                      sym41__[(1 - 1)], "assigning variable x_cov");
+                      rvalue(sym41__,
+                        cons_list(index_uni(1), nil_index_list()), "sym41__"),
+                      "assigning variable x_cov");
                     current_statement__ = 5;
                     pos__ = 2;
                   }
@@ -1589,11 +1598,15 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
       {
         {
           {
-            vars__.push_back(x_vector[(1 - 1)]);
+            vars__.push_back(
+              rvalue(x_vector, cons_list(index_uni(1), nil_index_list()),
+                "x_vector"));
           }
           {
             {
-              vars__.push_back(x_vector[(2 - 1)]);
+              vars__.push_back(
+                rvalue(x_vector, cons_list(index_uni(2), nil_index_list()),
+                  "x_vector"));
             }
           }
         }
@@ -1601,16 +1614,22 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
       {
         {
           {
-            vars__.push_back(x_cov_free__[(1 - 1)]);
+            vars__.push_back(
+              rvalue(x_cov_free__, cons_list(index_uni(1), nil_index_list()),
+                "x_cov_free__"));
           }
           {
             {
-              vars__.push_back(x_cov_free__[(2 - 1)]);
+              vars__.push_back(
+                rvalue(x_cov_free__,
+                  cons_list(index_uni(2), nil_index_list()), "x_cov_free__"));
             }
           }
           {
             {
-              vars__.push_back(x_cov_free__[(3 - 1)]);
+              vars__.push_back(
+                rvalue(x_cov_free__,
+                  cons_list(index_uni(3), nil_index_list()), "x_cov_free__"));
             }
           }
         }


### PR DESCRIPTION
Fixes #489 by forcing the use of `stan::model::rvalue()` instead of direct access. As far as I know that doesn't incur any performance penalty beyond the range check.

The range check is still skipped for compiler generated indexing as those are likely to be correct.