### PR TITLE
Improved support for Nix development

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Alternatively, the following is sometimes a faster way to build:
 
     nix-shell --command "dune build"
 
-To drop into a sandboxed development shell with all of the dependencies of Stanc3 plus `dune`, run:
+To drop into a sandboxed development shell with all of the dependencies of Stanc3 plus packages for an OCaml development environment (`dune`, `ocp-indent`, `ocamlformat`, `merlin` and `utop`), run:
 
     nix-shell
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ Alternatively, the following is sometimes a faster way to build:
 
     nix-shell --command "dune build"
 
-To drop into a sandboxed development shell with all of the dependencies of Stanc3 plus packages for an OCaml development environment (`dune`, `ocp-indent`, `ocamlformat`, `merlin` and `utop`), run:
-
-    nix-shell
-
 To run the test suite, run:
 
     nix-shell --command "dune build --profile release @runtest"
@@ -71,6 +67,14 @@ To run the test suite, run:
 To install Stanc3 to your system, run:
 
     nix-env -i -f default.nix
+
+To drop into a sandboxed development shell with all of the dependencies of Stanc3 plus packages for an OCaml development environment (`dune`, `ocp-indent`, `ocamlformat`, `merlin` and `utop`), run:
+
+    nix-shell
+
+To drop into a [UTop REPL](https://opam.ocaml.org/blog/about-utop/) with the Stanc3 modules available, run: 
+
+    nix-shell --command "dune utop"
 
 ### Development on Windows
 Having tried both native Windows development and development through [Ubuntu on WSL](https://www.microsoft.com/en-us/p/ubuntu-1804-lts/9n9tngvndl3q?activetab=pivot:overviewtab), the Ubuntu on WSL route seems vastly smoother and it is what we recommend as a default.

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,11 @@
 with (import (builtins.fetchTarball {
-  name = "nixpkgs-20.03";
-  # Tarball of tagged release of Nixpkgs 20.03
-  url = "https://github.com/nixos/nixpkgs/archive/5272327b81ed355bbed5659b8d303cf2979b6953.tar.gz";
+  name = "nixpkgs-19.09";
+  # Tarball of tagged release of Nixpkgs 19.09
+  url = "https://github.com/NixOS/nixpkgs/archive/19.09.tar.gz";
   # Tarball hash obtained using `nix-prefetch-url --unpack <url>`
-  sha256 = "0182ys095dfx02vl2a20j1hz92dx3mfgz2a6fhn31bqlp1wa8hlq";
+  sha256 = "0mhqhq21y5vrr1f30qd2bvydv4bbbslvyzclhw0kdxmkgg3z4c92";
 }) {});
+
 
 ocamlPackages.buildDunePackage rec {
   pname = "stanc";
@@ -39,4 +40,6 @@ ocamlPackages.buildDunePackage rec {
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ rybern ];
   };
+
+  inherit pkgs;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+let derivation = import ./default.nix; in
+
+with derivation.pkgs;
+stdenv.mkDerivation rec {
+  name = "stanc-env";
+
+  buildInputs = with pkgs.ocamlPackages; [
+    ocp-indent
+    ocamlformat
+    merlin
+    utop
+    findlib
+  ] ++ derivation.buildInputs;
+  
+  # This is useful for emacs integration
+  merlin = pkgs.ocamlPackages.merlin;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -10,8 +10,12 @@ stdenv.mkDerivation rec {
     merlin
     utop
     findlib
-  ] ++ derivation.buildInputs;
-  
+  ]
+  ++ [
+    ncurses
+  ]
+  ++ derivation.buildInputs;
+
   # This is useful for emacs integration
   merlin = pkgs.ocamlPackages.merlin;
 }


### PR DESCRIPTION
- Lowered the version of Nixpkgs so that ocamlformat matches our current standard of 0.8
- Added a shell.nix that manages a bunch of the useful dev environment tools, like dune, ocamlformat and merlin
- Added support for utop
- Updated the readme to match