### PR TITLE
Fix tests and dune subst bug with --print-cpp

### DIFF
--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -676,12 +676,12 @@ let pp_model ppf ({Program.prog_name; _} as p) =
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
+    stanc_info.push_back("stanc_version = %s");
     stanc_info.push_back("stancflags = %s");
     return stanc_info;
   }
   |}
-    stanc_args_to_print ;
+    "%%NAME%%3 %%VERSION%%" stanc_args_to_print ;
   pf ppf "@ %a@]@]@ };" pp_model_public p
 
 (** The C++ aliases needed for the model class*)

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -325,7 +325,7 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp --use-opencl");
     return stanc_info;
   }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -120,7 +120,7 @@ class eight_schools_ncp_model : public model_base_crtp<eight_schools_ncp_model> 
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -3195,7 +3195,7 @@ class mother_model : public model_base_crtp<mother_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -9730,7 +9730,7 @@ class motherHOF_model : public model_base_crtp<motherHOF_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -11674,7 +11674,7 @@ class optimize_glm_model : public model_base_crtp<optimize_glm_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -13363,7 +13363,7 @@ class reduce_sum_m1_model : public model_base_crtp<reduce_sum_m1_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -14961,7 +14961,7 @@ class reduce_sum_m2_model : public model_base_crtp<reduce_sum_m2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -18833,7 +18833,7 @@ class reduce_sum_m3_model : public model_base_crtp<reduce_sum_m3_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -21481,7 +21481,7 @@ class single_argument_lpmf_model : public model_base_crtp<single_argument_lpmf_m
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -21838,7 +21838,7 @@ class tilde_block_model : public model_base_crtp<tilde_block_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -22297,7 +22297,7 @@ class transform_model : public model_base_crtp<transform_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -26304,7 +26304,7 @@ class truncate_model : public model_base_crtp<truncate_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -26831,7 +26831,7 @@ class udf_tilde_stmt_conflict_model : public model_base_crtp<udf_tilde_stmt_conf
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }
@@ -27234,7 +27234,7 @@ class user_constrain_model : public model_base_crtp<user_constrain_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --print-cpp");
     return stanc_info;
   }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -221,7 +221,7 @@ class ad_level_failing_model : public model_base_crtp<ad_level_failing_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -1454,7 +1454,7 @@ class copy_fail_model : public model_base_crtp<copy_fail_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -3662,7 +3662,7 @@ class dce_fail_model : public model_base_crtp<dce_fail_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -5428,7 +5428,7 @@ class expr_prop_experiment_model : public model_base_crtp<expr_prop_experiment_m
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -5820,7 +5820,7 @@ class expr_prop_experiment2_model : public model_base_crtp<expr_prop_experiment2
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -6216,7 +6216,7 @@ class expr_prop_fail_model : public model_base_crtp<expr_prop_fail_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -6930,7 +6930,7 @@ class expr_prop_fail2_model : public model_base_crtp<expr_prop_fail2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -7533,7 +7533,7 @@ class expr_prop_fail3_model : public model_base_crtp<expr_prop_fail3_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -9377,7 +9377,7 @@ class expr_prop_fail4_model : public model_base_crtp<expr_prop_fail4_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -10695,7 +10695,7 @@ class expr_prop_fail5_model : public model_base_crtp<expr_prop_fail5_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -13767,7 +13767,7 @@ class expr_prop_fail6_model : public model_base_crtp<expr_prop_fail6_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -17014,7 +17014,7 @@ class expr_prop_fail7_model : public model_base_crtp<expr_prop_fail7_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -18742,7 +18742,7 @@ class expr_prop_fail8_model : public model_base_crtp<expr_prop_fail8_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -20004,7 +20004,7 @@ class fails_test_model : public model_base_crtp<fails_test_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -23281,7 +23281,7 @@ class inlining_fail2_model : public model_base_crtp<inlining_fail2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -26297,7 +26297,7 @@ class lcm_experiment_model : public model_base_crtp<lcm_experiment_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -26681,7 +26681,7 @@ class lcm_experiment2_model : public model_base_crtp<lcm_experiment2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -27072,7 +27072,7 @@ class lcm_fails_model : public model_base_crtp<lcm_fails_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -27897,7 +27897,7 @@ class lcm_fails2_model : public model_base_crtp<lcm_fails2_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -29778,7 +29778,7 @@ class off_dce_model : public model_base_crtp<off_dce_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -30895,7 +30895,7 @@ class off_small_model : public model_base_crtp<off_small_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -32168,7 +32168,7 @@ class optimizations_model : public model_base_crtp<optimizations_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -33584,7 +33584,7 @@ class partial_eval_model : public model_base_crtp<partial_eval_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -34544,7 +34544,7 @@ class stalled1_failure_model : public model_base_crtp<stalled1_failure_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }
@@ -35884,7 +35884,7 @@ class unroll_limit_model : public model_base_crtp<unroll_limit_model> {
 
   std::vector<std::string> model_compile_info() const {
     std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
+    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
     stanc_info.push_back("stancflags = --O --print-cpp");
     return stanc_info;
   }


### PR DESCRIPTION
In #598 we added %%NAME%% and %%VERSION%% as follows:

```ocaml
  pf ppf
    {|

  std::vector<std::string> model_compile_info() const {
    std::vector<std::string> stanc_info;
    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
    stanc_info.push_back("stancflags = %s");
    return stanc_info;
  }
  |}
```

running dune subst then building the binary and using it, it works fine. 

The problem is that --print-cpp that is used to buidl the .expected files for tests prints it as:
```
  std::vector<std::string> model_compile_info() const {
    std::vector<std::string> stanc_info;
    stanc_info.push_back("stanc_version = %NAME%3 %VERSION%");
    stanc_info.push_back("stancflags = --print-cpp");
    return stanc_info;
  }
```
which then means that dune subst does not work for the .expected files which broke master tests.

There might be other solutions to fixing this. The other question is why did the PR tests not catch this, but that can be resolved after fixing master.