### PR TITLE
No vertical bar required for single-argument calls

### DIFF
--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -426,7 +426,13 @@ common_expression:
   | LBRACK xs=separated_list(COMMA, expression) RBRACK
     {  grammar_logger "row_vector_expression" ; RowVectorExpr xs }
   | id=identifier LPAREN args=separated_list(COMMA, expression) RPAREN
-    {  grammar_logger "fun_app" ; FunApp ((), id, args) }
+    {  grammar_logger "fun_app" ;
+       if
+         List.length args = 1
+         && ( String.is_suffix ~suffix:"_lpdf" id.name
+            || String.is_suffix ~suffix:"_lpmf" id.name )
+       then CondDistApp ((), id, args)
+       else FunApp ((), id, args) }
   | TARGET LPAREN RPAREN
     { grammar_logger "target_read" ; GetTarget }
   | GETLP LPAREN RPAREN

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -4696,6 +4696,22 @@ generated quantities {
   real sd_y = sd(y);
 }
 
+  $ ../../../../install/default/bin/stanc --auto-format single-arg-conddist.stan
+functions {
+  real foo_lpdf(real x) {
+    return -square(x);
+  }
+}
+parameters {
+  real x;
+}
+model {
+  target += std_normal_lpdf(x| );
+  target += std_normal_lpdf(x| );
+  target += foo_lpdf(x| );
+  target += foo_lpdf(x| );
+}
+
   $ ../../../../install/default/bin/stanc --auto-format stanc_helper.stan
 parameters {
   real y;

--- a/test/integration/good/single-arg-conddist.stan
+++ b/test/integration/good/single-arg-conddist.stan
@@ -1,0 +1,14 @@
+functions {
+    real foo_lpdf(real x) {
+        return -square(x);
+    }
+}
+parameters {
+    real x;
+}
+model {
+    target += std_normal_lpdf(x);
+    target += std_normal_lpdf(x|);
+    target += foo_lpdf(x);
+    target += foo_lpdf(x|);
+}


### PR DESCRIPTION
Fix #393

Change the parser to recognize single-argument `_lpdf` calls as CondDistApp even if they don't have the vertical bar.