### PR TITLE
use _lpdf/_lpmf rather than _log

### DIFF
--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -463,7 +463,7 @@ let dist_name_suffix udf_names name =
 
 let%expect_test "dist name suffix" =
   dist_name_suffix [] "normal" |> print_endline ;
-  [%expect {| _log |}]
+  [%expect {| _lpdf |}]
 
 let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
   let stmt_typed = ts.stmt and smeta = ts.smeta.loc in

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -248,14 +248,6 @@ let all_declarative_sigs = distributions @ math_sigs
 let declarative_fnsigs =
   List.concat_map ~f:mk_declarative_sig all_declarative_sigs
 
-(* Name mangling helper functions for distributions *)
-let distribution_suffices = ["_log"; "_lpmf"; "_lpdf"]
-
-let remove_propto_infix suffix ~name =
-  name
-  |> String.chop_suffix ~suffix:(Utils.proportional_to_distribution_infix ^ suffix)
-  |> Option.map ~f:(fun x -> x ^ suffix)
-
 (* -- Querying stan_math_signatures -- *)
 let stan_math_returntype name args =
   let name = Utils.stdlib_distribution_name name in
@@ -280,18 +272,6 @@ let stan_math_returntype name args =
 let is_stan_math_function_name name =
   let name = Utils.stdlib_distribution_name name in
   Hashtbl.mem stan_math_signatures name
-
-(* XXX Refactor this out into full Distribution node in MIR *)
-let is_distribution_name ?(infix = "") s =
-  (not
-     ( String.is_suffix ~suffix:"_cdf_log" s
-     || String.is_suffix ~suffix:"_ccdf_log" s ))
-  && List.exists
-       ~f:(fun suffix -> String.is_suffix s ~suffix:(infix ^ suffix))
-       distribution_suffices
-
-let is_propto_distribution s =
-  is_distribution_name ~infix:Utils.proportional_to_distribution_infix s
 
 let assignmentoperator_to_stan_math_fn = function
   | Operator.Plus -> Some "assign_add"

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -249,12 +249,11 @@ let declarative_fnsigs =
   List.concat_map ~f:mk_declarative_sig all_declarative_sigs
 
 (* Name mangling helper functions for distributions *)
-let proportional_to_distribution_infix = "_propto"
 let distribution_suffices = ["_log"; "_lpmf"; "_lpdf"]
 
 let remove_propto_infix suffix ~name =
   name
-  |> String.chop_suffix ~suffix:(proportional_to_distribution_infix ^ suffix)
+  |> String.chop_suffix ~suffix:(Utils.proportional_to_distribution_infix ^ suffix)
   |> Option.map ~f:(fun x -> x ^ suffix)
 
 (* -- Querying stan_math_signatures -- *)
@@ -292,7 +291,7 @@ let is_distribution_name ?(infix = "") s =
        distribution_suffices
 
 let is_propto_distribution s =
-  is_distribution_name ~infix:proportional_to_distribution_infix s
+  is_distribution_name ~infix:Utils.proportional_to_distribution_infix s
 
 let assignmentoperator_to_stan_math_fn = function
   | Operator.Plus -> Some "assign_add"

--- a/src/middle/Utils.ml
+++ b/src/middle/Utils.ml
@@ -5,18 +5,21 @@ let option_or_else ~if_none x = Option.first_some x if_none
 (* Name mangling helper functions for distributions *)
 let proportional_to_distribution_infix = "_propto"
 let distribution_suffices = ["_lpmf"; "_lpdf"; "_log"]
+let propto_suffices = List.map ~f:(fun x -> proportional_to_distribution_infix ^ x) distribution_suffices
 let is_user_ident = Fn.non (String.is_suffix ~suffix:"__")
 
-let is_distribution_name ?(infix = "") s =
+let is_distribution_name s =
   (not
      ( String.is_suffix s ~suffix:"_cdf_log"
      || String.is_suffix s ~suffix:"_ccdf_log" ))
   && List.exists
-       ~f:(fun suffix -> String.is_suffix s ~suffix:(infix ^ suffix))
+       ~f:(fun suffix -> String.is_suffix s ~suffix)
        distribution_suffices
 
 let is_propto_distribution s =
-  is_distribution_name ~infix:proportional_to_distribution_infix s
+  List.exists
+       ~f:(fun suffix -> String.is_suffix s ~suffix)
+       propto_suffices
 
 let remove_propto_infix suffix ~name =
   name

--- a/src/middle/Utils.ml
+++ b/src/middle/Utils.ml
@@ -4,7 +4,7 @@ let option_or_else ~if_none x = Option.first_some x if_none
 
 (* Name mangling helper functions for distributions *)
 let proportional_to_distribution_infix = "_propto"
-let distribution_suffices = ["_log"; "_lpmf"; "_lpdf"]
+let distribution_suffices = ["_lpmf"; "_lpdf"; "_log"]
 let is_user_ident = Fn.non (String.is_suffix ~suffix:"__")
 
 let is_distribution_name ?(infix = "") s =

--- a/src/middle/Utils.ml
+++ b/src/middle/Utils.ml
@@ -28,10 +28,11 @@ let stdlib_distribution_name s =
   |> List.filter_opt |> List.hd |> Option.value ~default:s
 
 let%expect_test "propto name mangling" =
-  stdlib_distribution_name "normal_propto_lpdf" |> print_string ;
+  stdlib_distribution_name "bernoulli_logit_propto_lpmf" |> print_string ;
+  stdlib_distribution_name "normal_propto_lpdf" |> ( ^ ) "; " |> print_string ;
   stdlib_distribution_name "normal_lpdf" |> ( ^ ) "; " |> print_string ;
   stdlib_distribution_name "normal" |> ( ^ ) "; " |> print_string ;
