### PR TITLE
Add stanc info function to the model

### DIFF
--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -24,14 +24,13 @@ open Statement_gen
 
 let stanc_args_to_print =
   let sans_model_and_hpp_paths x =
-    not (String.is_suffix ~suffix:".stan" x || String.is_prefix ~prefix:"--o" x)
+    not String.(is_suffix ~suffix:".stan" x || is_prefix ~prefix:"--o" x)
   in
   (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
-  let stanc_flags_sans_model_and_hpp_paths =
-    List.filter ~f:sans_model_and_hpp_paths
-      (List.tl_exn (Array.to_list Sys.argv))
-  in
-  String.concat ~sep:" " stanc_flags_sans_model_and_hpp_paths
+  Array.to_list Sys.argv
+  |> List.tl_exn
+  |> List.filter ~f:sans_model_and_hpp_paths
+  |> String.concat ~sep:" "
 
 let pp_unused = fmt "(void) %s;  // suppress unused var warning@ "
 
@@ -678,12 +677,12 @@ let pp_model ppf ({Program.prog_name; _} as p) =
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %s");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = %s");
     return stanc_info;
   }
   |}
-    "%%NAME%%3 %%VERSION%%" stanc_args_to_print ;
+    stanc_args_to_print ;
   pf ppf "@ %a@]@]@ };" pp_model_public p
 
 (** The C++ aliases needed for the model class*)

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -27,8 +27,7 @@ let stanc_args_to_print =
     not String.(is_suffix ~suffix:".stan" x || is_prefix ~prefix:"--o" x)
   in
   (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
-  Array.to_list Sys.argv
-  |> List.tl_exn
+  Array.to_list Sys.argv |> List.tl_exn
   |> List.filter ~f:sans_model_and_hpp_paths
   |> String.concat ~sep:" "
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -23,15 +23,17 @@ open Expression_gen
 open Statement_gen
 
 let stanc_args_to_print =
-    let sans_model_and_hpp_paths x =
-      not (String.is_suffix ~suffix:".stan" x || String.is_prefix ~prefix:"--o" x)
-    in
-    (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
-    let stanc_flags_sans_model_and_hpp_paths = 
-      List.filter ~f:sans_model_and_hpp_paths (List.tl_exn (Array.to_list Sys.argv))
-    in
-    String.concat ~sep:" " stanc_flags_sans_model_and_hpp_paths
-    (* stanc_flags_sans_model_and_hpp_paths *)
+  let sans_model_and_hpp_paths x =
+    not (String.is_suffix ~suffix:".stan" x || String.is_prefix ~prefix:"--o" x)
+  in
+  (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
+  let stanc_flags_sans_model_and_hpp_paths =
+    List.filter ~f:sans_model_and_hpp_paths
+      (List.tl_exn (Array.to_list Sys.argv))
+  in
+  String.concat ~sep:" " stanc_flags_sans_model_and_hpp_paths
+
+(* stanc_flags_sans_model_and_hpp_paths *)
 
 let pp_unused = fmt "(void) %s;  // suppress unused var warning@ "
 
@@ -673,14 +675,16 @@ let pp_model ppf ({Program.prog_name; _} as p) =
   pf ppf "@ @[<v 1>@ private:@ @[<v 1> %a@]@ " pp_model_private p ;
   pf ppf "@ public:@ @[<v 1> ~%s() { }" p.prog_name ;
   pf ppf "@ @ std::string model_name() const { return \"%s\"; }" prog_name ;
-  pf ppf {|
+  pf ppf
+    {|
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %s");
     stanc_info.push_back("stancflags = %s");
     return stanc_info;
   }
-  |} "%%NAME%%3 %%VERSION%%" stanc_args_to_print; 
+  |}
+    "%%NAME%%3 %%VERSION%%" stanc_args_to_print ;
   pf ppf "@ %a@]@]@ };" pp_model_public p
 
 (** The C++ aliases needed for the model class*)

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -677,6 +677,7 @@ let pp_model ppf ({Program.prog_name; _} as p) =
   pf ppf "@ @ std::string model_name() const { return \"%s\"; }" prog_name ;
   pf ppf
     {|
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %s");

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -33,8 +33,6 @@ let stanc_args_to_print =
   in
   String.concat ~sep:" " stanc_flags_sans_model_and_hpp_paths
 
-(* stanc_flags_sans_model_and_hpp_paths *)
-
 let pp_unused = fmt "(void) %s;  // suppress unused var warning@ "
 
 (** Print name of model function.

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -22,6 +22,17 @@ open Fmt
 open Expression_gen
 open Statement_gen
 
+let stanc_args_to_print =
+    let sans_model_and_hpp_paths x =
+      not (String.is_suffix ~suffix:".stan" x || String.is_prefix ~prefix:"--o" x)
+    in
+    (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
+    let stanc_flags_sans_model_and_hpp_paths = 
+      List.filter ~f:sans_model_and_hpp_paths (List.tl_exn (Array.to_list Sys.argv))
+    in
+    String.concat ~sep:" " stanc_flags_sans_model_and_hpp_paths
+    (* stanc_flags_sans_model_and_hpp_paths *)
+
 let pp_unused = fmt "(void) %s;  // suppress unused var warning@ "
 
 (** Print name of model function.
@@ -662,6 +673,14 @@ let pp_model ppf ({Program.prog_name; _} as p) =
   pf ppf "@ @[<v 1>@ private:@ @[<v 1> %a@]@ " pp_model_private p ;
   pf ppf "@ public:@ @[<v 1> ~%s() { }" p.prog_name ;
   pf ppf "@ @ std::string model_name() const { return \"%s\"; }" prog_name ;
+  pf ppf {|
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %s");
+    stanc_info.push_back("stancflags = %s");
+    return stanc_info;
+  }
+  |} "%%NAME%%3 %%VERSION%%" stanc_args_to_print; 
   pf ppf "@ %a@]@]@ };" pp_model_public p
 
 (** The C++ aliases needed for the model class*)

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -322,6 +322,7 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
   ~optimize_glm_model() { }
   
   std::string model_name() const { return "optimize_glm_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -325,7 +325,7 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp --use-opencl");
     return stanc_info;
   }

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -322,6 +322,13 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
   ~optimize_glm_model() { }
   
   std::string model_name() const { return "optimize_glm_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp --use-opencl");
+    return stanc_info;
+  }
+  
   
   optimize_glm_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -120,7 +120,7 @@ class eight_schools_ncp_model : public model_base_crtp<eight_schools_ncp_model> 
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -3195,7 +3195,7 @@ class mother_model : public model_base_crtp<mother_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -9730,7 +9730,7 @@ class motherHOF_model : public model_base_crtp<motherHOF_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -11674,7 +11674,7 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -13363,7 +13363,7 @@ class reduce_sum_m1_model : public model_base_crtp<reduce_sum_m1_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -14961,7 +14961,7 @@ class reduce_sum_m2_model : public model_base_crtp<reduce_sum_m2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -18833,7 +18833,7 @@ class reduce_sum_m3_model : public model_base_crtp<reduce_sum_m3_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -21481,7 +21481,7 @@ class single_argument_lpmf_model : public model_base_crtp<single_argument_lpmf_m
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -21838,7 +21838,7 @@ class tilde_block_model : public model_base_crtp<tilde_block_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -22297,7 +22297,7 @@ class transform_model : public model_base_crtp<transform_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -26304,7 +26304,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -26831,7 +26831,7 @@ class udf_tilde_stmt_conflict_model : public model_base_crtp<udf_tilde_stmt_conf
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -27234,7 +27234,7 @@ class user_constrain_model : public model_base_crtp<user_constrain_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -117,6 +117,7 @@ class eight_schools_ncp_model : public model_base_crtp<eight_schools_ncp_model> 
   ~eight_schools_ncp_model() { }
   
   std::string model_name() const { return "eight_schools_ncp_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -3191,6 +3192,7 @@ class mother_model : public model_base_crtp<mother_model> {
   ~mother_model() { }
   
   std::string model_name() const { return "mother_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -9725,6 +9727,7 @@ class motherHOF_model : public model_base_crtp<motherHOF_model> {
   ~motherHOF_model() { }
   
   std::string model_name() const { return "motherHOF_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -11668,6 +11671,7 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
   ~optimize_glm_model() { }
   
   std::string model_name() const { return "optimize_glm_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -13356,6 +13360,7 @@ class reduce_sum_m1_model : public model_base_crtp<reduce_sum_m1_model> {
   ~reduce_sum_m1_model() { }
   
   std::string model_name() const { return "reduce_sum_m1_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -14953,6 +14958,7 @@ class reduce_sum_m2_model : public model_base_crtp<reduce_sum_m2_model> {
   ~reduce_sum_m2_model() { }
   
   std::string model_name() const { return "reduce_sum_m2_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -18824,6 +18830,7 @@ class reduce_sum_m3_model : public model_base_crtp<reduce_sum_m3_model> {
   ~reduce_sum_m3_model() { }
   
   std::string model_name() const { return "reduce_sum_m3_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -21471,6 +21478,7 @@ class single_argument_lpmf_model : public model_base_crtp<single_argument_lpmf_m
   ~single_argument_lpmf_model() { }
   
   std::string model_name() const { return "single_argument_lpmf_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -21827,6 +21835,7 @@ class tilde_block_model : public model_base_crtp<tilde_block_model> {
   ~tilde_block_model() { }
   
   std::string model_name() const { return "tilde_block_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -22285,6 +22294,7 @@ class transform_model : public model_base_crtp<transform_model> {
   ~transform_model() { }
   
   std::string model_name() const { return "transform_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -26291,6 +26301,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
   ~truncate_model() { }
   
   std::string model_name() const { return "truncate_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -26817,6 +26828,7 @@ class udf_tilde_stmt_conflict_model : public model_base_crtp<udf_tilde_stmt_conf
   ~udf_tilde_stmt_conflict_model() { }
   
   std::string model_name() const { return "udf_tilde_stmt_conflict_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -27219,6 +27231,7 @@ class user_constrain_model : public model_base_crtp<user_constrain_model> {
   ~user_constrain_model() { }
   
   std::string model_name() const { return "user_constrain_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -117,6 +117,13 @@ class eight_schools_ncp_model : public model_base_crtp<eight_schools_ncp_model> 
   ~eight_schools_ncp_model() { }
   
   std::string model_name() const { return "eight_schools_ncp_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   eight_schools_ncp_model(stan::io::var_context& context__,
                           unsigned int random_seed__ = 0,
@@ -3184,6 +3191,13 @@ class mother_model : public model_base_crtp<mother_model> {
   ~mother_model() { }
   
   std::string model_name() const { return "mother_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   mother_model(stan::io::var_context& context__,
                unsigned int random_seed__ = 0,
@@ -9711,6 +9725,13 @@ class motherHOF_model : public model_base_crtp<motherHOF_model> {
   ~motherHOF_model() { }
   
   std::string model_name() const { return "motherHOF_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   motherHOF_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
@@ -11647,6 +11668,13 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
   ~optimize_glm_model() { }
   
   std::string model_name() const { return "optimize_glm_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   optimize_glm_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,
@@ -13328,6 +13356,13 @@ class reduce_sum_m1_model : public model_base_crtp<reduce_sum_m1_model> {
   ~reduce_sum_m1_model() { }
   
   std::string model_name() const { return "reduce_sum_m1_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   reduce_sum_m1_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
@@ -14918,6 +14953,13 @@ class reduce_sum_m2_model : public model_base_crtp<reduce_sum_m2_model> {
   ~reduce_sum_m2_model() { }
   
   std::string model_name() const { return "reduce_sum_m2_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   reduce_sum_m2_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
@@ -18782,6 +18824,13 @@ class reduce_sum_m3_model : public model_base_crtp<reduce_sum_m3_model> {
   ~reduce_sum_m3_model() { }
   
   std::string model_name() const { return "reduce_sum_m3_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   reduce_sum_m3_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
@@ -21422,6 +21471,13 @@ class single_argument_lpmf_model : public model_base_crtp<single_argument_lpmf_m
   ~single_argument_lpmf_model() { }
   
   std::string model_name() const { return "single_argument_lpmf_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   single_argument_lpmf_model(stan::io::var_context& context__,
                              unsigned int random_seed__ = 0,
@@ -21771,6 +21827,13 @@ class tilde_block_model : public model_base_crtp<tilde_block_model> {
   ~tilde_block_model() { }
   
   std::string model_name() const { return "tilde_block_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   tilde_block_model(stan::io::var_context& context__,
                     unsigned int random_seed__ = 0,
@@ -22222,6 +22285,13 @@ class transform_model : public model_base_crtp<transform_model> {
   ~transform_model() { }
   
   std::string model_name() const { return "transform_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   transform_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
@@ -26221,6 +26291,13 @@ class truncate_model : public model_base_crtp<truncate_model> {
   ~truncate_model() { }
   
   std::string model_name() const { return "truncate_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   truncate_model(stan::io::var_context& context__,
                  unsigned int random_seed__ = 0,
@@ -26740,6 +26817,13 @@ class udf_tilde_stmt_conflict_model : public model_base_crtp<udf_tilde_stmt_conf
   ~udf_tilde_stmt_conflict_model() { }
   
   std::string model_name() const { return "udf_tilde_stmt_conflict_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   udf_tilde_stmt_conflict_model(stan::io::var_context& context__,
                                 unsigned int random_seed__ = 0,
@@ -27135,6 +27219,13 @@ class user_constrain_model : public model_base_crtp<user_constrain_model> {
   ~user_constrain_model() { }
   
   std::string model_name() const { return "user_constrain_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = --print-cpp");
+    return stanc_info;
+  }
+  
   
   user_constrain_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -221,7 +221,7 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -1453,7 +1453,7 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -3660,7 +3660,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -5425,7 +5425,7 @@ class expr_prop_experiment_model : public model_base_crtp<expr_prop_experiment_m
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -5816,7 +5816,7 @@ class expr_prop_experiment2_model : public model_base_crtp<expr_prop_experiment2
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -6211,7 +6211,7 @@ class expr_prop_fail_model : public model_base_crtp<expr_prop_fail_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -6924,7 +6924,7 @@ class expr_prop_fail2_model : public model_base_crtp<expr_prop_fail2_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -7526,7 +7526,7 @@ class expr_prop_fail3_model : public model_base_crtp<expr_prop_fail3_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -9369,7 +9369,7 @@ class expr_prop_fail4_model : public model_base_crtp<expr_prop_fail4_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -10686,7 +10686,7 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -13757,7 +13757,7 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -17003,7 +17003,7 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -18730,7 +18730,7 @@ class expr_prop_fail8_model : public model_base_crtp<expr_prop_fail8_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -19991,7 +19991,7 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -23267,7 +23267,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -26282,7 +26282,7 @@ class lcm_experiment_model : public model_base_crtp<lcm_experiment_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -26665,7 +26665,7 @@ class lcm_experiment2_model : public model_base_crtp<lcm_experiment2_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -27055,7 +27055,7 @@ class lcm_fails_model : public model_base_crtp<lcm_fails_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -27879,7 +27879,7 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -29759,7 +29759,7 @@ class off_dce_model : public model_base_crtp<off_dce_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -30875,7 +30875,7 @@ class off_small_model : public model_base_crtp<off_small_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -32147,7 +32147,7 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -33562,7 +33562,7 @@ class partial_eval_model : public model_base_crtp<partial_eval_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -34521,7 +34521,7 @@ class stalled1_failure_model : public model_base_crtp<stalled1_failure_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   
@@ -35860,7 +35860,7 @@ class unroll_limit_model : public model_base_crtp<unroll_limit_model> {
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = ");
+    stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
   

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -221,7 +221,7 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -1454,7 +1454,7 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -3662,7 +3662,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -5428,7 +5428,7 @@ class expr_prop_experiment_model : public model_base_crtp<expr_prop_experiment_m
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -5820,7 +5820,7 @@ class expr_prop_experiment2_model : public model_base_crtp<expr_prop_experiment2
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -6216,7 +6216,7 @@ class expr_prop_fail_model : public model_base_crtp<expr_prop_fail_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -6930,7 +6930,7 @@ class expr_prop_fail2_model : public model_base_crtp<expr_prop_fail2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -7533,7 +7533,7 @@ class expr_prop_fail3_model : public model_base_crtp<expr_prop_fail3_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -9377,7 +9377,7 @@ class expr_prop_fail4_model : public model_base_crtp<expr_prop_fail4_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -10695,7 +10695,7 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -13767,7 +13767,7 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -17014,7 +17014,7 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -18742,7 +18742,7 @@ class expr_prop_fail8_model : public model_base_crtp<expr_prop_fail8_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -20004,7 +20004,7 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -23281,7 +23281,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -26297,7 +26297,7 @@ class lcm_experiment_model : public model_base_crtp<lcm_experiment_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -26681,7 +26681,7 @@ class lcm_experiment2_model : public model_base_crtp<lcm_experiment2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -27072,7 +27072,7 @@ class lcm_fails_model : public model_base_crtp<lcm_fails_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -27897,7 +27897,7 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -29778,7 +29778,7 @@ class off_dce_model : public model_base_crtp<off_dce_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -30895,7 +30895,7 @@ class off_small_model : public model_base_crtp<off_small_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -32168,7 +32168,7 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -33584,7 +33584,7 @@ class partial_eval_model : public model_base_crtp<partial_eval_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -34544,7 +34544,7 @@ class stalled1_failure_model : public model_base_crtp<stalled1_failure_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -35884,7 +35884,7 @@ class unroll_limit_model : public model_base_crtp<unroll_limit_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -218,6 +218,7 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
   ~ad_level_failing_model() { }
   
   std::string model_name() const { return "ad_level_failing_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -1450,6 +1451,7 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
   ~copy_fail_model() { }
   
   std::string model_name() const { return "copy_fail_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -3657,6 +3659,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
   ~dce_fail_model() { }
   
   std::string model_name() const { return "dce_fail_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -5422,6 +5425,7 @@ class expr_prop_experiment_model : public model_base_crtp<expr_prop_experiment_m
   ~expr_prop_experiment_model() { }
   
   std::string model_name() const { return "expr_prop_experiment_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -5813,6 +5817,7 @@ class expr_prop_experiment2_model : public model_base_crtp<expr_prop_experiment2
   ~expr_prop_experiment2_model() { }
   
   std::string model_name() const { return "expr_prop_experiment2_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -6208,6 +6213,7 @@ class expr_prop_fail_model : public model_base_crtp<expr_prop_fail_model> {
   ~expr_prop_fail_model() { }
   
   std::string model_name() const { return "expr_prop_fail_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -6921,6 +6927,7 @@ class expr_prop_fail2_model : public model_base_crtp<expr_prop_fail2_model> {
   ~expr_prop_fail2_model() { }
   
   std::string model_name() const { return "expr_prop_fail2_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -7523,6 +7530,7 @@ class expr_prop_fail3_model : public model_base_crtp<expr_prop_fail3_model> {
   ~expr_prop_fail3_model() { }
   
   std::string model_name() const { return "expr_prop_fail3_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -9366,6 +9374,7 @@ class expr_prop_fail4_model : public model_base_crtp<expr_prop_fail4_model> {
   ~expr_prop_fail4_model() { }
   
   std::string model_name() const { return "expr_prop_fail4_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -10683,6 +10692,7 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
   ~expr_prop_fail5_model() { }
   
   std::string model_name() const { return "expr_prop_fail5_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -13754,6 +13764,7 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
   ~expr_prop_fail6_model() { }
   
   std::string model_name() const { return "expr_prop_fail6_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -17000,6 +17011,7 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
   ~expr_prop_fail7_model() { }
   
   std::string model_name() const { return "expr_prop_fail7_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -18727,6 +18739,7 @@ class expr_prop_fail8_model : public model_base_crtp<expr_prop_fail8_model> {
   ~expr_prop_fail8_model() { }
   
   std::string model_name() const { return "expr_prop_fail8_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -19988,6 +20001,7 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
   ~fails_test_model() { }
   
   std::string model_name() const { return "fails_test_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -23264,6 +23278,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
   ~inlining_fail2_model() { }
   
   std::string model_name() const { return "inlining_fail2_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -26279,6 +26294,7 @@ class lcm_experiment_model : public model_base_crtp<lcm_experiment_model> {
   ~lcm_experiment_model() { }
   
   std::string model_name() const { return "lcm_experiment_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -26662,6 +26678,7 @@ class lcm_experiment2_model : public model_base_crtp<lcm_experiment2_model> {
   ~lcm_experiment2_model() { }
   
   std::string model_name() const { return "lcm_experiment2_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -27052,6 +27069,7 @@ class lcm_fails_model : public model_base_crtp<lcm_fails_model> {
   ~lcm_fails_model() { }
   
   std::string model_name() const { return "lcm_fails_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -27876,6 +27894,7 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
   ~lcm_fails2_model() { }
   
   std::string model_name() const { return "lcm_fails2_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -29756,6 +29775,7 @@ class off_dce_model : public model_base_crtp<off_dce_model> {
   ~off_dce_model() { }
   
   std::string model_name() const { return "off_dce_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -30872,6 +30892,7 @@ class off_small_model : public model_base_crtp<off_small_model> {
   ~off_small_model() { }
   
   std::string model_name() const { return "off_small_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -32144,6 +32165,7 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
   ~optimizations_model() { }
   
   std::string model_name() const { return "optimizations_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -33559,6 +33581,7 @@ class partial_eval_model : public model_base_crtp<partial_eval_model> {
   ~partial_eval_model() { }
   
   std::string model_name() const { return "partial_eval_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -34518,6 +34541,7 @@ class stalled1_failure_model : public model_base_crtp<stalled1_failure_model> {
   ~stalled1_failure_model() { }
   
   std::string model_name() const { return "stalled1_failure_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
@@ -35857,6 +35881,7 @@ class unroll_limit_model : public model_base_crtp<unroll_limit_model> {
   ~unroll_limit_model() { }
   
   std::string model_name() const { return "unroll_limit_model"; }
+
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
     stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -218,6 +218,13 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
   ~ad_level_failing_model() { }
   
   std::string model_name() const { return "ad_level_failing_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   ad_level_failing_model(stan::io::var_context& context__,
                          unsigned int random_seed__ = 0,
@@ -1443,6 +1450,13 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
   ~copy_fail_model() { }
   
   std::string model_name() const { return "copy_fail_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   copy_fail_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
@@ -3643,6 +3657,13 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
   ~dce_fail_model() { }
   
   std::string model_name() const { return "dce_fail_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   dce_fail_model(stan::io::var_context& context__,
                  unsigned int random_seed__ = 0,
@@ -5401,6 +5422,13 @@ class expr_prop_experiment_model : public model_base_crtp<expr_prop_experiment_m
   ~expr_prop_experiment_model() { }
   
   std::string model_name() const { return "expr_prop_experiment_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_experiment_model(stan::io::var_context& context__,
                              unsigned int random_seed__ = 0,
@@ -5785,6 +5813,13 @@ class expr_prop_experiment2_model : public model_base_crtp<expr_prop_experiment2
   ~expr_prop_experiment2_model() { }
   
   std::string model_name() const { return "expr_prop_experiment2_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_experiment2_model(stan::io::var_context& context__,
                               unsigned int random_seed__ = 0,
@@ -6173,6 +6208,13 @@ class expr_prop_fail_model : public model_base_crtp<expr_prop_fail_model> {
   ~expr_prop_fail_model() { }
   
   std::string model_name() const { return "expr_prop_fail_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
@@ -6879,6 +6921,13 @@ class expr_prop_fail2_model : public model_base_crtp<expr_prop_fail2_model> {
   ~expr_prop_fail2_model() { }
   
   std::string model_name() const { return "expr_prop_fail2_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail2_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -7474,6 +7523,13 @@ class expr_prop_fail3_model : public model_base_crtp<expr_prop_fail3_model> {
   ~expr_prop_fail3_model() { }
   
   std::string model_name() const { return "expr_prop_fail3_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail3_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -9310,6 +9366,13 @@ class expr_prop_fail4_model : public model_base_crtp<expr_prop_fail4_model> {
   ~expr_prop_fail4_model() { }
   
   std::string model_name() const { return "expr_prop_fail4_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail4_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -10620,6 +10683,13 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
   ~expr_prop_fail5_model() { }
   
   std::string model_name() const { return "expr_prop_fail5_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail5_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -13684,6 +13754,13 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
   ~expr_prop_fail6_model() { }
   
   std::string model_name() const { return "expr_prop_fail6_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail6_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -16923,6 +17000,13 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
   ~expr_prop_fail7_model() { }
   
   std::string model_name() const { return "expr_prop_fail7_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail7_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -18643,6 +18727,13 @@ class expr_prop_fail8_model : public model_base_crtp<expr_prop_fail8_model> {
   ~expr_prop_fail8_model() { }
   
   std::string model_name() const { return "expr_prop_fail8_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   expr_prop_fail8_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -19897,6 +19988,13 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
   ~fails_test_model() { }
   
   std::string model_name() const { return "fails_test_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   fails_test_model(stan::io::var_context& context__,
                    unsigned int random_seed__ = 0,
@@ -23166,6 +23264,13 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
   ~inlining_fail2_model() { }
   
   std::string model_name() const { return "inlining_fail2_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   inlining_fail2_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
@@ -26174,6 +26279,13 @@ class lcm_experiment_model : public model_base_crtp<lcm_experiment_model> {
   ~lcm_experiment_model() { }
   
   std::string model_name() const { return "lcm_experiment_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   lcm_experiment_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
@@ -26550,6 +26662,13 @@ class lcm_experiment2_model : public model_base_crtp<lcm_experiment2_model> {
   ~lcm_experiment2_model() { }
   
   std::string model_name() const { return "lcm_experiment2_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   lcm_experiment2_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
@@ -26933,6 +27052,13 @@ class lcm_fails_model : public model_base_crtp<lcm_fails_model> {
   ~lcm_fails_model() { }
   
   std::string model_name() const { return "lcm_fails_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   lcm_fails_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
@@ -27750,6 +27876,13 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
   ~lcm_fails2_model() { }
   
   std::string model_name() const { return "lcm_fails2_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   lcm_fails2_model(stan::io::var_context& context__,
                    unsigned int random_seed__ = 0,
@@ -29623,6 +29756,13 @@ class off_dce_model : public model_base_crtp<off_dce_model> {
   ~off_dce_model() { }
   
   std::string model_name() const { return "off_dce_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   off_dce_model(stan::io::var_context& context__,
                 unsigned int random_seed__ = 0,
@@ -30732,6 +30872,13 @@ class off_small_model : public model_base_crtp<off_small_model> {
   ~off_small_model() { }
   
   std::string model_name() const { return "off_small_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   off_small_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
@@ -31997,6 +32144,13 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
   ~optimizations_model() { }
   
   std::string model_name() const { return "optimizations_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   optimizations_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
@@ -33405,6 +33559,13 @@ class partial_eval_model : public model_base_crtp<partial_eval_model> {
   ~partial_eval_model() { }
   
   std::string model_name() const { return "partial_eval_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   partial_eval_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,
@@ -34357,6 +34518,13 @@ class stalled1_failure_model : public model_base_crtp<stalled1_failure_model> {
   ~stalled1_failure_model() { }
   
   std::string model_name() const { return "stalled1_failure_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   stalled1_failure_model(stan::io::var_context& context__,
                          unsigned int random_seed__ = 0,
@@ -35689,6 +35857,13 @@ class unroll_limit_model : public model_base_crtp<unroll_limit_model> {
   ~unroll_limit_model() { }
   
   std::string model_name() const { return "unroll_limit_model"; }
+  std::vector<std::string> model_compile_info() const {
+    std::vector<std::string> stanc_info;
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stancflags = ");
+    return stanc_info;
+  }
+  
   
   unroll_limit_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,


### PR DESCRIPTION
Adds the following function to the model:

```cpp
std::vector<std::string> model_compile_info() const {
  std::vector<std::string> stanc_info;
  stanc_info.push_back("stanc_version = stanc3 66c38187 (Unix)");
  stanc_info.push_back("stancflags = --warn-pedantic");
  return stanc_info;
}
```

This will be used to add the compile info to the CSV and the standard output:

```
# init = 2 (Default)
# random
#   seed = 21139381 (Default)
# output
#   file = output.csv (Default)
#   diagnostic_file =  (Default)
#   refresh = 100 (Default)
# stanc_version = stanc3 66c38187 (Unix)
# stancflags = --warn-pedantic
```
