### PR TITLE
Feature/468 Use hyphens in all arguments

### DIFF
--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -111,19 +111,39 @@ let options =
     ; ( "--print-cpp"
       , Arg.Set print_model_cpp
       , " If set, output the generated C++ Stan model class to stdout." )
-    ; ( "--allow_undefined"
+    ; ( "--allow-undefined"
       , Arg.Clear Semantic_check.check_that_all_functions_have_definition
       , " Do not fail if a function is declared but not defined" )
-    ; ( "--include_paths"
+    ; ( "--allow_undefined"
+      , Arg.Clear Semantic_check.check_that_all_functions_have_definition
+      , " Deprecated. Same as --allow-undefined." )
+    ; ( "--include-paths"
       , Arg.String
           (fun str ->
             Preprocessor.include_paths := String.split_on_chars ~on:[','] str
             )
       , " Takes a comma-separated list of directories that may contain a file \
          in an #include directive (default = \"\")" )
+    ; ( "--include_paths"
+      , Arg.String
+          (fun str ->
+            Preprocessor.include_paths :=
+              !Preprocessor.include_paths @ String.split_on_chars ~on:[','] str
+            )
+      , " Deprecated. Same as --include-paths." )
     ; ( "--use-opencl"
       , Arg.Set Transform_Mir.use_opencl
       , " If set, try to use matrix_cl signatures." ) ]
+
+let print_deprecated_arg_warning =
+  (* is_prefix is used to also cover the --include-paths=... *)
+  let arg_is_used arg =
+    Array.mem ~equal:(fun x y -> String.is_prefix ~prefix:x y) Sys.argv arg
+  in
+  if arg_is_used "--allow_undefined" then
+    eprintf "--allow_undefined is deprecated. Please use --allow-undefined.\n" ;
+  if arg_is_used "--include_paths" then
+    eprintf "--include_paths is deprecated. Please use --include-paths.\n"
 
 let model_file_err () =
   Arg.usage options ("Please specify one model_file.\n\n" ^ usage) ;
@@ -188,6 +208,8 @@ let model_name_check_regex = Str.regexp "^[a-zA-Z_].*$"
 let main () =
   (* Parse the arguments. *)
   Arg.parse options add_file usage ;
+  print_deprecated_arg_warning ;
+  (* print_deprecated_arg_warning options; *)
   (* Deal with multiple modalities *)
   if !dump_stan_math_sigs then (
     Stan_math_signatures.pretty_print_all_math_sigs Format.std_formatter () ;

--- a/test/integration/included/dune
+++ b/test/integration/included/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../included\" " %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../included\" " %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/included/stanc.expected
+++ b/test/integration/included/stanc.expected
@@ -1,4 +1,4 @@
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  badrecurse1.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  badrecurse1.stan
 
 Syntax error in '../included/badrecurse1.stan', line 1, column 0, included from
 '../included/badrecurse1.stan', line 1, column 0, included from
@@ -11,7 +11,7 @@ Syntax error in '../included/badrecurse1.stan', line 1, column 0, included from
 File badrecurse1.stan recursively included itself.
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  badrecurse2.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  badrecurse2.stan
 
 Syntax error in '../included/badrecurse3.stan', line 1, column 0, included from
 '../included/badrecurse2.stan', line 1, column 0, included from
@@ -25,7 +25,7 @@ Syntax error in '../included/badrecurse3.stan', line 1, column 0, included from
 File badrecurse2.stan recursively included itself.
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  badrecurse3.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  badrecurse3.stan
 
 Syntax error in '../included/badrecurse2.stan', line 1, column 0, included from
 '../included/badrecurse3.stan', line 1, column 0, included from
@@ -39,7 +39,7 @@ Syntax error in '../included/badrecurse2.stan', line 1, column 0, included from
 File badrecurse3.stan recursively included itself.
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  dep-warning.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  dep-warning.stan
 
 Syntax error in 'dep-warning.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -51,7 +51,7 @@ Syntax error in 'dep-warning.stan', line 1, column 2 to column 6, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  error_spread_over_files.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  error_spread_over_files.stan
 
 Syntax error in 'error_spread_over_files.stan', line 1, column 2 to column 3, parsing error:
    -------------------------------------------------
@@ -62,7 +62,7 @@ Syntax error in 'error_spread_over_files.stan', line 1, column 2 to column 3, pa
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl-err.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl-err.stan
 
 Syntax error in 'incl-err.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -74,7 +74,7 @@ Syntax error in 'incl-err.stan', line 1, column 2 to column 6, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper.stan
 
 Syntax error in 'incl_stanc_helper.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -86,7 +86,7 @@ Syntax error in 'incl_stanc_helper.stan', line 1, column 2 to column 6, parsing 
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper2.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper2.stan
 
 Syntax error in 'incl_stanc_helper2.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -98,7 +98,7 @@ Syntax error in 'incl_stanc_helper2.stan', line 1, column 2 to column 6, parsing
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper_deprecated_warning.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper_deprecated_warning.stan
 
 Syntax error in 'incl_stanc_helper_deprecated_warning.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -110,7 +110,7 @@ Syntax error in 'incl_stanc_helper_deprecated_warning.stan', line 1, column 2 to
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper_error_spread_over_files.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper_error_spread_over_files.stan
 
 Syntax error in 'incl_stanc_helper_error_spread_over_files.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -122,7 +122,7 @@ Syntax error in 'incl_stanc_helper_error_spread_over_files.stan', line 1, column
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper_include_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper_include_error.stan
 
 Syntax error in 'incl_stanc_helper_include_error.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -134,7 +134,7 @@ Syntax error in 'incl_stanc_helper_include_error.stan', line 1, column 2 to colu
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper_lex_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper_lex_error.stan
 
 Syntax error in 'incl_stanc_helper_lex_error.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -146,7 +146,7 @@ Syntax error in 'incl_stanc_helper_lex_error.stan', line 1, column 2 to column 6
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper_parse_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper_parse_error.stan
 
 Syntax error in 'incl_stanc_helper_parse_error.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -158,7 +158,7 @@ Syntax error in 'incl_stanc_helper_parse_error.stan', line 1, column 2 to column
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  incl_stanc_helper_semantic_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  incl_stanc_helper_semantic_error.stan
 
 Syntax error in 'incl_stanc_helper_semantic_error.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -170,11 +170,11 @@ Syntax error in 'incl_stanc_helper_semantic_error.stan', line 1, column 2 to col
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  included-brackets.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  included-brackets.stan
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  included-quote.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  included-quote.stan
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  lex-err.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  lex-err.stan
 
 Syntax error in 'lex-err.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -186,7 +186,7 @@ Syntax error in 'lex-err.stan', line 1, column 2 to column 6, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  parse-err.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  parse-err.stan
 
 Syntax error in 'parse-err.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -198,7 +198,7 @@ Syntax error in 'parse-err.stan', line 1, column 2 to column 6, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  sem-err.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  sem-err.stan
 
 Syntax error in 'sem-err.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -210,7 +210,7 @@ Syntax error in 'sem-err.stan', line 1, column 2 to column 6, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_bad_include_deprecated_warning.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_bad_include_deprecated_warning.stan
 
 Warning: deprecated language construct used in '../included/dep-warning.stan', line 2, column 2, included from
 '../included/incl_stanc_helper_deprecated_warning.stan', line 2, column 2, included from
@@ -223,7 +223,7 @@ Warning: deprecated language construct used in '../included/dep-warning.stan', l
 
 Comments beginning with # are deprecated. Please use // in place of # for line comments.
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_bad_include_error_spread_over_files.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_bad_include_error_spread_over_files.stan
 
 Semantic error in '../included/incl_stanc_helper_error_spread_over_files.stan', line 2, column 2, included from
 'stanc_helper_with_bad_include_error_spread_over_files.stan', line 2, column 0:
@@ -235,7 +235,7 @@ Semantic error in '../included/incl_stanc_helper_error_spread_over_files.stan', 
 
 (Transformed) Parameters cannot be integers.
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_bad_include_include_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_bad_include_include_error.stan
 
 Syntax error in '../included/incl-err.stan', line 2, column 2, included from
 '../included/incl_stanc_helper_include_error.stan', line 2, column 2, included from
@@ -249,7 +249,7 @@ Syntax error in '../included/incl-err.stan', line 2, column 2, included from
 Could not find include file I'm not here.stan in specified include paths.
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_bad_include_lex_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_bad_include_lex_error.stan
 
 Syntax error in '../included/lex-err.stan', line 2, column 8, included from
 '../included/incl_stanc_helper_lex_error.stan', line 2, column 2, included from
@@ -262,7 +262,7 @@ Syntax error in '../included/lex-err.stan', line 2, column 8, included from
 
 Invalid character found.
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_bad_include_parse_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_bad_include_parse_error.stan
 
 Syntax error in '../included/parse-err.stan', line 2, column 2, included from
 '../included/incl_stanc_helper_parse_error.stan', line 2, column 2, included from
@@ -276,7 +276,7 @@ Syntax error in '../included/parse-err.stan', line 2, column 2, included from
 Only top-level variable declarations allowed in data and parameters blocks.
 
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_bad_include_semantic_error.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_bad_include_semantic_error.stan
 
 Semantic error in '../included/sem-err.stan', line 2, column 2, included from
 '../included/incl_stanc_helper_semantic_error.stan', line 2, column 2, included from
@@ -289,9 +289,9 @@ Semantic error in '../included/sem-err.stan', line 2, column 2, included from
 
 (Transformed) Parameters cannot be integers.
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_good_include.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_good_include.stan
 
-  $ ../../../../install/default/bin/stanc --include_paths="../included"  stanc_helper_with_good_include_err_after_incl.stan
+  $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_good_include_err_after_incl.stan
 
 Semantic error in 'stanc_helper_with_good_include_err_after_incl.stan', line 9, column 8 to column 10:
    -------------------------------------------------

--- a/test/integration/rstanarm/data/pretty.expected
+++ b/test/integration/rstanarm/data/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined NKX.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined NKX.stan
 
 Syntax error in 'NKX.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -12,7 +12,7 @@ Syntax error in 'NKX.stan', line 2, column 2 to column 5, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined data_assoc.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined data_assoc.stan
 
 Syntax error in 'data_assoc.stan', line 3, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -27,7 +27,7 @@ Syntax error in 'data_assoc.stan', line 3, column 2 to column 5, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined data_betareg.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined data_betareg.stan
 
 Syntax error in 'data_betareg.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -41,7 +41,7 @@ Syntax error in 'data_betareg.stan', line 2, column 2 to column 5, parsing error
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined data_event.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined data_event.stan
 
 Syntax error in 'data_event.stan', line 3, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -56,7 +56,7 @@ Syntax error in 'data_event.stan', line 3, column 2 to column 5, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined data_glm.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined data_glm.stan
 
 Syntax error in 'data_glm.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -70,7 +70,7 @@ Syntax error in 'data_glm.stan', line 2, column 2 to column 5, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined data_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined data_mvmer.stan
 
 Syntax error in 'data_mvmer.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -84,7 +84,7 @@ Syntax error in 'data_mvmer.stan', line 2, column 2 to column 5, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined dimensions_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined dimensions_mvmer.stan
 
 Syntax error in 'dimensions_mvmer.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -98,7 +98,7 @@ Syntax error in 'dimensions_mvmer.stan', line 2, column 2 to column 5, parsing e
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined glmer_stuff.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined glmer_stuff.stan
 
 Syntax error in 'glmer_stuff.stan', line 3, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -113,7 +113,7 @@ Syntax error in 'glmer_stuff.stan', line 3, column 2 to column 5, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined glmer_stuff2.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined glmer_stuff2.stan
 
 Syntax error in 'glmer_stuff2.stan', line 1, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -126,7 +126,7 @@ Syntax error in 'glmer_stuff2.stan', line 1, column 2 to column 5, parsing error
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined hyperparameters.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined hyperparameters.stan
 
 Syntax error in 'hyperparameters.stan', line 2, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -140,7 +140,7 @@ Syntax error in 'hyperparameters.stan', line 2, column 2 to column 8, parsing er
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined hyperparameters_assoc.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined hyperparameters_assoc.stan
 
 Syntax error in 'hyperparameters_assoc.stan', line 2, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -154,7 +154,7 @@ Syntax error in 'hyperparameters_assoc.stan', line 2, column 2 to column 8, pars
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined hyperparameters_event.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined hyperparameters_event.stan
 
 Syntax error in 'hyperparameters_event.stan', line 2, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -168,7 +168,7 @@ Syntax error in 'hyperparameters_event.stan', line 2, column 2 to column 8, pars
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined hyperparameters_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined hyperparameters_mvmer.stan
 
 Syntax error in 'hyperparameters_mvmer.stan', line 4, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -183,7 +183,7 @@ Syntax error in 'hyperparameters_mvmer.stan', line 4, column 2 to column 8, pars
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined weights_offset.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined weights_offset.stan
 
 Syntax error in 'weights_offset.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------

--- a/test/integration/rstanarm/dune
+++ b/test/integration/rstanarm/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\".\" --auto-format --allow_undefined" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\".\" --auto-format --allow-undefined" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/functions/dune
+++ b/test/integration/rstanarm/functions/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../\" --auto-format" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../\" --auto-format" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/functions/pretty.expected
+++ b/test/integration/rstanarm/functions/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format SSfunctions.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format SSfunctions.stan
 
 Syntax error in 'SSfunctions.stan', line 1, column 0 to column 6, parsing error:
    -------------------------------------------------
@@ -11,7 +11,7 @@ Syntax error in 'SSfunctions.stan', line 1, column 0 to column 6, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format bernoulli_likelihoods.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format bernoulli_likelihoods.stan
 
 Syntax error in 'bernoulli_likelihoods.stan', line 9, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -26,7 +26,7 @@ Syntax error in 'bernoulli_likelihoods.stan', line 9, column 2 to column 8, pars
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format binomial_likelihoods.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format binomial_likelihoods.stan
 
 Syntax error in 'binomial_likelihoods.stan', line 8, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -41,7 +41,7 @@ Syntax error in 'binomial_likelihoods.stan', line 8, column 2 to column 8, parsi
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format common_functions.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format common_functions.stan
 
 Syntax error in 'common_functions.stan', line 19, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -56,7 +56,7 @@ Syntax error in 'common_functions.stan', line 19, column 2 to column 8, parsing 
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format continuous_likelihoods.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format continuous_likelihoods.stan
 
 Syntax error in 'continuous_likelihoods.stan', line 8, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -71,7 +71,7 @@ Syntax error in 'continuous_likelihoods.stan', line 8, column 2 to column 8, par
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format count_likelihoods.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format count_likelihoods.stan
 
 Syntax error in 'count_likelihoods.stan', line 9, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -86,7 +86,7 @@ Syntax error in 'count_likelihoods.stan', line 9, column 2 to column 8, parsing 
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format jm_functions.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format jm_functions.stan
 
 Syntax error in 'jm_functions.stan', line 10, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -101,7 +101,7 @@ Syntax error in 'jm_functions.stan', line 10, column 2 to column 8, parsing erro
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format mvmer_functions.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format mvmer_functions.stan
 
 Syntax error in 'mvmer_functions.stan', line 7, column 2 to column 5, parsing error:
    -------------------------------------------------

--- a/test/integration/rstanarm/gqs/dune
+++ b/test/integration/rstanarm/gqs/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../\" --auto-format" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../\" --auto-format" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/gqs/pretty.expected
+++ b/test/integration/rstanarm/gqs/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format gen_quantities_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format gen_quantities_mvmer.stan
 
 Syntax error in 'gen_quantities_mvmer.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------

--- a/test/integration/rstanarm/model/dune
+++ b/test/integration/rstanarm/model/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../\" --auto-format" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../\" --auto-format" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/model/pretty.expected
+++ b/test/integration/rstanarm/model/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format assoc_evaluate.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format assoc_evaluate.stan
 
 Syntax error in 'assoc_evaluate.stan', line 5, column 4 to column 7, parsing error:
    -------------------------------------------------
@@ -13,7 +13,7 @@ Syntax error in 'assoc_evaluate.stan', line 5, column 4 to column 7, parsing err
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format eta_add_Zb.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format eta_add_Zb.stan
 
 Syntax error in 'eta_add_Zb.stan', line 1, column 4 to column 6, parsing error:
    -------------------------------------------------
@@ -25,7 +25,7 @@ Syntax error in 'eta_add_Zb.stan', line 1, column 4 to column 6, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format eta_no_intercept.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format eta_no_intercept.stan
 
 Syntax error in 'eta_no_intercept.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -37,7 +37,7 @@ Syntax error in 'eta_no_intercept.stan', line 2, column 2 to column 5, parsing e
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format eta_z_no_intercept.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format eta_z_no_intercept.stan
 
 Syntax error in 'eta_z_no_intercept.stan', line 1, column 2 to column 4, parsing error:
    -------------------------------------------------
@@ -50,7 +50,7 @@ Syntax error in 'eta_z_no_intercept.stan', line 1, column 2 to column 4, parsing
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format event_lp.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format event_lp.stan
 
 Syntax error in 'event_lp.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -63,7 +63,7 @@ Syntax error in 'event_lp.stan', line 1, column 2 to column 8, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format make_eta.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format make_eta.stan
 
 Syntax error in 'make_eta.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -76,7 +76,7 @@ Syntax error in 'make_eta.stan', line 1, column 2 to column 8, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format make_eta_bern.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format make_eta_bern.stan
 
 Syntax error in 'make_eta_bern.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -89,7 +89,7 @@ Syntax error in 'make_eta_bern.stan', line 1, column 2 to column 8, parsing erro
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format make_eta_tmp.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format make_eta_tmp.stan
 
 Syntax error in 'make_eta_tmp.stan', line 1, column 8 to column 14, parsing error:
    -------------------------------------------------
@@ -102,7 +102,7 @@ Syntax error in 'make_eta_tmp.stan', line 1, column 8 to column 14, parsing erro
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format make_eta_tmp2.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format make_eta_tmp2.stan
 
 Syntax error in 'make_eta_tmp2.stan', line 1, column 12 to column 18, parsing error:
    -------------------------------------------------
@@ -115,7 +115,7 @@ Syntax error in 'make_eta_tmp2.stan', line 1, column 12 to column 18, parsing er
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format make_eta_z.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format make_eta_z.stan
 
 Syntax error in 'make_eta_z.stan', line 1, column 1 to column 3, parsing error:
    -------------------------------------------------
@@ -128,7 +128,7 @@ Syntax error in 'make_eta_z.stan', line 1, column 1 to column 3, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format mvmer_lp.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format mvmer_lp.stan
 
 Syntax error in 'mvmer_lp.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -141,7 +141,7 @@ Syntax error in 'mvmer_lp.stan', line 1, column 2 to column 8, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format priors_betareg.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format priors_betareg.stan
 
 Syntax error in 'priors_betareg.stan', line 2, column 2 to column 4, parsing error:
    -------------------------------------------------
@@ -155,7 +155,7 @@ Syntax error in 'priors_betareg.stan', line 2, column 2 to column 4, parsing err
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format priors_glm.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format priors_glm.stan
 
 Syntax error in 'priors_glm.stan', line 2, column 7 to column 9, parsing error:
    -------------------------------------------------
@@ -169,7 +169,7 @@ Syntax error in 'priors_glm.stan', line 2, column 7 to column 9, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format priors_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format priors_mvmer.stan
 
 Syntax error in 'priors_mvmer.stan', line 2, column 2 to column 4, parsing error:
    -------------------------------------------------

--- a/test/integration/rstanarm/parameters/dune
+++ b/test/integration/rstanarm/parameters/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../\" --auto-format" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../\" --auto-format" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/parameters/pretty.expected
+++ b/test/integration/rstanarm/parameters/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format parameters_assoc.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format parameters_assoc.stan
 
 Syntax error in 'parameters_assoc.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -11,7 +11,7 @@ Syntax error in 'parameters_assoc.stan', line 1, column 2 to column 8, parsing e
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format parameters_betareg.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format parameters_betareg.stan
 
 Syntax error in 'parameters_betareg.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -24,7 +24,7 @@ Syntax error in 'parameters_betareg.stan', line 1, column 2 to column 8, parsing
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format parameters_event.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format parameters_event.stan
 
 Syntax error in 'parameters_event.stan', line 1, column 2 to column 6, parsing error:
    -------------------------------------------------
@@ -37,7 +37,7 @@ Syntax error in 'parameters_event.stan', line 1, column 2 to column 6, parsing e
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format parameters_glm.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format parameters_glm.stan
 
 Syntax error in 'parameters_glm.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -50,7 +50,7 @@ Syntax error in 'parameters_glm.stan', line 1, column 2 to column 8, parsing err
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format parameters_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format parameters_mvmer.stan
 
 Syntax error in 'parameters_mvmer.stan', line 2, column 2 to column 6, parsing error:
    -------------------------------------------------

--- a/test/integration/rstanarm/pre/dune
+++ b/test/integration/rstanarm/pre/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../\" --auto-format" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../\" --auto-format" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/pre/pretty.expected
+++ b/test/integration/rstanarm/pre/pretty.expected
@@ -1,6 +1,6 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format Brilleman_copyright.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format Brilleman_copyright.stan
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format Columbia_copyright.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format Columbia_copyright.stan
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format license.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format license.stan
 

--- a/test/integration/rstanarm/pretty.expected
+++ b/test/integration/rstanarm/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined bernoulli.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined bernoulli.stan
 functions {
   vector make_theta_L(int len_theta_L, int[] p, real dispersion, vector tau,
                       vector scale, vector zeta, vector rho, vector z_T) {
@@ -678,7 +678,7 @@ generated quantities {
   }
 }
 
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined binomial.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined binomial.stan
 functions {
   vector make_theta_L(int len_theta_L, int[] p, real dispersion, vector tau,
                       vector scale, vector zeta, vector rho, vector z_T) {
@@ -1235,7 +1235,7 @@ generated quantities {
   }
 }
 
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined continuous.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined continuous.stan
 functions {
   vector make_theta_L(int len_theta_L, int[] p, real dispersion, vector tau,
                       vector scale, vector zeta, vector rho, vector z_T) {
@@ -2373,7 +2373,7 @@ generated quantities {
   }
 }
 
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined count.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined count.stan
 functions {
   vector make_theta_L(int len_theta_L, int[] p, real dispersion, vector tau,
                       vector scale, vector zeta, vector rho, vector z_T) {
@@ -2985,7 +2985,7 @@ generated quantities {
   }
 }
 
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined jm.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined jm.stan
 functions {
   vector make_theta_L(int len_theta_L, int[] p, real dispersion, vector tau,
                       vector scale, vector zeta, vector rho, vector z_T) {
@@ -5022,7 +5022,7 @@ generated quantities {
               - dot_product(a_xbar, a_beta);
 }
 
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined lm.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined lm.stan
 functions {
   real ll_mvn_ols_qr_lp(vector theta, vector b, real intercept, real ybar,
                         real SSR, real sigma, int N) {
@@ -5121,7 +5121,7 @@ generated quantities {
   }
 }
 
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined mvmer.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined mvmer.stan
 functions {
   vector make_theta_L(int len_theta_L, int[] p, real dispersion, vector tau,
                       vector scale, vector zeta, vector rho, vector z_T) {
@@ -6336,7 +6336,7 @@ generated quantities {
   }
 }
 
-  $ ../../../../install/default/bin/stanc --include_paths="." --auto-format --allow_undefined polr.stan
+  $ ../../../../install/default/bin/stanc --include-paths="." --auto-format --allow-undefined polr.stan
 functions {
   real CDF_polr(real x, int link) {
     if (link == 1) 

--- a/test/integration/rstanarm/tdata/dune
+++ b/test/integration/rstanarm/tdata/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../\" --auto-format" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../\" --auto-format" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/tdata/pretty.expected
+++ b/test/integration/rstanarm/tdata/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format tdata_betareg.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format tdata_betareg.stan
 
 Syntax error in 'tdata_betareg.stan', line 1, column 2 to column 4, parsing error:
    -------------------------------------------------
@@ -11,7 +11,7 @@ Syntax error in 'tdata_betareg.stan', line 1, column 2 to column 4, parsing erro
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format tdata_glm.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format tdata_glm.stan
 
 Syntax error in 'tdata_glm.stan', line 1, column 2 to column 5, parsing error:
    -------------------------------------------------
@@ -24,7 +24,7 @@ Syntax error in 'tdata_glm.stan', line 1, column 2 to column 5, parsing error:
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format tdata_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format tdata_mvmer.stan
 
 Syntax error in 'tdata_mvmer.stan', line 2, column 2 to column 5, parsing error:
    -------------------------------------------------

--- a/test/integration/rstanarm/tparameters/dune
+++ b/test/integration/rstanarm/tparameters/dune
@@ -3,7 +3,7 @@
  (deps (package stanc) (:stanfiles (glob_files *.stan)))
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --include_paths=\"../\" --auto-format" %{stanfiles}))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=\"../\" --auto-format" %{stanfiles}))))
 
 (alias
  (name runtest)

--- a/test/integration/rstanarm/tparameters/pretty.expected
+++ b/test/integration/rstanarm/tparameters/pretty.expected
@@ -1,4 +1,4 @@
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format tparameters_betareg.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format tparameters_betareg.stan
 
 Syntax error in 'tparameters_betareg.stan', line 1, column 2 to column 4, parsing error:
    -------------------------------------------------
@@ -11,7 +11,7 @@ Syntax error in 'tparameters_betareg.stan', line 1, column 2 to column 4, parsin
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format tparameters_glm.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format tparameters_glm.stan
 
 Syntax error in 'tparameters_glm.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------
@@ -24,7 +24,7 @@ Syntax error in 'tparameters_glm.stan', line 1, column 2 to column 8, parsing er
 Expected "functions {" or "data {" or "transformed data {" or "parameters {" or "transformed parameters {" or "model {" or "generated quantities {".
 
 
-  $ ../../../../../install/default/bin/stanc --include_paths="../" --auto-format tparameters_mvmer.stan
+  $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format tparameters_mvmer.stan
 
 Syntax error in 'tparameters_mvmer.stan', line 1, column 2 to column 8, parsing error:
    -------------------------------------------------


### PR DESCRIPTION
Fixes #468 by deprecating `--allow_undefined` and `--include_paths` in favor of `--allow-undefined` and `--include-paths`
to consistently use hyphens in all stanc arguments.