### PR TITLE
integer division operator

### DIFF
--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -41,6 +41,7 @@ let apply_operator_int (op : string) i1 i2 =
         | "Minus__" -> i1 - i2
         | "Times__" -> i1 * i2
         | "Divide__" -> i1 / i2
+        | "IntDivide__" -> i1 / i2
         | "Modulo__" -> i1 % i2
         | "Equals__" -> Bool.to_int (i1 = i2)
         | "NEquals__" -> Bool.to_int (i1 <> i2)
@@ -509,6 +510,7 @@ let rec eval_expr (e : Expr.Typed.t) =
             | "pow", [x; {pattern= FunApp (StanLib, "Divide__", [y; z]); _}]
               when is_int 1 y && is_int 2 z ->
                 FunApp (StanLib, "sqrt", [x])
+                (* This is wrong; if both are type UInt the exponent is rounds down to zero. *)
             | "square", [{pattern= FunApp (StanLib, "sd", [x]); _}] ->
                 FunApp (StanLib, "variance", [x])
             | "sqrt", [x] when is_int 2 x -> FunApp (StanLib, "sqrt2", [])
@@ -558,7 +560,7 @@ let rec eval_expr (e : Expr.Typed.t) =
                 FunApp (StanLib, "expm1", l')
             | "Plus__", [{pattern= FunApp (StanLib, "Times__", [x; y]); _}; z]
              |"Plus__", [z; {pattern= FunApp (StanLib, "Times__", [x; y]); _}]
-               when not preserve_stability ->
+              when not preserve_stability ->
                 FunApp (StanLib, "fma", [x; y; z])
             | "Minus__", [x; {pattern= FunApp (StanLib, "gamma_p", l); _}]
               when is_int 1 x ->
@@ -593,7 +595,7 @@ let rec eval_expr (e : Expr.Typed.t) =
                 FunApp (StanLib, "matrix_exp_multiply", [a; b])
             | "Times__", [x; {pattern= FunApp (StanLib, "log", [y]); _}]
              |"Times__", [{pattern= FunApp (StanLib, "log", [y]); _}; x]
-               when not preserve_stability ->
+              when not preserve_stability ->
                 FunApp (StanLib, "lmultiply", [x; y])
             | ( "Times__"
               , [ {pattern= FunApp (StanLib, "diag_matrix", [v]); _}
@@ -640,9 +642,9 @@ let rec eval_expr (e : Expr.Typed.t) =
               | _ -> FunApp (t, op, l) )
             | op, [{pattern= Lit (Int, i1); _}; {pattern= Lit (Int, i2); _}] -> (
               match op with
-              | "Plus__" | "Minus__" | "Times__" | "Divide__" | "Modulo__"
-               |"Or__" | "And__" | "Equals__" | "NEquals__" | "Less__"
-               |"Leq__" | "Greater__" | "Geq__" ->
+              | "Plus__" | "Minus__" | "Times__" | "Divide__" | "IntDivide__"
+               |"Modulo__" | "Or__" | "And__" | "Equals__" | "NEquals__"
+               |"Less__" | "Leq__" | "Greater__" | "Geq__" ->
                   apply_operator_int op (Int.of_string i1) (Int.of_string i2)
               | _ -> FunApp (t, op, l) )
             | op, [{pattern= Lit (Real, i1); _}; {pattern= Lit (Real, i2); _}]

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -89,6 +89,7 @@ and pp_operator ppf = function
   | Times -> Fmt.pf ppf "*"
   | Divide -> Fmt.pf ppf "/"
   | Modulo -> Fmt.pf ppf "%%"
+  | IntDivide -> Fmt.pf ppf "%%/%%"
   | LDivide -> Fmt.pf ppf "\\"
   | EltTimes -> Fmt.pf ppf ".*"
   | EltDivide -> Fmt.pf ppf "./"

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -130,6 +130,7 @@ rule token = parse
   | '*'                       { lexer_logger "*" ; Parser.TIMES }
   | '/'                       { lexer_logger "/" ; Parser.DIVIDE }
   | '%'                       { lexer_logger "%" ; Parser.MODULO }
+  | "%/%"                     { lexer_logger "%/%" ; Parser.IDIVIDE }
   | "\\"                      { lexer_logger "\\" ; Parser.LDIVIDE }
   | ".*"                      { lexer_logger ".*" ; Parser.ELTTIMES }
   | "./"                      { lexer_logger "./" ; Parser.ELTDIVIDE }

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -465,7 +465,7 @@ common_expression:
   | DIVIDE
     {  grammar_logger "infix_divide" ; Operator.Divide }
   | IDIVIDE
-    {  grammar_logger "infix_divide" ; Operator.IntDivide }
+    {  grammar_logger "infix_intdivide" ; Operator.IntDivide }
   | MODULO
     {  grammar_logger "infix_modulo" ; Operator.Modulo }
   | LDIVIDE

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -25,8 +25,8 @@ let reducearray (sbt, l) =
 %token <string> STRINGLITERAL
 %token <string> IDENTIFIER
 %token TARGET
-%token QMARK COLON BANG MINUS PLUS HAT TRANSPOSE TIMES DIVIDE MODULO LDIVIDE
-       ELTTIMES ELTDIVIDE OR AND EQUALS NEQUALS LEQ GEQ TILDE
+%token QMARK COLON BANG MINUS PLUS HAT TRANSPOSE TIMES DIVIDE MODULO IDIVIDE
+       LDIVIDE ELTTIMES ELTDIVIDE OR AND EQUALS NEQUALS LEQ GEQ TILDE
 %token ASSIGN PLUSASSIGN MINUSASSIGN TIMESASSIGN DIVIDEASSIGN
    ELTDIVIDEASSIGN ELTTIMESASSIGN
 %token ARROWASSIGN INCREMENTLOGPROB GETLP (* all of these are deprecated *)
@@ -43,7 +43,7 @@ let reducearray (sbt, l) =
 %left LEQ LABRACK GEQ RABRACK
 %left PLUS MINUS
 %left TIMES DIVIDE MODULO ELTTIMES ELTDIVIDE
-%left LDIVIDE
+%left IDIVIDE LDIVIDE
 %nonassoc unary_over_binary
 %right HAT
 %left TRANSPOSE
@@ -464,6 +464,8 @@ common_expression:
     {  grammar_logger "infix_times" ; Operator.Times }
   | DIVIDE
     {  grammar_logger "infix_divide" ; Operator.Divide }
+  | IDIVIDE
+    {  grammar_logger "infix_divide" ; Operator.IntDivide }
   | MODULO
     {  grammar_logger "infix_modulo" ; Operator.Modulo }
   | LDIVIDE

--- a/src/middle/Operator.ml
+++ b/src/middle/Operator.ml
@@ -7,6 +7,7 @@ type t =
   | PMinus
   | Times
   | Divide
+  | IntDivide
   | Modulo
   | LDivide
   | EltTimes
@@ -29,6 +30,7 @@ let pp ppf = function
   | Minus | PMinus -> Fmt.pf ppf "-"
   | Times -> Fmt.pf ppf "*"
   | Divide -> Fmt.pf ppf "/"
+  | IntDivide -> Fmt.pf ppf "%%/%%"
   | Modulo -> Fmt.pf ppf "%%"
   | LDivide -> Fmt.pf ppf "\\"
   | EltTimes -> Fmt.pf ppf ".*"
@@ -66,6 +68,7 @@ let stan_math_name = function
     *)
   | Divide -> "mdivide_right"
   (* | Divide -> "divide" *)
+  | IntDivide -> "divide"
   | Modulo -> "modulus"
   | LDivide -> "mdivide_left"
   | EltTimes -> "elt_multiply"

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -202,7 +202,7 @@ and gen_operator_app = function
       fun ppf es -> pp_scalar_binary ppf "(%a@ -@ %a)" "subtract(@,%a,@ %a)" es
   | Times ->
       fun ppf es -> pp_scalar_binary ppf "(%a@ *@ %a)" "multiply(@,%a,@ %a)" es
-  | Divide ->
+  | Divide | IntDivide ->
       fun ppf es ->
         if
           is_matrix (second es)
@@ -313,8 +313,8 @@ and gen_fun_app ppf fname es =
         when Stan_math_signatures.is_reduce_sum_fn x ->
           (strf "%s<%s>" fname f, grainsize :: container :: msgs :: tl)
       | true, "map_rect", {pattern= FunApp (_, f, _); _} :: tl ->
-          let next_map_rect_id = (Hashtbl.length map_rect_calls + 1) in
-          Hashtbl.add_exn map_rect_calls ~key:next_map_rect_id ~data:f;
+          let next_map_rect_id = Hashtbl.length map_rect_calls + 1 in
+          Hashtbl.add_exn map_rect_calls ~key:next_map_rect_id ~data:f ;
           (strf "%s<%d, %s>" fname next_map_rect_id f, tl @ [msgs])
       | true, _, args -> (fname, args @ [msgs])
       | false, _, args -> (fname, args)

--- a/src/tfp_backend/Code_gen.ml
+++ b/src/tfp_backend/Code_gen.ml
@@ -8,7 +8,10 @@ let pp_call ppf (name, pp_arg, args) =
   pf ppf "%s(@[<hov>%a@])" name (list ~sep:comma pp_arg) args
 
 let pp_call_str ppf (name, args) = pp_call ppf (name, string, args)
-let pystring_of_operator = function x -> strf "%a" Operator.pp x
+
+let pystring_of_operator = function
+  | Operator.IntDivide -> "//"
+  | x -> strf "%a" Operator.pp x
 
 let rec pp_expr ppf {Expr.Fixed.pattern; _} =
   match pattern with

--- a/test/integration/bad/op_intdivide_bad.stan
+++ b/test/integration/bad/op_intdivide_bad.stan
@@ -1,0 +1,8 @@
+parameters {
+  matrix[3,3] a;
+}
+model {
+  int b[4];
+  matrix[3,3] c;
+  c = b %/% a;
+}

--- a/test/integration/bad/op_intdivide_bad_1.stan
+++ b/test/integration/bad/op_intdivide_bad_1.stan
@@ -1,0 +1,8 @@
+data {
+  real a;
+  real b;
+}
+transformed data {
+  real c = a %/% b;
+  real c = a %/% b;
+}

--- a/test/integration/bad/op_intdivide_bad_2.stan
+++ b/test/integration/bad/op_intdivide_bad_2.stan
@@ -1,0 +1,8 @@
+data {
+  int a;
+  real b;
+}
+transformed data {
+  real c = a %/% b;
+  real c = a %/% b;
+}

--- a/test/integration/bad/op_intdivide_bad_3.stan
+++ b/test/integration/bad/op_intdivide_bad_3.stan
@@ -1,0 +1,8 @@
+data {
+  real a;
+  int b;
+}
+transformed data {
+  real c = a %/% b;
+  real c = a %/% b;
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1807,6 +1807,69 @@ Ill-typed arguments supplied to infix operator .*. Available signatures:
 (matrix, matrix) => matrix
 Instead supplied arguments of incompatible type: int[], matrix.
 
+  $ ../../../../install/default/bin/stanc op_intdivide_bad.stan
+
+Semantic error in 'op_intdivide_bad.stan', line 7, column 6 to column 13:
+   -------------------------------------------------
+     5:    int b[4];
+     6:    matrix[3,3] c;
+     7:    c = b %/% a;
+               ^
+     8:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to infix operator %/%. Available signatures: 
+(int, int) => int
+Instead supplied arguments of incompatible type: int[], matrix.
+
+  $ ../../../../install/default/bin/stanc op_intdivide_bad_1.stan
+
+Semantic error in 'op_intdivide_bad_1.stan', line 6, column 11 to column 18:
+   -------------------------------------------------
+     4:  }
+     5:  transformed data {
+     6:    real c = a %/% b;
+                    ^
+     7:    real c = a %/% b;
+     8:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to infix operator %/%. Available signatures: 
+(int, int) => int
+Instead supplied arguments of incompatible type: real, real.
+
+  $ ../../../../install/default/bin/stanc op_intdivide_bad_2.stan
+
+Semantic error in 'op_intdivide_bad_2.stan', line 6, column 11 to column 18:
+   -------------------------------------------------
+     4:  }
+     5:  transformed data {
+     6:    real c = a %/% b;
+                    ^
+     7:    real c = a %/% b;
+     8:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to infix operator %/%. Available signatures: 
+(int, int) => int
+Instead supplied arguments of incompatible type: int, real.
+
+  $ ../../../../install/default/bin/stanc op_intdivide_bad_3.stan
+
+Semantic error in 'op_intdivide_bad_3.stan', line 6, column 11 to column 18:
+   -------------------------------------------------
+     4:  }
+     5:  transformed data {
+     6:    real c = a %/% b;
+                    ^
+     7:    real c = a %/% b;
+     8:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to infix operator %/%. Available signatures: 
+(int, int) => int
+Instead supplied arguments of incompatible type: real, int.
+
   $ ../../../../install/default/bin/stanc op_logical_negation_bad.stan
 
 Semantic error in 'op_logical_negation_bad.stan', line 7, column 6 to column 8:

--- a/test/integration/example-models/bugs_examples/vol1/equiv/pretty.expected
+++ b/test/integration/example-models/bugs_examples/vol1/equiv/pretty.expected
@@ -49,7 +49,10 @@ generated quantities {
 
 Info: Found int division at 'equiv.stan', line 16, column 16 to column 44:
   (group[n] * (2 * p - 3) + 3) / 2
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  (group[n] * (2 * p - 3) + 3) / 2.0
+If rounding is intended please use the integer division operator %/%.
 
 Warning: deprecated language construct used in 'equiv.stan', line 1, column 0:
    -------------------------------------------------

--- a/test/integration/good/function-signatures/math/functions/operators_int.stan
+++ b/test/integration/good/function-signatures/math/functions/operators_int.stan
@@ -8,6 +8,8 @@ transformed data {
   transformed_data_int = d_int - d_int;
   transformed_data_int = d_int * d_int;
   transformed_data_int = d_int / d_int;
+  transformed_data_int = d_int %/% d_int;
+  transformed_data_int = d_int % d_int;
 
   transformed_data_int = -d_int;
   transformed_data_int = +d_int;
@@ -22,6 +24,8 @@ transformed parameters {
   transformed_param_real = d_int - d_int;
   transformed_param_real = d_int * d_int;
   transformed_param_real = d_int / d_int;
+  transformed_param_real = d_int %/% d_int;
+  transformed_param_real = d_int % d_int;
 
   transformed_param_real = -d_int;
   transformed_param_real = +d_int;

--- a/test/integration/good/function-signatures/math/functions/operators_real.stan
+++ b/test/integration/good/function-signatures/math/functions/operators_real.stan
@@ -21,6 +21,8 @@ transformed data {
   transformed_data_real = d_int / d_real;
   transformed_data_real = d_real / d_int;
   transformed_data_real = d_int / d_int;
+  transformed_data_real = d_int %/% d_int;
+  transformed_data_real = d_int % d_int;
 
   transformed_data_real = -d_real;
   transformed_data_real = -d_int;
@@ -65,6 +67,8 @@ transformed parameters {
   transformed_param_real = d_real / d_int;
   transformed_param_real = d_int / d_real;
   transformed_param_real = d_int / d_int;
+  transformed_param_real = d_int %/% d_int;
+  transformed_param_real = d_int % d_int;
   transformed_param_real = p_real / d_real;
   transformed_param_real = p_real / d_int;
   transformed_param_real = d_real / p_real;

--- a/test/integration/good/function-signatures/math/functions/pretty.expected
+++ b/test/integration/good/function-signatures/math/functions/pretty.expected
@@ -2119,6 +2119,8 @@ transformed data {
   transformed_data_int = d_int - d_int;
   transformed_data_int = d_int * d_int;
   transformed_data_int = d_int / d_int;
+  transformed_data_int = d_int %/% d_int;
+  transformed_data_int = d_int % d_int;
   transformed_data_int = -d_int;
   transformed_data_int = +d_int;
 }
@@ -2131,6 +2133,8 @@ transformed parameters {
   transformed_param_real = d_int - d_int;
   transformed_param_real = d_int * d_int;
   transformed_param_real = d_int / d_int;
+  transformed_param_real = d_int %/% d_int;
+  transformed_param_real = d_int % d_int;
   transformed_param_real = -d_int;
   transformed_param_real = +d_int;
 }
@@ -2140,10 +2144,16 @@ model {
 
 Info: Found int division at 'operators_int.stan', line 10, column 25 to column 30:
   d_int / d_int
-Values will be rounded towards zero.
-Info: Found int division at 'operators_int.stan', line 24, column 27 to column 32:
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  d_int * 1.0 / d_int
+If rounding is intended please use the integer division operator %/%.
+Info: Found int division at 'operators_int.stan', line 26, column 27 to column 32:
   d_int / d_int
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  d_int * 1.0 / d_int
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../../../../install/default/bin/stanc --auto-format operators_real.stan
 data {
   int d_int;
@@ -2167,6 +2177,8 @@ transformed data {
   transformed_data_real = d_int / d_real;
   transformed_data_real = d_real / d_int;
   transformed_data_real = d_int / d_int;
+  transformed_data_real = d_int %/% d_int;
+  transformed_data_real = d_int % d_int;
   transformed_data_real = -d_real;
   transformed_data_real = -d_int;
   transformed_data_real = +d_real;
@@ -2209,6 +2221,8 @@ transformed parameters {
   transformed_param_real = d_real / d_int;
   transformed_param_real = d_int / d_real;
   transformed_param_real = d_int / d_int;
+  transformed_param_real = d_int %/% d_int;
+  transformed_param_real = d_int % d_int;
   transformed_param_real = p_real / d_real;
   transformed_param_real = p_real / d_int;
   transformed_param_real = d_real / p_real;
@@ -2227,10 +2241,16 @@ model {
 
 Info: Found int division at 'operators_real.stan', line 23, column 26 to column 31:
   d_int / d_int
-Values will be rounded towards zero.
-Info: Found int division at 'operators_real.stan', line 67, column 27 to column 32:
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  d_int * 1.0 / d_int
+If rounding is intended please use the integer division operator %/%.
+Info: Found int division at 'operators_real.stan', line 69, column 27 to column 32:
   d_int / d_int
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  d_int * 1.0 / d_int
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../../../../install/default/bin/stanc --auto-format owens_t.stan
 data {
   int d_int;

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -958,7 +958,10 @@ model {
 
 Info: Found int division at 'bernoulli_logit_glm_old_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format bernoulli_logit_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -989,7 +992,10 @@ model {
 
 Info: Found int division at 'bernoulli_logit_glm_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format break-continue.stan
 functions {
   int foo(int a) {
@@ -3594,7 +3600,10 @@ model {
 
 Info: Found int division at 'int_div_user.stan', line 7, column 6 to column 10:
   a[1] / b[2]
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  a[1] * 1.0 / b[2]
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format int_fun.stan
 functions {
   int foo(int x) {
@@ -4156,7 +4165,10 @@ model {
 
 Info: Found int division at 'neg_binomial_2_log_glm_old_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format neg_binomial_2_log_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4188,7 +4200,10 @@ model {
 
 Info: Found int division at 'neg_binomial_2_log_glm_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format new-prob-fun-suffixes.stan
 parameters {
   real y;
@@ -4234,7 +4249,10 @@ model {
 
 Info: Found int division at 'normal_id_glm_old_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format normal_id_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4266,7 +4284,10 @@ model {
 
 Info: Found int division at 'normal_id_glm_performance.stan', line 11, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format nullary-unconflicted.stan
 parameters {
   real e;
@@ -4432,7 +4453,10 @@ model {
 
 Info: Found int division at 'poisson_log_glm_old_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format poisson_log_glm_performance.stan
 transformed data {
   int<lower=0> N = 50;
@@ -4463,7 +4487,10 @@ model {
 
 Info: Found int division at 'poisson_log_glm_performance.stan', line 10, column 19 to column 20:
   j / M
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / M
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format pound-comment-deprecated.stan
 data {
   int N;
@@ -5126,7 +5153,10 @@ model {
 
 Info: Found int division at 'validate_division_good.stan', line 19, column 7 to column 8:
   2 / 3
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  2.0 / 3
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format validate_division_int_warning.stan
 transformed data {
   real u;
@@ -5145,7 +5175,10 @@ model {
 
 Info: Found int division at 'validate_division_int_warning.stan', line 7, column 6 to column 7:
   j / k
-Values will be rounded towards zero.
+Values will be rounded towards zero. If rounding is not desired you can write
+the division as
+  j * 1.0 / k
+If rounding is intended please use the integer division operator %/%.
   $ ../../../../install/default/bin/stanc --auto-format validate_elt_division_good.stan
 transformed data {
   matrix[3, 3] m;
@@ -5306,6 +5339,32 @@ generated quantities {
   real gq_d1 = my_fun(p_d1);
   real gq_d2 = my_fun(gq_d1);
   gq_d2 = my_fun3(gq_d1);
+}
+
+  $ ../../../../install/default/bin/stanc --auto-format validate_int_divide_good.stan
+data {
+  int i;
+  int j;
+}
+transformed data {
+  int k;
+  k = i %/% j;
+}
+parameters {
+  real y;
+}
+model {
+  int i2;
+  int j2;
+  int k2;
+  k2 = i2 %/% j2;
+  y ~ normal(0, 1);
+}
+generated quantities {
+  int i3;
+  int j3;
+  int k3;
+  k3 = i3 %/% j3;
 }
 
   $ ../../../../install/default/bin/stanc --auto-format validate_int_expr2_good.stan

--- a/test/integration/good/validate_int_divide_good.stan
+++ b/test/integration/good/validate_int_divide_good.stan
@@ -1,0 +1,24 @@
+data {
+  int i;
+  int j;
+}
+transformed data {
+  int k;
+  k = i %/% j;  // int, int
+}
+parameters {
+  real y;
+}
+model {
+  int i2;
+  int j2;
+  int k2;
+  k2 = i2 %/% j2;
+  y ~ normal(0,1);
+}
+generated quantities {
+  int i3;
+  int j3;
+  int k3;
+  k3 = i3 %/% j3;
+}

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -2172,7 +2172,7 @@ model {
     target += i+j;
     target += i-j;
     target += i*j;
-    target += i/j;
+    target += i%/%j;
     target += i==j;
     target += i!=j;
     target += i<j;
@@ -2285,12 +2285,6 @@ model {
   Fmt.strf "@[<v>%a@]" Program.Typed.pp mir |> print_endline ;
   [%expect
     {|
-      Info: Found int division at 'string', line 27, column 14 to column 15:
-        i / j
-      Values will be rounded towards zero.
-
-
-
       log_prob {
         matrix[3, 2] x_matrix;
         matrix[2, 4] y_matrix;


### PR DESCRIPTION
Fix #533 
Adds new operator `%/%` for integer division that rounds toward zero. The warning the ordinary division operator emits when applied to integers is now more informative.

The `IntDivide` operator is not implemented in the Stan Math Library  as such a function would be redundant in C++. Instead the compiler special-cases the operator when type-checking and turns it into an ordinary division in the backend.