### PR TITLE
Disallow rng in top level size declarations

### DIFF
--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -241,6 +241,7 @@ end
 module ExpressionError = struct
   type t =
     | InvalidMapRectFn of string
+    | InvalidSizeDeclRng
     | InvalidRngFunction
     | ConditionalNotationNotAllowed
     | ConditioningRequired
@@ -253,6 +254,10 @@ module ExpressionError = struct
           "Mapped function cannot be an _rng or _lp function, found function \
            name: %s"
           fn_name
+    | InvalidSizeDeclRng ->
+        Fmt.pf ppf
+          "Random number generators are not allowed in top level size \
+           declarations."
     | InvalidRngFunction ->
         Fmt.pf ppf
           "Random number generators are only allowed in transformed data \
@@ -506,6 +511,9 @@ let ident_not_in_scope loc name =
 
 let invalid_map_rect_fn loc name =
   ExpressionError (loc, ExpressionError.InvalidMapRectFn name)
+
+let invalid_decl_rng_fn loc =
+  ExpressionError (loc, ExpressionError.InvalidSizeDeclRng)
 
 let invalid_rng_fn loc =
   ExpressionError (loc, ExpressionError.InvalidRngFunction)

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -73,6 +73,7 @@ val ident_is_stanmath_name : Location_span.t -> string -> t
 val ident_in_use : Location_span.t -> string -> t
 val ident_not_in_scope : Location_span.t -> string -> t
 val invalid_map_rect_fn : Location_span.t -> string -> t
+val invalid_decl_rng_fn : Location_span.t -> t
 val invalid_rng_fn : Location_span.t -> t
 val conditional_notation_not_allowed : Location_span.t -> t
 val conditioning_required : Location_span.t -> t

--- a/test/integration/bad/data_index/rng_index1.stan
+++ b/test/integration/bad/data_index/rng_index1.stan
@@ -1,0 +1,7 @@
+parameters {
+  real y[3];
+
+}
+transformed parameters {
+  real z[poisson_rng(10)];
+}

--- a/test/integration/bad/data_index/stanc.expected
+++ b/test/integration/bad/data_index/stanc.expected
@@ -1,11 +1,11 @@
   $ ../../../../../install/default/bin/stanc non_data_index1.stan
 
-Semantic error in 'non_data_index1.stan', line 6, column 2 to column 18:
+Semantic error in 'non_data_index1.stan', line 6, column 14 to column 15:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    real z[size(y)];
-           ^
+                       ^
      7:  }
    -------------------------------------------------
 
@@ -13,12 +13,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index10.stan
 
-Semantic error in 'non_data_index10.stan', line 6, column 2 to column 33:
+Semantic error in 'non_data_index10.stan', line 6, column 27 to column 28:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    cholesky_factor_cov[size(y)] z;
-           ^
+                                    ^
      7:  }
    -------------------------------------------------
 
@@ -26,12 +26,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index11.stan
 
-Semantic error in 'non_data_index11.stan', line 6, column 2 to column 36:
+Semantic error in 'non_data_index11.stan', line 6, column 30 to column 31:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    cholesky_factor_cov[3, size(y)] z;
-           ^
+                                       ^
      7:  }
    -------------------------------------------------
 
@@ -39,12 +39,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index12.stan
 
-Semantic error in 'non_data_index12.stan', line 6, column 2 to column 34:
+Semantic error in 'non_data_index12.stan', line 6, column 28 to column 29:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    cholesky_factor_corr[size(y)] z;
-           ^
+                                     ^
      7:  }
    -------------------------------------------------
 
@@ -52,12 +52,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index13.stan
 
-Semantic error in 'non_data_index13.stan', line 6, column 2 to column 25:
+Semantic error in 'non_data_index13.stan', line 6, column 19 to column 20:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    corr_matrix[size(y)] z;
-           ^
+                            ^
      7:  }
    -------------------------------------------------
 
@@ -65,12 +65,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index14.stan
 
-Semantic error in 'non_data_index14.stan', line 6, column 2 to column 24:
+Semantic error in 'non_data_index14.stan', line 6, column 18 to column 19:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    cov_matrix[size(y)] z;
-           ^
+                           ^
      7:  }
    -------------------------------------------------
 
@@ -78,12 +78,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index2.stan
 
-Semantic error in 'non_data_index2.stan', line 6, column 2 to column 20:
+Semantic error in 'non_data_index2.stan', line 6, column 14 to column 15:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    vector[size(y)] z;
-           ^
+                       ^
      7:  }
    -------------------------------------------------
 
@@ -91,12 +91,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index3.stan
 
