### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+
+## Release notes
+
+Replace this text with a short note on what will change if this pull request is merged. This will be included in the release notes.
+
+## Copyright and Licensing
+
+By submitting this pull request, the copyright holder is agreeing to 
+license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)


### PR DESCRIPTION
This adds 2 sections in the PR: 

- Release notes: We do this in Math and its really nice for creating release notes, you can parse it nicely from the Github API
- Copyright and Licensing: Just a note that by submitting the copyright holder agrees that the PR is submitted under BSD-3. This is implied anyways based on Github rules, this just makes this explicit.