### PR TITLE
fix array literal type-checking

### DIFF
--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -8,8 +8,11 @@ val location : t -> Location_span.t
 val mismatched_return_types :
   Location_span.t -> UnsizedType.returntype -> UnsizedType.returntype -> t
 
-val mismatched_array_types : Location_span.t -> t
-val invalid_row_vector_types : Location_span.t -> t
+val mismatched_array_types :
+  Location_span.t -> UnsizedType.t -> UnsizedType.t -> t
+
+val invalid_row_vector_types : Location_span.t -> UnsizedType.t -> t
+val invalid_matrix_types : Location_span.t -> UnsizedType.t -> t
 val int_expected : Location_span.t -> string -> UnsizedType.t -> t
 val int_or_real_expected : Location_span.t -> string -> UnsizedType.t -> t
 val int_intarray_or_range_expected : Location_span.t -> UnsizedType.t -> t

--- a/test/integration/bad/array_expr_bad1.stan
+++ b/test/integration/bad/array_expr_bad1.stan
@@ -1,0 +1,5 @@
+transformed data {
+  real td_arr32[3,2] = { 1, 3 };
+}
+model {
+}

--- a/test/integration/bad/array_expr_bad2.stan
+++ b/test/integration/bad/array_expr_bad2.stan
@@ -1,0 +1,5 @@
+transformed data {
+  real td_arr32[3,2] = {{ 1, 3 }, 1, 2 };
+}
+model {
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1,5 +1,31 @@
   $ ../../../../install/default/bin/stanc 1_starts_with_number.stan
 Model name must not start with a number or symbol other than underscore.
+  $ ../../../../install/default/bin/stanc array_expr_bad1.stan
+
+Semantic error in 'array_expr_bad1.stan', line 2, column 2 to column 32:
+   -------------------------------------------------
+     1:  transformed data {
+     2:    real td_arr32[3,2] = { 1, 3 };
+           ^
+     3:  }
+     4:  model {
+   -------------------------------------------------
+
+Ill-typed arguments supplied to assignment operator =: lhs has type real[,] and rhs has type int[]
+
+  $ ../../../../install/default/bin/stanc array_expr_bad2.stan
+
+Semantic error in 'array_expr_bad2.stan', line 2, column 34 to column 35:
+   -------------------------------------------------
+     1:  transformed data {
+     2:    real td_arr32[3,2] = {{ 1, 3 }, 1, 2 };
+                                           ^
+     3:  }
+     4:  model {
+   -------------------------------------------------
+
+Array expression must have entries of consistent type. Expected int[] but found int.
+
   $ ../../../../install/default/bin/stanc assign_real_to_int.stan
 
 Semantic error in 'assign_real_to_int.stan', line 11, column 2 to column 8:
@@ -1621,16 +1647,16 @@ Ill-typed arguments supplied to assignment operator =: lhs has type matrix and r
 
   $ ../../../../install/default/bin/stanc matrix_expr_bad2.stan
 
-Semantic error in 'matrix_expr_bad2.stan', line 2, column 25 to column 37:
+Semantic error in 'matrix_expr_bad2.stan', line 2, column 34 to column 35:
    -------------------------------------------------
      1:  transformed data {
      2:    matrix[3,2] td_mat32 = [ [ 1 ], 3 ];
-                                  ^
+                                           ^
      3:  }
      4:  model {
    -------------------------------------------------
 
-Row_vector expression must have all int and real entries or all row_vector entries.
+Matrix expression must have all row_vector entries. Found type int.
 
   $ ../../../../install/default/bin/stanc matrix_expr_bad3.stan
 
@@ -2408,17 +2434,17 @@ Ill-typed arguments supplied to assignment operator =: lhs has type row_vector a
 
   $ ../../../../install/default/bin/stanc row_vector_expr_bad2.stan
 
-Semantic error in 'row_vector_expr_bad2.stan', line 5, column 20 to column 28:
+Semantic error in 'row_vector_expr_bad2.stan', line 5, column 25 to column 26:
    -------------------------------------------------
      3:    row_vector[2] A;
      4:    row_vector[3] B;
      5:    row_vector[2] X = [ x, A ];
-                             ^
+                                  ^
      6:  }
      7:  model {
    -------------------------------------------------
 
-Row_vector expression must have all int and real entries or all row_vector entries.
+Row_vector expression must have all int or real entries. Found type row_vector.
 
   $ ../../../../install/default/bin/stanc signature_function_known.stan
 

--- a/test/integration/good/array-expr/pretty.expected
+++ b/test/integration/good/array-expr/pretty.expected
@@ -135,6 +135,11 @@ generated quantities {
   print("gq_m_ar_dim2_2 = ", gq_m_ar_dim2_2);
 }
 
+  $ ../../../../../install/default/bin/stanc --auto-format validate_array_expr_mixed.stan
+transformed parameters {
+  real td_arr33[3, 3] = {{1, 2, 3}, {1, 2., 3}, {1., 2., 3}};
+}
+
   $ ../../../../../install/default/bin/stanc --auto-format validate_array_expr_primitives.stan
 functions {
   int[] f1_arr_int() {

--- a/test/integration/good/array-expr/validate_array_expr_mixed.stan
+++ b/test/integration/good/array-expr/validate_array_expr_mixed.stan
@@ -1,0 +1,6 @@
+transformed parameters {
+  real td_arr33[3,3]
+      = { {1 , 2 , 3 }, 
+          {1 , 2., 3 }, 
+          {1., 2., 3 } };
+}


### PR DESCRIPTION
Related issue: #321 

Here's an example of what was failing:
```stan
transformed parameters {
  real x[2,2] = {{1 ,2},{3 ,4}}; // ok
  real y[2,2] = {{1.,2},{3.,4}}; // ok
  real z[2,2] = {{1 ,2},{3.,4}}; // bad
}
```
The last array is a mix of int arrays and real arrays. Int arrays are convertible to real array but the typechecker got confused.