### PR TITLE
Check for invalid literals

### DIFF
--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -678,10 +678,13 @@ and semantic_check_expression cf ({emeta; expr} : Ast.untyped_expression) :
   | Variable id ->
       semantic_check_variable cf emeta.loc id
       |> Validate.apply_const (semantic_check_identifier id)
-  | IntNumeral s ->
-      mk_typed_expression ~expr:(IntNumeral s) ~ad_level:DataOnly ~type_:UInt
-        ~loc:emeta.loc
-      |> Validate.ok
+  | IntNumeral s -> (
+    match int_of_string_opt s with
+    | Some i when i < 2_147_483_648 ->
+        mk_typed_expression ~expr:(IntNumeral s) ~ad_level:DataOnly ~type_:UInt
+          ~loc:emeta.loc
+        |> Validate.ok
+    | _ -> Semantic_error.bad_int_literal emeta.loc |> Validate.error )
   | RealNumeral s ->
       mk_typed_expression ~expr:(RealNumeral s) ~ad_level:DataOnly ~type_:UReal
         ~loc:emeta.loc

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -263,6 +263,7 @@ module ExpressionError = struct
     | ConditioningRequired
     | NotPrintable
     | EmptyArray
+    | IntTooLarge
 
   let pp ppf = function
     | InvalidMapRectFn fn_name ->
@@ -290,6 +291,8 @@ module ExpressionError = struct
     | NotPrintable -> Fmt.pf ppf "Functions cannot be printed."
     | EmptyArray ->
         Fmt.pf ppf "Array expressions must contain at least one element."
+    | IntTooLarge ->
+        Fmt.pf ppf "Integer literal cannot be larger than 2_147_483_647."
 end
 
 module StatementError = struct
@@ -549,6 +552,7 @@ let conditioning_required loc =
 
 let not_printable loc = ExpressionError (loc, ExpressionError.NotPrintable)
 let empty_array loc = ExpressionError (loc, ExpressionError.EmptyArray)
+let bad_int_literal loc = ExpressionError (loc, ExpressionError.IntTooLarge)
 
 let cannot_assign_to_read_only loc name =
   StatementError (loc, StatementError.CannotAssignToReadOnly name)

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -85,6 +85,7 @@ val conditional_notation_not_allowed : Location_span.t -> t
 val conditioning_required : Location_span.t -> t
 val not_printable : Location_span.t -> t
 val empty_array : Location_span.t -> t
+val bad_int_literal : Location_span.t -> t
 val cannot_assign_to_read_only : Location_span.t -> string -> t
 val cannot_assign_to_global : Location_span.t -> string -> t
 val invalid_sampling_pdf_or_pmf : Location_span.t -> t

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -16,7 +16,7 @@
 }
 
 (* Some auxiliary definition for variables and constants *)
-let string_literal = '"' [^'"']* '"'
+let string_literal = '"' [^ '"' '\r' '\n']* '"'
 let identifier = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*   (* TODO: We should probably expand the alphabet *)
 
 let integer_constant =  ['0'-'9']+ ('_' ['0'-'9']+)*
@@ -41,8 +41,8 @@ rule token = parse
                                 singleline_comment lexbuf ; token lexbuf }
   | "#include"
     ( ( space | newline)+)
-    ( '"' ([^ '"']* as fname) '"'
-    | '<' ([^ '>']* as fname) '>'
+    ( '"' ([^ '"' '\r' '\n']* as fname) '"'
+    | '<' ([^ '>' '\r' '\n']* as fname) '>'
     | (non_space_or_newline* as fname)
     )                         { lexer_logger ("include " ^ fname) ;
                                 let new_lexbuf =

--- a/test/integration/bad/numeric-literal/int-bad3.stan
+++ b/test/integration/bad/numeric-literal/int-bad3.stan
@@ -1,0 +1,3 @@
+transformed data {
+    int n = 10_000_000_000;
+}

--- a/test/integration/bad/numeric-literal/stanc.expected
+++ b/test/integration/bad/numeric-literal/stanc.expected
@@ -24,6 +24,18 @@ Syntax error in 'int-bad2.stan', line 2, column 12 to column 14, parsing error:
 Ill-formed expression. Expression followed by ";" expected after "=".
 
 
+  $ ../../../../../install/default/bin/stanc int-bad3.stan
+
+Semantic error in 'int-bad3.stan', line 2, column 12 to column 26:
+   -------------------------------------------------
+     1:  transformed data {
+     2:      int n = 10_000_000_000;
+                     ^
+     3:  }
+   -------------------------------------------------
+
+Integer literal cannot be larger than 2_147_483_647.
+
   $ ../../../../../install/default/bin/stanc real-bad1.stan
 
 Syntax error in 'real-bad1.stan', line 2, column 12, lexing error:

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2544,6 +2544,20 @@ Semantic error in 'stanc_helper.stan', line 5, column 2 to column 18:
 
 Ill-typed arguments to '~' statement. No distribution 'ormal' was found with the correct signature.
 
+  $ ../../../../install/default/bin/stanc string_literal_newline.stan
+
+Syntax error in 'string_literal_newline.stan', line 3, column 1, lexing error:
+   -------------------------------------------------
+     1:  transformed data {
+     2:    print(
+     3:    "print
+           ^
+     4:    lines");
+     5:  }
+   -------------------------------------------------
+
+Invalid character found.
+
   $ ../../../../install/default/bin/stanc target-reserved.stan
 
 Syntax error in 'target-reserved.stan', line 2, column 7 to column 13, parsing error:

--- a/test/integration/bad/string_literal_newline.stan
+++ b/test/integration/bad/string_literal_newline.stan
@@ -1,0 +1,5 @@
+transformed data {
+  print(
+  "print
+  lines");
+}


### PR DESCRIPTION
Fix parser to deal with some bad literals.
* Line breaks in string literals mess up line numbering. Now disallowed. (stanc2 did allow a line break but ignored everything after it.)
* Integers larger than signed 32-bit would fail C++ compilation. Now disallowed.
* In contrast to integers, too-big reals simply overflow to infinity. Although stanc2 did not allow these they are currently allowed.