-Semantic error in 'non_data_index3.stan', line 6, column 2 to column 24:
+Semantic error in 'non_data_index3.stan', line 6, column 18 to column 19:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    row_vector[size(y)] z;
-           ^
+                           ^
      7:  }
    -------------------------------------------------
 
@@ -104,12 +104,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index4.stan
 
-Semantic error in 'non_data_index4.stan', line 5, column 2 to column 23:
+Semantic error in 'non_data_index4.stan', line 5, column 14 to column 15:
    -------------------------------------------------
      3:  }
      4:  transformed parameters {
      5:    matrix[size(y), 2] m;
-           ^
+                       ^
      6:  }
    -------------------------------------------------
 
@@ -117,12 +117,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index5.stan
 
-Semantic error in 'non_data_index5.stan', line 6, column 2 to column 23:
+Semantic error in 'non_data_index5.stan', line 6, column 17 to column 18:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    matrix[2, size(y)] m;
-           ^
+                          ^
      7:  
      8:  }
    -------------------------------------------------
@@ -131,12 +131,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index6.stan
 
-Semantic error in 'non_data_index6.stan', line 6, column 2 to column 21:
+Semantic error in 'non_data_index6.stan', line 6, column 15 to column 16:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    simplex[size(y)] z;
-           ^
+                        ^
      7:  }
    -------------------------------------------------
 
@@ -144,12 +144,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index7.stan
 
-Semantic error in 'non_data_index7.stan', line 6, column 2 to column 21:
+Semantic error in 'non_data_index7.stan', line 6, column 15 to column 16:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    ordered[size(y)] z;
-           ^
+                        ^
      7:  }
    -------------------------------------------------
 
@@ -157,12 +157,12 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index8.stan
 
-Semantic error in 'non_data_index8.stan', line 6, column 2 to column 30:
+Semantic error in 'non_data_index8.stan', line 6, column 24 to column 25:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    positive_ordered[size(y)] z;
-           ^
+                                 ^
      7:  }
    -------------------------------------------------
 
@@ -170,14 +170,27 @@ Non-data variables are not allowed in top level size declarations.
 
   $ ../../../../../install/default/bin/stanc non_data_index9.stan
 
-Semantic error in 'non_data_index9.stan', line 6, column 2 to column 25:
+Semantic error in 'non_data_index9.stan', line 6, column 19 to column 20:
    -------------------------------------------------
      4:  }
      5:  transformed parameters {
      6:    unit_vector[size(y)] z;
-           ^
+                            ^
      7:  }
    -------------------------------------------------
 
 Non-data variables are not allowed in top level size declarations.
+
+  $ ../../../../../install/default/bin/stanc rng_index1.stan
+
+Semantic error in 'rng_index1.stan', line 6, column 9 to column 24:
+   -------------------------------------------------
+     4:  }
+     5:  transformed parameters {
+     6:    real z[poisson_rng(10)];
+                  ^
+     7:  }
+   -------------------------------------------------
+
+Random number generators are not allowed in top level size declarations.
 

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -3207,15 +3207,29 @@ Matrix sizes must be of type int. Instead found type real.
 
   $ ../../../../install/default/bin/stanc var-decl-bad-1.stan
 
-Semantic error in 'var-decl-bad-1.stan', line 3, column 2 to column 18:
+Semantic error in 'var-decl-bad-1.stan', line 3, column 14 to column 15:
    -------------------------------------------------
      1:  parameters {
      2:    real x[3];
      3:    real y[size(x)];
-           ^
+                       ^
      4:  }
      5:  model {
    -------------------------------------------------
 
 Non-data variables are not allowed in top level size declarations.
+
+  $ ../../../../install/default/bin/stanc var-decl-bad-2.stan
+
+Semantic error in 'var-decl-bad-2.stan', line 3, column 9 to column 23:
+   -------------------------------------------------
+     1:  parameters {
+     2:    real x[3];
+     3:    real y[poisson_rng(3)];
+                  ^
+     4:  }
+     5:  model {
+   -------------------------------------------------
+
+Random number generators are not allowed in top level size declarations.
 

--- a/test/integration/bad/var-decl-bad-2.stan
+++ b/test/integration/bad/var-decl-bad-2.stan
@@ -1,0 +1,7 @@
+parameters {
+  real x[3];
+  real y[poisson_rng(3)];
+}
+model {
+  y ~ normal(0,1);
+}


### PR DESCRIPTION
Fix #526 

Toplevel declared sizes must always be (transformed) data. Code like this
```stan
generated quantities {
  int N = 5;
  real x[N];
}
```
has never worked but with this PR stanc3 catches the error before passing it to the C++ compiler.