-  [%expect {| normal_lpdf; normal_lpdf; normal |}]
+  [%expect {| bernoulli_logit_lpmf; normal_lpdf; normal_lpdf; normal |}]
 
 let all_but_last_n l n =
   List.fold_right l ~init:([], n) ~f:(fun ele (accum, n) ->

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -55,12 +55,9 @@ let rec switch_expr_to_opencl available_cl_vars (Expr.Fixed.({pattern; _}) as e)
     | true -> List.mapi args ~f:(move_cl_args cl_args)
     | false -> args
   in
-  let trim_propto f =
-    Utils.stdlib_distribution_name f
-  in
   match pattern with
-  | FunApp (StanLib, f, args) when Map.mem opencl_triggers (trim_propto f) ->
-      let trigger = Map.find_exn opencl_triggers (trim_propto f) in
+  | FunApp (StanLib, f, args) when Map.mem opencl_triggers (Utils.stdlib_distribution_name f) ->
+      let trigger = Map.find_exn opencl_triggers (Utils.stdlib_distribution_name f) in
       {e with pattern= FunApp (StanLib, f, maybe_map_args args trigger)}
   | x ->
       { e with

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -56,7 +56,7 @@ let rec switch_expr_to_opencl available_cl_vars (Expr.Fixed.({pattern; _}) as e)
     | false -> args
   in
   let trim_propto f =
-    String.substr_replace_all ~pattern:"_propto_" ~with_:"_" f
+    Utils.stdlib_distribution_name f
   in
   match pattern with
   | FunApp (StanLib, f, args) when Map.mem opencl_triggers (trim_propto f) ->

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -239,13 +239,13 @@ class eight_schools_ncp_model : public model_base_crtp<eight_schools_ncp_model> 
         "assigning variable theta");
       {
         current_statement__ = 5;
-        lp_accum__.add(normal_log<propto__>(mu, 0, 5));
+        lp_accum__.add(normal_lpdf<propto__>(mu, 0, 5));
         current_statement__ = 6;
-        lp_accum__.add(normal_log<propto__>(tau, 0, 5));
+        lp_accum__.add(normal_lpdf<propto__>(tau, 0, 5));
         current_statement__ = 7;
-        lp_accum__.add(normal_log<propto__>(theta_tilde, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(theta_tilde, 0, 1));
         current_statement__ = 8;
-        lp_accum__.add(normal_log<propto__>(y, theta, sigma));
+        lp_accum__.add(normal_lpdf<propto__>(y, theta, sigma));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1398,7 +1398,7 @@ unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
     current_statement__ = 290;
     lp_accum__.add(normal_log<false>(u, 0, 1));
     current_statement__ = 291;
-    lp_accum__.add(uniform_log<propto__>(u, -100, 100));
+    lp_accum__.add(uniform_lpdf<propto__>(u, -100, 100));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -5136,33 +5136,33 @@ class mother_model : public model_base_crtp<mother_model> {
         current_statement__ = 148;
         r2 = foo_bar1(J, pstream__);
         current_statement__ = 149;
-        lp_accum__.add(normal_log<propto__>(p_real, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(p_real, 0, 1));
         current_statement__ = 150;
-        lp_accum__.add(normal_log<propto__>(offset_multiplier, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(offset_multiplier, 0, 1));
         current_statement__ = 151;
-        lp_accum__.add(normal_log<propto__>(no_offset_multiplier, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(no_offset_multiplier, 0, 1));
         current_statement__ = 152;
-        lp_accum__.add(normal_log<propto__>(offset_no_multiplier, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(offset_no_multiplier, 0, 1));
         current_statement__ = 153;
-        lp_accum__.add(normal_log<propto__>(to_vector(p_real_1d_ar), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_real_1d_ar), 0, 1));
         current_statement__ = 166;
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 154;
           lp_accum__.add(
-            normal_log<propto__>(
+            normal_lpdf<propto__>(
               to_vector(
                 rvalue(p_1d_vec, cons_list(index_uni(n), nil_index_list()),
                   "p_1d_vec")), 0, 1));
           current_statement__ = 155;
           lp_accum__.add(
-            normal_log<propto__>(
+            normal_lpdf<propto__>(
               to_vector(
                 rvalue(p_1d_row_vec,
                   cons_list(index_uni(n), nil_index_list()), "p_1d_row_vec")),
               0, 1));
           current_statement__ = 156;
           lp_accum__.add(
-            normal_log<propto__>(
+            normal_lpdf<propto__>(
               to_vector(
                 rvalue(p_1d_simplex,
                   cons_list(index_uni(n), nil_index_list()), "p_1d_simplex")),
@@ -5173,7 +5173,7 @@ class mother_model : public model_base_crtp<mother_model> {
             for (int k = 1; k <= K; ++k) {
               current_statement__ = 157;
               lp_accum__.add(
-                normal_log<propto__>(
+                normal_lpdf<propto__>(
                   to_vector(
                     rvalue(p_3d_vec,
                       cons_list(index_uni(n),
@@ -5187,7 +5187,7 @@ class mother_model : public model_base_crtp<mother_model> {
                     "d_3d_vec"), 1));
               current_statement__ = 158;
               lp_accum__.add(
-                normal_log<propto__>(
+                normal_lpdf<propto__>(
                   to_vector(
                     rvalue(p_3d_row_vec,
                       cons_list(index_uni(n),
@@ -5201,7 +5201,7 @@ class mother_model : public model_base_crtp<mother_model> {
                     "d_3d_row_vec"), 1));
               current_statement__ = 159;
               lp_accum__.add(
-                normal_log<propto__>(
+                normal_lpdf<propto__>(
                   to_vector(
                     rvalue(p_3d_simplex,
                       cons_list(index_uni(n),
@@ -5215,7 +5215,7 @@ class mother_model : public model_base_crtp<mother_model> {
                     "d_3d_simplex"), 1));
               current_statement__ = 160;
               lp_accum__.add(
-                normal_log<propto__>(
+                normal_lpdf<propto__>(
                   rvalue(p_real_3d_ar,
                     cons_list(index_uni(n),
                       cons_list(index_uni(m),
@@ -5232,7 +5232,7 @@ class mother_model : public model_base_crtp<mother_model> {
           for (int j = 1; j <= 5; ++j) {
             current_statement__ = 167;
             lp_accum__.add(
-              normal_log<propto__>(
+              normal_lpdf<propto__>(
                 to_vector(
                   rvalue(p_ar_mat,
                     cons_list(index_uni(i),
@@ -5242,21 +5242,21 @@ class mother_model : public model_base_crtp<mother_model> {
         for (int k = 1; k <= K; ++k) {
           current_statement__ = 172;
           lp_accum__.add(
-            normal_log<propto__>(
+            normal_lpdf<propto__>(
               to_vector(
                 rvalue(p_cfcov_33_ar,
                   cons_list(index_uni(k), nil_index_list()), "p_cfcov_33_ar")),
               0, 1));}
         current_statement__ = 175;
-        lp_accum__.add(normal_log<propto__>(to_vector(p_vec), d_vec, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_vec), d_vec, 1));
         current_statement__ = 176;
-        lp_accum__.add(normal_log<propto__>(to_vector(p_row_vec), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_row_vec), 0, 1));
         current_statement__ = 177;
-        lp_accum__.add(normal_log<propto__>(to_vector(p_simplex), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_simplex), 0, 1));
         current_statement__ = 178;
-        lp_accum__.add(normal_log<propto__>(to_vector(p_cfcov_54), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_cfcov_54), 0, 1));
         current_statement__ = 179;
-        lp_accum__.add(normal_log<propto__>(to_vector(p_cfcov_33), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_cfcov_33), 0, 1));
         current_statement__ = 180;
         lp_accum__.add(
           map_rect<1, binomialf_functor__>(tmp, tmp2, x_r, x_i, pstream__));
@@ -20959,7 +20959,7 @@ class tilde_block_model : public model_base_crtp<tilde_block_model> {
             lp_accum__.add(-student_t_ccdf_log(0, 10, 0, 1));
           }
           current_statement__ = 6;
-          lp_accum__.add(student_t_log<propto__>(x, 10, 0, 1));
+          lp_accum__.add(student_t_lpdf<propto__>(x, 10, 0, 1));
         } else {
           current_statement__ = 2;
           if (logical_lt(x, 0)) {
@@ -20970,7 +20970,7 @@ class tilde_block_model : public model_base_crtp<tilde_block_model> {
             lp_accum__.add(-normal_ccdf_log(0, 0, 1));
           }
           current_statement__ = 3;
-          lp_accum__.add(normal_log<propto__>(x, 0, 1));
+          lp_accum__.add(normal_lpdf<propto__>(x, 0, 1));
         }
       }
     } catch (const std::exception& e) {
@@ -21383,7 +21383,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
       }
       {
         current_statement__ = 3;
-        lp_accum__.add(normal_log<propto__>(x, m, 1));
+        lp_accum__.add(normal_lpdf<propto__>(x, m, 1));
         current_statement__ = 4;
         if (logical_lt(x, 0.0)) {
           current_statement__ = 4;
@@ -21393,7 +21393,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
           lp_accum__.add(-normal_ccdf_log(0.0, m, 1));
         }
         current_statement__ = 5;
-        lp_accum__.add(normal_log<propto__>(x, m, 1));
+        lp_accum__.add(normal_lpdf<propto__>(x, m, 1));
         current_statement__ = 6;
         if (logical_gt(x, 10.0)) {
           current_statement__ = 6;
@@ -21403,7 +21403,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
           lp_accum__.add(-normal_cdf_log(10.0, m, 1));
         }
         current_statement__ = 7;
-        lp_accum__.add(normal_log<propto__>(x, m, 1));
+        lp_accum__.add(normal_lpdf<propto__>(x, m, 1));
         current_statement__ = 9;
         if (logical_lt(x, 0.0)) {
           current_statement__ = 9;
@@ -21421,9 +21421,9 @@ class truncate_model : public model_base_crtp<truncate_model> {
           }
         }
         current_statement__ = 10;
-        lp_accum__.add(normal_log<propto__>(x, m, 1));
+        lp_accum__.add(normal_lpdf<propto__>(x, m, 1));
         current_statement__ = 11;
-        lp_accum__.add(poisson_log<propto__>(n, y));
+        lp_accum__.add(poisson_lpmf<propto__>(n, y));
         current_statement__ = 12;
         if (logical_lt(n, 10)) {
           current_statement__ = 12;
@@ -21433,7 +21433,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
           lp_accum__.add(-poisson_ccdf_log((10 - 1), y));
         }
         current_statement__ = 13;
-        lp_accum__.add(poisson_log<propto__>(n, y));
+        lp_accum__.add(poisson_lpmf<propto__>(n, y));
         current_statement__ = 14;
         if (logical_gt(n, 20)) {
           current_statement__ = 14;
@@ -21443,7 +21443,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
           lp_accum__.add(-poisson_cdf_log(20, y));
         }
         current_statement__ = 15;
-        lp_accum__.add(poisson_log<propto__>(n, y));
+        lp_accum__.add(poisson_lpmf<propto__>(n, y));
         current_statement__ = 17;
         if (logical_lt(n, 10)) {
           current_statement__ = 17;
@@ -21461,7 +21461,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
           }
         }
         current_statement__ = 18;
-        lp_accum__.add(poisson_log<propto__>(n, y));
+        lp_accum__.add(poisson_lpmf<propto__>(n, y));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21884,7 +21884,7 @@ class user_constrain_model : public model_base_crtp<user_constrain_model> {
       }
       {
         current_statement__ = 2;
-        lp_accum__.add(std_normal_log<propto__>(x));
+        lp_accum__.add(std_normal_lpdf<propto__>(x));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -251,7 +251,7 @@
          ((pattern
            (TargetPE
             ((pattern
-              (FunApp StanLib uniform_propto_log
+              (FunApp StanLib uniform_propto_lpdf
                (((pattern (Var u))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern
@@ -5904,7 +5904,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern (Var p_real))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
               ((pattern (Lit Int 0))
@@ -5916,7 +5916,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern (Var offset_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -5930,7 +5930,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern (Var no_offset_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -5944,7 +5944,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern (Var offset_no_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -5958,7 +5958,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern
                 (FunApp StanLib to_vector
                  (((pattern (Var p_real_1d_ar))
@@ -5986,7 +5986,7 @@
               (((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp StanLib normal_propto_log
+                    (FunApp StanLib normal_propto_lpdf
                      (((pattern
                         (FunApp StanLib to_vector
                          (((pattern
@@ -6018,7 +6018,7 @@
                ((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp StanLib normal_propto_log
+                    (FunApp StanLib normal_propto_lpdf
                      (((pattern
                         (FunApp StanLib to_vector
                          (((pattern
@@ -6050,7 +6050,7 @@
                ((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp StanLib normal_propto_log
+                    (FunApp StanLib normal_propto_lpdf
                      (((pattern
                         (FunApp StanLib to_vector
                          (((pattern
@@ -6106,7 +6106,7 @@
                               (((pattern
                                  (TargetPE
                                   ((pattern
-                                    (FunApp StanLib normal_propto_log
+                                    (FunApp StanLib normal_propto_lpdf
                                      (((pattern
                                         (FunApp StanLib to_vector
                                          (((pattern
@@ -6177,7 +6177,7 @@
                                ((pattern
                                  (TargetPE
                                   ((pattern
-                                    (FunApp StanLib normal_propto_log
+                                    (FunApp StanLib normal_propto_lpdf
                                      (((pattern
                                         (FunApp StanLib to_vector
                                          (((pattern
@@ -6250,7 +6250,7 @@
                                ((pattern
                                  (TargetPE
                                   ((pattern
-                                    (FunApp StanLib normal_propto_log
+                                    (FunApp StanLib normal_propto_lpdf
                                      (((pattern
                                         (FunApp StanLib to_vector
                                          (((pattern
@@ -6321,7 +6321,7 @@
                                ((pattern
                                  (TargetPE
                                   ((pattern
-                                    (FunApp StanLib normal_propto_log
+                                    (FunApp StanLib normal_propto_lpdf
                                      (((pattern
                                         (Indexed
                                          ((pattern (Var p_real_3d_ar))
@@ -6413,7 +6413,7 @@
                       (((pattern
                          (TargetPE
                           ((pattern
-                            (FunApp StanLib normal_propto_log
+                            (FunApp StanLib normal_propto_lpdf
                              (((pattern
                                 (FunApp StanLib to_vector
                                  (((pattern
@@ -6469,7 +6469,7 @@
               (((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp StanLib normal_propto_log
+                    (FunApp StanLib normal_propto_lpdf
                      (((pattern
                         (FunApp StanLib to_vector
                          (((pattern
@@ -6503,7 +6503,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern
                 (FunApp StanLib to_vector
                  (((pattern (Var p_vec))
@@ -6519,7 +6519,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern
                 (FunApp StanLib to_vector
                  (((pattern (Var p_row_vec))
@@ -6536,7 +6536,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern
                 (FunApp StanLib to_vector
                  (((pattern (Var p_simplex))
@@ -6552,7 +6552,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern
                 (FunApp StanLib to_vector
                  (((pattern (Var p_cfcov_54))
@@ -6568,7 +6568,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp StanLib normal_propto_log
+            (FunApp StanLib normal_propto_lpdf
              (((pattern
                 (FunApp StanLib to_vector
                  (((pattern (Var p_cfcov_33))

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -516,16 +516,16 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
       }
       {
         current_statement__ = 8;
-        lp_accum__.add(cauchy_log<propto__>(beta, 0, 2.5));
+        lp_accum__.add(cauchy_lpdf<propto__>(beta, 0, 2.5));
         current_statement__ = 9;
-        lp_accum__.add(cauchy_log<propto__>(gamma, 0, 1));
+        lp_accum__.add(cauchy_lpdf<propto__>(gamma, 0, 1));
         current_statement__ = 10;
-        lp_accum__.add(cauchy_log<propto__>(xi, 0, 25));
+        lp_accum__.add(cauchy_lpdf<propto__>(xi, 0, 25));
         current_statement__ = 11;
-        lp_accum__.add(cauchy_log<propto__>(delta, 0, 1));
+        lp_accum__.add(cauchy_lpdf<propto__>(delta, 0, 1));
         current_statement__ = 12;
         lp_accum__.add(
-          poisson_log<propto__>(
+          poisson_lpmf<propto__>(
             rvalue(stoi_hat, cons_list(index_uni(1), nil_index_list()),
               "stoi_hat"),
             (rvalue(y0, cons_list(index_uni(1), nil_index_list()), "y0") -
@@ -534,7 +534,7 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
         if (logical_gte(N_t, 2)) {
           current_statement__ = 13;
           lp_accum__.add(
-            poisson_log<propto__>(
+            poisson_lpmf<propto__>(
               rvalue(stoi_hat, cons_list(index_uni(2), nil_index_list()),
                 "stoi_hat"),
               (lcm_sym29__ -
@@ -545,7 +545,7 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
           for (int n = 3; n <= N_t; ++n) {
             current_statement__ = 13;
             lp_accum__.add(
-              poisson_log<propto__>(
+              poisson_lpmf<propto__>(
                 rvalue(stoi_hat, cons_list(index_uni(n), nil_index_list()),
                   "stoi_hat"),
                 (rvalue(lcm_sym20__,
@@ -559,7 +559,7 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
         } 
         current_statement__ = 15;
         lp_accum__.add(
-          lognormal_log<propto__>(B_hat,
+          lognormal_lpdf<propto__>(B_hat,
             stan::math::log(col(to_matrix(lcm_sym20__), 4)), 0.15));
       }
     } catch (const std::exception& e) {
@@ -2378,14 +2378,14 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
             if (logical_gte(lcm_sym140__, lcm_sym116__)) {
               current_statement__ = 22;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym116__ - 1)),
                         nil_index_list())), "phi")));
               lcm_sym114__ = (lcm_sym116__ + 1);
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(1),
                       cons_list(index_uni(lcm_sym116__), nil_index_list())),
@@ -2397,14 +2397,14 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
               for (int t = lcm_sym114__; t <= lcm_sym140__; ++t) {
                 current_statement__ = 22;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
                       "phi")));
                 current_statement__ = 23;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(1),
                         cons_list(index_uni(t), nil_index_list())), "y"),
@@ -2415,7 +2415,7 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
             } 
             current_statement__ = 25;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(inline_sym9__,
                   cons_list(index_uni(1),
                     cons_list(index_uni(lcm_sym140__), nil_index_list())),
@@ -2433,14 +2433,14 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
               if (logical_gte(lcm_sym139__, lcm_sym115__)) {
                 current_statement__ = 22;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym115__ - 1)),
                           nil_index_list())), "phi")));
                 lcm_sym113__ = (lcm_sym115__ + 1);
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(i),
                         cons_list(index_uni(lcm_sym115__), nil_index_list())),
@@ -2452,14 +2452,14 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
                 for (int t = lcm_sym113__; t <= lcm_sym139__; ++t) {
                   current_statement__ = 22;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(phi,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
                         "phi")));
                   current_statement__ = 23;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(i),
                           cons_list(index_uni(t), nil_index_list())), "y"),
@@ -2470,7 +2470,7 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
               } 
               current_statement__ = 25;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(inline_sym9__,
                     cons_list(index_uni(i),
                       cons_list(index_uni(lcm_sym139__), nil_index_list())),
@@ -3993,26 +3993,26 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
         stan::math::fill(b_state_hat, DUMMY_VAR__);
         
         current_statement__ = 19;
-        lp_accum__.add(normal_log<propto__>(b_0, 0, 100));
+        lp_accum__.add(normal_lpdf<propto__>(b_0, 0, 100));
         current_statement__ = 20;
-        lp_accum__.add(normal_log<propto__>(b_female, 0, 100));
+        lp_accum__.add(normal_lpdf<propto__>(b_female, 0, 100));
         current_statement__ = 21;
-        lp_accum__.add(normal_log<propto__>(b_black, 0, 100));
+        lp_accum__.add(normal_lpdf<propto__>(b_black, 0, 100));
         current_statement__ = 22;
-        lp_accum__.add(normal_log<propto__>(b_female_black, 0, 100));
+        lp_accum__.add(normal_lpdf<propto__>(b_female_black, 0, 100));
         current_statement__ = 23;
-        lp_accum__.add(normal_log<propto__>(b_age, 0, sigma_age));
+        lp_accum__.add(normal_lpdf<propto__>(b_age, 0, sigma_age));
         current_statement__ = 24;
-        lp_accum__.add(normal_log<propto__>(b_edu, 0, sigma_edu));
+        lp_accum__.add(normal_lpdf<propto__>(b_edu, 0, sigma_edu));
         current_statement__ = 25;
-        lp_accum__.add(normal_log<propto__>(b_region, 0, sigma_region));
+        lp_accum__.add(normal_lpdf<propto__>(b_region, 0, sigma_region));
         current_statement__ = 29;
         if (logical_gte(n_age, 1)) {
           lcm_sym48__ = logical_gte(n_edu, 1);
           if (lcm_sym48__) {
             current_statement__ = 26;
             lp_accum__.add(
-              normal_log<propto__>(
+              normal_lpdf<propto__>(
                 rvalue(b_age_edu,
                   cons_list(index_uni(1),
                     cons_list(index_uni(1), nil_index_list())), "b_age_edu"),
@@ -4020,7 +4020,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
             for (int i = 2; i <= n_edu; ++i) {
               current_statement__ = 26;
               lp_accum__.add(
-                normal_log<propto__>(
+                normal_lpdf<propto__>(
                   rvalue(b_age_edu,
                     cons_list(index_uni(1),
                       cons_list(index_uni(i), nil_index_list())),
@@ -4031,7 +4031,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
             if (lcm_sym48__) {
               current_statement__ = 26;
               lp_accum__.add(
-                normal_log<propto__>(
+                normal_lpdf<propto__>(
                   rvalue(b_age_edu,
                     cons_list(index_uni(j),
                       cons_list(index_uni(1), nil_index_list())),
@@ -4039,7 +4039,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
               for (int i = 2; i <= n_edu; ++i) {
                 current_statement__ = 26;
                 lp_accum__.add(
-                  normal_log<propto__>(
+                  normal_lpdf<propto__>(
                     rvalue(b_age_edu,
                       cons_list(index_uni(j),
                         cons_list(index_uni(i), nil_index_list())),
@@ -4047,7 +4047,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
             } }
         } 
         current_statement__ = 30;
-        lp_accum__.add(normal_log<propto__>(b_v_prev, 0, 100));
+        lp_accum__.add(normal_lpdf<propto__>(b_v_prev, 0, 100));
         current_statement__ = 32;
         if (logical_gte(n_state, 1)) {
           current_statement__ = 31;
@@ -4075,7 +4075,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
               "assigning variable b_state_hat");}
         } 
         current_statement__ = 33;
-        lp_accum__.add(normal_log<propto__>(b_hat, b_state_hat, sigma_state));
+        lp_accum__.add(normal_lpdf<propto__>(b_hat, b_state_hat, sigma_state));
         current_statement__ = 35;
         if (logical_gte(N, 1)) {
           current_statement__ = 34;
@@ -4179,7 +4179,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
               "assigning variable p");}
         } 
         current_statement__ = 36;
-        lp_accum__.add(bernoulli_log<propto__>(y, p));
+        lp_accum__.add(bernoulli_lpmf<propto__>(y, p));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6079,11 +6079,11 @@ class expr_prop_fail_model : public model_base_crtp<expr_prop_fail_model> {
       }
       {
         current_statement__ = 4;
-        lp_accum__.add(normal_log<propto__>(sigma, 0, 2));
+        lp_accum__.add(normal_lpdf<propto__>(sigma, 0, 2));
         current_statement__ = 5;
-        lp_accum__.add(normal_log<propto__>(mu, 0, 2));
+        lp_accum__.add(normal_lpdf<propto__>(mu, 0, 2));
         current_statement__ = 6;
-        lp_accum__.add(beta_log<propto__>(theta, 5, 5));
+        lp_accum__.add(beta_lpdf<propto__>(theta, 5, 5));
         current_statement__ = 8;
         if (logical_gte(N, 1)) {
           lcm_sym27__ = rvalue(sigma,
@@ -6732,9 +6732,9 @@ class expr_prop_fail2_model : public model_base_crtp<expr_prop_fail2_model> {
       }
       {
         current_statement__ = 4;
-        lp_accum__.add(normal_log<propto__>(theta, mu, tau));
+        lp_accum__.add(normal_lpdf<propto__>(theta, mu, tau));
         current_statement__ = 5;
-        lp_accum__.add(normal_log<propto__>(y, theta, sigma));
+        lp_accum__.add(normal_lpdf<propto__>(y, theta, sigma));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7900,19 +7900,19 @@ class expr_prop_fail3_model : public model_base_crtp<expr_prop_fail3_model> {
       } 
       {
         current_statement__ = 15;
-        lp_accum__.add(normal_log<propto__>(a, 0, sigma_a));
+        lp_accum__.add(normal_lpdf<propto__>(a, 0, sigma_a));
         current_statement__ = 16;
-        lp_accum__.add(normal_log<propto__>(b, 0, sigma_b));
+        lp_accum__.add(normal_lpdf<propto__>(b, 0, sigma_b));
         current_statement__ = 17;
-        lp_accum__.add(normal_log<propto__>(c, 0, sigma_c));
+        lp_accum__.add(normal_lpdf<propto__>(c, 0, sigma_c));
         current_statement__ = 18;
-        lp_accum__.add(normal_log<propto__>(d, 0, sigma_d));
+        lp_accum__.add(normal_lpdf<propto__>(d, 0, sigma_d));
         current_statement__ = 19;
-        lp_accum__.add(normal_log<propto__>(e, 0, sigma_e));
+        lp_accum__.add(normal_lpdf<propto__>(e, 0, sigma_e));
         current_statement__ = 20;
-        lp_accum__.add(normal_log<propto__>(beta, 0, 100));
+        lp_accum__.add(normal_lpdf<propto__>(beta, 0, 100));
         current_statement__ = 21;
-        lp_accum__.add(bernoulli_logit_log<propto__>(y, y_hat));
+        lp_accum__.add(bernoulli_logit_lpmf<propto__>(y, y_hat));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9213,7 +9213,7 @@ class expr_prop_fail4_model : public model_base_crtp<expr_prop_fail4_model> {
                 rvalue(phi, cons_list(index_multi(node2), nil_index_list()),
                   "phi")))));
         current_statement__ = 27;
-        lp_accum__.add(gamma_log<propto__>(tau_phi, 1, 1));
+        lp_accum__.add(gamma_lpdf<propto__>(tau_phi, 1, 1));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -11017,7 +11017,7 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
       check_less_or_equal(function__, "chi", inline_sym9__, 1);
       {
         current_statement__ = 27;
-        lp_accum__.add(normal_log<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(normal_lpdf<propto__>(epsilon, 0, sigma));
         current_statement__ = 34;
         if (lcm_sym91__) {
           lcm_sym128__ = rvalue(first,
@@ -11031,14 +11031,14 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
             if (logical_gte(lcm_sym130__, lcm_sym110__)) {
               current_statement__ = 28;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym110__ - 1)),
                         nil_index_list())), "phi")));
               lcm_sym108__ = (lcm_sym110__ + 1);
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(1),
                       cons_list(index_uni(lcm_sym110__), nil_index_list())),
@@ -11050,14 +11050,14 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
               for (int t = lcm_sym108__; t <= lcm_sym130__; ++t) {
                 current_statement__ = 28;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
                       "phi")));
                 current_statement__ = 29;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(1),
                         cons_list(index_uni(t), nil_index_list())), "y"),
@@ -11068,7 +11068,7 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
             } 
             current_statement__ = 31;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(inline_sym9__,
                   cons_list(index_uni(1),
                     cons_list(index_uni(lcm_sym130__), nil_index_list())),
@@ -11086,14 +11086,14 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
               if (logical_gte(lcm_sym129__, lcm_sym109__)) {
                 current_statement__ = 28;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym109__ - 1)),
                           nil_index_list())), "phi")));
                 lcm_sym107__ = (lcm_sym109__ + 1);
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(i),
                         cons_list(index_uni(lcm_sym109__), nil_index_list())),
@@ -11105,14 +11105,14 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
                 for (int t = lcm_sym107__; t <= lcm_sym129__; ++t) {
                   current_statement__ = 28;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(phi,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
                         "phi")));
                   current_statement__ = 29;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(i),
                           cons_list(index_uni(t), nil_index_list())), "y"),
@@ -11123,7 +11123,7 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
               } 
               current_statement__ = 31;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(inline_sym9__,
                     cons_list(index_uni(i),
                       cons_list(index_uni(lcm_sym129__), nil_index_list())),
@@ -12512,12 +12512,12 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                          cons_list(index_uni(1), nil_index_list()), "first");
         if (lcm_sym111__) {
           current_statement__ = 82;
-          lp_accum__.add(bernoulli_log<propto__>(1, psi));
+          lp_accum__.add(bernoulli_lpmf<propto__>(1, psi));
           current_statement__ = 90;
           if (logical_eq(lcm_sym111__, 1)) {
             current_statement__ = 88;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 (rvalue(nu, cons_list(index_uni(1), nil_index_list()), "nu")
                   *
                   rvalue(p,
@@ -12632,14 +12632,14 @@ js_super_lp(const std::vector<std::vector<int>>& y,
           if (logical_gte(lcm_sym113__, (lcm_sym111__ + 1))) {
             current_statement__ = 91;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(phi,
                   cons_list(index_uni(1),
                     cons_list(index_uni(((lcm_sym111__ + 1) - 1)),
                       nil_index_list())), "phi")));
             lcm_sym93__ = ((lcm_sym111__ + 1) + 1);
             lp_accum__.add(
-              bernoulli_log<propto__>(
+              bernoulli_lpmf<propto__>(
                 rvalue(y,
                   cons_list(index_uni(1),
                     cons_list(index_uni((lcm_sym111__ + 1)),
@@ -12651,14 +12651,14 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             for (int t = lcm_sym93__; t <= lcm_sym113__; ++t) {
               current_statement__ = 91;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(1),
                       cons_list(index_uni((t - 1)), nil_index_list())),
                     "phi")));
               current_statement__ = 92;
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(1),
                       cons_list(index_uni(t), nil_index_list())), "y"),
@@ -12668,7 +12668,7 @@ js_super_lp(const std::vector<std::vector<int>>& y,
           } 
           current_statement__ = 94;
           lp_accum__.add(
-            bernoulli_log<propto__>(1,
+            bernoulli_lpmf<propto__>(1,
               rvalue(chi,
                 cons_list(index_uni(1),
                   cons_list(index_uni(lcm_sym113__), nil_index_list())),
@@ -12762,12 +12762,12 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                            "first");
           if (lcm_sym110__) {
             current_statement__ = 82;
-            lp_accum__.add(bernoulli_log<propto__>(1, psi));
+            lp_accum__.add(bernoulli_lpmf<propto__>(1, psi));
             current_statement__ = 90;
             if (logical_eq(lcm_sym110__, 1)) {
               current_statement__ = 88;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   (rvalue(nu, cons_list(index_uni(1), nil_index_list()),
                      "nu") *
                     rvalue(p,
@@ -12886,14 +12886,14 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             if (logical_gte(lcm_sym112__, (lcm_sym110__ + 1))) {
               current_statement__ = 91;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(i),
                       cons_list(index_uni(((lcm_sym110__ + 1) - 1)),
                         nil_index_list())), "phi")));
               lcm_sym92__ = ((lcm_sym110__ + 1) + 1);
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(i),
                       cons_list(index_uni((lcm_sym110__ + 1)),
@@ -12905,14 +12905,14 @@ js_super_lp(const std::vector<std::vector<int>>& y,
               for (int t = lcm_sym92__; t <= lcm_sym112__; ++t) {
                 current_statement__ = 91;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(i),
                         cons_list(index_uni((t - 1)), nil_index_list())),
                       "phi")));
                 current_statement__ = 92;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(i),
                         cons_list(index_uni(t), nil_index_list())), "y"),
@@ -12922,7 +12922,7 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             } 
             current_statement__ = 94;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(chi,
                   cons_list(index_uni(i),
                     cons_list(index_uni(lcm_sym112__), nil_index_list())),
@@ -13893,9 +13893,9 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
       check_less_or_equal(function__, "chi", inline_sym15__, 1);
       {
         current_statement__ = 70;
-        lp_accum__.add(normal_log<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(normal_lpdf<propto__>(epsilon, 0, sigma));
         current_statement__ = 71;
-        lp_accum__.add(gamma_log<propto__>(beta, 1, 1));
+        lp_accum__.add(gamma_lpdf<propto__>(beta, 1, 1));
         int inline_sym32__;
         inline_sym32__ = std::numeric_limits<int>::min();
         
@@ -13938,12 +13938,12 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
                              "first");
             if (lcm_sym284__) {
               current_statement__ = 82;
-              lp_accum__.add(bernoulli_log<propto__>(1, psi));
+              lp_accum__.add(bernoulli_lpmf<propto__>(1, psi));
               current_statement__ = 90;
               if (logical_eq(lcm_sym284__, 1)) {
                 current_statement__ = 88;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     (rvalue(nu, cons_list(index_uni(1), nil_index_list()),
                        "nu") *
                       rvalue(p,
@@ -14068,14 +14068,14 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
               if (logical_gte(lcm_sym286__, (lcm_sym284__ + 1))) {
                 current_statement__ = 91;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(lcm_sym277__,
                       cons_list(index_uni(1),
                         cons_list(index_uni(((lcm_sym284__ + 1) - 1)),
                           nil_index_list())), "lcm_sym277__")));
                 lcm_sym253__ = ((lcm_sym284__ + 1) + 1);
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(1),
                         cons_list(index_uni((lcm_sym284__ + 1)),
@@ -14088,14 +14088,14 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
                      inline_sym30__ <= lcm_sym286__; ++inline_sym30__) {
                   current_statement__ = 91;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(lcm_sym277__,
                         cons_list(index_uni(1),
                           cons_list(index_uni((inline_sym30__ - 1)),
                             nil_index_list())), "lcm_sym277__")));
                   current_statement__ = 92;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(1),
                           cons_list(index_uni(inline_sym30__),
@@ -14107,7 +14107,7 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
               } 
               current_statement__ = 94;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(inline_sym15__,
                     cons_list(index_uni(1),
                       cons_list(index_uni(lcm_sym286__), nil_index_list())),
@@ -14211,12 +14211,12 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
               lcm_sym283__ = first[(inline_sym31__ - 1)];
               if (lcm_sym283__) {
                 current_statement__ = 82;
-                lp_accum__.add(bernoulli_log<propto__>(1, psi));
+                lp_accum__.add(bernoulli_lpmf<propto__>(1, psi));
                 current_statement__ = 90;
                 if (logical_eq(lcm_sym283__, 1)) {
                   current_statement__ = 88;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       (rvalue(nu, cons_list(index_uni(1), nil_index_list()),
                          "nu") *
                         rvalue(p,
@@ -14341,14 +14341,14 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
                 if (logical_gte(lcm_sym285__, (lcm_sym283__ + 1))) {
                   current_statement__ = 91;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(lcm_sym277__,
                         cons_list(index_uni(inline_sym31__),
                           cons_list(index_uni(((lcm_sym283__ + 1) - 1)),
                             nil_index_list())), "lcm_sym277__")));
                   lcm_sym252__ = ((lcm_sym283__ + 1) + 1);
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(inline_sym31__),
                           cons_list(index_uni((lcm_sym283__ + 1)),
@@ -14361,14 +14361,14 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
                        inline_sym30__ <= lcm_sym285__; ++inline_sym30__) {
                     current_statement__ = 91;
                     lp_accum__.add(
-                      bernoulli_log<propto__>(1,
+                      bernoulli_lpmf<propto__>(1,
                         rvalue(lcm_sym277__,
                           cons_list(index_uni(inline_sym31__),
                             cons_list(index_uni((inline_sym30__ - 1)),
                               nil_index_list())), "lcm_sym277__")));
                     current_statement__ = 92;
                     lp_accum__.add(
-                      bernoulli_log<propto__>(
+                      bernoulli_lpmf<propto__>(
                         y[(inline_sym31__ - 1)][(inline_sym30__ - 1)],
                         rvalue(p,
                           cons_list(index_uni(inline_sym31__),
@@ -14377,7 +14377,7 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
                 } 
                 current_statement__ = 94;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(inline_sym15__,
                       cons_list(index_uni(inline_sym31__),
                         cons_list(index_uni(lcm_sym285__), nil_index_list())),
@@ -16554,14 +16554,14 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
       } 
       {
         current_statement__ = 9;
-        lp_accum__.add(dirichlet_log<propto__>(pi, alpha));
+        lp_accum__.add(dirichlet_lpdf<propto__>(pi, alpha));
         current_statement__ = 12;
         if (lcm_sym55__) {
           lcm_sym56__ = logical_gte(K, 1);
           if (lcm_sym56__) {
             current_statement__ = 10;
             lp_accum__.add(
-              dirichlet_log<propto__>(
+              dirichlet_lpdf<propto__>(
                 rvalue(theta,
                   cons_list(index_uni(1),
                     cons_list(index_uni(1), nil_index_list())), "theta"),
@@ -16570,7 +16570,7 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
             for (int k = 2; k <= K; ++k) {
               current_statement__ = 10;
               lp_accum__.add(
-                dirichlet_log<propto__>(
+                dirichlet_lpdf<propto__>(
                   rvalue(theta,
                     cons_list(index_uni(1),
                       cons_list(index_uni(k), nil_index_list())), "theta"),
@@ -16582,7 +16582,7 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
             if (lcm_sym56__) {
               current_statement__ = 10;
               lp_accum__.add(
-                dirichlet_log<propto__>(
+                dirichlet_lpdf<propto__>(
                   rvalue(theta,
                     cons_list(index_uni(j),
                       cons_list(index_uni(1), nil_index_list())), "theta"),
@@ -16591,7 +16591,7 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
               for (int k = 2; k <= K; ++k) {
                 current_statement__ = 10;
                 lp_accum__.add(
-                  dirichlet_log<propto__>(
+                  dirichlet_lpdf<propto__>(
                     rvalue(theta,
                       cons_list(index_uni(j),
                         cons_list(index_uni(k), nil_index_list())), "theta"),
@@ -19896,14 +19896,14 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
             if (logical_gte(lcm_sym140__, lcm_sym116__)) {
               current_statement__ = 22;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym116__ - 1)),
                         nil_index_list())), "phi")));
               lcm_sym114__ = (lcm_sym116__ + 1);
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(1),
                       cons_list(index_uni(lcm_sym116__), nil_index_list())),
@@ -19915,14 +19915,14 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
               for (int t = lcm_sym114__; t <= lcm_sym140__; ++t) {
                 current_statement__ = 22;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
                       "phi")));
                 current_statement__ = 23;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(1),
                         cons_list(index_uni(t), nil_index_list())), "y"),
@@ -19933,7 +19933,7 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
             } 
             current_statement__ = 25;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(inline_sym9__,
                   cons_list(index_uni(1),
                     cons_list(index_uni(lcm_sym140__), nil_index_list())),
@@ -19951,14 +19951,14 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
               if (logical_gte(lcm_sym139__, lcm_sym115__)) {
                 current_statement__ = 22;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym115__ - 1)),
                           nil_index_list())), "phi")));
                 lcm_sym113__ = (lcm_sym115__ + 1);
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(i),
                         cons_list(index_uni(lcm_sym115__), nil_index_list())),
@@ -19970,14 +19970,14 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
                 for (int t = lcm_sym113__; t <= lcm_sym139__; ++t) {
                   current_statement__ = 22;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(phi,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
                         "phi")));
                   current_statement__ = 23;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(i),
                           cons_list(index_uni(t), nil_index_list())), "y"),
@@ -19988,7 +19988,7 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
               } 
               current_statement__ = 25;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(inline_sym9__,
                     cons_list(index_uni(i),
                       cons_list(index_uni(lcm_sym139__), nil_index_list())),
@@ -21347,7 +21347,7 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
           if (logical_eq(lcm_sym117__, 1)) {
             current_statement__ = 90;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 (rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
                    "gamma") *
                   rvalue(p,
@@ -21463,14 +21463,14 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
           if (logical_gte(lcm_sym119__, (lcm_sym117__ + 1))) {
             current_statement__ = 84;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(phi,
                   cons_list(index_uni(1),
                     cons_list(index_uni(((lcm_sym117__ + 1) - 1)),
                       nil_index_list())), "phi")));
             lcm_sym100__ = ((lcm_sym117__ + 1) + 1);
             lp_accum__.add(
-              bernoulli_log<propto__>(
+              bernoulli_lpmf<propto__>(
                 rvalue(y,
                   cons_list(index_uni(1),
                     cons_list(index_uni((lcm_sym117__ + 1)),
@@ -21482,14 +21482,14 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             for (int t = lcm_sym100__; t <= lcm_sym119__; ++t) {
               current_statement__ = 84;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(1),
                       cons_list(index_uni((t - 1)), nil_index_list())),
                     "phi")));
               current_statement__ = 85;
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(1),
                       cons_list(index_uni(t), nil_index_list())), "y"),
@@ -21499,7 +21499,7 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
           } 
           current_statement__ = 87;
           lp_accum__.add(
-            bernoulli_log<propto__>(1,
+            bernoulli_lpmf<propto__>(1,
               rvalue(chi,
                 cons_list(index_uni(1),
                   cons_list(index_uni(lcm_sym119__), nil_index_list())),
@@ -21595,7 +21595,7 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             if (logical_eq(lcm_sym116__, 1)) {
               current_statement__ = 90;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   (rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
                      "gamma") *
                     rvalue(p,
@@ -21714,14 +21714,14 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             if (logical_gte(lcm_sym118__, (lcm_sym116__ + 1))) {
               current_statement__ = 84;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(i),
                       cons_list(index_uni(((lcm_sym116__ + 1) - 1)),
                         nil_index_list())), "phi")));
               lcm_sym99__ = ((lcm_sym116__ + 1) + 1);
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(i),
                       cons_list(index_uni((lcm_sym116__ + 1)),
@@ -21733,14 +21733,14 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
               for (int t = lcm_sym99__; t <= lcm_sym118__; ++t) {
                 current_statement__ = 84;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(i),
                         cons_list(index_uni((t - 1)), nil_index_list())),
                       "phi")));
                 current_statement__ = 85;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(i),
                         cons_list(index_uni(t), nil_index_list())), "y"),
@@ -21750,7 +21750,7 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             } 
             current_statement__ = 87;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(chi,
                   cons_list(index_uni(i),
                     cons_list(index_uni(lcm_sym118__), nil_index_list())),
@@ -22743,7 +22743,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
       check_less_or_equal(function__, "chi", inline_sym22__, 1);
       {
         current_statement__ = 67;
-        lp_accum__.add(normal_log<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(normal_lpdf<propto__>(epsilon, 0, sigma));
         int inline_sym39__;
         inline_sym39__ = std::numeric_limits<int>::min();
         
@@ -22792,7 +22792,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
                                  cons_list(index_uni(1), nil_index_list()),
                                  "gamma");
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     (lcm_sym293__ *
                       rvalue(lcm_sym288__,
                         cons_list(index_uni(1),
@@ -22918,14 +22918,14 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
               if (logical_gte(lcm_sym298__, (lcm_sym296__ + 1))) {
                 current_statement__ = 84;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(1),
                         cons_list(index_uni(((lcm_sym296__ + 1) - 1)),
                           nil_index_list())), "phi")));
                 lcm_sym266__ = ((lcm_sym296__ + 1) + 1);
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(1),
                         cons_list(index_uni((lcm_sym296__ + 1)),
@@ -22938,14 +22938,14 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
                      inline_sym37__ <= lcm_sym298__; ++inline_sym37__) {
                   current_statement__ = 84;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(phi,
                         cons_list(index_uni(1),
                           cons_list(index_uni((inline_sym37__ - 1)),
                             nil_index_list())), "phi")));
                   current_statement__ = 85;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(1),
                           cons_list(index_uni(inline_sym37__),
@@ -22957,7 +22957,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
               } 
               current_statement__ = 87;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(inline_sym22__,
                     cons_list(index_uni(1),
                       cons_list(index_uni(lcm_sym298__), nil_index_list())),
@@ -23064,7 +23064,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
                 if (logical_eq(lcm_sym295__, 1)) {
                   current_statement__ = 90;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       (lcm_sym293__ *
                         rvalue(lcm_sym288__,
                           cons_list(index_uni(inline_sym38__),
@@ -23186,14 +23186,14 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
                 if (logical_gte(lcm_sym297__, (lcm_sym295__ + 1))) {
                   current_statement__ = 84;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(phi,
                         cons_list(index_uni(inline_sym38__),
                           cons_list(index_uni(((lcm_sym295__ + 1) - 1)),
                             nil_index_list())), "phi")));
                   lcm_sym265__ = ((lcm_sym295__ + 1) + 1);
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(inline_sym38__),
                           cons_list(index_uni((lcm_sym295__ + 1)),
@@ -23206,14 +23206,14 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
                        inline_sym37__ <= lcm_sym297__; ++inline_sym37__) {
                     current_statement__ = 84;
                     lp_accum__.add(
-                      bernoulli_log<propto__>(1,
+                      bernoulli_lpmf<propto__>(1,
                         rvalue(phi,
                           cons_list(index_uni(inline_sym38__),
                             cons_list(index_uni((inline_sym37__ - 1)),
                               nil_index_list())), "phi")));
                     current_statement__ = 85;
                     lp_accum__.add(
-                      bernoulli_log<propto__>(
+                      bernoulli_lpmf<propto__>(
                         y[(inline_sym38__ - 1)][(inline_sym37__ - 1)],
                         rvalue(lcm_sym288__,
                           cons_list(index_uni(inline_sym38__),
@@ -23222,7 +23222,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
                 } 
                 current_statement__ = 87;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(inline_sym22__,
                       cons_list(index_uni(inline_sym38__),
                         cons_list(index_uni(lcm_sym297__), nil_index_list())),
@@ -25568,7 +25568,7 @@ class lcm_fails_model : public model_base_crtp<lcm_fails_model> {
       } 
       {
         current_statement__ = 2;
-        lp_accum__.add(normal_log<propto__>(y, theta, 1));
+        lp_accum__.add(normal_lpdf<propto__>(y, theta, 1));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -27035,14 +27035,14 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
             if (logical_gte(lcm_sym114__, lcm_sym98__)) {
               current_statement__ = 22;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(phi,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym98__ - 1)),
                         nil_index_list())), "phi")));
               lcm_sym96__ = (lcm_sym98__ + 1);
               lp_accum__.add(
-                bernoulli_log<propto__>(
+                bernoulli_lpmf<propto__>(
                   rvalue(y,
                     cons_list(index_uni(1),
                       cons_list(index_uni(lcm_sym98__), nil_index_list())),
@@ -27054,14 +27054,14 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
               for (int t = lcm_sym96__; t <= lcm_sym114__; ++t) {
                 current_statement__ = 22;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
                       "phi")));
                 current_statement__ = 23;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(1),
                         cons_list(index_uni(t), nil_index_list())), "y"),
@@ -27072,7 +27072,7 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
             } 
             current_statement__ = 25;
             lp_accum__.add(
-              bernoulli_log<propto__>(1,
+              bernoulli_lpmf<propto__>(1,
                 rvalue(inline_sym9__,
                   cons_list(index_uni(1),
                     cons_list(index_uni(lcm_sym114__), nil_index_list())),
@@ -27090,14 +27090,14 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
               if (logical_gte(lcm_sym113__, lcm_sym97__)) {
                 current_statement__ = 22;
                 lp_accum__.add(
-                  bernoulli_log<propto__>(1,
+                  bernoulli_lpmf<propto__>(1,
                     rvalue(phi,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym97__ - 1)),
                           nil_index_list())), "phi")));
                 lcm_sym95__ = (lcm_sym97__ + 1);
                 lp_accum__.add(
-                  bernoulli_log<propto__>(
+                  bernoulli_lpmf<propto__>(
                     rvalue(y,
                       cons_list(index_uni(i),
                         cons_list(index_uni(lcm_sym97__), nil_index_list())),
@@ -27109,14 +27109,14 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
                 for (int t = lcm_sym95__; t <= lcm_sym113__; ++t) {
                   current_statement__ = 22;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(1,
+                    bernoulli_lpmf<propto__>(1,
                       rvalue(phi,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
                         "phi")));
                   current_statement__ = 23;
                   lp_accum__.add(
-                    bernoulli_log<propto__>(
+                    bernoulli_lpmf<propto__>(
                       rvalue(y,
                         cons_list(index_uni(i),
                           cons_list(index_uni(t), nil_index_list())), "y"),
@@ -27127,7 +27127,7 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
               } 
               current_statement__ = 25;
               lp_accum__.add(
-                bernoulli_log<propto__>(1,
+                bernoulli_lpmf<propto__>(1,
                   rvalue(inline_sym9__,
                     cons_list(index_uni(i),
                       cons_list(index_uni(lcm_sym113__), nil_index_list())),
@@ -28301,12 +28301,12 @@ class off_dce_model : public model_base_crtp<off_dce_model> {
                 "sum_y")) {
             current_statement__ = 24;
             lp_accum__.add(
-              bernoulli_logit_log<propto__>(1,
+              bernoulli_logit_lpmf<propto__>(1,
                 rvalue(lcm_sym31__,
                   cons_list(index_uni(1), nil_index_list()), "lcm_sym31__")));
             current_statement__ = 25;
             lp_accum__.add(
-              bernoulli_logit_log<propto__>(
+              bernoulli_logit_lpmf<propto__>(
                 rvalue(y, cons_list(index_uni(1), nil_index_list()), "y"),
                 rvalue(lcm_sym38__,
                   cons_list(index_uni(1), nil_index_list()), "lcm_sym38__")));
@@ -28332,12 +28332,12 @@ class off_dce_model : public model_base_crtp<off_dce_model> {
                   "sum_y")) {
               current_statement__ = 24;
               lp_accum__.add(
-                bernoulli_logit_log<propto__>(1,
+                bernoulli_logit_lpmf<propto__>(1,
                   rvalue(lcm_sym31__,
                     cons_list(index_uni(i), nil_index_list()), "lcm_sym31__")));
               current_statement__ = 25;
               lp_accum__.add(
-                bernoulli_logit_log<propto__>(
+                bernoulli_logit_lpmf<propto__>(
                   rvalue(y, cons_list(index_uni(i), nil_index_list()), "y"),
                   rvalue(lcm_sym38__,
                     cons_list(index_uni(i), nil_index_list()), "lcm_sym38__")));
@@ -29396,17 +29396,17 @@ class off_small_model : public model_base_crtp<off_small_model> {
       } 
       {
         current_statement__ = 14;
-        lp_accum__.add(normal_log<propto__>(mu_a1, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(mu_a1, 0, 1));
         current_statement__ = 15;
-        lp_accum__.add(normal_log<propto__>(eta1, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(eta1, 0, 1));
         current_statement__ = 16;
-        lp_accum__.add(normal_log<propto__>(mu_a2, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(mu_a2, 0, 1));
         current_statement__ = 17;
-        lp_accum__.add(normal_log<propto__>(eta2, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(eta2, 0, 1));
         current_statement__ = 18;
-        lp_accum__.add(normal_log<propto__>(beta, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(beta, 0, 1));
         current_statement__ = 19;
-        lp_accum__.add(normal_log<propto__>(y, y_hat, sigma_y));
+        lp_accum__.add(normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -32009,13 +32009,13 @@ class partial_eval_model : public model_base_crtp<partial_eval_model> {
       } 
       {
         current_statement__ = 9;
-        lp_accum__.add(normal_log<propto__>(mu_a, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(mu_a, 0, 1));
         current_statement__ = 10;
-        lp_accum__.add(normal_log<propto__>(a, (100 * mu_a), sigma_a));
+        lp_accum__.add(normal_lpdf<propto__>(a, (100 * mu_a), sigma_a));
         current_statement__ = 11;
-        lp_accum__.add(normal_log<propto__>(beta, 0, 100));
+        lp_accum__.add(normal_lpdf<propto__>(beta, 0, 100));
         current_statement__ = 12;
-        lp_accum__.add(normal_log<propto__>(y, y_hat, sigma_y));
+        lp_accum__.add(normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -32876,25 +32876,25 @@ class stalled1_failure_model : public model_base_crtp<stalled1_failure_model> {
       sigma = lcm_sym17__;
       {
         current_statement__ = 8;
-        lp_accum__.add(normal_log<propto__>(alpha0, 0.0, 1.0E3));
+        lp_accum__.add(normal_lpdf<propto__>(alpha0, 0.0, 1.0E3));
         current_statement__ = 9;
-        lp_accum__.add(normal_log<propto__>(alpha1, 0.0, 1.0E3));
+        lp_accum__.add(normal_lpdf<propto__>(alpha1, 0.0, 1.0E3));
         current_statement__ = 10;
-        lp_accum__.add(normal_log<propto__>(alpha2, 0.0, 1.0E3));
+        lp_accum__.add(normal_lpdf<propto__>(alpha2, 0.0, 1.0E3));
         current_statement__ = 11;
-        lp_accum__.add(normal_log<propto__>(alpha12, 0.0, 1.0E3));
+        lp_accum__.add(normal_lpdf<propto__>(alpha12, 0.0, 1.0E3));
         current_statement__ = 12;
-        lp_accum__.add(gamma_log<propto__>(tau, 1.0E-3, 1.0E-3));
+        lp_accum__.add(gamma_lpdf<propto__>(tau, 1.0E-3, 1.0E-3));
         current_statement__ = 16;
         if (lcm_sym18__) {
           current_statement__ = 13;
           lp_accum__.add(
-            normal_log<propto__>(
+            normal_lpdf<propto__>(
               rvalue(b, cons_list(index_uni(1), nil_index_list()), "b"), 0.0,
               lcm_sym17__));
           current_statement__ = 14;
           lp_accum__.add(
-            binomial_logit_log<propto__>(
+            binomial_logit_lpmf<propto__>(
               rvalue(n, cons_list(index_uni(1), nil_index_list()), "n"),
               rvalue(N, cons_list(index_uni(1), nil_index_list()), "N"),
               add(
@@ -32911,12 +32911,12 @@ class stalled1_failure_model : public model_base_crtp<stalled1_failure_model> {
           for (int i = 2; i <= I; ++i) {
             current_statement__ = 13;
             lp_accum__.add(
-              normal_log<propto__>(
+              normal_lpdf<propto__>(
                 rvalue(b, cons_list(index_uni(i), nil_index_list()), "b"),
                 0.0, lcm_sym17__));
             current_statement__ = 14;
             lp_accum__.add(
-              binomial_logit_log<propto__>(
+              binomial_logit_lpmf<propto__>(
                 rvalue(n, cons_list(index_uni(i), nil_index_list()), "n"),
                 rvalue(N, cons_list(index_uni(i), nil_index_list()), "N"),
                 add(

--- a/test/unit/Factor_graph.ml
+++ b/test/unit/Factor_graph.ml
@@ -130,7 +130,7 @@ let%expect_test "Factor graph complex example" =
           ((VVar a) (VVar b) (VVar c) (VVar d) (VVar e)))
          (((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var a))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Var b))
@@ -142,7 +142,7 @@ let%expect_test "Factor graph complex example" =
           ((VVar a) (VVar b)))
          (((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var b))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Lit Int 0))
@@ -154,7 +154,7 @@ let%expect_test "Factor graph complex example" =
           ((VVar b)))
          (((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var c))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Var x))
@@ -166,7 +166,7 @@ let%expect_test "Factor graph complex example" =
           ((VVar a) (VVar c)))
          (((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var d))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Var c))
@@ -189,7 +189,7 @@ let%expect_test "Factor graph complex example" =
             21)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var a))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Var b))
@@ -200,7 +200,7 @@ let%expect_test "Factor graph complex example" =
             10)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var c))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Var x))
@@ -221,7 +221,7 @@ let%expect_test "Factor graph complex example" =
             21)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var a))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Var b))
@@ -232,7 +232,7 @@ let%expect_test "Factor graph complex example" =
             10)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var b))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Lit Int 0))
@@ -243,7 +243,7 @@ let%expect_test "Factor graph complex example" =
             9)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var d))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Var c))
@@ -264,7 +264,7 @@ let%expect_test "Factor graph complex example" =
             21)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var c))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Var x))
@@ -275,7 +275,7 @@ let%expect_test "Factor graph complex example" =
             17)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var d))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Var c))
@@ -296,7 +296,7 @@ let%expect_test "Factor graph complex example" =
             21)
            ((TargetTerm
              ((pattern
-               (FunApp StanLib normal_propto_log
+               (FunApp StanLib normal_propto_lpdf
                 (((pattern (Var d))
                   (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern (Var c))
@@ -366,7 +366,7 @@ let%expect_test "Priors complex example" =
       (((VVar a)
         ((((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var a))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Lit Int 0))
@@ -377,7 +377,7 @@ let%expect_test "Priors complex example" =
            9)
           ((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var e))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Var a))
@@ -388,7 +388,7 @@ let%expect_test "Priors complex example" =
            14)
           ((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var f))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Var a))
@@ -400,7 +400,7 @@ let%expect_test "Priors complex example" =
        ((VVar b)
         ((((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var b))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Var a))
@@ -411,7 +411,7 @@ let%expect_test "Priors complex example" =
            10)
           ((TargetTerm
             ((pattern
-              (FunApp StanLib normal_propto_log
+              (FunApp StanLib normal_propto_lpdf
                (((pattern (Var d))
                  (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern (Var b))


### PR DESCRIPTION
Fixes #563 

Uses _lpdf or _lpmf instead of _log in tilde statements. See issue for examples.

The suffices were listed as 
```ocaml
["_log"; "_lpmf"; "_lpdf"]
```
and stanc3 used the first one that existed. So for `y ~ normal` it basically looked for `normal_log`, `normal_lpmf` and `normal_lpdf`, then filtered the ones that actually exists and took the first one.

Changed the suffices list to 
```ocaml
["_lpmf"; "_lpdf"; "_log"]
```
and that is it. The rest changes are just for tests.