### PR TITLE
more *_free__ variables in transform_inits

### DIFF
--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -385,7 +385,7 @@ let constrain_decl st dconstrain t decl_id decl_var smeta =
       let unconstrained_decls, decl_id, ut =
         let ut = SizedType.to_unsized (param_size t st) in
         match dconstrain with
-        | Some Unconstrain when SizedType.to_unsized st <> ut ->
+        | Some Unconstrain when t <> Identity ->
             ( [ Stmt.Fixed.
                   { pattern=
                       Decl

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -472,10 +472,8 @@ let trans_prog (p : Program.Typed.t) =
   let get_pname_ust = function
     | ( name
       , { Program.out_block= Parameters
-        ; out_constrained_st
-        ; out_unconstrained_st; _ } )
-      when SizedType.to_unsized out_constrained_st
-           = SizedType.to_unsized out_unconstrained_st ->
+        ; out_unconstrained_st
+        ; out_trans= Identity; _ } ) ->
         Some (name, out_unconstrained_st)
     | name, {Program.out_block= Parameters; out_unconstrained_st; _} ->
         Some (name ^ "_free__", out_unconstrained_st)

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1420,8 +1420,11 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       
       current_statement__ = 4;
       sigma = context__.vals_r("sigma")[(1 - 1)];
+      double sigma_free__;
+      sigma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      sigma = stan::math::lb_free(sigma, 0);
+      sigma_free__ = stan::math::lb_free(sigma, 0);
       double alpha;
       alpha = std::numeric_limits<double>::quiet_NaN();
       
@@ -1503,7 +1506,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
         vars__.emplace_back(beta[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         vars__.emplace_back(cuts[(sym1__ - 1)]);}
-      vars__.emplace_back(sigma);
+      vars__.emplace_back(sigma_free__);
       vars__.emplace_back(alpha);
       vars__.emplace_back(phi);
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -331,8 +331,11 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       
       current_statement__ = 2;
       tau = context__.vals_r("tau")[(1 - 1)];
+      double tau_free__;
+      tau_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      tau = stan::math::lb_free(tau, 0);
+      tau_free__ = stan::math::lb_free(tau, 0);
       Eigen::Matrix<double, -1, 1> theta_tilde;
       theta_tilde = Eigen::Matrix<double, -1, 1>(J);
       stan::math::fill(theta_tilde, std::numeric_limits<double>::quiet_NaN());
@@ -354,7 +357,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
           pos__ = (pos__ + 1);}
       }
       vars__.emplace_back(mu);
-      vars__.emplace_back(tau);
+      vars__.emplace_back(tau_free__);
       for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
         vars__.emplace_back(theta_tilde[(sym1__ - 1)]);}
     } catch (const std::exception& e) {
@@ -1188,8 +1191,11 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       
       current_statement__ = 2;
       tau = context__.vals_r("tau")[(1 - 1)];
+      double tau_free__;
+      tau_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      tau = stan::math::lb_free(tau, 0);
+      tau_free__ = stan::math::lb_free(tau, 0);
       Eigen::Matrix<double, -1, 1> theta_tilde;
       theta_tilde = Eigen::Matrix<double, -1, 1>(J);
       stan::math::fill(theta_tilde, std::numeric_limits<double>::quiet_NaN());
@@ -1211,7 +1217,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
           pos__ = (pos__ + 1);}
       }
       vars__.emplace_back(mu);
-      vars__.emplace_back(tau);
+      vars__.emplace_back(tau_free__);
       for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
         vars__.emplace_back(theta_tilde[(sym1__ - 1)]);}
     } catch (const std::exception& e) {
@@ -1430,185 +1436,187 @@ using stan::math::pow;
 static int current_statement__ = 0;
 static const std::vector<string> locations_array__ = {" (found before start of program)",
                                                       " (in 'mother.stan', line 546, column 2 to column 14)",
-                                                      " (in 'mother.stan', line 547, column 2 to column 52)",
-                                                      " (in 'mother.stan', line 548, column 2 to column 45)",
-                                                      " (in 'mother.stan', line 549, column 2 to column 41)",
-                                                      " (in 'mother.stan', line 550, column 2 to column 32)",
-                                                      " (in 'mother.stan', line 551, column 2 to column 36)",
-                                                      " (in 'mother.stan', line 552, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 553, column 2 to column 24)",
-                                                      " (in 'mother.stan', line 554, column 2 to column 28)",
-                                                      " (in 'mother.stan', line 555, column 2 to column 26)",
-                                                      " (in 'mother.stan', line 556, column 2 to column 32)",
-                                                      " (in 'mother.stan', line 557, column 2 to column 36)",
-                                                      " (in 'mother.stan', line 558, column 2 to column 45)",
-                                                      " (in 'mother.stan', line 559, column 2 to column 23)",
-                                                      " (in 'mother.stan', line 560, column 2 to column 29)",
-                                                      " (in 'mother.stan', line 561, column 2 to column 33)",
-                                                      " (in 'mother.stan', line 562, column 2 to column 38)",
-                                                      " (in 'mother.stan', line 563, column 2 to column 36)",
-                                                      " (in 'mother.stan', line 564, column 2 to column 42)",
-                                                      " (in 'mother.stan', line 565, column 2 to column 16)",
-                                                      " (in 'mother.stan', line 566, column 2 to column 16)",
-                                                      " (in 'mother.stan', line 569, column 2 to column 33)",
-                                                      " (in 'mother.stan', line 570, column 2 to column 37)",
-                                                      " (in 'mother.stan', line 571, column 2 to column 28)",
-                                                      " (in 'mother.stan', line 572, column 2 to column 25)",
-                                                      " (in 'mother.stan', line 573, column 2 to column 29)",
-                                                      " (in 'mother.stan', line 574, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 575, column 2 to column 33)",
-                                                      " (in 'mother.stan', line 576, column 2 to column 37)",
-                                                      " (in 'mother.stan', line 577, column 2 to column 46)",
-                                                      " (in 'mother.stan', line 578, column 2 to column 24)",
-                                                      " (in 'mother.stan', line 579, column 2 to column 30)",
-                                                      " (in 'mother.stan', line 580, column 2 to column 34)",
-                                                      " (in 'mother.stan', line 581, column 2 to column 39)",
-                                                      " (in 'mother.stan', line 582, column 2 to column 37)",
-                                                      " (in 'mother.stan', line 583, column 2 to column 43)",
-                                                      " (in 'mother.stan', line 584, column 2 to column 20)",
-                                                      " (in 'mother.stan', line 586, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 587, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 588, column 2 to column 23)",
-                                                      " (in 'mother.stan', line 589, column 2 to column 23)",
-                                                      " (in 'mother.stan', line 591, column 2 to column 25)",
-                                                      " (in 'mother.stan', line 592, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 593, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 595, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 596, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 597, column 2 to column 33)",
-                                                      " (in 'mother.stan', line 603, column 10 to column 38)",
-                                                      " (in 'mother.stan', line 602, column 23 to line 603, column 39)",
-                                                      " (in 'mother.stan', line 602, column 8 to line 603, column 39)",
-                                                      " (in 'mother.stan', line 601, column 21 to line 603, column 40)",
-                                                      " (in 'mother.stan', line 601, column 6 to line 603, column 40)",
-                                                      " (in 'mother.stan', line 600, column 19 to line 603, column 41)",
-                                                      " (in 'mother.stan', line 600, column 4 to line 603, column 41)",
-                                                      " (in 'mother.stan', line 599, column 17 to line 603, column 42)",
-                                                      " (in 'mother.stan', line 599, column 2 to line 603, column 42)",
-                                                      " (in 'mother.stan', line 605, column 17 to column 45)",
-                                                      " (in 'mother.stan', line 605, column 2 to column 45)",
-                                                      " (in 'mother.stan', line 606, column 2 to column 29)",
-                                                      " (in 'mother.stan', line 607, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 608, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 610, column 2 to column 63)",
-                                                      " (in 'mother.stan', line 611, column 2 to column 79)",
-                                                      " (in 'mother.stan', line 612, column 2 to column 81)",
-                                                      " (in 'mother.stan', line 613, column 2 to column 65)",
+                                                      " (in 'mother.stan', line 547, column 2 to column 29)",
+                                                      " (in 'mother.stan', line 548, column 2 to column 30)",
+                                                      " (in 'mother.stan', line 549, column 2 to column 52)",
+                                                      " (in 'mother.stan', line 550, column 2 to column 45)",
+                                                      " (in 'mother.stan', line 551, column 2 to column 41)",
+                                                      " (in 'mother.stan', line 552, column 2 to column 32)",
+                                                      " (in 'mother.stan', line 553, column 2 to column 36)",
+                                                      " (in 'mother.stan', line 554, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 555, column 2 to column 24)",
+                                                      " (in 'mother.stan', line 556, column 2 to column 28)",
+                                                      " (in 'mother.stan', line 557, column 2 to column 26)",
+                                                      " (in 'mother.stan', line 558, column 2 to column 32)",
+                                                      " (in 'mother.stan', line 559, column 2 to column 36)",
+                                                      " (in 'mother.stan', line 560, column 2 to column 45)",
+                                                      " (in 'mother.stan', line 561, column 2 to column 23)",
+                                                      " (in 'mother.stan', line 562, column 2 to column 29)",
+                                                      " (in 'mother.stan', line 563, column 2 to column 33)",
+                                                      " (in 'mother.stan', line 564, column 2 to column 38)",
+                                                      " (in 'mother.stan', line 565, column 2 to column 36)",
+                                                      " (in 'mother.stan', line 566, column 2 to column 42)",
+                                                      " (in 'mother.stan', line 567, column 2 to column 16)",
+                                                      " (in 'mother.stan', line 568, column 2 to column 16)",
+                                                      " (in 'mother.stan', line 571, column 2 to column 33)",
+                                                      " (in 'mother.stan', line 572, column 2 to column 37)",
+                                                      " (in 'mother.stan', line 573, column 2 to column 28)",
+                                                      " (in 'mother.stan', line 574, column 2 to column 25)",
+                                                      " (in 'mother.stan', line 575, column 2 to column 29)",
+                                                      " (in 'mother.stan', line 576, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 577, column 2 to column 33)",
+                                                      " (in 'mother.stan', line 578, column 2 to column 37)",
+                                                      " (in 'mother.stan', line 579, column 2 to column 46)",
+                                                      " (in 'mother.stan', line 580, column 2 to column 24)",
+                                                      " (in 'mother.stan', line 581, column 2 to column 30)",
+                                                      " (in 'mother.stan', line 582, column 2 to column 34)",
+                                                      " (in 'mother.stan', line 583, column 2 to column 39)",
+                                                      " (in 'mother.stan', line 584, column 2 to column 37)",
+                                                      " (in 'mother.stan', line 585, column 2 to column 43)",
+                                                      " (in 'mother.stan', line 586, column 2 to column 20)",
+                                                      " (in 'mother.stan', line 588, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 589, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 590, column 2 to column 23)",
+                                                      " (in 'mother.stan', line 591, column 2 to column 23)",
+                                                      " (in 'mother.stan', line 593, column 2 to column 25)",
+                                                      " (in 'mother.stan', line 594, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 595, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 597, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 598, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 599, column 2 to column 33)",
+                                                      " (in 'mother.stan', line 605, column 10 to column 38)",
+                                                      " (in 'mother.stan', line 604, column 23 to line 605, column 39)",
+                                                      " (in 'mother.stan', line 604, column 8 to line 605, column 39)",
+                                                      " (in 'mother.stan', line 603, column 21 to line 605, column 40)",
+                                                      " (in 'mother.stan', line 603, column 6 to line 605, column 40)",
+                                                      " (in 'mother.stan', line 602, column 19 to line 605, column 41)",
+                                                      " (in 'mother.stan', line 602, column 4 to line 605, column 41)",
+                                                      " (in 'mother.stan', line 601, column 17 to line 605, column 42)",
+                                                      " (in 'mother.stan', line 601, column 2 to line 605, column 42)",
+                                                      " (in 'mother.stan', line 607, column 17 to column 45)",
+                                                      " (in 'mother.stan', line 607, column 2 to column 45)",
+                                                      " (in 'mother.stan', line 608, column 2 to column 29)",
+                                                      " (in 'mother.stan', line 609, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 610, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 612, column 2 to column 63)",
+                                                      " (in 'mother.stan', line 613, column 2 to column 79)",
                                                       " (in 'mother.stan', line 614, column 2 to column 81)",
-                                                      " (in 'mother.stan', line 615, column 2 to column 67)",
-                                                      " (in 'mother.stan', line 616, column 2 to column 83)",
-                                                      " (in 'mother.stan', line 660, column 2 to column 32)",
-                                                      " (in 'mother.stan', line 661, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 662, column 2 to column 35)",
-                                                      " (in 'mother.stan', line 663, column 2 to column 39)",
-                                                      " (in 'mother.stan', line 664, column 2 to column 28)",
-                                                      " (in 'mother.stan', line 665, column 2 to column 25)",
-                                                      " (in 'mother.stan', line 666, column 2 to column 29)",
-                                                      " (in 'mother.stan', line 667, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 668, column 2 to column 33)",
-                                                      " (in 'mother.stan', line 669, column 2 to column 37)",
-                                                      " (in 'mother.stan', line 670, column 2 to column 46)",
-                                                      " (in 'mother.stan', line 671, column 2 to column 24)",
-                                                      " (in 'mother.stan', line 672, column 2 to column 30)",
-                                                      " (in 'mother.stan', line 673, column 2 to column 34)",
-                                                      " (in 'mother.stan', line 674, column 2 to column 39)",
-                                                      " (in 'mother.stan', line 675, column 2 to column 37)",
-                                                      " (in 'mother.stan', line 676, column 2 to column 43)",
-                                                      " (in 'mother.stan', line 677, column 2 to column 29)",
-                                                      " (in 'mother.stan', line 678, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 679, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 680, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 615, column 2 to column 65)",
+                                                      " (in 'mother.stan', line 616, column 2 to column 81)",
+                                                      " (in 'mother.stan', line 617, column 2 to column 67)",
+                                                      " (in 'mother.stan', line 618, column 2 to column 83)",
+                                                      " (in 'mother.stan', line 662, column 2 to column 32)",
+                                                      " (in 'mother.stan', line 663, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 664, column 2 to column 35)",
+                                                      " (in 'mother.stan', line 665, column 2 to column 39)",
+                                                      " (in 'mother.stan', line 666, column 2 to column 28)",
+                                                      " (in 'mother.stan', line 667, column 2 to column 25)",
+                                                      " (in 'mother.stan', line 668, column 2 to column 29)",
+                                                      " (in 'mother.stan', line 669, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 670, column 2 to column 33)",
+                                                      " (in 'mother.stan', line 671, column 2 to column 37)",
+                                                      " (in 'mother.stan', line 672, column 2 to column 46)",
+                                                      " (in 'mother.stan', line 673, column 2 to column 24)",
+                                                      " (in 'mother.stan', line 674, column 2 to column 30)",
+                                                      " (in 'mother.stan', line 675, column 2 to column 34)",
+                                                      " (in 'mother.stan', line 676, column 2 to column 39)",
+                                                      " (in 'mother.stan', line 677, column 2 to column 37)",
+                                                      " (in 'mother.stan', line 678, column 2 to column 43)",
+                                                      " (in 'mother.stan', line 679, column 2 to column 29)",
+                                                      " (in 'mother.stan', line 680, column 2 to column 31)",
                                                       " (in 'mother.stan', line 681, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 682, column 2 to column 28)",
-                                                      " (in 'mother.stan', line 683, column 2 to column 28)",
+                                                      " (in 'mother.stan', line 682, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 683, column 2 to column 27)",
                                                       " (in 'mother.stan', line 684, column 2 to column 28)",
                                                       " (in 'mother.stan', line 685, column 2 to column 28)",
-                                                      " (in 'mother.stan', line 686, column 2 to column 24)",
-                                                      " (in 'mother.stan', line 688, column 2 to column 35)",
-                                                      " (in 'mother.stan', line 689, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 690, column 2 to column 23)",
-                                                      " (in 'mother.stan', line 691, column 2 to column 23)",
-                                                      " (in 'mother.stan', line 692, column 2 to column 25)",
-                                                      " (in 'mother.stan', line 693, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 694, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 696, column 2 to column 35)",
-                                                      " (in 'mother.stan', line 697, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 698, column 2 to column 31)",
-                                                      " (in 'mother.stan', line 700, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 701, column 2 to column 27)",
-                                                      " (in 'mother.stan', line 702, column 2 to column 33)",
-                                                      " (in 'mother.stan', line 708, column 10 to column 38)",
-                                                      " (in 'mother.stan', line 707, column 23 to line 708, column 39)",
-                                                      " (in 'mother.stan', line 707, column 8 to line 708, column 39)",
-                                                      " (in 'mother.stan', line 706, column 21 to line 708, column 40)",
-                                                      " (in 'mother.stan', line 706, column 6 to line 708, column 40)",
-                                                      " (in 'mother.stan', line 705, column 19 to line 708, column 41)",
-                                                      " (in 'mother.stan', line 705, column 4 to line 708, column 41)",
-                                                      " (in 'mother.stan', line 704, column 17 to line 708, column 42)",
-                                                      " (in 'mother.stan', line 704, column 2 to line 708, column 42)",
-                                                      " (in 'mother.stan', line 710, column 17 to column 45)",
-                                                      " (in 'mother.stan', line 710, column 2 to column 45)",
-                                                      " (in 'mother.stan', line 716, column 8 to column 49)",
-                                                      " (in 'mother.stan', line 715, column 6 to line 716, column 49)",
-                                                      " (in 'mother.stan', line 714, column 4 to line 716, column 49)",
-                                                      " (in 'mother.stan', line 713, column 2 to line 716, column 49)",
-                                                      " (in 'mother.stan', line 721, column 6 to column 60)",
-                                                      " (in 'mother.stan', line 720, column 4 to line 721, column 60)",
-                                                      " (in 'mother.stan', line 719, column 2 to line 721, column 60)",
-                                                      " (in 'mother.stan', line 723, column 2 to column 45)",
-                                                      " (in 'mother.stan', line 724, column 64 to column 97)",
-                                                      " (in 'mother.stan', line 724, column 2 to column 97)",
-                                                      " (in 'mother.stan', line 729, column 6 to column 51)",
-                                                      " (in 'mother.stan', line 728, column 4 to line 729, column 51)",
-                                                      " (in 'mother.stan', line 727, column 2 to line 729, column 51)",
-                                                      " (in 'mother.stan', line 730, column 2 to column 39)",
-                                                      " (in 'mother.stan', line 732, column 58 to column 91)",
-                                                      " (in 'mother.stan', line 732, column 2 to column 91)",
-                                                      " (in 'mother.stan', line 738, column 8 to column 68)",
-                                                      " (in 'mother.stan', line 737, column 6 to line 738, column 68)",
-                                                      " (in 'mother.stan', line 736, column 4 to line 738, column 68)",
-                                                      " (in 'mother.stan', line 735, column 2 to line 738, column 68)",
-                                                      " (in 'mother.stan', line 739, column 2 to column 48)",
-                                                      " (in 'mother.stan', line 740, column 67 to column 100)",
-                                                      " (in 'mother.stan', line 740, column 2 to column 100)",
-                                                      " (in 'mother.stan', line 742, column 2 to column 36)",
-                                                      " (in 'mother.stan', line 743, column 2 to column 38)",
-                                                      " (in 'mother.stan', line 619, column 2 to column 16)",
-                                                      " (in 'mother.stan', line 620, column 2 to column 20)",
-                                                      " (in 'mother.stan', line 621, column 2 to column 29)",
-                                                      " (in 'mother.stan', line 622, column 2 to column 24)",
-                                                      " (in 'mother.stan', line 623, column 2 to column 23)",
-                                                      " (in 'mother.stan', line 624, column 2 to column 35)",
-                                                      " (in 'mother.stan', line 626, column 2 to column 38)",
-                                                      " (in 'mother.stan', line 627, column 2 to column 38)",
-                                                      " (in 'mother.stan', line 629, column 2 to column 41)",
-                                                      " (in 'mother.stan', line 631, column 4 to column 42)",
-                                                      " (in 'mother.stan', line 632, column 4 to column 46)",
-                                                      " (in 'mother.stan', line 633, column 4 to column 46)",
-                                                      " (in 'mother.stan', line 636, column 8 to column 68)",
-                                                      " (in 'mother.stan', line 637, column 8 to column 76)",
-                                                      " (in 'mother.stan', line 638, column 8 to column 76)",
-                                                      " (in 'mother.stan', line 639, column 8 to column 65)",
-                                                      " (in 'mother.stan', line 635, column 21 to line 640, column 7)",
-                                                      " (in 'mother.stan', line 635, column 6 to line 640, column 7)",
-                                                      " (in 'mother.stan', line 634, column 19 to line 641, column 5)",
-                                                      " (in 'mother.stan', line 634, column 4 to line 641, column 5)",
-                                                      " (in 'mother.stan', line 630, column 17 to line 642, column 3)",
-                                                      " (in 'mother.stan', line 630, column 2 to line 642, column 3)",
-                                                      " (in 'mother.stan', line 645, column 6 to column 47)",
-                                                      " (in 'mother.stan', line 644, column 19 to line 646, column 5)",
-                                                      " (in 'mother.stan', line 644, column 4 to line 646, column 5)",
-                                                      " (in 'mother.stan', line 643, column 17 to line 647, column 3)",
-                                                      " (in 'mother.stan', line 643, column 2 to line 647, column 3)",
-                                                      " (in 'mother.stan', line 649, column 4 to column 47)",
-                                                      " (in 'mother.stan', line 648, column 17 to line 650, column 3)",
-                                                      " (in 'mother.stan', line 648, column 2 to line 650, column 3)",
-                                                      " (in 'mother.stan', line 651, column 2 to column 38)",
-                                                      " (in 'mother.stan', line 652, column 2 to column 38)",
+                                                      " (in 'mother.stan', line 686, column 2 to column 28)",
+                                                      " (in 'mother.stan', line 687, column 2 to column 28)",
+                                                      " (in 'mother.stan', line 688, column 2 to column 24)",
+                                                      " (in 'mother.stan', line 690, column 2 to column 35)",
+                                                      " (in 'mother.stan', line 691, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 692, column 2 to column 23)",
+                                                      " (in 'mother.stan', line 693, column 2 to column 23)",
+                                                      " (in 'mother.stan', line 694, column 2 to column 25)",
+                                                      " (in 'mother.stan', line 695, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 696, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 698, column 2 to column 35)",
+                                                      " (in 'mother.stan', line 699, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 700, column 2 to column 31)",
+                                                      " (in 'mother.stan', line 702, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 703, column 2 to column 27)",
+                                                      " (in 'mother.stan', line 704, column 2 to column 33)",
+                                                      " (in 'mother.stan', line 710, column 10 to column 38)",
+                                                      " (in 'mother.stan', line 709, column 23 to line 710, column 39)",
+                                                      " (in 'mother.stan', line 709, column 8 to line 710, column 39)",
+                                                      " (in 'mother.stan', line 708, column 21 to line 710, column 40)",
+                                                      " (in 'mother.stan', line 708, column 6 to line 710, column 40)",
+                                                      " (in 'mother.stan', line 707, column 19 to line 710, column 41)",
+                                                      " (in 'mother.stan', line 707, column 4 to line 710, column 41)",
+                                                      " (in 'mother.stan', line 706, column 17 to line 710, column 42)",
+                                                      " (in 'mother.stan', line 706, column 2 to line 710, column 42)",
+                                                      " (in 'mother.stan', line 712, column 17 to column 45)",
+                                                      " (in 'mother.stan', line 712, column 2 to column 45)",
+                                                      " (in 'mother.stan', line 718, column 8 to column 49)",
+                                                      " (in 'mother.stan', line 717, column 6 to line 718, column 49)",
+                                                      " (in 'mother.stan', line 716, column 4 to line 718, column 49)",
+                                                      " (in 'mother.stan', line 715, column 2 to line 718, column 49)",
+                                                      " (in 'mother.stan', line 723, column 6 to column 60)",
+                                                      " (in 'mother.stan', line 722, column 4 to line 723, column 60)",
+                                                      " (in 'mother.stan', line 721, column 2 to line 723, column 60)",
+                                                      " (in 'mother.stan', line 725, column 2 to column 45)",
+                                                      " (in 'mother.stan', line 726, column 64 to column 97)",
+                                                      " (in 'mother.stan', line 726, column 2 to column 97)",
+                                                      " (in 'mother.stan', line 731, column 6 to column 51)",
+                                                      " (in 'mother.stan', line 730, column 4 to line 731, column 51)",
+                                                      " (in 'mother.stan', line 729, column 2 to line 731, column 51)",
+                                                      " (in 'mother.stan', line 732, column 2 to column 39)",
+                                                      " (in 'mother.stan', line 734, column 58 to column 91)",
+                                                      " (in 'mother.stan', line 734, column 2 to column 91)",
+                                                      " (in 'mother.stan', line 740, column 8 to column 68)",
+                                                      " (in 'mother.stan', line 739, column 6 to line 740, column 68)",
+                                                      " (in 'mother.stan', line 738, column 4 to line 740, column 68)",
+                                                      " (in 'mother.stan', line 737, column 2 to line 740, column 68)",
+                                                      " (in 'mother.stan', line 741, column 2 to column 48)",
+                                                      " (in 'mother.stan', line 742, column 67 to column 100)",
+                                                      " (in 'mother.stan', line 742, column 2 to column 100)",
+                                                      " (in 'mother.stan', line 744, column 2 to column 36)",
+                                                      " (in 'mother.stan', line 745, column 2 to column 38)",
+                                                      " (in 'mother.stan', line 621, column 2 to column 16)",
+                                                      " (in 'mother.stan', line 622, column 2 to column 20)",
+                                                      " (in 'mother.stan', line 623, column 2 to column 29)",
+                                                      " (in 'mother.stan', line 624, column 2 to column 24)",
+                                                      " (in 'mother.stan', line 625, column 2 to column 23)",
+                                                      " (in 'mother.stan', line 626, column 2 to column 35)",
+                                                      " (in 'mother.stan', line 628, column 2 to column 38)",
+                                                      " (in 'mother.stan', line 629, column 2 to column 38)",
+                                                      " (in 'mother.stan', line 631, column 2 to column 41)",
+                                                      " (in 'mother.stan', line 633, column 4 to column 42)",
+                                                      " (in 'mother.stan', line 634, column 4 to column 46)",
+                                                      " (in 'mother.stan', line 635, column 4 to column 46)",
+                                                      " (in 'mother.stan', line 638, column 8 to column 68)",
+                                                      " (in 'mother.stan', line 639, column 8 to column 76)",
+                                                      " (in 'mother.stan', line 640, column 8 to column 76)",
+                                                      " (in 'mother.stan', line 641, column 8 to column 65)",
+                                                      " (in 'mother.stan', line 637, column 21 to line 642, column 7)",
+                                                      " (in 'mother.stan', line 637, column 6 to line 642, column 7)",
+                                                      " (in 'mother.stan', line 636, column 19 to line 643, column 5)",
+                                                      " (in 'mother.stan', line 636, column 4 to line 643, column 5)",
+                                                      " (in 'mother.stan', line 632, column 17 to line 644, column 3)",
+                                                      " (in 'mother.stan', line 632, column 2 to line 644, column 3)",
+                                                      " (in 'mother.stan', line 647, column 6 to column 47)",
+                                                      " (in 'mother.stan', line 646, column 19 to line 648, column 5)",
+                                                      " (in 'mother.stan', line 646, column 4 to line 648, column 5)",
+                                                      " (in 'mother.stan', line 645, column 17 to line 649, column 3)",
+                                                      " (in 'mother.stan', line 645, column 2 to line 649, column 3)",
+                                                      " (in 'mother.stan', line 651, column 4 to column 47)",
+                                                      " (in 'mother.stan', line 650, column 17 to line 652, column 3)",
+                                                      " (in 'mother.stan', line 650, column 2 to line 652, column 3)",
                                                       " (in 'mother.stan', line 653, column 2 to column 38)",
-                                                      " (in 'mother.stan', line 654, column 2 to column 39)",
-                                                      " (in 'mother.stan', line 655, column 2 to column 39)",
-                                                      " (in 'mother.stan', line 657, column 2 to column 53)",
+                                                      " (in 'mother.stan', line 654, column 2 to column 38)",
+                                                      " (in 'mother.stan', line 655, column 2 to column 38)",
+                                                      " (in 'mother.stan', line 656, column 2 to column 39)",
+                                                      " (in 'mother.stan', line 657, column 2 to column 39)",
+                                                      " (in 'mother.stan', line 659, column 2 to column 53)",
                                                       " (in 'mother.stan', line 316, column 2 to column 17)",
                                                       " (in 'mother.stan', line 317, column 2 to column 17)",
                                                       " (in 'mother.stan', line 318, column 2 to column 28)",
@@ -1921,87 +1929,87 @@ static const std::vector<string> locations_array__ = {" (found before start of p
                                                       " (in 'mother.stan', line 541, column 2 to column 67)",
                                                       " (in 'mother.stan', line 542, column 2 to column 76)",
                                                       " (in 'mother.stan', line 543, column 2 to column 76)",
-                                                      " (in 'mother.stan', line 550, column 29 to column 30)",
-                                                      " (in 'mother.stan', line 551, column 29 to column 30)",
-                                                      " (in 'mother.stan', line 551, column 31 to column 32)",
-                                                      " (in 'mother.stan', line 551, column 33 to column 34)",
-                                                      " (in 'mother.stan', line 552, column 18 to column 19)",
-                                                      " (in 'mother.stan', line 553, column 21 to column 22)",
-                                                      " (in 'mother.stan', line 553, column 9 to column 10)",
-                                                      " (in 'mother.stan', line 554, column 21 to column 22)",
-                                                      " (in 'mother.stan', line 554, column 23 to column 24)",
-                                                      " (in 'mother.stan', line 554, column 25 to column 26)",
-                                                      " (in 'mother.stan', line 554, column 9 to column 10)",
-                                                      " (in 'mother.stan', line 555, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 556, column 29 to column 30)",
-                                                      " (in 'mother.stan', line 556, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 557, column 29 to column 30)",
-                                                      " (in 'mother.stan', line 557, column 31 to column 32)",
-                                                      " (in 'mother.stan', line 557, column 33 to column 34)",
+                                                      " (in 'mother.stan', line 552, column 29 to column 30)",
+                                                      " (in 'mother.stan', line 553, column 29 to column 30)",
+                                                      " (in 'mother.stan', line 553, column 31 to column 32)",
+                                                      " (in 'mother.stan', line 553, column 33 to column 34)",
+                                                      " (in 'mother.stan', line 554, column 18 to column 19)",
+                                                      " (in 'mother.stan', line 555, column 21 to column 22)",
+                                                      " (in 'mother.stan', line 555, column 9 to column 10)",
+                                                      " (in 'mother.stan', line 556, column 21 to column 22)",
+                                                      " (in 'mother.stan', line 556, column 23 to column 24)",
+                                                      " (in 'mother.stan', line 556, column 25 to column 26)",
+                                                      " (in 'mother.stan', line 556, column 9 to column 10)",
                                                       " (in 'mother.stan', line 557, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 559, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 560, column 26 to column 27)",
-                                                      " (in 'mother.stan', line 560, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 561, column 26 to column 27)",
-                                                      " (in 'mother.stan', line 561, column 28 to column 29)",
-                                                      " (in 'mother.stan', line 561, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 558, column 29 to column 30)",
+                                                      " (in 'mother.stan', line 558, column 13 to column 14)",
+                                                      " (in 'mother.stan', line 559, column 29 to column 30)",
+                                                      " (in 'mother.stan', line 559, column 31 to column 32)",
+                                                      " (in 'mother.stan', line 559, column 33 to column 34)",
+                                                      " (in 'mother.stan', line 559, column 13 to column 14)",
                                                       " (in 'mother.stan', line 561, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 562, column 22 to column 23)",
-                                                      " (in 'mother.stan', line 563, column 22 to column 23)",
-                                                      " (in 'mother.stan', line 564, column 39 to column 40)",
+                                                      " (in 'mother.stan', line 562, column 26 to column 27)",
+                                                      " (in 'mother.stan', line 562, column 10 to column 11)",
+                                                      " (in 'mother.stan', line 563, column 26 to column 27)",
+                                                      " (in 'mother.stan', line 563, column 28 to column 29)",
+                                                      " (in 'mother.stan', line 563, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 563, column 10 to column 11)",
                                                       " (in 'mother.stan', line 564, column 22 to column 23)",
-                                                      " (in 'mother.stan', line 569, column 30 to column 31)",
-                                                      " (in 'mother.stan', line 570, column 30 to column 31)",
-                                                      " (in 'mother.stan', line 570, column 32 to column 33)",
-                                                      " (in 'mother.stan', line 570, column 34 to column 35)",
-                                                      " (in 'mother.stan', line 571, column 18 to column 19)",
-                                                      " (in 'mother.stan', line 572, column 22 to column 23)",
-                                                      " (in 'mother.stan', line 572, column 9 to column 10)",
-                                                      " (in 'mother.stan', line 573, column 22 to column 23)",
-                                                      " (in 'mother.stan', line 573, column 24 to column 25)",
-                                                      " (in 'mother.stan', line 573, column 26 to column 27)",
-                                                      " (in 'mother.stan', line 573, column 9 to column 10)",
-                                                      " (in 'mother.stan', line 574, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 575, column 30 to column 31)",
-                                                      " (in 'mother.stan', line 575, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 576, column 30 to column 31)",
-                                                      " (in 'mother.stan', line 576, column 32 to column 33)",
-                                                      " (in 'mother.stan', line 576, column 34 to column 35)",
+                                                      " (in 'mother.stan', line 565, column 22 to column 23)",
+                                                      " (in 'mother.stan', line 566, column 39 to column 40)",
+                                                      " (in 'mother.stan', line 566, column 22 to column 23)",
+                                                      " (in 'mother.stan', line 571, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 572, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 572, column 32 to column 33)",
+                                                      " (in 'mother.stan', line 572, column 34 to column 35)",
+                                                      " (in 'mother.stan', line 573, column 18 to column 19)",
+                                                      " (in 'mother.stan', line 574, column 22 to column 23)",
+                                                      " (in 'mother.stan', line 574, column 9 to column 10)",
+                                                      " (in 'mother.stan', line 575, column 22 to column 23)",
+                                                      " (in 'mother.stan', line 575, column 24 to column 25)",
+                                                      " (in 'mother.stan', line 575, column 26 to column 27)",
+                                                      " (in 'mother.stan', line 575, column 9 to column 10)",
                                                       " (in 'mother.stan', line 576, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 578, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 579, column 27 to column 28)",
-                                                      " (in 'mother.stan', line 579, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 580, column 27 to column 28)",
-                                                      " (in 'mother.stan', line 580, column 29 to column 30)",
-                                                      " (in 'mother.stan', line 580, column 31 to column 32)",
+                                                      " (in 'mother.stan', line 577, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 577, column 13 to column 14)",
+                                                      " (in 'mother.stan', line 578, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 578, column 32 to column 33)",
+                                                      " (in 'mother.stan', line 578, column 34 to column 35)",
+                                                      " (in 'mother.stan', line 578, column 13 to column 14)",
                                                       " (in 'mother.stan', line 580, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 583, column 40 to column 41)",
-                                                      " (in 'mother.stan', line 662, column 32 to column 33)",
-                                                      " (in 'mother.stan', line 663, column 32 to column 33)",
-                                                      " (in 'mother.stan', line 663, column 34 to column 35)",
-                                                      " (in 'mother.stan', line 663, column 36 to column 37)",
-                                                      " (in 'mother.stan', line 664, column 18 to column 19)",
-                                                      " (in 'mother.stan', line 665, column 22 to column 23)",
-                                                      " (in 'mother.stan', line 665, column 9 to column 10)",
-                                                      " (in 'mother.stan', line 666, column 22 to column 23)",
-                                                      " (in 'mother.stan', line 666, column 24 to column 25)",
-                                                      " (in 'mother.stan', line 666, column 26 to column 27)",
-                                                      " (in 'mother.stan', line 666, column 9 to column 10)",
-                                                      " (in 'mother.stan', line 667, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 668, column 30 to column 31)",
-                                                      " (in 'mother.stan', line 668, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 669, column 30 to column 31)",
-                                                      " (in 'mother.stan', line 669, column 32 to column 33)",
-                                                      " (in 'mother.stan', line 669, column 34 to column 35)",
+                                                      " (in 'mother.stan', line 581, column 27 to column 28)",
+                                                      " (in 'mother.stan', line 581, column 10 to column 11)",
+                                                      " (in 'mother.stan', line 582, column 27 to column 28)",
+                                                      " (in 'mother.stan', line 582, column 29 to column 30)",
+                                                      " (in 'mother.stan', line 582, column 31 to column 32)",
+                                                      " (in 'mother.stan', line 582, column 10 to column 11)",
+                                                      " (in 'mother.stan', line 585, column 40 to column 41)",
+                                                      " (in 'mother.stan', line 664, column 32 to column 33)",
+                                                      " (in 'mother.stan', line 665, column 32 to column 33)",
+                                                      " (in 'mother.stan', line 665, column 34 to column 35)",
+                                                      " (in 'mother.stan', line 665, column 36 to column 37)",
+                                                      " (in 'mother.stan', line 666, column 18 to column 19)",
+                                                      " (in 'mother.stan', line 667, column 22 to column 23)",
+                                                      " (in 'mother.stan', line 667, column 9 to column 10)",
+                                                      " (in 'mother.stan', line 668, column 22 to column 23)",
+                                                      " (in 'mother.stan', line 668, column 24 to column 25)",
+                                                      " (in 'mother.stan', line 668, column 26 to column 27)",
+                                                      " (in 'mother.stan', line 668, column 9 to column 10)",
                                                       " (in 'mother.stan', line 669, column 13 to column 14)",
-                                                      " (in 'mother.stan', line 671, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 672, column 27 to column 28)",
-                                                      " (in 'mother.stan', line 672, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 673, column 27 to column 28)",
-                                                      " (in 'mother.stan', line 673, column 29 to column 30)",
-                                                      " (in 'mother.stan', line 673, column 31 to column 32)",
+                                                      " (in 'mother.stan', line 670, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 670, column 13 to column 14)",
+                                                      " (in 'mother.stan', line 671, column 30 to column 31)",
+                                                      " (in 'mother.stan', line 671, column 32 to column 33)",
+                                                      " (in 'mother.stan', line 671, column 34 to column 35)",
+                                                      " (in 'mother.stan', line 671, column 13 to column 14)",
                                                       " (in 'mother.stan', line 673, column 10 to column 11)",
-                                                      " (in 'mother.stan', line 676, column 40 to column 41)",
+                                                      " (in 'mother.stan', line 674, column 27 to column 28)",
+                                                      " (in 'mother.stan', line 674, column 10 to column 11)",
+                                                      " (in 'mother.stan', line 675, column 27 to column 28)",
+                                                      " (in 'mother.stan', line 675, column 29 to column 30)",
+                                                      " (in 'mother.stan', line 675, column 31 to column 32)",
+                                                      " (in 'mother.stan', line 675, column 10 to column 11)",
+                                                      " (in 'mother.stan', line 678, column 40 to column 41)",
                                                       " (in 'mother.stan', line 10, column 16 to column 17)",
                                                       " (in 'mother.stan', line 13, column 16 to column 25)",
                                                       " (in 'mother.stan', line 13, column 4 to column 25)",
@@ -2213,12 +2221,12 @@ foo(const int& n, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 576;
+    current_statement__ = 578;
     if (logical_eq(n, 0)) {
-      current_statement__ = 575;
+      current_statement__ = 577;
       return 1;
     } 
-    current_statement__ = 577;
+    current_statement__ = 579;
     return (n * foo((n - 1), pstream__));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2259,14 +2267,14 @@ sho(const T0__& t, const std::vector<T1__>& y,
     std::vector<local_scalar_t__> dydt;
     dydt = std::vector<local_scalar_t__>(2, DUMMY_VAR__);
     
-    current_statement__ = 581;
+    current_statement__ = 583;
     assign(dydt, cons_list(index_uni(1), nil_index_list()), y[(2 - 1)],
       "assigning variable dydt");
-    current_statement__ = 582;
+    current_statement__ = 584;
     assign(dydt, cons_list(index_uni(2), nil_index_list()),
       (-y[(1 - 1)] - (theta[(1 - 1)] * y[(2 - 1)])),
       "assigning variable dydt");
-    current_statement__ = 583;
+    current_statement__ = 585;
     return dydt;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2297,7 +2305,7 @@ foo_bar0(std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 585;
+    current_statement__ = 587;
     return 0.0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2325,7 +2333,7 @@ foo_bar1(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 587;
+    current_statement__ = 589;
     return 1.0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2355,7 +2363,7 @@ foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 589;
+    current_statement__ = 591;
     return 2.0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2383,7 +2391,7 @@ foo_lpmf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 591;
+    current_statement__ = 593;
     return 1.0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2412,7 +2420,7 @@ foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 593;
+    current_statement__ = 595;
     return 1.0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2441,7 +2449,7 @@ foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 595;
+    current_statement__ = 597;
     return 1.0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2472,7 +2480,7 @@ foo_rng(const T0__& mu, const T1__& sigma, RNG& base_rng__,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 597;
+    current_statement__ = 599;
     return normal_rng(mu, sigma, base_rng__);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2503,9 +2511,9 @@ unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 599;
+    current_statement__ = 601;
     lp_accum__.add(normal_log<false>(u, 0, 1));
-    current_statement__ = 600;
+    current_statement__ = 602;
     lp_accum__.add(uniform_lpdf<propto__>(u, -100, 100));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2535,34 +2543,34 @@ foo_1(const int& a, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 603;
+    current_statement__ = 605;
     while (1) {
       break;
     }
-    current_statement__ = 605;
+    current_statement__ = 607;
     while (0) {
       continue;
     }
-    current_statement__ = 607;
-    for (int i = 1; i <= 10; ++i) { break;}
     current_statement__ = 609;
+    for (int i = 1; i <= 10; ++i) { break;}
+    current_statement__ = 611;
     for (int i = 1; i <= 10; ++i) { continue;}
-    current_statement__ = 614;
+    current_statement__ = 616;
     while (1) {
       int b;
       b = std::numeric_limits<int>::min();
       
-      current_statement__ = 611;
+      current_statement__ = 613;
       b = 5;
       break;
     }
-    current_statement__ = 621;
+    current_statement__ = 623;
     while (1) {
-      current_statement__ = 619;
+      current_statement__ = 621;
       if (0) {
         break;
       } else {
-        current_statement__ = 617;
+        current_statement__ = 619;
         if (1) {
           break;
         } else {
@@ -2570,19 +2578,19 @@ foo_1(const int& a, std::ostream* pstream__) {
         }
       }
     }
-    current_statement__ = 624;
+    current_statement__ = 626;
     while (1) {
-      current_statement__ = 623;
+      current_statement__ = 625;
       while (0) {
         break;
       }
     }
-    current_statement__ = 628;
+    current_statement__ = 630;
     while (1) {
-      current_statement__ = 626;
+      current_statement__ = 628;
       for (int i = 1; i <= 10; ++i) { break;}
     }
-    current_statement__ = 643;
+    current_statement__ = 645;
     while (1) {
       std::vector<std::vector<int>> vs;
       vs = std::vector<std::vector<int>>(2, std::vector<int>(3, std::numeric_limits<int>::min()));
@@ -2590,50 +2598,50 @@ foo_1(const int& a, std::ostream* pstream__) {
       int z;
       z = std::numeric_limits<int>::min();
       
-      current_statement__ = 631;
+      current_statement__ = 633;
       for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
         {
           std::vector<int> v;
-          current_statement__ = 631;
+          current_statement__ = 633;
           assign(v, nil_index_list(), vs[(sym1__ - 1)],
             "assigning variable v");
-          current_statement__ = 632;
+          current_statement__ = 634;
           z = 0;
           break;
         }}
-      current_statement__ = 634;
+      current_statement__ = 636;
       for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
         {
           std::vector<int> v;
-          current_statement__ = 634;
+          current_statement__ = 636;
           assign(v, nil_index_list(), vs[(sym1__ - 1)],
             "assigning variable v");
-          current_statement__ = 635;
+          current_statement__ = 637;
           z = 0;
           continue;
         }}
-      current_statement__ = 637;
+      current_statement__ = 639;
       for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
         {
           std::vector<int> v;
-          current_statement__ = 637;
+          current_statement__ = 639;
           assign(v, nil_index_list(), vs[(sym1__ - 1)],
             "assigning variable v");
-          current_statement__ = 638;
+          current_statement__ = 640;
           for (int sym1__ = 1; sym1__ <= stan::math::size(v); ++sym1__) {
             {
               int vv;
-              current_statement__ = 638;
+              current_statement__ = 640;
               vv = v[(sym1__ - 1)];
-              current_statement__ = 639;
+              current_statement__ = 641;
               z = 0;
               break;
             }}
-          current_statement__ = 641;
+          current_statement__ = 643;
           z = 1;
         }}
     }
-    current_statement__ = 653;
+    current_statement__ = 655;
     while (1) {
       local_scalar_t__ z;
       z = DUMMY_VAR__;
@@ -2642,9 +2650,9 @@ foo_1(const int& a, std::ostream* pstream__) {
       vs = Eigen::Matrix<local_scalar_t__, -1, -1>(2, 3);
       stan::math::fill(vs, DUMMY_VAR__);
       
-      current_statement__ = 646;
+      current_statement__ = 648;
       for (int sym1__ = 1; sym1__ <= rows(vs); ++sym1__) {
-        current_statement__ = 646;
+        current_statement__ = 648;
         for (int sym2__ = 1;
              sym2__ <= stan::math::size(
                          rvalue(vs,
@@ -2652,17 +2660,17 @@ foo_1(const int& a, std::ostream* pstream__) {
                            "vs")); ++sym2__) {
           {
             local_scalar_t__ v;
-            current_statement__ = 646;
+            current_statement__ = 648;
             v = rvalue(vs,
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__), nil_index_list())), "vs");
-            current_statement__ = 647;
+            current_statement__ = 649;
             z = 0;
             break;
           }}}
-      current_statement__ = 649;
+      current_statement__ = 651;
       for (int sym1__ = 1; sym1__ <= rows(vs); ++sym1__) {
-        current_statement__ = 649;
+        current_statement__ = 651;
         for (int sym2__ = 1;
              sym2__ <= stan::math::size(
                          rvalue(vs,
@@ -2670,16 +2678,16 @@ foo_1(const int& a, std::ostream* pstream__) {
                            "vs")); ++sym2__) {
           {
             local_scalar_t__ v;
-            current_statement__ = 649;
+            current_statement__ = 651;
             v = rvalue(vs,
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__), nil_index_list())), "vs");
-            current_statement__ = 650;
+            current_statement__ = 652;
             z = 3.1;
             continue;
           }}}
     }
-    current_statement__ = 663;
+    current_statement__ = 665;
     while (1) {
       local_scalar_t__ z;
       z = DUMMY_VAR__;
@@ -2688,28 +2696,28 @@ foo_1(const int& a, std::ostream* pstream__) {
       vs = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
       stan::math::fill(vs, DUMMY_VAR__);
       
-      current_statement__ = 656;
+      current_statement__ = 658;
       for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
         {
           local_scalar_t__ v;
-          current_statement__ = 656;
+          current_statement__ = 658;
           v = vs[(sym1__ - 1)];
-          current_statement__ = 657;
+          current_statement__ = 659;
           z = 0;
           break;
         }}
-      current_statement__ = 659;
+      current_statement__ = 661;
       for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
         {
           local_scalar_t__ v;
-          current_statement__ = 659;
+          current_statement__ = 661;
           v = vs[(sym1__ - 1)];
-          current_statement__ = 660;
+          current_statement__ = 662;
           z = 3.2;
           continue;
         }}
     }
-    current_statement__ = 673;
+    current_statement__ = 675;
     while (1) {
       local_scalar_t__ z;
       z = DUMMY_VAR__;
@@ -2718,44 +2726,44 @@ foo_1(const int& a, std::ostream* pstream__) {
       vs = Eigen::Matrix<local_scalar_t__, 1, -1>(2);
       stan::math::fill(vs, DUMMY_VAR__);
       
-      current_statement__ = 666;
+      current_statement__ = 668;
       for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
         {
           local_scalar_t__ v;
-          current_statement__ = 666;
+          current_statement__ = 668;
           v = vs[(sym1__ - 1)];
-          current_statement__ = 667;
+          current_statement__ = 669;
           z = 0;
           break;
         }}
-      current_statement__ = 669;
+      current_statement__ = 671;
       for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
         {
           local_scalar_t__ v;
-          current_statement__ = 669;
+          current_statement__ = 671;
           v = vs[(sym1__ - 1)];
-          current_statement__ = 670;
+          current_statement__ = 672;
           z = 3.3;
           continue;
         }}
     }
-    current_statement__ = 681;
+    current_statement__ = 683;
     while (1) {
       int b;
       b = std::numeric_limits<int>::min();
       
-      current_statement__ = 675;
+      current_statement__ = 677;
       b = 5;
       {
         int c;
         c = std::numeric_limits<int>::min();
         
-        current_statement__ = 677;
+        current_statement__ = 679;
         c = 6;
         break;
       }
     }
-    current_statement__ = 682;
+    current_statement__ = 684;
     return 0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2788,16 +2796,16 @@ foo_2(const int& a, std::ostream* pstream__) {
     int y;
     y = std::numeric_limits<int>::min();
     
-    current_statement__ = 686;
+    current_statement__ = 688;
     for (int sym1__ = 1; sym1__ <= stan::math::size(vs); ++sym1__) {
       {
         int v;
-        current_statement__ = 686;
+        current_statement__ = 688;
         v = vs[(sym1__ - 1)];
-        current_statement__ = 687;
+        current_statement__ = 689;
         y = v;
       }}
-    current_statement__ = 688;
+    current_statement__ = 690;
     return 0;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2825,7 +2833,7 @@ foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 690;
+    current_statement__ = 692;
     return rep_array(t, n);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2854,7 +2862,7 @@ foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 692;
+    current_statement__ = 694;
     return (x + get_lp(lp__, lp_accum__));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2885,7 +2893,7 @@ foo_4(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 694;
+    current_statement__ = 696;
     std::stringstream errmsg_stream__;
     errmsg_stream__ << "user-specified rejection";
     errmsg_stream__ << x;
@@ -2925,13 +2933,13 @@ relative_diff(const T0__& x, const T1__& y, const T2__& max_,
     local_scalar_t__ avg_scale;
     avg_scale = DUMMY_VAR__;
     
-    current_statement__ = 698;
+    current_statement__ = 700;
     abs_diff = stan::math::fabs((x - y));
-    current_statement__ = 699;
-    avg_scale = ((stan::math::fabs(x) + stan::math::fabs(y)) / 2);
     current_statement__ = 701;
+    avg_scale = ((stan::math::fabs(x) + stan::math::fabs(y)) / 2);
+    current_statement__ = 703;
     if (logical_gt((abs_diff / avg_scale), max_)) {
-      current_statement__ = 700;
+      current_statement__ = 702;
       std::stringstream errmsg_stream__;
       errmsg_stream__ << "user-specified rejection, difference above ";
       errmsg_stream__ << max_;
@@ -2941,9 +2949,9 @@ relative_diff(const T0__& x, const T1__& y, const T2__& max_,
       errmsg_stream__ << y;
       throw std::domain_error(errmsg_stream__.str());
     } 
-    current_statement__ = 703;
+    current_statement__ = 705;
     if (logical_lt((abs_diff / avg_scale), min_)) {
-      current_statement__ = 702;
+      current_statement__ = 704;
       std::stringstream errmsg_stream__;
       errmsg_stream__ << "user-specified rejection, difference below ";
       errmsg_stream__ << min_;
@@ -2953,7 +2961,7 @@ relative_diff(const T0__& x, const T1__& y, const T2__& max_,
       errmsg_stream__ << y;
       throw std::domain_error(errmsg_stream__.str());
     } 
-    current_statement__ = 704;
+    current_statement__ = 706;
     return (abs_diff / avg_scale);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2988,7 +2996,7 @@ foo_5(const Eigen::Matrix<T0__, -1, 1>& shared_params,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 706;
+    current_statement__ = 708;
     return transpose(stan::math::to_row_vector(
              stan::math::array_builder<int>().add(1).add(2).add(3).array()));
   } catch (const std::exception& e) {
@@ -3029,7 +3037,7 @@ foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 708;
+    current_statement__ = 710;
     return x1;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3069,7 +3077,7 @@ foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 710;
+    current_statement__ = 712;
     return x1;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3105,27 +3113,27 @@ covsqrt2corsqrt(const Eigen::Matrix<T0__, -1, -1>& mat, const int& invert,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 712;
+    current_statement__ = 714;
     validate_non_negative_index("o", "rows(mat)", rows(mat));
-    current_statement__ = 713;
+    current_statement__ = 715;
     validate_non_negative_index("o", "cols(mat)", cols(mat));
     Eigen::Matrix<local_scalar_t__, -1, -1> o;
     o = Eigen::Matrix<local_scalar_t__, -1, -1>(rows(mat), cols(mat));
     stan::math::fill(o, DUMMY_VAR__);
     
-    current_statement__ = 715;
+    current_statement__ = 717;
     assign(o, nil_index_list(), mat, "assigning variable o");
-    current_statement__ = 716;
+    current_statement__ = 718;
     assign(o, cons_list(index_uni(1), nil_index_list()),
       stan::model::deep_copy(
         rvalue(o, cons_list(index_uni(2), nil_index_list()), "o")),
       "assigning variable o");
-    current_statement__ = 717;
+    current_statement__ = 719;
     assign(o, cons_list(index_min_max(3, 4), nil_index_list()),
       stan::model::deep_copy(
         rvalue(o, cons_list(index_min_max(1, 2), nil_index_list()), "o")),
       "assigning variable o");
-    current_statement__ = 718;
+    current_statement__ = 720;
     return o;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3172,7 +3180,7 @@ f0(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 720;
+    current_statement__ = 722;
     if (pstream__) {
       stan_print(pstream__, "hi");
       stan_print(pstream__, "\n");
@@ -3232,7 +3240,7 @@ f1(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 722;
+    current_statement__ = 724;
     return a1;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3289,7 +3297,7 @@ f2(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 724;
+    current_statement__ = 726;
     return a2;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3346,7 +3354,7 @@ f3(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 726;
+    current_statement__ = 728;
     return a3;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3405,7 +3413,7 @@ f4(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 728;
+    current_statement__ = 730;
     return a4;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3466,7 +3474,7 @@ f5(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 730;
+    current_statement__ = 732;
     return a5;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3527,7 +3535,7 @@ f6(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 732;
+    current_statement__ = 734;
     return a6;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3588,7 +3596,7 @@ f7(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 734;
+    current_statement__ = 736;
     return a7;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3649,7 +3657,7 @@ f8(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 736;
+    current_statement__ = 738;
     return a8;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3710,7 +3718,7 @@ f9(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 738;
+    current_statement__ = 740;
     return a9;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3771,7 +3779,7 @@ f10(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 740;
+    current_statement__ = 742;
     return a10;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3832,7 +3840,7 @@ f11(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 742;
+    current_statement__ = 744;
     return a11;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3893,7 +3901,7 @@ f12(const int& a1, const std::vector<int>& a2,
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 744;
+    current_statement__ = 746;
     return a12;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3947,7 +3955,7 @@ foo_6(std::ostream* pstream__) {
     ar_mat = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>>(60, std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>(70, Eigen::Matrix<local_scalar_t__, -1, -1>(40, 50)));
     stan::math::fill(ar_mat, DUMMY_VAR__);
     
-    current_statement__ = 750;
+    current_statement__ = 752;
     assign(ar_mat,
       cons_list(index_uni(1),
         cons_list(index_uni(1),
@@ -3978,7 +3986,7 @@ matfoo(std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 752;
+    current_statement__ = 754;
     return stan::math::to_matrix(
         stan::math::array_builder<Eigen::Matrix<double, 1, -1>>()
         .add(stan::math::to_row_vector(stan::math::array_builder<int>()
@@ -4014,7 +4022,7 @@ vecfoo(std::ostream* pstream__) {
   (void) DUMMY_VAR__;  // suppress unused var warning
   
   try {
-    current_statement__ = 754;
+    current_statement__ = 756;
     return transpose(stan::math::to_row_vector(
              stan::math::array_builder<int>().add(1).add(2).add(3).add(4)
              .add(5).add(6).add(7).add(8).add(9).add(10).array()));
@@ -4048,10 +4056,10 @@ vecmufoo(const T0__& mu, std::ostream* pstream__) {
     l = Eigen::Matrix<local_scalar_t__, -1, 1>(10);
     stan::math::fill(l, DUMMY_VAR__);
     
-    current_statement__ = 756;
+    current_statement__ = 758;
     assign(l, nil_index_list(), multiply(mu, vecfoo(pstream__)),
       "assigning variable l");
-    current_statement__ = 757;
+    current_statement__ = 759;
     return l;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4084,13 +4092,13 @@ vecmubar(const T0__& mu, std::ostream* pstream__) {
     l = Eigen::Matrix<local_scalar_t__, -1, 1>(10);
     stan::math::fill(l, DUMMY_VAR__);
     
-    current_statement__ = 759;
+    current_statement__ = 761;
     assign(l, nil_index_list(),
       multiply(mu,
         transpose(stan::math::to_row_vector(stan::math::array_builder<int>()
           .add(1).add(2).add(3).add(4).add(5).add(6).add(7).add(8).add(9)
           .add(10).array()))), "assigning variable l");
-    current_statement__ = 760;
+    current_statement__ = 762;
     return rvalue(l,
              cons_list(index_multi(stan::math::array_builder<int>().add(1)
                .add(2).add(3).add(4).add(5).array()), nil_index_list()), "l");
@@ -4129,13 +4137,13 @@ algebra_system(const Eigen::Matrix<T0__, -1, 1>& x,
     f_x = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
     stan::math::fill(f_x, DUMMY_VAR__);
     
-    current_statement__ = 763;
+    current_statement__ = 765;
     assign(f_x, cons_list(index_uni(1), nil_index_list()),
       (x[(1 - 1)] - y[(1 - 1)]), "assigning variable f_x");
-    current_statement__ = 764;
+    current_statement__ = 766;
     assign(f_x, cons_list(index_uni(2), nil_index_list()),
       (x[(2 - 1)] - y[(2 - 1)]), "assigning variable f_x");
-    current_statement__ = 765;
+    current_statement__ = 767;
     return f_x;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4175,10 +4183,10 @@ binomialf(const Eigen::Matrix<T0__, -1, 1>& phi,
     lpmf = Eigen::Matrix<local_scalar_t__, -1, 1>(1);
     stan::math::fill(lpmf, DUMMY_VAR__);
     
-    current_statement__ = 768;
+    current_statement__ = 770;
     assign(lpmf, cons_list(index_uni(1), nil_index_list()), 0.0,
       "assigning variable lpmf");
-    current_statement__ = 769;
+    current_statement__ = 771;
     return lpmf;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4312,163 +4320,163 @@ class mother_model final : public model_base_crtp<mother_model> {
       pos__ = std::numeric_limits<int>::min();
       
       pos__ = 1;
-      current_statement__ = 181;
+      current_statement__ = 183;
       context__.validate_dims("data initialization","N","int",
           context__.to_vec());
       N = std::numeric_limits<int>::min();
       
-      current_statement__ = 181;
+      current_statement__ = 183;
       N = context__.vals_i("N")[(1 - 1)];
-      current_statement__ = 181;
-      current_statement__ = 181;
+      current_statement__ = 183;
+      current_statement__ = 183;
       check_greater_or_equal(function__, "N", N, 0);
-      current_statement__ = 182;
+      current_statement__ = 184;
       context__.validate_dims("data initialization","M","int",
           context__.to_vec());
       M = std::numeric_limits<int>::min();
       
-      current_statement__ = 182;
+      current_statement__ = 184;
       M = context__.vals_i("M")[(1 - 1)];
-      current_statement__ = 182;
-      current_statement__ = 182;
+      current_statement__ = 184;
+      current_statement__ = 184;
       check_greater_or_equal(function__, "M", M, 0);
-      current_statement__ = 183;
+      current_statement__ = 185;
       context__.validate_dims("data initialization","K","int",
           context__.to_vec());
       K = std::numeric_limits<int>::min();
       
-      current_statement__ = 183;
-      K = context__.vals_i("K")[(1 - 1)];
-      current_statement__ = 183;
-      current_statement__ = 183;
-      check_greater_or_equal(function__, "K", K, 0);
-      current_statement__ = 183;
-      current_statement__ = 183;
-      check_less_or_equal(function__, "K", K, (N * M));
-      current_statement__ = 184;
-      validate_non_negative_index("d_int_1d_ar", "N", N);
       current_statement__ = 185;
+      K = context__.vals_i("K")[(1 - 1)];
+      current_statement__ = 185;
+      current_statement__ = 185;
+      check_greater_or_equal(function__, "K", K, 0);
+      current_statement__ = 185;
+      current_statement__ = 185;
+      check_less_or_equal(function__, "K", K, (N * M));
+      current_statement__ = 186;
+      validate_non_negative_index("d_int_1d_ar", "N", N);
+      current_statement__ = 187;
       context__.validate_dims("data initialization","d_int_1d_ar","int",
           context__.to_vec(N));
       d_int_1d_ar = std::vector<int>(N, std::numeric_limits<int>::min());
       
-      current_statement__ = 185;
+      current_statement__ = 187;
       assign(d_int_1d_ar, nil_index_list(), context__.vals_i("d_int_1d_ar"),
         "assigning variable d_int_1d_ar");
-      current_statement__ = 185;
+      current_statement__ = 187;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 185;
-        current_statement__ = 185;
+        current_statement__ = 187;
+        current_statement__ = 187;
         check_less_or_equal(function__, "d_int_1d_ar[sym1__]",
                             d_int_1d_ar[(sym1__ - 1)], N);}
-      current_statement__ = 186;
-      validate_non_negative_index("d_int_3d_ar", "N", N);
-      current_statement__ = 187;
-      validate_non_negative_index("d_int_3d_ar", "M", M);
       current_statement__ = 188;
-      validate_non_negative_index("d_int_3d_ar", "K", K);
+      validate_non_negative_index("d_int_3d_ar", "N", N);
       current_statement__ = 189;
+      validate_non_negative_index("d_int_3d_ar", "M", M);
+      current_statement__ = 190;
+      validate_non_negative_index("d_int_3d_ar", "K", K);
+      current_statement__ = 191;
       context__.validate_dims("data initialization","d_int_3d_ar","int",
           context__.to_vec(N, M, K));
       d_int_3d_ar = std::vector<std::vector<std::vector<int>>>(N, std::vector<std::vector<int>>(M, std::vector<int>(K, std::numeric_limits<int>::min())));
       
       {
         std::vector<int> d_int_3d_ar_flat__;
-        current_statement__ = 189;
+        current_statement__ = 191;
         assign(d_int_3d_ar_flat__, nil_index_list(),
           context__.vals_i("d_int_3d_ar"),
           "assigning variable d_int_3d_ar_flat__");
-        current_statement__ = 189;
+        current_statement__ = 191;
         pos__ = 1;
-        current_statement__ = 189;
+        current_statement__ = 191;
         for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-          current_statement__ = 189;
+          current_statement__ = 191;
           for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-            current_statement__ = 189;
+            current_statement__ = 191;
             for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-              current_statement__ = 189;
+              current_statement__ = 191;
               assign(d_int_3d_ar,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_int_3d_ar_flat__[(pos__ - 1)],
                 "assigning variable d_int_3d_ar");
-              current_statement__ = 189;
+              current_statement__ = 191;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 189;
+      current_statement__ = 191;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 189;
+        current_statement__ = 191;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 189;
+          current_statement__ = 191;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 189;
-            current_statement__ = 189;
+            current_statement__ = 191;
+            current_statement__ = 191;
             check_less_or_equal(function__,
                                 "d_int_3d_ar[sym1__, sym2__, sym3__]",
                                 d_int_3d_ar[(sym1__ - 1)][(sym2__ - 1)][
                                 (sym3__ - 1)], N);}}}
-      current_statement__ = 190;
+      current_statement__ = 192;
       context__.validate_dims("data initialization","J","double",
           context__.to_vec());
       J = std::numeric_limits<double>::quiet_NaN();
       
-      current_statement__ = 190;
-      J = context__.vals_r("J")[(1 - 1)];
-      current_statement__ = 190;
-      current_statement__ = 190;
-      check_greater_or_equal(function__, "J", J, -2.0);
-      current_statement__ = 190;
-      current_statement__ = 190;
-      check_less_or_equal(function__, "J", J, 2.0);
-      current_statement__ = 191;
-      validate_non_negative_index("d_real_1d_ar", "N", N);
       current_statement__ = 192;
+      J = context__.vals_r("J")[(1 - 1)];
+      current_statement__ = 192;
+      current_statement__ = 192;
+      check_greater_or_equal(function__, "J", J, -2.0);
+      current_statement__ = 192;
+      current_statement__ = 192;
+      check_less_or_equal(function__, "J", J, 2.0);
+      current_statement__ = 193;
+      validate_non_negative_index("d_real_1d_ar", "N", N);
+      current_statement__ = 194;
       context__.validate_dims("data initialization","d_real_1d_ar","double",
           context__.to_vec(N));
       d_real_1d_ar = std::vector<double>(N, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 192;
+      current_statement__ = 194;
       assign(d_real_1d_ar, nil_index_list(),
         context__.vals_r("d_real_1d_ar"), "assigning variable d_real_1d_ar");
-      current_statement__ = 193;
-      validate_non_negative_index("d_real_3d_ar", "N", N);
-      current_statement__ = 194;
-      validate_non_negative_index("d_real_3d_ar", "M", M);
       current_statement__ = 195;
-      validate_non_negative_index("d_real_3d_ar", "K", K);
+      validate_non_negative_index("d_real_3d_ar", "N", N);
       current_statement__ = 196;
+      validate_non_negative_index("d_real_3d_ar", "M", M);
+      current_statement__ = 197;
+      validate_non_negative_index("d_real_3d_ar", "K", K);
+      current_statement__ = 198;
       context__.validate_dims("data initialization","d_real_3d_ar","double",
           context__.to_vec(N, M, K));
       d_real_3d_ar = std::vector<std::vector<std::vector<double>>>(N, std::vector<std::vector<double>>(M, std::vector<double>(K, std::numeric_limits<double>::quiet_NaN())));
       
       {
         std::vector<local_scalar_t__> d_real_3d_ar_flat__;
-        current_statement__ = 196;
+        current_statement__ = 198;
         assign(d_real_3d_ar_flat__, nil_index_list(),
           context__.vals_r("d_real_3d_ar"),
           "assigning variable d_real_3d_ar_flat__");
-        current_statement__ = 196;
+        current_statement__ = 198;
         pos__ = 1;
-        current_statement__ = 196;
+        current_statement__ = 198;
         for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-          current_statement__ = 196;
+          current_statement__ = 198;
           for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-            current_statement__ = 196;
+            current_statement__ = 198;
             for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-              current_statement__ = 196;
+              current_statement__ = 198;
               assign(d_real_3d_ar,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_real_3d_ar_flat__[(pos__ - 1)],
                 "assigning variable d_real_3d_ar");
-              current_statement__ = 196;
+              current_statement__ = 198;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 197;
+      current_statement__ = 199;
       validate_non_negative_index("d_vec", "N", N);
-      current_statement__ = 198;
+      current_statement__ = 200;
       context__.validate_dims("data initialization","d_vec","double",
           context__.to_vec(N));
       d_vec = Eigen::Matrix<double, -1, 1>(N);
@@ -4476,24 +4484,24 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_vec_flat__;
-        current_statement__ = 198;
+        current_statement__ = 200;
         assign(d_vec_flat__, nil_index_list(), context__.vals_r("d_vec"),
           "assigning variable d_vec_flat__");
-        current_statement__ = 198;
+        current_statement__ = 200;
         pos__ = 1;
-        current_statement__ = 198;
+        current_statement__ = 200;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 198;
+          current_statement__ = 200;
           assign(d_vec, cons_list(index_uni(sym1__), nil_index_list()),
             d_vec_flat__[(pos__ - 1)], "assigning variable d_vec");
-          current_statement__ = 198;
+          current_statement__ = 200;
           pos__ = (pos__ + 1);}
       }
-      current_statement__ = 199;
-      validate_non_negative_index("d_1d_vec", "N", N);
-      current_statement__ = 200;
-      validate_non_negative_index("d_1d_vec", "N", N);
       current_statement__ = 201;
+      validate_non_negative_index("d_1d_vec", "N", N);
+      current_statement__ = 202;
+      validate_non_negative_index("d_1d_vec", "N", N);
+      current_statement__ = 203;
       context__.validate_dims("data initialization","d_1d_vec","double",
           context__.to_vec(N, N));
       d_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
@@ -4501,32 +4509,32 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_1d_vec_flat__;
-        current_statement__ = 201;
+        current_statement__ = 203;
         assign(d_1d_vec_flat__, nil_index_list(),
           context__.vals_r("d_1d_vec"), "assigning variable d_1d_vec_flat__");
-        current_statement__ = 201;
+        current_statement__ = 203;
         pos__ = 1;
-        current_statement__ = 201;
+        current_statement__ = 203;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 201;
+          current_statement__ = 203;
           for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-            current_statement__ = 201;
+            current_statement__ = 203;
             assign(d_1d_vec,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_1d_vec_flat__[(pos__ - 1)], "assigning variable d_1d_vec");
-            current_statement__ = 201;
+            current_statement__ = 203;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 202;
-      validate_non_negative_index("d_3d_vec", "N", N);
-      current_statement__ = 203;
-      validate_non_negative_index("d_3d_vec", "M", M);
       current_statement__ = 204;
-      validate_non_negative_index("d_3d_vec", "K", K);
-      current_statement__ = 205;
       validate_non_negative_index("d_3d_vec", "N", N);
+      current_statement__ = 205;
+      validate_non_negative_index("d_3d_vec", "M", M);
       current_statement__ = 206;
+      validate_non_negative_index("d_3d_vec", "K", K);
+      current_statement__ = 207;
+      validate_non_negative_index("d_3d_vec", "N", N);
+      current_statement__ = 208;
       context__.validate_dims("data initialization","d_3d_vec","double",
           context__.to_vec(N, M, K, N));
       d_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
@@ -4534,32 +4542,32 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_3d_vec_flat__;
-        current_statement__ = 206;
+        current_statement__ = 208;
         assign(d_3d_vec_flat__, nil_index_list(),
           context__.vals_r("d_3d_vec"), "assigning variable d_3d_vec_flat__");
-        current_statement__ = 206;
+        current_statement__ = 208;
         pos__ = 1;
-        current_statement__ = 206;
+        current_statement__ = 208;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 206;
+          current_statement__ = 208;
           for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-            current_statement__ = 206;
+            current_statement__ = 208;
             for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-              current_statement__ = 206;
+              current_statement__ = 208;
               for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-                current_statement__ = 206;
+                current_statement__ = 208;
                 assign(d_3d_vec,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
                       cons_list(index_uni(sym2__),
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   d_3d_vec_flat__[(pos__ - 1)], "assigning variable d_3d_vec");
-                current_statement__ = 206;
+                current_statement__ = 208;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 207;
+      current_statement__ = 209;
       validate_non_negative_index("d_row_vec", "N", N);
-      current_statement__ = 208;
+      current_statement__ = 210;
       context__.validate_dims("data initialization","d_row_vec","double",
           context__.to_vec(N));
       d_row_vec = Eigen::Matrix<double, 1, -1>(N);
@@ -4567,25 +4575,25 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_row_vec_flat__;
-        current_statement__ = 208;
+        current_statement__ = 210;
         assign(d_row_vec_flat__, nil_index_list(),
           context__.vals_r("d_row_vec"),
           "assigning variable d_row_vec_flat__");
-        current_statement__ = 208;
+        current_statement__ = 210;
         pos__ = 1;
-        current_statement__ = 208;
+        current_statement__ = 210;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 208;
+          current_statement__ = 210;
           assign(d_row_vec, cons_list(index_uni(sym1__), nil_index_list()),
             d_row_vec_flat__[(pos__ - 1)], "assigning variable d_row_vec");
-          current_statement__ = 208;
+          current_statement__ = 210;
           pos__ = (pos__ + 1);}
       }
-      current_statement__ = 209;
-      validate_non_negative_index("d_1d_row_vec", "N", N);
-      current_statement__ = 210;
-      validate_non_negative_index("d_1d_row_vec", "N", N);
       current_statement__ = 211;
+      validate_non_negative_index("d_1d_row_vec", "N", N);
+      current_statement__ = 212;
+      validate_non_negative_index("d_1d_row_vec", "N", N);
+      current_statement__ = 213;
       context__.validate_dims("data initialization","d_1d_row_vec","double",
           context__.to_vec(N, N));
       d_1d_row_vec = std::vector<Eigen::Matrix<double, 1, -1>>(N, Eigen::Matrix<double, 1, -1>(N));
@@ -4593,34 +4601,34 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_1d_row_vec_flat__;
-        current_statement__ = 211;
+        current_statement__ = 213;
         assign(d_1d_row_vec_flat__, nil_index_list(),
           context__.vals_r("d_1d_row_vec"),
           "assigning variable d_1d_row_vec_flat__");
-        current_statement__ = 211;
+        current_statement__ = 213;
         pos__ = 1;
-        current_statement__ = 211;
+        current_statement__ = 213;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 211;
+          current_statement__ = 213;
           for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-            current_statement__ = 211;
+            current_statement__ = 213;
             assign(d_1d_row_vec,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_1d_row_vec_flat__[(pos__ - 1)],
               "assigning variable d_1d_row_vec");
-            current_statement__ = 211;
+            current_statement__ = 213;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 212;
-      validate_non_negative_index("d_3d_row_vec", "N", N);
-      current_statement__ = 213;
-      validate_non_negative_index("d_3d_row_vec", "M", M);
       current_statement__ = 214;
-      validate_non_negative_index("d_3d_row_vec", "K", K);
-      current_statement__ = 215;
       validate_non_negative_index("d_3d_row_vec", "N", N);
+      current_statement__ = 215;
+      validate_non_negative_index("d_3d_row_vec", "M", M);
       current_statement__ = 216;
+      validate_non_negative_index("d_3d_row_vec", "K", K);
+      current_statement__ = 217;
+      validate_non_negative_index("d_3d_row_vec", "N", N);
+      current_statement__ = 218;
       context__.validate_dims("data initialization","d_3d_row_vec","double",
           context__.to_vec(N, M, K, N));
       d_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(M, std::vector<Eigen::Matrix<double, 1, -1>>(K, Eigen::Matrix<double, 1, -1>(N))));
@@ -4628,21 +4636,21 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_3d_row_vec_flat__;
-        current_statement__ = 216;
+        current_statement__ = 218;
         assign(d_3d_row_vec_flat__, nil_index_list(),
           context__.vals_r("d_3d_row_vec"),
           "assigning variable d_3d_row_vec_flat__");
-        current_statement__ = 216;
+        current_statement__ = 218;
         pos__ = 1;
-        current_statement__ = 216;
+        current_statement__ = 218;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 216;
+          current_statement__ = 218;
           for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-            current_statement__ = 216;
+            current_statement__ = 218;
             for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-              current_statement__ = 216;
+              current_statement__ = 218;
               for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-                current_statement__ = 216;
+                current_statement__ = 218;
                 assign(d_3d_row_vec,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
@@ -4650,10 +4658,10 @@ class mother_model final : public model_base_crtp<mother_model> {
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   d_3d_row_vec_flat__[(pos__ - 1)],
                   "assigning variable d_3d_row_vec");
-                current_statement__ = 216;
+                current_statement__ = 218;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 217;
+      current_statement__ = 219;
       context__.validate_dims("data initialization","d_ar_mat","double",
           context__.to_vec(4, 5, 2, 3));
       d_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
@@ -4661,39 +4669,39 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_ar_mat_flat__;
-        current_statement__ = 217;
+        current_statement__ = 219;
         assign(d_ar_mat_flat__, nil_index_list(),
           context__.vals_r("d_ar_mat"), "assigning variable d_ar_mat_flat__");
-        current_statement__ = 217;
+        current_statement__ = 219;
         pos__ = 1;
-        current_statement__ = 217;
+        current_statement__ = 219;
         for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-          current_statement__ = 217;
+          current_statement__ = 219;
           for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-            current_statement__ = 217;
+            current_statement__ = 219;
             for (int sym3__ = 1; sym3__ <= 5; ++sym3__) {
-              current_statement__ = 217;
+              current_statement__ = 219;
               for (int sym4__ = 1; sym4__ <= 4; ++sym4__) {
-                current_statement__ = 217;
+                current_statement__ = 219;
                 assign(d_ar_mat,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
                       cons_list(index_uni(sym2__),
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   d_ar_mat_flat__[(pos__ - 1)], "assigning variable d_ar_mat");
-                current_statement__ = 217;
+                current_statement__ = 219;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 217;
+      current_statement__ = 219;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 217;
+        current_statement__ = 219;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 217;
+          current_statement__ = 219;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 217;
+            current_statement__ = 219;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 217;
-              current_statement__ = 217;
+              current_statement__ = 219;
+              current_statement__ = 219;
               check_greater_or_equal(function__,
                                      "d_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                      rvalue(d_ar_mat,
@@ -4703,16 +4711,16 @@ class mother_model final : public model_base_crtp<mother_model> {
                                              cons_list(index_uni(sym4__),
                                                nil_index_list())))),
                                        "d_ar_mat"), 0);}}}}
-      current_statement__ = 217;
+      current_statement__ = 219;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 217;
+        current_statement__ = 219;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 217;
+          current_statement__ = 219;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 217;
+            current_statement__ = 219;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 217;
-              current_statement__ = 217;
+              current_statement__ = 219;
+              current_statement__ = 219;
               check_less_or_equal(function__,
                                   "d_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                   rvalue(d_ar_mat,
@@ -4722,9 +4730,9 @@ class mother_model final : public model_base_crtp<mother_model> {
                                           cons_list(index_uni(sym4__),
                                             nil_index_list())))), "d_ar_mat"),
                                   1);}}}}
-      current_statement__ = 218;
+      current_statement__ = 220;
       validate_non_negative_index("d_simplex", "N", N);
-      current_statement__ = 219;
+      current_statement__ = 221;
       context__.validate_dims("data initialization","d_simplex","double",
           context__.to_vec(N));
       d_simplex = Eigen::Matrix<double, -1, 1>(N);
@@ -4732,28 +4740,28 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_simplex_flat__;
-        current_statement__ = 219;
+        current_statement__ = 221;
         assign(d_simplex_flat__, nil_index_list(),
           context__.vals_r("d_simplex"),
           "assigning variable d_simplex_flat__");
-        current_statement__ = 219;
+        current_statement__ = 221;
         pos__ = 1;
-        current_statement__ = 219;
+        current_statement__ = 221;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 219;
+          current_statement__ = 221;
           assign(d_simplex, cons_list(index_uni(sym1__), nil_index_list()),
             d_simplex_flat__[(pos__ - 1)], "assigning variable d_simplex");
-          current_statement__ = 219;
+          current_statement__ = 221;
           pos__ = (pos__ + 1);}
       }
-      current_statement__ = 219;
-      current_statement__ = 219;
-      check_simplex(function__, "d_simplex", d_simplex);
-      current_statement__ = 220;
-      validate_non_negative_index("d_1d_simplex", "N", N);
       current_statement__ = 221;
-      validate_non_negative_index("d_1d_simplex", "N", N);
+      current_statement__ = 221;
+      check_simplex(function__, "d_simplex", d_simplex);
       current_statement__ = 222;
+      validate_non_negative_index("d_1d_simplex", "N", N);
+      current_statement__ = 223;
+      validate_non_negative_index("d_1d_simplex", "N", N);
+      current_statement__ = 224;
       context__.validate_dims("data initialization","d_1d_simplex","double",
           context__.to_vec(N, N));
       d_1d_simplex = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
@@ -4761,40 +4769,40 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_1d_simplex_flat__;
-        current_statement__ = 222;
+        current_statement__ = 224;
         assign(d_1d_simplex_flat__, nil_index_list(),
           context__.vals_r("d_1d_simplex"),
           "assigning variable d_1d_simplex_flat__");
-        current_statement__ = 222;
+        current_statement__ = 224;
         pos__ = 1;
-        current_statement__ = 222;
+        current_statement__ = 224;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 222;
+          current_statement__ = 224;
           for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-            current_statement__ = 222;
+            current_statement__ = 224;
             assign(d_1d_simplex,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_1d_simplex_flat__[(pos__ - 1)],
               "assigning variable d_1d_simplex");
-            current_statement__ = 222;
+            current_statement__ = 224;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 222;
+      current_statement__ = 224;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 222;
-        current_statement__ = 222;
+        current_statement__ = 224;
+        current_statement__ = 224;
         check_simplex(function__, "d_1d_simplex[sym1__]",
                       d_1d_simplex[(sym1__ - 1)]);}
-      current_statement__ = 223;
-      validate_non_negative_index("d_3d_simplex", "N", N);
-      current_statement__ = 224;
-      validate_non_negative_index("d_3d_simplex", "M", M);
       current_statement__ = 225;
-      validate_non_negative_index("d_3d_simplex", "K", K);
-      current_statement__ = 226;
       validate_non_negative_index("d_3d_simplex", "N", N);
+      current_statement__ = 226;
+      validate_non_negative_index("d_3d_simplex", "M", M);
       current_statement__ = 227;
+      validate_non_negative_index("d_3d_simplex", "K", K);
+      current_statement__ = 228;
+      validate_non_negative_index("d_3d_simplex", "N", N);
+      current_statement__ = 229;
       context__.validate_dims("data initialization","d_3d_simplex","double",
           context__.to_vec(N, M, K, N));
       d_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
@@ -4802,21 +4810,21 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_3d_simplex_flat__;
-        current_statement__ = 227;
+        current_statement__ = 229;
         assign(d_3d_simplex_flat__, nil_index_list(),
           context__.vals_r("d_3d_simplex"),
           "assigning variable d_3d_simplex_flat__");
-        current_statement__ = 227;
+        current_statement__ = 229;
         pos__ = 1;
-        current_statement__ = 227;
+        current_statement__ = 229;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 227;
+          current_statement__ = 229;
           for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-            current_statement__ = 227;
+            current_statement__ = 229;
             for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-              current_statement__ = 227;
+              current_statement__ = 229;
               for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-                current_statement__ = 227;
+                current_statement__ = 229;
                 assign(d_3d_simplex,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
@@ -4824,21 +4832,21 @@ class mother_model final : public model_base_crtp<mother_model> {
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   d_3d_simplex_flat__[(pos__ - 1)],
                   "assigning variable d_3d_simplex");
-                current_statement__ = 227;
+                current_statement__ = 229;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 227;
+      current_statement__ = 229;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 227;
+        current_statement__ = 229;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 227;
+          current_statement__ = 229;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 227;
-            current_statement__ = 227;
+            current_statement__ = 229;
+            current_statement__ = 229;
             check_simplex(function__, "d_3d_simplex[sym1__, sym2__, sym3__]",
                           d_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ -
                                                                     1)]);}}}
-      current_statement__ = 228;
+      current_statement__ = 230;
       context__.validate_dims("data initialization","d_cfcov_54","double",
           context__.to_vec(5, 4));
       d_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 4);
@@ -4846,28 +4854,28 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_cfcov_54_flat__;
-        current_statement__ = 228;
+        current_statement__ = 230;
         assign(d_cfcov_54_flat__, nil_index_list(),
           context__.vals_r("d_cfcov_54"),
           "assigning variable d_cfcov_54_flat__");
-        current_statement__ = 228;
+        current_statement__ = 230;
         pos__ = 1;
-        current_statement__ = 228;
+        current_statement__ = 230;
         for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-          current_statement__ = 228;
+          current_statement__ = 230;
           for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-            current_statement__ = 228;
+            current_statement__ = 230;
             assign(d_cfcov_54,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_cfcov_54_flat__[(pos__ - 1)], "assigning variable d_cfcov_54");
-            current_statement__ = 228;
+            current_statement__ = 230;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 228;
-      current_statement__ = 228;
+      current_statement__ = 230;
+      current_statement__ = 230;
       check_cholesky_factor(function__, "d_cfcov_54", d_cfcov_54);
-      current_statement__ = 229;
+      current_statement__ = 231;
       context__.validate_dims("data initialization","d_cfcov_33","double",
           context__.to_vec(3, 3));
       d_cfcov_33 = Eigen::Matrix<double, -1, -1>(3, 3);
@@ -4875,41 +4883,10 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_cfcov_33_flat__;
-        current_statement__ = 229;
+        current_statement__ = 231;
         assign(d_cfcov_33_flat__, nil_index_list(),
           context__.vals_r("d_cfcov_33"),
           "assigning variable d_cfcov_33_flat__");
-        current_statement__ = 229;
-        pos__ = 1;
-        current_statement__ = 229;
-        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-          current_statement__ = 229;
-          for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-            current_statement__ = 229;
-            assign(d_cfcov_33,
-              cons_list(index_uni(sym2__),
-                cons_list(index_uni(sym1__), nil_index_list())),
-              d_cfcov_33_flat__[(pos__ - 1)], "assigning variable d_cfcov_33");
-            current_statement__ = 229;
-            pos__ = (pos__ + 1);}}
-      }
-      current_statement__ = 229;
-      current_statement__ = 229;
-      check_cholesky_factor(function__, "d_cfcov_33", d_cfcov_33);
-      current_statement__ = 230;
-      validate_non_negative_index("d_cfcov_33_ar", "K", K);
-      current_statement__ = 231;
-      context__.validate_dims("data initialization","d_cfcov_33_ar","double",
-          context__.to_vec(K, 3, 3));
-      d_cfcov_33_ar = std::vector<Eigen::Matrix<double, -1, -1>>(K, Eigen::Matrix<double, -1, -1>(3, 3));
-      stan::math::fill(d_cfcov_33_ar, std::numeric_limits<double>::quiet_NaN());
-      
-      {
-        std::vector<local_scalar_t__> d_cfcov_33_ar_flat__;
-        current_statement__ = 231;
-        assign(d_cfcov_33_ar_flat__, nil_index_list(),
-          context__.vals_r("d_cfcov_33_ar"),
-          "assigning variable d_cfcov_33_ar_flat__");
         current_statement__ = 231;
         pos__ = 1;
         current_statement__ = 231;
@@ -4917,180 +4894,211 @@ class mother_model final : public model_base_crtp<mother_model> {
           current_statement__ = 231;
           for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
             current_statement__ = 231;
+            assign(d_cfcov_33,
+              cons_list(index_uni(sym2__),
+                cons_list(index_uni(sym1__), nil_index_list())),
+              d_cfcov_33_flat__[(pos__ - 1)], "assigning variable d_cfcov_33");
+            current_statement__ = 231;
+            pos__ = (pos__ + 1);}}
+      }
+      current_statement__ = 231;
+      current_statement__ = 231;
+      check_cholesky_factor(function__, "d_cfcov_33", d_cfcov_33);
+      current_statement__ = 232;
+      validate_non_negative_index("d_cfcov_33_ar", "K", K);
+      current_statement__ = 233;
+      context__.validate_dims("data initialization","d_cfcov_33_ar","double",
+          context__.to_vec(K, 3, 3));
+      d_cfcov_33_ar = std::vector<Eigen::Matrix<double, -1, -1>>(K, Eigen::Matrix<double, -1, -1>(3, 3));
+      stan::math::fill(d_cfcov_33_ar, std::numeric_limits<double>::quiet_NaN());
+      
+      {
+        std::vector<local_scalar_t__> d_cfcov_33_ar_flat__;
+        current_statement__ = 233;
+        assign(d_cfcov_33_ar_flat__, nil_index_list(),
+          context__.vals_r("d_cfcov_33_ar"),
+          "assigning variable d_cfcov_33_ar_flat__");
+        current_statement__ = 233;
+        pos__ = 1;
+        current_statement__ = 233;
+        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+          current_statement__ = 233;
+          for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+            current_statement__ = 233;
             for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-              current_statement__ = 231;
+              current_statement__ = 233;
               assign(d_cfcov_33_ar,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_cfcov_33_ar_flat__[(pos__ - 1)],
                 "assigning variable d_cfcov_33_ar");
-              current_statement__ = 231;
+              current_statement__ = 233;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 231;
+      current_statement__ = 233;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 231;
-        current_statement__ = 231;
+        current_statement__ = 233;
+        current_statement__ = 233;
         check_cholesky_factor(function__, "d_cfcov_33_ar[sym1__]",
                               d_cfcov_33_ar[(sym1__ - 1)]);}
-      current_statement__ = 232;
+      current_statement__ = 234;
       context__.validate_dims("data initialization","d_int","int",
           context__.to_vec());
       d_int = std::numeric_limits<int>::min();
       
-      current_statement__ = 232;
-      d_int = context__.vals_i("d_int")[(1 - 1)];
-      current_statement__ = 233;
-      validate_non_negative_index("d_int_array", "d_int", d_int);
       current_statement__ = 234;
+      d_int = context__.vals_i("d_int")[(1 - 1)];
+      current_statement__ = 235;
+      validate_non_negative_index("d_int_array", "d_int", d_int);
+      current_statement__ = 236;
       context__.validate_dims("data initialization","d_int_array","int",
           context__.to_vec(d_int));
       d_int_array = std::vector<int>(d_int, std::numeric_limits<int>::min());
       
-      current_statement__ = 234;
+      current_statement__ = 236;
       assign(d_int_array, nil_index_list(), context__.vals_i("d_int_array"),
         "assigning variable d_int_array");
-      current_statement__ = 235;
+      current_statement__ = 237;
       validate_non_negative_index("d_int_array_2d", "d_int", d_int);
-      current_statement__ = 236;
+      current_statement__ = 238;
       context__.validate_dims("data initialization","d_int_array_2d","int",
           context__.to_vec(d_int, 2));
       d_int_array_2d = std::vector<std::vector<int>>(d_int, std::vector<int>(2, std::numeric_limits<int>::min()));
       
       {
         std::vector<int> d_int_array_2d_flat__;
-        current_statement__ = 236;
+        current_statement__ = 238;
         assign(d_int_array_2d_flat__, nil_index_list(),
           context__.vals_i("d_int_array_2d"),
           "assigning variable d_int_array_2d_flat__");
-        current_statement__ = 236;
+        current_statement__ = 238;
         pos__ = 1;
-        current_statement__ = 236;
+        current_statement__ = 238;
         for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-          current_statement__ = 236;
+          current_statement__ = 238;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 236;
+            current_statement__ = 238;
             assign(d_int_array_2d,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_int_array_2d_flat__[(pos__ - 1)],
               "assigning variable d_int_array_2d");
-            current_statement__ = 236;
+            current_statement__ = 238;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 237;
+      current_statement__ = 239;
       validate_non_negative_index("d_int_array_3d", "d_int", d_int);
-      current_statement__ = 238;
+      current_statement__ = 240;
       context__.validate_dims("data initialization","d_int_array_3d","int",
           context__.to_vec(d_int, 2, 3));
       d_int_array_3d = std::vector<std::vector<std::vector<int>>>(d_int, std::vector<std::vector<int>>(2, std::vector<int>(3, std::numeric_limits<int>::min())));
       
       {
         std::vector<int> d_int_array_3d_flat__;
-        current_statement__ = 238;
+        current_statement__ = 240;
         assign(d_int_array_3d_flat__, nil_index_list(),
           context__.vals_i("d_int_array_3d"),
           "assigning variable d_int_array_3d_flat__");
-        current_statement__ = 238;
+        current_statement__ = 240;
         pos__ = 1;
-        current_statement__ = 238;
+        current_statement__ = 240;
         for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-          current_statement__ = 238;
+          current_statement__ = 240;
           for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-            current_statement__ = 238;
+            current_statement__ = 240;
             for (int sym3__ = 1; sym3__ <= d_int; ++sym3__) {
-              current_statement__ = 238;
+              current_statement__ = 240;
               assign(d_int_array_3d,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_int_array_3d_flat__[(pos__ - 1)],
                 "assigning variable d_int_array_3d");
-              current_statement__ = 238;
+              current_statement__ = 240;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 239;
+      current_statement__ = 241;
       context__.validate_dims("data initialization","d_real","double",
           context__.to_vec());
       d_real = std::numeric_limits<double>::quiet_NaN();
       
-      current_statement__ = 239;
-      d_real = context__.vals_r("d_real")[(1 - 1)];
-      current_statement__ = 240;
-      validate_non_negative_index("d_real_array", "d_int", d_int);
       current_statement__ = 241;
+      d_real = context__.vals_r("d_real")[(1 - 1)];
+      current_statement__ = 242;
+      validate_non_negative_index("d_real_array", "d_int", d_int);
+      current_statement__ = 243;
       context__.validate_dims("data initialization","d_real_array","double",
           context__.to_vec(d_int));
       d_real_array = std::vector<double>(d_int, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 241;
+      current_statement__ = 243;
       assign(d_real_array, nil_index_list(),
         context__.vals_r("d_real_array"), "assigning variable d_real_array");
-      current_statement__ = 242;
+      current_statement__ = 244;
       validate_non_negative_index("d_real_array_2d", "d_int", d_int);
-      current_statement__ = 243;
+      current_statement__ = 245;
       context__.validate_dims("data initialization","d_real_array_2d",
           "double",context__.to_vec(d_int, 2));
       d_real_array_2d = std::vector<std::vector<double>>(d_int, std::vector<double>(2, std::numeric_limits<double>::quiet_NaN()));
       
       {
         std::vector<local_scalar_t__> d_real_array_2d_flat__;
-        current_statement__ = 243;
+        current_statement__ = 245;
         assign(d_real_array_2d_flat__, nil_index_list(),
           context__.vals_r("d_real_array_2d"),
           "assigning variable d_real_array_2d_flat__");
-        current_statement__ = 243;
+        current_statement__ = 245;
         pos__ = 1;
-        current_statement__ = 243;
+        current_statement__ = 245;
         for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-          current_statement__ = 243;
+          current_statement__ = 245;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 243;
+            current_statement__ = 245;
             assign(d_real_array_2d,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_real_array_2d_flat__[(pos__ - 1)],
               "assigning variable d_real_array_2d");
-            current_statement__ = 243;
+            current_statement__ = 245;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 244;
+      current_statement__ = 246;
       validate_non_negative_index("d_real_array_3d", "d_int", d_int);
-      current_statement__ = 245;
+      current_statement__ = 247;
       context__.validate_dims("data initialization","d_real_array_3d",
           "double",context__.to_vec(d_int, 2, 3));
       d_real_array_3d = std::vector<std::vector<std::vector<double>>>(d_int, std::vector<std::vector<double>>(2, std::vector<double>(3, std::numeric_limits<double>::quiet_NaN())));
       
       {
         std::vector<local_scalar_t__> d_real_array_3d_flat__;
-        current_statement__ = 245;
+        current_statement__ = 247;
         assign(d_real_array_3d_flat__, nil_index_list(),
           context__.vals_r("d_real_array_3d"),
           "assigning variable d_real_array_3d_flat__");
-        current_statement__ = 245;
+        current_statement__ = 247;
         pos__ = 1;
-        current_statement__ = 245;
+        current_statement__ = 247;
         for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-          current_statement__ = 245;
+          current_statement__ = 247;
           for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-            current_statement__ = 245;
+            current_statement__ = 247;
             for (int sym3__ = 1; sym3__ <= d_int; ++sym3__) {
-              current_statement__ = 245;
+              current_statement__ = 247;
               assign(d_real_array_3d,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_real_array_3d_flat__[(pos__ - 1)],
                 "assigning variable d_real_array_3d");
-              current_statement__ = 245;
+              current_statement__ = 247;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 246;
-      validate_non_negative_index("d_matrix", "d_int", d_int);
-      current_statement__ = 247;
-      validate_non_negative_index("d_matrix", "d_int", d_int);
       current_statement__ = 248;
+      validate_non_negative_index("d_matrix", "d_int", d_int);
+      current_statement__ = 249;
+      validate_non_negative_index("d_matrix", "d_int", d_int);
+      current_statement__ = 250;
       context__.validate_dims("data initialization","d_matrix","double",
           context__.to_vec(d_int, d_int));
       d_matrix = Eigen::Matrix<double, -1, -1>(d_int, d_int);
@@ -5098,30 +5106,30 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_matrix_flat__;
-        current_statement__ = 248;
+        current_statement__ = 250;
         assign(d_matrix_flat__, nil_index_list(),
           context__.vals_r("d_matrix"), "assigning variable d_matrix_flat__");
-        current_statement__ = 248;
+        current_statement__ = 250;
         pos__ = 1;
-        current_statement__ = 248;
+        current_statement__ = 250;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 248;
+          current_statement__ = 250;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 248;
+            current_statement__ = 250;
             assign(d_matrix,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_matrix_flat__[(pos__ - 1)], "assigning variable d_matrix");
-            current_statement__ = 248;
+            current_statement__ = 250;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 249;
-      validate_non_negative_index("d_matrix_array", "d_int", d_int);
-      current_statement__ = 250;
-      validate_non_negative_index("d_matrix_array", "d_int", d_int);
       current_statement__ = 251;
       validate_non_negative_index("d_matrix_array", "d_int", d_int);
       current_statement__ = 252;
+      validate_non_negative_index("d_matrix_array", "d_int", d_int);
+      current_statement__ = 253;
+      validate_non_negative_index("d_matrix_array", "d_int", d_int);
+      current_statement__ = 254;
       context__.validate_dims("data initialization","d_matrix_array",
           "double",context__.to_vec(d_int, d_int, d_int));
       d_matrix_array = std::vector<Eigen::Matrix<double, -1, -1>>(d_int, Eigen::Matrix<double, -1, -1>(d_int, d_int));
@@ -5129,35 +5137,35 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_matrix_array_flat__;
-        current_statement__ = 252;
+        current_statement__ = 254;
         assign(d_matrix_array_flat__, nil_index_list(),
           context__.vals_r("d_matrix_array"),
           "assigning variable d_matrix_array_flat__");
-        current_statement__ = 252;
+        current_statement__ = 254;
         pos__ = 1;
-        current_statement__ = 252;
+        current_statement__ = 254;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 252;
+          current_statement__ = 254;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 252;
+            current_statement__ = 254;
             for (int sym3__ = 1; sym3__ <= d_int; ++sym3__) {
-              current_statement__ = 252;
+              current_statement__ = 254;
               assign(d_matrix_array,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_matrix_array_flat__[(pos__ - 1)],
                 "assigning variable d_matrix_array");
-              current_statement__ = 252;
+              current_statement__ = 254;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 253;
-      validate_non_negative_index("d_matrix_array_2d", "d_int", d_int);
-      current_statement__ = 254;
-      validate_non_negative_index("d_matrix_array_2d", "d_int", d_int);
       current_statement__ = 255;
       validate_non_negative_index("d_matrix_array_2d", "d_int", d_int);
       current_statement__ = 256;
+      validate_non_negative_index("d_matrix_array_2d", "d_int", d_int);
+      current_statement__ = 257;
+      validate_non_negative_index("d_matrix_array_2d", "d_int", d_int);
+      current_statement__ = 258;
       context__.validate_dims("data initialization","d_matrix_array_2d",
           "double",context__.to_vec(d_int, 2, d_int, d_int));
       d_matrix_array_2d = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(d_int, std::vector<Eigen::Matrix<double, -1, -1>>(2, Eigen::Matrix<double, -1, -1>(d_int, d_int)));
@@ -5165,21 +5173,21 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_matrix_array_2d_flat__;
-        current_statement__ = 256;
+        current_statement__ = 258;
         assign(d_matrix_array_2d_flat__, nil_index_list(),
           context__.vals_r("d_matrix_array_2d"),
           "assigning variable d_matrix_array_2d_flat__");
-        current_statement__ = 256;
+        current_statement__ = 258;
         pos__ = 1;
-        current_statement__ = 256;
+        current_statement__ = 258;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 256;
+          current_statement__ = 258;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 256;
+            current_statement__ = 258;
             for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-              current_statement__ = 256;
+              current_statement__ = 258;
               for (int sym4__ = 1; sym4__ <= d_int; ++sym4__) {
-                current_statement__ = 256;
+                current_statement__ = 258;
                 assign(d_matrix_array_2d,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
@@ -5187,16 +5195,16 @@ class mother_model final : public model_base_crtp<mother_model> {
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   d_matrix_array_2d_flat__[(pos__ - 1)],
                   "assigning variable d_matrix_array_2d");
-                current_statement__ = 256;
+                current_statement__ = 258;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 257;
-      validate_non_negative_index("d_matrix_array_3d", "d_int", d_int);
-      current_statement__ = 258;
-      validate_non_negative_index("d_matrix_array_3d", "d_int", d_int);
       current_statement__ = 259;
       validate_non_negative_index("d_matrix_array_3d", "d_int", d_int);
       current_statement__ = 260;
+      validate_non_negative_index("d_matrix_array_3d", "d_int", d_int);
+      current_statement__ = 261;
+      validate_non_negative_index("d_matrix_array_3d", "d_int", d_int);
+      current_statement__ = 262;
       context__.validate_dims("data initialization","d_matrix_array_3d",
           "double",context__.to_vec(d_int, 2, 3, d_int, d_int));
       d_matrix_array_3d = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>>(d_int, std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(2, std::vector<Eigen::Matrix<double, -1, -1>>(3, Eigen::Matrix<double, -1, -1>(d_int, d_int))));
@@ -5204,23 +5212,23 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_matrix_array_3d_flat__;
-        current_statement__ = 260;
+        current_statement__ = 262;
         assign(d_matrix_array_3d_flat__, nil_index_list(),
           context__.vals_r("d_matrix_array_3d"),
           "assigning variable d_matrix_array_3d_flat__");
-        current_statement__ = 260;
+        current_statement__ = 262;
         pos__ = 1;
-        current_statement__ = 260;
+        current_statement__ = 262;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 260;
+          current_statement__ = 262;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 260;
+            current_statement__ = 262;
             for (int sym3__ = 1; sym3__ <= 3; ++sym3__) {
-              current_statement__ = 260;
+              current_statement__ = 262;
               for (int sym4__ = 1; sym4__ <= 2; ++sym4__) {
-                current_statement__ = 260;
+                current_statement__ = 262;
                 for (int sym5__ = 1; sym5__ <= d_int; ++sym5__) {
-                  current_statement__ = 260;
+                  current_statement__ = 262;
                   assign(d_matrix_array_3d,
                     cons_list(index_uni(sym5__),
                       cons_list(index_uni(sym4__),
@@ -5229,12 +5237,12 @@ class mother_model final : public model_base_crtp<mother_model> {
                             cons_list(index_uni(sym1__), nil_index_list()))))),
                     d_matrix_array_3d_flat__[(pos__ - 1)],
                     "assigning variable d_matrix_array_3d");
-                  current_statement__ = 260;
+                  current_statement__ = 262;
                   pos__ = (pos__ + 1);}}}}}
       }
-      current_statement__ = 261;
+      current_statement__ = 263;
       validate_non_negative_index("d_vector", "d_int", d_int);
-      current_statement__ = 262;
+      current_statement__ = 264;
       context__.validate_dims("data initialization","d_vector","double",
           context__.to_vec(d_int));
       d_vector = Eigen::Matrix<double, -1, 1>(d_int);
@@ -5242,24 +5250,24 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_vector_flat__;
-        current_statement__ = 262;
+        current_statement__ = 264;
         assign(d_vector_flat__, nil_index_list(),
           context__.vals_r("d_vector"), "assigning variable d_vector_flat__");
-        current_statement__ = 262;
+        current_statement__ = 264;
         pos__ = 1;
-        current_statement__ = 262;
+        current_statement__ = 264;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 262;
+          current_statement__ = 264;
           assign(d_vector, cons_list(index_uni(sym1__), nil_index_list()),
             d_vector_flat__[(pos__ - 1)], "assigning variable d_vector");
-          current_statement__ = 262;
+          current_statement__ = 264;
           pos__ = (pos__ + 1);}
       }
-      current_statement__ = 263;
-      validate_non_negative_index("d_vector_array", "d_int", d_int);
-      current_statement__ = 264;
-      validate_non_negative_index("d_vector_array", "d_int", d_int);
       current_statement__ = 265;
+      validate_non_negative_index("d_vector_array", "d_int", d_int);
+      current_statement__ = 266;
+      validate_non_negative_index("d_vector_array", "d_int", d_int);
+      current_statement__ = 267;
       context__.validate_dims("data initialization","d_vector_array",
           "double",context__.to_vec(d_int, d_int));
       d_vector_array = std::vector<Eigen::Matrix<double, -1, 1>>(d_int, Eigen::Matrix<double, -1, 1>(d_int));
@@ -5267,30 +5275,30 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_vector_array_flat__;
-        current_statement__ = 265;
+        current_statement__ = 267;
         assign(d_vector_array_flat__, nil_index_list(),
           context__.vals_r("d_vector_array"),
           "assigning variable d_vector_array_flat__");
-        current_statement__ = 265;
+        current_statement__ = 267;
         pos__ = 1;
-        current_statement__ = 265;
+        current_statement__ = 267;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 265;
+          current_statement__ = 267;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 265;
+            current_statement__ = 267;
             assign(d_vector_array,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_vector_array_flat__[(pos__ - 1)],
               "assigning variable d_vector_array");
-            current_statement__ = 265;
+            current_statement__ = 267;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 266;
-      validate_non_negative_index("d_vector_array_2d", "d_int", d_int);
-      current_statement__ = 267;
-      validate_non_negative_index("d_vector_array_2d", "d_int", d_int);
       current_statement__ = 268;
+      validate_non_negative_index("d_vector_array_2d", "d_int", d_int);
+      current_statement__ = 269;
+      validate_non_negative_index("d_vector_array_2d", "d_int", d_int);
+      current_statement__ = 270;
       context__.validate_dims("data initialization","d_vector_array_2d",
           "double",context__.to_vec(d_int, 2, d_int));
       d_vector_array_2d = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(d_int, std::vector<Eigen::Matrix<double, -1, 1>>(2, Eigen::Matrix<double, -1, 1>(d_int)));
@@ -5298,33 +5306,33 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_vector_array_2d_flat__;
-        current_statement__ = 268;
+        current_statement__ = 270;
         assign(d_vector_array_2d_flat__, nil_index_list(),
           context__.vals_r("d_vector_array_2d"),
           "assigning variable d_vector_array_2d_flat__");
-        current_statement__ = 268;
+        current_statement__ = 270;
         pos__ = 1;
-        current_statement__ = 268;
+        current_statement__ = 270;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 268;
+          current_statement__ = 270;
           for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-            current_statement__ = 268;
+            current_statement__ = 270;
             for (int sym3__ = 1; sym3__ <= d_int; ++sym3__) {
-              current_statement__ = 268;
+              current_statement__ = 270;
               assign(d_vector_array_2d,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_vector_array_2d_flat__[(pos__ - 1)],
                 "assigning variable d_vector_array_2d");
-              current_statement__ = 268;
+              current_statement__ = 270;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 269;
-      validate_non_negative_index("d_vector_array_3d", "d_int", d_int);
-      current_statement__ = 270;
-      validate_non_negative_index("d_vector_array_3d", "d_int", d_int);
       current_statement__ = 271;
+      validate_non_negative_index("d_vector_array_3d", "d_int", d_int);
+      current_statement__ = 272;
+      validate_non_negative_index("d_vector_array_3d", "d_int", d_int);
+      current_statement__ = 273;
       context__.validate_dims("data initialization","d_vector_array_3d",
           "double",context__.to_vec(d_int, 2, 3, d_int));
       d_vector_array_3d = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(d_int, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(2, std::vector<Eigen::Matrix<double, -1, 1>>(3, Eigen::Matrix<double, -1, 1>(d_int))));
@@ -5332,21 +5340,21 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_vector_array_3d_flat__;
-        current_statement__ = 271;
+        current_statement__ = 273;
         assign(d_vector_array_3d_flat__, nil_index_list(),
           context__.vals_r("d_vector_array_3d"),
           "assigning variable d_vector_array_3d_flat__");
-        current_statement__ = 271;
+        current_statement__ = 273;
         pos__ = 1;
-        current_statement__ = 271;
+        current_statement__ = 273;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 271;
+          current_statement__ = 273;
           for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-            current_statement__ = 271;
+            current_statement__ = 273;
             for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-              current_statement__ = 271;
+              current_statement__ = 273;
               for (int sym4__ = 1; sym4__ <= d_int; ++sym4__) {
-                current_statement__ = 271;
+                current_statement__ = 273;
                 assign(d_vector_array_3d,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
@@ -5354,12 +5362,12 @@ class mother_model final : public model_base_crtp<mother_model> {
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   d_vector_array_3d_flat__[(pos__ - 1)],
                   "assigning variable d_vector_array_3d");
-                current_statement__ = 271;
+                current_statement__ = 273;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 272;
+      current_statement__ = 274;
       validate_non_negative_index("d_row_vector", "d_int", d_int);
-      current_statement__ = 273;
+      current_statement__ = 275;
       context__.validate_dims("data initialization","d_row_vector","double",
           context__.to_vec(d_int));
       d_row_vector = Eigen::Matrix<double, 1, -1>(d_int);
@@ -5367,27 +5375,27 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_row_vector_flat__;
-        current_statement__ = 273;
+        current_statement__ = 275;
         assign(d_row_vector_flat__, nil_index_list(),
           context__.vals_r("d_row_vector"),
           "assigning variable d_row_vector_flat__");
-        current_statement__ = 273;
+        current_statement__ = 275;
         pos__ = 1;
-        current_statement__ = 273;
+        current_statement__ = 275;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 273;
+          current_statement__ = 275;
           assign(d_row_vector,
             cons_list(index_uni(sym1__), nil_index_list()),
             d_row_vector_flat__[(pos__ - 1)],
             "assigning variable d_row_vector");
-          current_statement__ = 273;
+          current_statement__ = 275;
           pos__ = (pos__ + 1);}
       }
-      current_statement__ = 274;
-      validate_non_negative_index("d_row_vector_array", "d_int", d_int);
-      current_statement__ = 275;
-      validate_non_negative_index("d_row_vector_array", "d_int", d_int);
       current_statement__ = 276;
+      validate_non_negative_index("d_row_vector_array", "d_int", d_int);
+      current_statement__ = 277;
+      validate_non_negative_index("d_row_vector_array", "d_int", d_int);
+      current_statement__ = 278;
       context__.validate_dims("data initialization","d_row_vector_array",
           "double",context__.to_vec(d_int, d_int));
       d_row_vector_array = std::vector<Eigen::Matrix<double, 1, -1>>(d_int, Eigen::Matrix<double, 1, -1>(d_int));
@@ -5395,30 +5403,30 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_row_vector_array_flat__;
-        current_statement__ = 276;
+        current_statement__ = 278;
         assign(d_row_vector_array_flat__, nil_index_list(),
           context__.vals_r("d_row_vector_array"),
           "assigning variable d_row_vector_array_flat__");
-        current_statement__ = 276;
+        current_statement__ = 278;
         pos__ = 1;
-        current_statement__ = 276;
+        current_statement__ = 278;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 276;
+          current_statement__ = 278;
           for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-            current_statement__ = 276;
+            current_statement__ = 278;
             assign(d_row_vector_array,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               d_row_vector_array_flat__[(pos__ - 1)],
               "assigning variable d_row_vector_array");
-            current_statement__ = 276;
+            current_statement__ = 278;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 277;
-      validate_non_negative_index("d_row_vector_array_2d", "d_int", d_int);
-      current_statement__ = 278;
-      validate_non_negative_index("d_row_vector_array_2d", "d_int", d_int);
       current_statement__ = 279;
+      validate_non_negative_index("d_row_vector_array_2d", "d_int", d_int);
+      current_statement__ = 280;
+      validate_non_negative_index("d_row_vector_array_2d", "d_int", d_int);
+      current_statement__ = 281;
       context__.validate_dims("data initialization","d_row_vector_array_2d",
           "double",context__.to_vec(d_int, 2, d_int));
       d_row_vector_array_2d = std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(d_int, std::vector<Eigen::Matrix<double, 1, -1>>(2, Eigen::Matrix<double, 1, -1>(d_int)));
@@ -5426,33 +5434,33 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_row_vector_array_2d_flat__;
-        current_statement__ = 279;
+        current_statement__ = 281;
         assign(d_row_vector_array_2d_flat__, nil_index_list(),
           context__.vals_r("d_row_vector_array_2d"),
           "assigning variable d_row_vector_array_2d_flat__");
-        current_statement__ = 279;
+        current_statement__ = 281;
         pos__ = 1;
-        current_statement__ = 279;
+        current_statement__ = 281;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 279;
+          current_statement__ = 281;
           for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-            current_statement__ = 279;
+            current_statement__ = 281;
             for (int sym3__ = 1; sym3__ <= d_int; ++sym3__) {
-              current_statement__ = 279;
+              current_statement__ = 281;
               assign(d_row_vector_array_2d,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 d_row_vector_array_2d_flat__[(pos__ - 1)],
                 "assigning variable d_row_vector_array_2d");
-              current_statement__ = 279;
+              current_statement__ = 281;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 280;
-      validate_non_negative_index("d_row_vector_array_3d", "d_int", d_int);
-      current_statement__ = 281;
-      validate_non_negative_index("d_row_vector_array_3d", "d_int", d_int);
       current_statement__ = 282;
+      validate_non_negative_index("d_row_vector_array_3d", "d_int", d_int);
+      current_statement__ = 283;
+      validate_non_negative_index("d_row_vector_array_3d", "d_int", d_int);
+      current_statement__ = 284;
       context__.validate_dims("data initialization","d_row_vector_array_3d",
           "double",context__.to_vec(d_int, 2, 3, d_int));
       d_row_vector_array_3d = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(d_int, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(2, std::vector<Eigen::Matrix<double, 1, -1>>(3, Eigen::Matrix<double, 1, -1>(d_int))));
@@ -5460,21 +5468,21 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> d_row_vector_array_3d_flat__;
-        current_statement__ = 282;
+        current_statement__ = 284;
         assign(d_row_vector_array_3d_flat__, nil_index_list(),
           context__.vals_r("d_row_vector_array_3d"),
           "assigning variable d_row_vector_array_3d_flat__");
-        current_statement__ = 282;
+        current_statement__ = 284;
         pos__ = 1;
-        current_statement__ = 282;
+        current_statement__ = 284;
         for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-          current_statement__ = 282;
+          current_statement__ = 284;
           for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-            current_statement__ = 282;
+            current_statement__ = 284;
             for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-              current_statement__ = 282;
+              current_statement__ = 284;
               for (int sym4__ = 1; sym4__ <= d_int; ++sym4__) {
-                current_statement__ = 282;
+                current_statement__ = 284;
                 assign(d_row_vector_array_3d,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
@@ -5482,152 +5490,152 @@ class mother_model final : public model_base_crtp<mother_model> {
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   d_row_vector_array_3d_flat__[(pos__ - 1)],
                   "assigning variable d_row_vector_array_3d");
-                current_statement__ = 282;
+                current_statement__ = 284;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 283;
+      current_statement__ = 285;
       td_int = std::numeric_limits<int>::min();
       
-      current_statement__ = 284;
+      current_statement__ = 286;
       validate_non_negative_index("td_1d", "N", N);
-      current_statement__ = 285;
+      current_statement__ = 287;
       td_1d = std::vector<int>(N, std::numeric_limits<int>::min());
       
-      current_statement__ = 286;
+      current_statement__ = 288;
       validate_non_negative_index("td_1dk", "M", M);
-      current_statement__ = 287;
+      current_statement__ = 289;
       td_1dk = std::vector<int>(M, std::numeric_limits<int>::min());
       
-      current_statement__ = 287;
+      current_statement__ = 289;
       assign(td_1dk, nil_index_list(), rep_array(1, M),
         "assigning variable td_1dk");
-      current_statement__ = 288;
+      current_statement__ = 290;
       td_a = std::numeric_limits<int>::min();
       
-      current_statement__ = 288;
+      current_statement__ = 290;
       td_a = N;
-      current_statement__ = 289;
+      current_statement__ = 291;
       td_b = std::numeric_limits<double>::quiet_NaN();
       
-      current_statement__ = 289;
+      current_statement__ = 291;
       td_b = (N * J);
-      current_statement__ = 290;
+      current_statement__ = 292;
       td_c = std::numeric_limits<double>::quiet_NaN();
       
-      current_statement__ = 290;
+      current_statement__ = 292;
       td_c = foo_bar1(td_b, pstream__);
-      current_statement__ = 291;
+      current_statement__ = 293;
       td_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
       stan::math::fill(td_ar_mat, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 292;
+      current_statement__ = 294;
       validate_non_negative_index("td_simplex", "N", N);
-      current_statement__ = 293;
+      current_statement__ = 295;
       td_simplex = Eigen::Matrix<double, -1, 1>(N);
       stan::math::fill(td_simplex, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 294;
-      validate_non_negative_index("td_1d_simplex", "N", N);
-      current_statement__ = 295;
-      validate_non_negative_index("td_1d_simplex", "N", N);
       current_statement__ = 296;
+      validate_non_negative_index("td_1d_simplex", "N", N);
+      current_statement__ = 297;
+      validate_non_negative_index("td_1d_simplex", "N", N);
+      current_statement__ = 298;
       td_1d_simplex = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       stan::math::fill(td_1d_simplex, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 297;
-      validate_non_negative_index("td_3d_simplex", "N", N);
-      current_statement__ = 298;
-      validate_non_negative_index("td_3d_simplex", "M", M);
       current_statement__ = 299;
-      validate_non_negative_index("td_3d_simplex", "K", K);
-      current_statement__ = 300;
       validate_non_negative_index("td_3d_simplex", "N", N);
+      current_statement__ = 300;
+      validate_non_negative_index("td_3d_simplex", "M", M);
       current_statement__ = 301;
+      validate_non_negative_index("td_3d_simplex", "K", K);
+      current_statement__ = 302;
+      validate_non_negative_index("td_3d_simplex", "N", N);
+      current_statement__ = 303;
       td_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       stan::math::fill(td_3d_simplex, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 302;
+      current_statement__ = 304;
       td_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 5);
       stan::math::fill(td_cfcov_54, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 303;
+      current_statement__ = 305;
       td_cfcov_33 = Eigen::Matrix<double, -1, -1>(3, 3);
       stan::math::fill(td_cfcov_33, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 304;
+      current_statement__ = 306;
       x = Eigen::Matrix<double, -1, 1>(2);
       stan::math::fill(x, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 305;
+      current_statement__ = 307;
       y = Eigen::Matrix<double, -1, 1>(2);
       stan::math::fill(y, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 306;
+      current_statement__ = 308;
       dat = std::vector<double>(0, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 307;
+      current_statement__ = 309;
       dat_int = std::vector<int>(0, std::numeric_limits<int>::min());
       
-      current_statement__ = 308;
+      current_statement__ = 310;
       x_r = std::vector<std::vector<double>>(0, std::vector<double>(0, std::numeric_limits<double>::quiet_NaN()));
       
-      current_statement__ = 309;
+      current_statement__ = 311;
       x_i = std::vector<std::vector<int>>(0, std::vector<int>(0, std::numeric_limits<int>::min()));
       
-      current_statement__ = 310;
+      current_statement__ = 312;
       td_int = (primitive_value(1) || primitive_value(2));
-      current_statement__ = 311;
+      current_statement__ = 313;
       td_int = (primitive_value(1) && primitive_value(2));
-      current_statement__ = 320;
+      current_statement__ = 322;
       for (int i = 1; i <= 2; ++i) {
-        current_statement__ = 318;
+        current_statement__ = 320;
         for (int j = 1; j <= 3; ++j) {
-          current_statement__ = 316;
+          current_statement__ = 318;
           for (int m = 1; m <= 4; ++m) {
-            current_statement__ = 314;
+            current_statement__ = 316;
             for (int n = 1; n <= 5; ++n) {
-              current_statement__ = 312;
+              current_statement__ = 314;
               assign(td_ar_mat,
                 cons_list(index_uni(m),
                   cons_list(index_uni(n),
                     cons_list(index_uni(i),
                       cons_list(index_uni(j), nil_index_list())))), 0.4,
                 "assigning variable td_ar_mat");}}}}
-      current_statement__ = 331;
+      current_statement__ = 333;
       for (int i = 1; i <= N; ++i) {
-        current_statement__ = 321;
+        current_statement__ = 323;
         assign(td_simplex, cons_list(index_uni(i), nil_index_list()),
           (1.0 / N), "assigning variable td_simplex");
-        current_statement__ = 329;
+        current_statement__ = 331;
         for (int n = 1; n <= N; ++n) {
-          current_statement__ = 322;
+          current_statement__ = 324;
           assign(td_1d_simplex,
             cons_list(index_uni(n),
               cons_list(index_uni(i), nil_index_list())), (1.0 / N),
             "assigning variable td_1d_simplex");
-          current_statement__ = 327;
+          current_statement__ = 329;
           for (int m = 1; m <= M; ++m) {
-            current_statement__ = 325;
+            current_statement__ = 327;
             for (int k = 1; k <= K; ++k) {
-              current_statement__ = 323;
+              current_statement__ = 325;
               assign(td_3d_simplex,
                 cons_list(index_uni(n),
                   cons_list(index_uni(m),
                     cons_list(index_uni(k),
                       cons_list(index_uni(i), nil_index_list())))),
                 (1.0 / N), "assigning variable td_3d_simplex");}}}}
-      current_statement__ = 337;
+      current_statement__ = 339;
       for (int i = 1; i <= 4; ++i) {
-        current_statement__ = 335;
+        current_statement__ = 337;
         for (int j = 1; j <= 5; ++j) {
           Eigen::Matrix<double, -1, -1> l_mat;
           l_mat = Eigen::Matrix<double, -1, -1>(2, 3);
           stan::math::fill(l_mat, std::numeric_limits<double>::quiet_NaN());
           
-          current_statement__ = 332;
+          current_statement__ = 334;
           assign(l_mat, nil_index_list(), d_ar_mat[(i - 1)][(j - 1)],
             "assigning variable l_mat");
-          current_statement__ = 333;
+          current_statement__ = 335;
           if (pstream__) {
             stan_print(pstream__, "ar dim1: ");
             stan_print(pstream__, i);
@@ -5637,11 +5645,11 @@ class mother_model final : public model_base_crtp<mother_model> {
             stan_print(pstream__, l_mat);
             stan_print(pstream__, "\n");
           }}}
-      current_statement__ = 338;
+      current_statement__ = 340;
       assign(td_cfcov_54, nil_index_list(),
         diag_matrix(rep_vector(1, rows(td_cfcov_54))),
         "assigning variable td_cfcov_54");
-      current_statement__ = 339;
+      current_statement__ = 341;
       assign(td_cfcov_33, nil_index_list(),
         diag_matrix(rep_vector(1, rows(td_cfcov_33))),
         "assigning variable td_cfcov_33");
@@ -5653,584 +5661,584 @@ class mother_model final : public model_base_crtp<mother_model> {
         blocked_tdata_vs = Eigen::Matrix<double, 1, -1>(2);
         stan::math::fill(blocked_tdata_vs, std::numeric_limits<double>::quiet_NaN());
         
-        current_statement__ = 342;
+        current_statement__ = 344;
         for (int sym1__ = 1; sym1__ <= stan::math::size(blocked_tdata_vs);
              ++sym1__) {
           {
             double v;
-            current_statement__ = 342;
+            current_statement__ = 344;
             v = blocked_tdata_vs[(sym1__ - 1)];
-            current_statement__ = 343;
+            current_statement__ = 345;
             z = 0;
           }}
         std::vector<int> indices;
         indices = std::vector<int>(4, std::numeric_limits<int>::min());
         
-        current_statement__ = 344;
+        current_statement__ = 346;
         assign(indices, nil_index_list(), stan::math::array_builder<int>()
           .add(1).add(2).add(3).add(4).array(), "assigning variable indices");
         {
           std::vector<int> sym1__;
-          current_statement__ = 345;
+          current_statement__ = 347;
           assign(sym1__, nil_index_list(),
             rvalue(indices, cons_list(index_min_max(1, 3), nil_index_list()),
               "indices"), "assigning variable sym1__");
-          current_statement__ = 345;
+          current_statement__ = 347;
           for (int sym2__ = 1; sym2__ <= stan::math::size(sym1__); ++sym2__) {
             {
               int i;
-              current_statement__ = 345;
+              current_statement__ = 347;
               i = sym1__[(sym2__ - 1)];
-              current_statement__ = 346;
+              current_statement__ = 348;
               z = i;
             }}
         }
       }
-      current_statement__ = 348;
+      current_statement__ = 350;
       assign(td_1dk, nil_index_list(),
         rvalue(td_1d,
           cons_list(index_multi(stan::model::deep_copy(td_1dk)),
             nil_index_list()), "td_1d"), "assigning variable td_1dk");
-      current_statement__ = 349;
-      assign(td_simplex, nil_index_list(),
-        rvalue(td_1d_simplex,
-          cons_list(index_uni(1), cons_list(index_omni(), nil_index_list())),
-          "td_1d_simplex"), "assigning variable td_simplex");
-      current_statement__ = 350;
-      assign(td_simplex, nil_index_list(),
-        rvalue(td_1d_simplex,
-          cons_list(index_uni(1), cons_list(index_omni(), nil_index_list())),
-          "td_1d_simplex"), "assigning variable td_simplex");
       current_statement__ = 351;
+      assign(td_simplex, nil_index_list(),
+        rvalue(td_1d_simplex,
+          cons_list(index_uni(1), cons_list(index_omni(), nil_index_list())),
+          "td_1d_simplex"), "assigning variable td_simplex");
+      current_statement__ = 352;
+      assign(td_simplex, nil_index_list(),
+        rvalue(td_1d_simplex,
+          cons_list(index_uni(1), cons_list(index_omni(), nil_index_list())),
+          "td_1d_simplex"), "assigning variable td_simplex");
+      current_statement__ = 353;
       assign(td_simplex, nil_index_list(),
         rvalue(td_1d_simplex,
           cons_list(index_uni(1),
             cons_list(index_min_max(1, N), nil_index_list())),
           "td_1d_simplex"), "assigning variable td_simplex");
-      current_statement__ = 352;
+      current_statement__ = 354;
       arr_mul_ind = std::vector<std::vector<int>>(2, std::vector<int>(2, std::numeric_limits<int>::min()));
       
-      current_statement__ = 353;
+      current_statement__ = 355;
       assign(arr_mul_ind,
         cons_list(index_uni(1),
           cons_list(index_min_max(1, 2), nil_index_list())),
         stan::math::array_builder<int>().add(1).add(1).array(),
         "assigning variable arr_mul_ind");
-      current_statement__ = 354;
+      current_statement__ = 356;
       x_mul_ind = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 354;
+      current_statement__ = 356;
       assign(x_mul_ind, nil_index_list(), stan::math::array_builder<int>()
         .add(1).add(2).array(), "assigning variable x_mul_ind");
-      current_statement__ = 355;
+      current_statement__ = 357;
       transformed_data_real = std::numeric_limits<double>::quiet_NaN();
       
-      current_statement__ = 356;
+      current_statement__ = 358;
       validate_non_negative_index("transformed_data_real_array", "d_int",
                                   d_int);
-      current_statement__ = 357;
+      current_statement__ = 359;
       transformed_data_real_array = std::vector<double>(d_int, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 358;
+      current_statement__ = 360;
       validate_non_negative_index("transformed_data_real_array_2d", "d_int",
                                   d_int);
-      current_statement__ = 359;
+      current_statement__ = 361;
       transformed_data_real_array_2d = std::vector<std::vector<double>>(d_int, std::vector<double>(2, std::numeric_limits<double>::quiet_NaN()));
       
-      current_statement__ = 360;
+      current_statement__ = 362;
       validate_non_negative_index("transformed_data_real_array_3d", "d_int",
                                   d_int);
-      current_statement__ = 361;
+      current_statement__ = 363;
       transformed_data_real_array_3d = std::vector<std::vector<std::vector<double>>>(d_int, std::vector<std::vector<double>>(2, std::vector<double>(3, std::numeric_limits<double>::quiet_NaN())));
       
-      current_statement__ = 362;
-      validate_non_negative_index("transformed_data_matrix", "d_int", d_int);
-      current_statement__ = 363;
-      validate_non_negative_index("transformed_data_matrix", "d_int", d_int);
       current_statement__ = 364;
+      validate_non_negative_index("transformed_data_matrix", "d_int", d_int);
+      current_statement__ = 365;
+      validate_non_negative_index("transformed_data_matrix", "d_int", d_int);
+      current_statement__ = 366;
       transformed_data_matrix = Eigen::Matrix<double, -1, -1>(d_int, d_int);
       stan::math::fill(transformed_data_matrix, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 365;
-      validate_non_negative_index("transformed_data_matrix_array", "d_int",
-                                  d_int);
-      current_statement__ = 366;
-      validate_non_negative_index("transformed_data_matrix_array", "d_int",
-                                  d_int);
       current_statement__ = 367;
       validate_non_negative_index("transformed_data_matrix_array", "d_int",
                                   d_int);
       current_statement__ = 368;
+      validate_non_negative_index("transformed_data_matrix_array", "d_int",
+                                  d_int);
+      current_statement__ = 369;
+      validate_non_negative_index("transformed_data_matrix_array", "d_int",
+                                  d_int);
+      current_statement__ = 370;
       transformed_data_matrix_array = std::vector<Eigen::Matrix<double, -1, -1>>(d_int, Eigen::Matrix<double, -1, -1>(d_int, d_int));
       stan::math::fill(transformed_data_matrix_array, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 369;
-      validate_non_negative_index("transformed_data_matrix_array_2d",
-                                  "d_int", d_int);
-      current_statement__ = 370;
-      validate_non_negative_index("transformed_data_matrix_array_2d",
-                                  "d_int", d_int);
       current_statement__ = 371;
       validate_non_negative_index("transformed_data_matrix_array_2d",
                                   "d_int", d_int);
       current_statement__ = 372;
+      validate_non_negative_index("transformed_data_matrix_array_2d",
+                                  "d_int", d_int);
+      current_statement__ = 373;
+      validate_non_negative_index("transformed_data_matrix_array_2d",
+                                  "d_int", d_int);
+      current_statement__ = 374;
       transformed_data_matrix_array_2d = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(d_int, std::vector<Eigen::Matrix<double, -1, -1>>(2, Eigen::Matrix<double, -1, -1>(d_int, d_int)));
       stan::math::fill(transformed_data_matrix_array_2d, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 373;
-      validate_non_negative_index("transformed_data_matrix_array_3d",
-                                  "d_int", d_int);
-      current_statement__ = 374;
-      validate_non_negative_index("transformed_data_matrix_array_3d",
-                                  "d_int", d_int);
       current_statement__ = 375;
       validate_non_negative_index("transformed_data_matrix_array_3d",
                                   "d_int", d_int);
       current_statement__ = 376;
+      validate_non_negative_index("transformed_data_matrix_array_3d",
+                                  "d_int", d_int);
+      current_statement__ = 377;
+      validate_non_negative_index("transformed_data_matrix_array_3d",
+                                  "d_int", d_int);
+      current_statement__ = 378;
       transformed_data_matrix_array_3d = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>>(d_int, std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(2, std::vector<Eigen::Matrix<double, -1, -1>>(3, Eigen::Matrix<double, -1, -1>(d_int, d_int))));
       stan::math::fill(transformed_data_matrix_array_3d, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 377;
+      current_statement__ = 379;
       validate_non_negative_index("transformed_data_vector", "d_int", d_int);
-      current_statement__ = 378;
+      current_statement__ = 380;
       transformed_data_vector = Eigen::Matrix<double, -1, 1>(d_int);
       stan::math::fill(transformed_data_vector, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 379;
-      validate_non_negative_index("transformed_data_vector_array", "d_int",
-                                  d_int);
-      current_statement__ = 380;
-      validate_non_negative_index("transformed_data_vector_array", "d_int",
-                                  d_int);
       current_statement__ = 381;
+      validate_non_negative_index("transformed_data_vector_array", "d_int",
+                                  d_int);
+      current_statement__ = 382;
+      validate_non_negative_index("transformed_data_vector_array", "d_int",
+                                  d_int);
+      current_statement__ = 383;
       transformed_data_vector_array = std::vector<Eigen::Matrix<double, -1, 1>>(d_int, Eigen::Matrix<double, -1, 1>(d_int));
       stan::math::fill(transformed_data_vector_array, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 382;
-      validate_non_negative_index("transformed_data_vector_array_2d",
-                                  "d_int", d_int);
-      current_statement__ = 383;
-      validate_non_negative_index("transformed_data_vector_array_2d",
-                                  "d_int", d_int);
       current_statement__ = 384;
+      validate_non_negative_index("transformed_data_vector_array_2d",
+                                  "d_int", d_int);
+      current_statement__ = 385;
+      validate_non_negative_index("transformed_data_vector_array_2d",
+                                  "d_int", d_int);
+      current_statement__ = 386;
       transformed_data_vector_array_2d = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(d_int, std::vector<Eigen::Matrix<double, -1, 1>>(2, Eigen::Matrix<double, -1, 1>(d_int)));
       stan::math::fill(transformed_data_vector_array_2d, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 385;
-      validate_non_negative_index("transformed_data_vector_array_3d",
-                                  "d_int", d_int);
-      current_statement__ = 386;
-      validate_non_negative_index("transformed_data_vector_array_3d",
-                                  "d_int", d_int);
       current_statement__ = 387;
+      validate_non_negative_index("transformed_data_vector_array_3d",
+                                  "d_int", d_int);
+      current_statement__ = 388;
+      validate_non_negative_index("transformed_data_vector_array_3d",
+                                  "d_int", d_int);
+      current_statement__ = 389;
       transformed_data_vector_array_3d = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(d_int, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(2, std::vector<Eigen::Matrix<double, -1, 1>>(3, Eigen::Matrix<double, -1, 1>(d_int))));
       stan::math::fill(transformed_data_vector_array_3d, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 388;
+      current_statement__ = 390;
       validate_non_negative_index("transformed_data_row_vector", "d_int",
                                   d_int);
-      current_statement__ = 389;
+      current_statement__ = 391;
       transformed_data_row_vector = Eigen::Matrix<double, 1, -1>(d_int);
       stan::math::fill(transformed_data_row_vector, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 390;
-      validate_non_negative_index("transformed_data_row_vector_array",
-                                  "d_int", d_int);
-      current_statement__ = 391;
-      validate_non_negative_index("transformed_data_row_vector_array",
-                                  "d_int", d_int);
       current_statement__ = 392;
+      validate_non_negative_index("transformed_data_row_vector_array",
+                                  "d_int", d_int);
+      current_statement__ = 393;
+      validate_non_negative_index("transformed_data_row_vector_array",
+                                  "d_int", d_int);
+      current_statement__ = 394;
       transformed_data_row_vector_array = std::vector<Eigen::Matrix<double, 1, -1>>(d_int, Eigen::Matrix<double, 1, -1>(d_int));
       stan::math::fill(transformed_data_row_vector_array, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 393;
-      validate_non_negative_index("transformed_data_row_vector_array_2d",
-                                  "d_int", d_int);
-      current_statement__ = 394;
-      validate_non_negative_index("transformed_data_row_vector_array_2d",
-                                  "d_int", d_int);
       current_statement__ = 395;
+      validate_non_negative_index("transformed_data_row_vector_array_2d",
+                                  "d_int", d_int);
+      current_statement__ = 396;
+      validate_non_negative_index("transformed_data_row_vector_array_2d",
+                                  "d_int", d_int);
+      current_statement__ = 397;
       transformed_data_row_vector_array_2d = std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(d_int, std::vector<Eigen::Matrix<double, 1, -1>>(2, Eigen::Matrix<double, 1, -1>(d_int)));
       stan::math::fill(transformed_data_row_vector_array_2d, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 396;
-      validate_non_negative_index("transformed_data_row_vector_array_3d",
-                                  "d_int", d_int);
-      current_statement__ = 397;
-      validate_non_negative_index("transformed_data_row_vector_array_3d",
-                                  "d_int", d_int);
       current_statement__ = 398;
+      validate_non_negative_index("transformed_data_row_vector_array_3d",
+                                  "d_int", d_int);
+      current_statement__ = 399;
+      validate_non_negative_index("transformed_data_row_vector_array_3d",
+                                  "d_int", d_int);
+      current_statement__ = 400;
       transformed_data_row_vector_array_3d = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(d_int, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(2, std::vector<Eigen::Matrix<double, 1, -1>>(3, Eigen::Matrix<double, 1, -1>(d_int))));
       stan::math::fill(transformed_data_row_vector_array_3d, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 399;
-      transformed_data_real = pow(d_int, d_int);
-      current_statement__ = 400;
-      transformed_data_real = pow(d_real, d_int);
       current_statement__ = 401;
-      transformed_data_real = pow(d_int, d_real);
+      transformed_data_real = pow(d_int, d_int);
       current_statement__ = 402;
-      transformed_data_real = pow(d_real, d_real);
+      transformed_data_real = pow(d_real, d_int);
       current_statement__ = 403;
+      transformed_data_real = pow(d_int, d_real);
+      current_statement__ = 404;
+      transformed_data_real = pow(d_real, d_real);
+      current_statement__ = 405;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_int_array, d_int),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 404;
+      current_statement__ = 406;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_int_array, d_real),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 405;
+      current_statement__ = 407;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_int_array_2d, d_int),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 406;
+      current_statement__ = 408;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_int_array_2d, d_real),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 407;
+      current_statement__ = 409;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_int_array_3d, d_int),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 408;
+      current_statement__ = 410;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_int_array_3d, d_real),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 409;
+      current_statement__ = 411;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_int, d_int_array),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 410;
+      current_statement__ = 412;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_real, d_int_array),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 411;
+      current_statement__ = 413;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_int, d_int_array_2d),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 412;
+      current_statement__ = 414;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_real, d_int_array_2d),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 413;
+      current_statement__ = 415;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_int, d_int_array_3d),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 414;
+      current_statement__ = 416;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_real, d_int_array_3d),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 415;
+      current_statement__ = 417;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_int, d_real_array),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 416;
+      current_statement__ = 418;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_real, d_real_array),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 417;
+      current_statement__ = 419;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_int, d_real_array_2d),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 418;
+      current_statement__ = 420;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_real, d_real_array_2d),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 419;
+      current_statement__ = 421;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_int, d_real_array_3d),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 420;
+      current_statement__ = 422;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_real, d_real_array_3d),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 421;
+      current_statement__ = 423;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_real_array, d_int),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 422;
+      current_statement__ = 424;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_real_array, d_real),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 423;
+      current_statement__ = 425;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_real_array_2d, d_int),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 424;
+      current_statement__ = 426;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_real_array_2d, d_real),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 425;
+      current_statement__ = 427;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_real_array_3d, d_int),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 426;
+      current_statement__ = 428;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_real_array_3d, d_real),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 427;
+      current_statement__ = 429;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_int_array, d_int_array),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 428;
+      current_statement__ = 430;
       assign(transformed_data_real_array, nil_index_list(),
         pow(d_real_array, d_real_array),
         "assigning variable transformed_data_real_array");
-      current_statement__ = 429;
+      current_statement__ = 431;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_int_array_2d, d_int_array_2d),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 430;
+      current_statement__ = 432;
       assign(transformed_data_real_array_2d, nil_index_list(),
         pow(d_real_array_2d, d_real_array_2d),
         "assigning variable transformed_data_real_array_2d");
-      current_statement__ = 431;
+      current_statement__ = 433;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_int_array_3d, d_int_array_3d),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 432;
+      current_statement__ = 434;
       assign(transformed_data_real_array_3d, nil_index_list(),
         pow(d_real_array_3d, d_real_array_3d),
         "assigning variable transformed_data_real_array_3d");
-      current_statement__ = 433;
+      current_statement__ = 435;
       assign(transformed_data_vector, nil_index_list(), pow(d_vector, d_int),
         "assigning variable transformed_data_vector");
-      current_statement__ = 434;
+      current_statement__ = 436;
       assign(transformed_data_vector, nil_index_list(),
         pow(d_vector, d_real), "assigning variable transformed_data_vector");
-      current_statement__ = 435;
+      current_statement__ = 437;
       assign(transformed_data_vector_array, nil_index_list(),
         pow(d_vector_array, d_int),
         "assigning variable transformed_data_vector_array");
-      current_statement__ = 436;
+      current_statement__ = 438;
       assign(transformed_data_vector_array, nil_index_list(),
         pow(d_vector_array, d_real),
         "assigning variable transformed_data_vector_array");
-      current_statement__ = 437;
+      current_statement__ = 439;
       assign(transformed_data_vector_array_2d, nil_index_list(),
         pow(d_vector_array_2d, d_int),
         "assigning variable transformed_data_vector_array_2d");
-      current_statement__ = 438;
+      current_statement__ = 440;
       assign(transformed_data_vector_array_2d, nil_index_list(),
         pow(d_vector_array_2d, d_real),
         "assigning variable transformed_data_vector_array_2d");
-      current_statement__ = 439;
+      current_statement__ = 441;
       assign(transformed_data_vector_array_3d, nil_index_list(),
         pow(d_vector_array_3d, d_int),
         "assigning variable transformed_data_vector_array_3d");
-      current_statement__ = 440;
+      current_statement__ = 442;
       assign(transformed_data_vector_array_3d, nil_index_list(),
         pow(d_vector_array_3d, d_real),
         "assigning variable transformed_data_vector_array_3d");
-      current_statement__ = 441;
+      current_statement__ = 443;
       assign(transformed_data_vector, nil_index_list(), pow(d_int, d_vector),
         "assigning variable transformed_data_vector");
-      current_statement__ = 442;
+      current_statement__ = 444;
       assign(transformed_data_vector, nil_index_list(),
         pow(d_real, d_vector), "assigning variable transformed_data_vector");
-      current_statement__ = 443;
+      current_statement__ = 445;
       assign(transformed_data_vector_array, nil_index_list(),
         pow(d_int, d_vector_array),
         "assigning variable transformed_data_vector_array");
-      current_statement__ = 444;
+      current_statement__ = 446;
       assign(transformed_data_vector_array, nil_index_list(),
         pow(d_real, d_vector_array),
         "assigning variable transformed_data_vector_array");
-      current_statement__ = 445;
+      current_statement__ = 447;
       assign(transformed_data_vector_array_2d, nil_index_list(),
         pow(d_int, d_vector_array_2d),
         "assigning variable transformed_data_vector_array_2d");
-      current_statement__ = 446;
+      current_statement__ = 448;
       assign(transformed_data_vector_array_2d, nil_index_list(),
         pow(d_real, d_vector_array_2d),
         "assigning variable transformed_data_vector_array_2d");
-      current_statement__ = 447;
+      current_statement__ = 449;
       assign(transformed_data_vector_array_3d, nil_index_list(),
         pow(d_int, d_vector_array_3d),
         "assigning variable transformed_data_vector_array_3d");
-      current_statement__ = 448;
+      current_statement__ = 450;
       assign(transformed_data_vector_array_3d, nil_index_list(),
         pow(d_real, d_vector_array_3d),
         "assigning variable transformed_data_vector_array_3d");
-      current_statement__ = 449;
+      current_statement__ = 451;
       assign(transformed_data_vector, nil_index_list(),
         pow(d_vector, d_vector), "assigning variable transformed_data_vector");
-      current_statement__ = 450;
+      current_statement__ = 452;
       assign(transformed_data_vector_array, nil_index_list(),
         pow(d_vector_array, d_vector_array),
         "assigning variable transformed_data_vector_array");
-      current_statement__ = 451;
+      current_statement__ = 453;
       assign(transformed_data_vector_array_2d, nil_index_list(),
         pow(d_vector_array_2d, d_vector_array_2d),
         "assigning variable transformed_data_vector_array_2d");
-      current_statement__ = 452;
+      current_statement__ = 454;
       assign(transformed_data_vector_array_3d, nil_index_list(),
         pow(d_vector_array_3d, d_vector_array_3d),
         "assigning variable transformed_data_vector_array_3d");
-      current_statement__ = 453;
+      current_statement__ = 455;
       assign(transformed_data_row_vector, nil_index_list(),
         pow(d_row_vector, d_int),
         "assigning variable transformed_data_row_vector");
-      current_statement__ = 454;
+      current_statement__ = 456;
       assign(transformed_data_row_vector, nil_index_list(),
         pow(d_row_vector, d_real),
         "assigning variable transformed_data_row_vector");
-      current_statement__ = 455;
+      current_statement__ = 457;
       assign(transformed_data_row_vector_array, nil_index_list(),
         pow(d_row_vector_array, d_int),
         "assigning variable transformed_data_row_vector_array");
-      current_statement__ = 456;
+      current_statement__ = 458;
       assign(transformed_data_row_vector_array, nil_index_list(),
         pow(d_row_vector_array, d_real),
         "assigning variable transformed_data_row_vector_array");
-      current_statement__ = 457;
+      current_statement__ = 459;
       assign(transformed_data_row_vector_array_2d, nil_index_list(),
         pow(d_row_vector_array_2d, d_int),
         "assigning variable transformed_data_row_vector_array_2d");
-      current_statement__ = 458;
+      current_statement__ = 460;
       assign(transformed_data_row_vector_array_2d, nil_index_list(),
         pow(d_row_vector_array_2d, d_real),
         "assigning variable transformed_data_row_vector_array_2d");
-      current_statement__ = 459;
+      current_statement__ = 461;
       assign(transformed_data_row_vector_array_3d, nil_index_list(),
         pow(d_row_vector_array_3d, d_int),
         "assigning variable transformed_data_row_vector_array_3d");
-      current_statement__ = 460;
+      current_statement__ = 462;
       assign(transformed_data_row_vector_array_3d, nil_index_list(),
         pow(d_row_vector_array_3d, d_real),
         "assigning variable transformed_data_row_vector_array_3d");
-      current_statement__ = 461;
+      current_statement__ = 463;
       assign(transformed_data_row_vector, nil_index_list(),
         pow(d_int, d_row_vector),
         "assigning variable transformed_data_row_vector");
-      current_statement__ = 462;
+      current_statement__ = 464;
       assign(transformed_data_row_vector, nil_index_list(),
         pow(d_real, d_row_vector),
         "assigning variable transformed_data_row_vector");
-      current_statement__ = 463;
+      current_statement__ = 465;
       assign(transformed_data_row_vector_array, nil_index_list(),
         pow(d_int, d_row_vector_array),
         "assigning variable transformed_data_row_vector_array");
-      current_statement__ = 464;
+      current_statement__ = 466;
       assign(transformed_data_row_vector_array, nil_index_list(),
         pow(d_real, d_row_vector_array),
         "assigning variable transformed_data_row_vector_array");
-      current_statement__ = 465;
+      current_statement__ = 467;
       assign(transformed_data_row_vector_array_2d, nil_index_list(),
         pow(d_int, d_row_vector_array_2d),
         "assigning variable transformed_data_row_vector_array_2d");
-      current_statement__ = 466;
+      current_statement__ = 468;
       assign(transformed_data_row_vector_array_2d, nil_index_list(),
         pow(d_real, d_row_vector_array_2d),
         "assigning variable transformed_data_row_vector_array_2d");
-      current_statement__ = 467;
+      current_statement__ = 469;
       assign(transformed_data_row_vector_array_3d, nil_index_list(),
         pow(d_int, d_row_vector_array_3d),
         "assigning variable transformed_data_row_vector_array_3d");
-      current_statement__ = 468;
+      current_statement__ = 470;
       assign(transformed_data_row_vector_array_3d, nil_index_list(),
         pow(d_real, d_row_vector_array_3d),
         "assigning variable transformed_data_row_vector_array_3d");
-      current_statement__ = 469;
+      current_statement__ = 471;
       assign(transformed_data_row_vector, nil_index_list(),
         pow(d_row_vector, d_row_vector),
         "assigning variable transformed_data_row_vector");
-      current_statement__ = 470;
+      current_statement__ = 472;
       assign(transformed_data_row_vector_array, nil_index_list(),
         pow(d_row_vector_array, d_row_vector_array),
         "assigning variable transformed_data_row_vector_array");
-      current_statement__ = 471;
+      current_statement__ = 473;
       assign(transformed_data_row_vector_array_2d, nil_index_list(),
         pow(d_row_vector_array_2d, d_row_vector_array_2d),
         "assigning variable transformed_data_row_vector_array_2d");
-      current_statement__ = 472;
+      current_statement__ = 474;
       assign(transformed_data_row_vector_array_3d, nil_index_list(),
         pow(d_row_vector_array_3d, d_row_vector_array_3d),
         "assigning variable transformed_data_row_vector_array_3d");
-      current_statement__ = 473;
+      current_statement__ = 475;
       assign(transformed_data_matrix, nil_index_list(), pow(d_matrix, d_int),
         "assigning variable transformed_data_matrix");
-      current_statement__ = 474;
+      current_statement__ = 476;
       assign(transformed_data_matrix, nil_index_list(),
         pow(d_matrix, d_real), "assigning variable transformed_data_matrix");
-      current_statement__ = 475;
+      current_statement__ = 477;
       assign(transformed_data_matrix_array, nil_index_list(),
         pow(d_matrix_array, d_int),
         "assigning variable transformed_data_matrix_array");
-      current_statement__ = 476;
+      current_statement__ = 478;
       assign(transformed_data_matrix_array, nil_index_list(),
         pow(d_matrix_array, d_real),
         "assigning variable transformed_data_matrix_array");
-      current_statement__ = 477;
+      current_statement__ = 479;
       assign(transformed_data_matrix_array_2d, nil_index_list(),
         pow(d_matrix_array_2d, d_int),
         "assigning variable transformed_data_matrix_array_2d");
-      current_statement__ = 478;
+      current_statement__ = 480;
       assign(transformed_data_matrix_array_2d, nil_index_list(),
         pow(d_matrix_array_2d, d_real),
         "assigning variable transformed_data_matrix_array_2d");
-      current_statement__ = 479;
+      current_statement__ = 481;
       assign(transformed_data_matrix_array_3d, nil_index_list(),
         pow(d_matrix_array_3d, d_int),
         "assigning variable transformed_data_matrix_array_3d");
-      current_statement__ = 480;
+      current_statement__ = 482;
       assign(transformed_data_matrix_array_3d, nil_index_list(),
         pow(d_matrix_array_3d, d_real),
         "assigning variable transformed_data_matrix_array_3d");
-      current_statement__ = 481;
+      current_statement__ = 483;
       assign(transformed_data_matrix, nil_index_list(), pow(d_int, d_matrix),
         "assigning variable transformed_data_matrix");
-      current_statement__ = 482;
+      current_statement__ = 484;
       assign(transformed_data_matrix, nil_index_list(),
         pow(d_real, d_matrix), "assigning variable transformed_data_matrix");
-      current_statement__ = 483;
+      current_statement__ = 485;
       assign(transformed_data_matrix_array, nil_index_list(),
         pow(d_int, d_matrix_array),
         "assigning variable transformed_data_matrix_array");
-      current_statement__ = 484;
+      current_statement__ = 486;
       assign(transformed_data_matrix_array, nil_index_list(),
         pow(d_real, d_matrix_array),
         "assigning variable transformed_data_matrix_array");
-      current_statement__ = 485;
+      current_statement__ = 487;
       assign(transformed_data_matrix_array_2d, nil_index_list(),
         pow(d_int, d_matrix_array_2d),
         "assigning variable transformed_data_matrix_array_2d");
-      current_statement__ = 486;
+      current_statement__ = 488;
       assign(transformed_data_matrix_array_2d, nil_index_list(),
         pow(d_real, d_matrix_array_2d),
         "assigning variable transformed_data_matrix_array_2d");
-      current_statement__ = 487;
+      current_statement__ = 489;
       assign(transformed_data_matrix_array_3d, nil_index_list(),
         pow(d_int, d_matrix_array_3d),
         "assigning variable transformed_data_matrix_array_3d");
-      current_statement__ = 488;
+      current_statement__ = 490;
       assign(transformed_data_matrix_array_3d, nil_index_list(),
         pow(d_real, d_matrix_array_3d),
         "assigning variable transformed_data_matrix_array_3d");
-      current_statement__ = 489;
+      current_statement__ = 491;
       assign(transformed_data_matrix, nil_index_list(),
         pow(d_matrix, d_matrix), "assigning variable transformed_data_matrix");
-      current_statement__ = 490;
+      current_statement__ = 492;
       assign(transformed_data_matrix_array, nil_index_list(),
         pow(d_matrix_array, d_matrix_array),
         "assigning variable transformed_data_matrix_array");
-      current_statement__ = 491;
+      current_statement__ = 493;
       assign(transformed_data_matrix_array_2d, nil_index_list(),
         pow(d_matrix_array_2d, d_matrix_array_2d),
         "assigning variable transformed_data_matrix_array_2d");
-      current_statement__ = 492;
+      current_statement__ = 494;
       assign(transformed_data_matrix_array_3d, nil_index_list(),
         pow(d_matrix_array_3d, d_matrix_array_3d),
         "assigning variable transformed_data_matrix_array_3d");
-      current_statement__ = 291;
+      current_statement__ = 293;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 291;
+        current_statement__ = 293;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 291;
+          current_statement__ = 293;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 291;
+            current_statement__ = 293;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 291;
-              current_statement__ = 291;
+              current_statement__ = 293;
+              current_statement__ = 293;
               check_greater_or_equal(function__,
                                      "td_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                      rvalue(td_ar_mat,
@@ -6240,16 +6248,16 @@ class mother_model final : public model_base_crtp<mother_model> {
                                              cons_list(index_uni(sym4__),
                                                nil_index_list())))),
                                        "td_ar_mat"), 0);}}}}
-      current_statement__ = 291;
+      current_statement__ = 293;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 291;
+        current_statement__ = 293;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 291;
+          current_statement__ = 293;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 291;
+            current_statement__ = 293;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 291;
-              current_statement__ = 291;
+              current_statement__ = 293;
+              current_statement__ = 293;
               check_less_or_equal(function__,
                                   "td_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                   rvalue(td_ar_mat,
@@ -6259,200 +6267,200 @@ class mother_model final : public model_base_crtp<mother_model> {
                                           cons_list(index_uni(sym4__),
                                             nil_index_list())))),
                                     "td_ar_mat"), 1);}}}}
-      current_statement__ = 293;
-      current_statement__ = 293;
+      current_statement__ = 295;
+      current_statement__ = 295;
       check_simplex(function__, "td_simplex", td_simplex);
-      current_statement__ = 296;
+      current_statement__ = 298;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 296;
-        current_statement__ = 296;
+        current_statement__ = 298;
+        current_statement__ = 298;
         check_simplex(function__, "td_1d_simplex[sym1__]",
                       td_1d_simplex[(sym1__ - 1)]);}
-      current_statement__ = 301;
+      current_statement__ = 303;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 301;
+        current_statement__ = 303;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 301;
+          current_statement__ = 303;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 301;
-            current_statement__ = 301;
+            current_statement__ = 303;
+            current_statement__ = 303;
             check_simplex(function__,
                           "td_3d_simplex[sym1__, sym2__, sym3__]",
                           td_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ -
                                                                     1)]);}}}
-      current_statement__ = 302;
-      current_statement__ = 302;
+      current_statement__ = 304;
+      current_statement__ = 304;
       check_cholesky_factor(function__, "td_cfcov_54", td_cfcov_54);
-      current_statement__ = 303;
-      current_statement__ = 303;
+      current_statement__ = 305;
+      current_statement__ = 305;
       check_cholesky_factor(function__, "td_cfcov_33", td_cfcov_33);
-      current_statement__ = 493;
-      validate_non_negative_index("p_real_1d_ar", "N", N);
-      current_statement__ = 494;
-      validate_non_negative_index("p_real_3d_ar", "N", N);
       current_statement__ = 495;
-      validate_non_negative_index("p_real_3d_ar", "M", M);
+      validate_non_negative_index("p_real_1d_ar", "N", N);
       current_statement__ = 496;
-      validate_non_negative_index("p_real_3d_ar", "K", K);
+      validate_non_negative_index("p_real_3d_ar", "N", N);
       current_statement__ = 497;
-      validate_non_negative_index("p_vec", "N", N);
+      validate_non_negative_index("p_real_3d_ar", "M", M);
       current_statement__ = 498;
-      validate_non_negative_index("p_1d_vec", "N", N);
+      validate_non_negative_index("p_real_3d_ar", "K", K);
       current_statement__ = 499;
-      validate_non_negative_index("p_1d_vec", "N", N);
+      validate_non_negative_index("p_vec", "N", N);
       current_statement__ = 500;
-      validate_non_negative_index("p_3d_vec", "N", N);
+      validate_non_negative_index("p_1d_vec", "N", N);
       current_statement__ = 501;
-      validate_non_negative_index("p_3d_vec", "M", M);
+      validate_non_negative_index("p_1d_vec", "N", N);
       current_statement__ = 502;
-      validate_non_negative_index("p_3d_vec", "K", K);
-      current_statement__ = 503;
       validate_non_negative_index("p_3d_vec", "N", N);
+      current_statement__ = 503;
+      validate_non_negative_index("p_3d_vec", "M", M);
       current_statement__ = 504;
-      validate_non_negative_index("p_row_vec", "N", N);
+      validate_non_negative_index("p_3d_vec", "K", K);
       current_statement__ = 505;
-      validate_non_negative_index("p_1d_row_vec", "N", N);
+      validate_non_negative_index("p_3d_vec", "N", N);
       current_statement__ = 506;
-      validate_non_negative_index("p_1d_row_vec", "N", N);
+      validate_non_negative_index("p_row_vec", "N", N);
       current_statement__ = 507;
-      validate_non_negative_index("p_3d_row_vec", "N", N);
+      validate_non_negative_index("p_1d_row_vec", "N", N);
       current_statement__ = 508;
-      validate_non_negative_index("p_3d_row_vec", "M", M);
+      validate_non_negative_index("p_1d_row_vec", "N", N);
       current_statement__ = 509;
-      validate_non_negative_index("p_3d_row_vec", "K", K);
-      current_statement__ = 510;
       validate_non_negative_index("p_3d_row_vec", "N", N);
+      current_statement__ = 510;
+      validate_non_negative_index("p_3d_row_vec", "M", M);
       current_statement__ = 511;
-      validate_positive_index("p_simplex", "N", N);
+      validate_non_negative_index("p_3d_row_vec", "K", K);
       current_statement__ = 512;
-      validate_non_negative_index("p_1d_simplex", "N", N);
+      validate_non_negative_index("p_3d_row_vec", "N", N);
       current_statement__ = 513;
-      validate_positive_index("p_1d_simplex", "N", N);
+      validate_positive_index("p_simplex", "N", N);
       current_statement__ = 514;
-      validate_non_negative_index("p_3d_simplex", "N", N);
+      validate_non_negative_index("p_1d_simplex", "N", N);
       current_statement__ = 515;
-      validate_non_negative_index("p_3d_simplex", "M", M);
+      validate_positive_index("p_1d_simplex", "N", N);
       current_statement__ = 516;
-      validate_non_negative_index("p_3d_simplex", "K", K);
+      validate_non_negative_index("p_3d_simplex", "N", N);
       current_statement__ = 517;
-      validate_positive_index("p_3d_simplex", "N", N);
+      validate_non_negative_index("p_3d_simplex", "M", M);
       current_statement__ = 518;
+      validate_non_negative_index("p_3d_simplex", "K", K);
+      current_statement__ = 519;
+      validate_positive_index("p_3d_simplex", "N", N);
+      current_statement__ = 520;
       check_greater_or_equal("cholesky_factor_cov p_cfcov_54",
                              "num rows (must be greater or equal to num cols)",
                              5, 4);
-      current_statement__ = 519;
+      current_statement__ = 521;
       check_greater_or_equal("cholesky_factor_cov p_cfcov_33",
                              "num rows (must be greater or equal to num cols)",
                              3, 3);
-      current_statement__ = 520;
+      current_statement__ = 522;
       validate_non_negative_index("p_cfcov_33_ar", "K", K);
-      current_statement__ = 521;
+      current_statement__ = 523;
       check_greater_or_equal("cholesky_factor_cov p_cfcov_33_ar",
                              "num rows (must be greater or equal to num cols)",
                              3, 3);
-      current_statement__ = 522;
-      validate_non_negative_index("tp_real_1d_ar", "N", N);
-      current_statement__ = 523;
-      validate_non_negative_index("tp_real_3d_ar", "N", N);
       current_statement__ = 524;
-      validate_non_negative_index("tp_real_3d_ar", "M", M);
+      validate_non_negative_index("tp_real_1d_ar", "N", N);
       current_statement__ = 525;
-      validate_non_negative_index("tp_real_3d_ar", "K", K);
+      validate_non_negative_index("tp_real_3d_ar", "N", N);
       current_statement__ = 526;
-      validate_non_negative_index("tp_vec", "N", N);
+      validate_non_negative_index("tp_real_3d_ar", "M", M);
       current_statement__ = 527;
-      validate_non_negative_index("tp_1d_vec", "N", N);
+      validate_non_negative_index("tp_real_3d_ar", "K", K);
       current_statement__ = 528;
-      validate_non_negative_index("tp_1d_vec", "N", N);
+      validate_non_negative_index("tp_vec", "N", N);
       current_statement__ = 529;
-      validate_non_negative_index("tp_3d_vec", "N", N);
+      validate_non_negative_index("tp_1d_vec", "N", N);
       current_statement__ = 530;
-      validate_non_negative_index("tp_3d_vec", "M", M);
+      validate_non_negative_index("tp_1d_vec", "N", N);
       current_statement__ = 531;
-      validate_non_negative_index("tp_3d_vec", "K", K);
-      current_statement__ = 532;
       validate_non_negative_index("tp_3d_vec", "N", N);
+      current_statement__ = 532;
+      validate_non_negative_index("tp_3d_vec", "M", M);
       current_statement__ = 533;
-      validate_non_negative_index("tp_row_vec", "N", N);
+      validate_non_negative_index("tp_3d_vec", "K", K);
       current_statement__ = 534;
-      validate_non_negative_index("tp_1d_row_vec", "N", N);
+      validate_non_negative_index("tp_3d_vec", "N", N);
       current_statement__ = 535;
-      validate_non_negative_index("tp_1d_row_vec", "N", N);
+      validate_non_negative_index("tp_row_vec", "N", N);
       current_statement__ = 536;
-      validate_non_negative_index("tp_3d_row_vec", "N", N);
+      validate_non_negative_index("tp_1d_row_vec", "N", N);
       current_statement__ = 537;
-      validate_non_negative_index("tp_3d_row_vec", "M", M);
+      validate_non_negative_index("tp_1d_row_vec", "N", N);
       current_statement__ = 538;
-      validate_non_negative_index("tp_3d_row_vec", "K", K);
-      current_statement__ = 539;
       validate_non_negative_index("tp_3d_row_vec", "N", N);
+      current_statement__ = 539;
+      validate_non_negative_index("tp_3d_row_vec", "M", M);
       current_statement__ = 540;
-      validate_non_negative_index("tp_simplex", "N", N);
+      validate_non_negative_index("tp_3d_row_vec", "K", K);
       current_statement__ = 541;
-      validate_non_negative_index("tp_1d_simplex", "N", N);
+      validate_non_negative_index("tp_3d_row_vec", "N", N);
       current_statement__ = 542;
-      validate_non_negative_index("tp_1d_simplex", "N", N);
+      validate_non_negative_index("tp_simplex", "N", N);
       current_statement__ = 543;
-      validate_non_negative_index("tp_3d_simplex", "N", N);
+      validate_non_negative_index("tp_1d_simplex", "N", N);
       current_statement__ = 544;
-      validate_non_negative_index("tp_3d_simplex", "M", M);
+      validate_non_negative_index("tp_1d_simplex", "N", N);
       current_statement__ = 545;
-      validate_non_negative_index("tp_3d_simplex", "K", K);
-      current_statement__ = 546;
       validate_non_negative_index("tp_3d_simplex", "N", N);
+      current_statement__ = 546;
+      validate_non_negative_index("tp_3d_simplex", "M", M);
       current_statement__ = 547;
-      validate_non_negative_index("tp_cfcov_33_ar", "K", K);
+      validate_non_negative_index("tp_3d_simplex", "K", K);
       current_statement__ = 548;
-      validate_non_negative_index("gq_real_1d_ar", "N", N);
+      validate_non_negative_index("tp_3d_simplex", "N", N);
       current_statement__ = 549;
-      validate_non_negative_index("gq_real_3d_ar", "N", N);
+      validate_non_negative_index("tp_cfcov_33_ar", "K", K);
       current_statement__ = 550;
-      validate_non_negative_index("gq_real_3d_ar", "M", M);
+      validate_non_negative_index("gq_real_1d_ar", "N", N);
       current_statement__ = 551;
-      validate_non_negative_index("gq_real_3d_ar", "K", K);
+      validate_non_negative_index("gq_real_3d_ar", "N", N);
       current_statement__ = 552;
-      validate_non_negative_index("gq_vec", "N", N);
+      validate_non_negative_index("gq_real_3d_ar", "M", M);
       current_statement__ = 553;
-      validate_non_negative_index("gq_1d_vec", "N", N);
+      validate_non_negative_index("gq_real_3d_ar", "K", K);
       current_statement__ = 554;
-      validate_non_negative_index("gq_1d_vec", "N", N);
+      validate_non_negative_index("gq_vec", "N", N);
       current_statement__ = 555;
-      validate_non_negative_index("gq_3d_vec", "N", N);
+      validate_non_negative_index("gq_1d_vec", "N", N);
       current_statement__ = 556;
-      validate_non_negative_index("gq_3d_vec", "M", M);
+      validate_non_negative_index("gq_1d_vec", "N", N);
       current_statement__ = 557;
-      validate_non_negative_index("gq_3d_vec", "K", K);
-      current_statement__ = 558;
       validate_non_negative_index("gq_3d_vec", "N", N);
+      current_statement__ = 558;
+      validate_non_negative_index("gq_3d_vec", "M", M);
       current_statement__ = 559;
-      validate_non_negative_index("gq_row_vec", "N", N);
+      validate_non_negative_index("gq_3d_vec", "K", K);
       current_statement__ = 560;
-      validate_non_negative_index("gq_1d_row_vec", "N", N);
+      validate_non_negative_index("gq_3d_vec", "N", N);
       current_statement__ = 561;
-      validate_non_negative_index("gq_1d_row_vec", "N", N);
+      validate_non_negative_index("gq_row_vec", "N", N);
       current_statement__ = 562;
-      validate_non_negative_index("gq_3d_row_vec", "N", N);
+      validate_non_negative_index("gq_1d_row_vec", "N", N);
       current_statement__ = 563;
-      validate_non_negative_index("gq_3d_row_vec", "M", M);
+      validate_non_negative_index("gq_1d_row_vec", "N", N);
       current_statement__ = 564;
-      validate_non_negative_index("gq_3d_row_vec", "K", K);
-      current_statement__ = 565;
       validate_non_negative_index("gq_3d_row_vec", "N", N);
+      current_statement__ = 565;
+      validate_non_negative_index("gq_3d_row_vec", "M", M);
       current_statement__ = 566;
-      validate_non_negative_index("gq_simplex", "N", N);
+      validate_non_negative_index("gq_3d_row_vec", "K", K);
       current_statement__ = 567;
-      validate_non_negative_index("gq_1d_simplex", "N", N);
+      validate_non_negative_index("gq_3d_row_vec", "N", N);
       current_statement__ = 568;
-      validate_non_negative_index("gq_1d_simplex", "N", N);
+      validate_non_negative_index("gq_simplex", "N", N);
       current_statement__ = 569;
-      validate_non_negative_index("gq_3d_simplex", "N", N);
+      validate_non_negative_index("gq_1d_simplex", "N", N);
       current_statement__ = 570;
-      validate_non_negative_index("gq_3d_simplex", "M", M);
+      validate_non_negative_index("gq_1d_simplex", "N", N);
       current_statement__ = 571;
-      validate_non_negative_index("gq_3d_simplex", "K", K);
-      current_statement__ = 572;
       validate_non_negative_index("gq_3d_simplex", "N", N);
+      current_statement__ = 572;
+      validate_non_negative_index("gq_3d_simplex", "M", M);
       current_statement__ = 573;
+      validate_non_negative_index("gq_3d_simplex", "K", K);
+      current_statement__ = 574;
+      validate_non_negative_index("gq_3d_simplex", "N", N);
+      current_statement__ = 575;
       validate_non_negative_index("gq_cfcov_33_ar", "K", K);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6462,6 +6470,8 @@ class mother_model final : public model_base_crtp<mother_model> {
     num_params_r__ = 0U;
     
     try {
+      num_params_r__ += 1;
+      num_params_r__ += 1;
       num_params_r__ += 1;
       num_params_r__ += 5;
       num_params_r__ += 5;
@@ -6510,27 +6520,53 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       current_statement__ = 1;
       p_real = in__.scalar();
+      local_scalar_t__ p_upper;
+      p_upper = DUMMY_VAR__;
+      
+      current_statement__ = 2;
+      p_upper = in__.scalar();
+      current_statement__ = 2;
+      if (jacobian__) {
+        current_statement__ = 2;
+        p_upper = stan::math::lb_constrain(p_upper, p_real, lp__);
+      } else {
+        current_statement__ = 2;
+        p_upper = stan::math::lb_constrain(p_upper, p_real);
+      }
+      local_scalar_t__ p_lower;
+      p_lower = DUMMY_VAR__;
+      
+      current_statement__ = 3;
+      p_lower = in__.scalar();
+      current_statement__ = 3;
+      if (jacobian__) {
+        current_statement__ = 3;
+        p_lower = stan::math::ub_constrain(p_lower, p_upper, lp__);
+      } else {
+        current_statement__ = 3;
+        p_lower = stan::math::ub_constrain(p_lower, p_upper);
+      }
       std::vector<local_scalar_t__> offset_multiplier;
       offset_multiplier = std::vector<local_scalar_t__>(5, DUMMY_VAR__);
       
-      current_statement__ = 2;
+      current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 2;
+        current_statement__ = 4;
         assign(offset_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(),
           "assigning variable offset_multiplier");}
-      current_statement__ = 2;
+      current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 2;
+        current_statement__ = 4;
         if (jacobian__) {
-          current_statement__ = 2;
+          current_statement__ = 4;
           assign(offset_multiplier,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(
               offset_multiplier[(sym1__ - 1)], 1, 2, lp__),
             "assigning variable offset_multiplier");
         } else {
-          current_statement__ = 2;
+          current_statement__ = 4;
           assign(offset_multiplier,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(
@@ -6540,24 +6576,24 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<local_scalar_t__> no_offset_multiplier;
       no_offset_multiplier = std::vector<local_scalar_t__>(5, DUMMY_VAR__);
       
-      current_statement__ = 3;
+      current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 3;
+        current_statement__ = 5;
         assign(no_offset_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(),
           "assigning variable no_offset_multiplier");}
-      current_statement__ = 3;
+      current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 3;
+        current_statement__ = 5;
         if (jacobian__) {
-          current_statement__ = 3;
+          current_statement__ = 5;
           assign(no_offset_multiplier,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(
               no_offset_multiplier[(sym1__ - 1)], 0, 2, lp__),
             "assigning variable no_offset_multiplier");
         } else {
-          current_statement__ = 3;
+          current_statement__ = 5;
           assign(no_offset_multiplier,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(
@@ -6567,24 +6603,24 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<local_scalar_t__> offset_no_multiplier;
       offset_no_multiplier = std::vector<local_scalar_t__>(5, DUMMY_VAR__);
       
-      current_statement__ = 4;
+      current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 4;
+        current_statement__ = 6;
         assign(offset_no_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(),
           "assigning variable offset_no_multiplier");}
-      current_statement__ = 4;
+      current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 4;
+        current_statement__ = 6;
         if (jacobian__) {
-          current_statement__ = 4;
+          current_statement__ = 6;
           assign(offset_no_multiplier,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(
               offset_no_multiplier[(sym1__ - 1)], 3, 1, lp__),
             "assigning variable offset_no_multiplier");
         } else {
-          current_statement__ = 4;
+          current_statement__ = 6;
           assign(offset_no_multiplier,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(
@@ -6594,22 +6630,22 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<local_scalar_t__> p_real_1d_ar;
       p_real_1d_ar = std::vector<local_scalar_t__>(N, DUMMY_VAR__);
       
-      current_statement__ = 5;
+      current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 5;
+        current_statement__ = 7;
         assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()),
           in__.scalar(), "assigning variable p_real_1d_ar");}
-      current_statement__ = 5;
+      current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 5;
+        current_statement__ = 7;
         if (jacobian__) {
-          current_statement__ = 5;
+          current_statement__ = 7;
           assign(p_real_1d_ar,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lb_constrain(p_real_1d_ar[(sym1__ - 1)], 0, lp__),
             "assigning variable p_real_1d_ar");
         } else {
-          current_statement__ = 5;
+          current_statement__ = 7;
           assign(p_real_1d_ar,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lb_constrain(p_real_1d_ar[(sym1__ - 1)], 0),
@@ -6618,27 +6654,27 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<std::vector<std::vector<local_scalar_t__>>> p_real_3d_ar;
       p_real_3d_ar = std::vector<std::vector<std::vector<local_scalar_t__>>>(N, std::vector<std::vector<local_scalar_t__>>(M, std::vector<local_scalar_t__>(K, DUMMY_VAR__)));
       
-      current_statement__ = 6;
+      current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 6;
+        current_statement__ = 8;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 6;
+          current_statement__ = 8;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 6;
+            current_statement__ = 8;
             assign(p_real_3d_ar,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               in__.scalar(), "assigning variable p_real_3d_ar");}}}
-      current_statement__ = 6;
+      current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 6;
+        current_statement__ = 8;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 6;
+          current_statement__ = 8;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 6;
+            current_statement__ = 8;
             if (jacobian__) {
-              current_statement__ = 6;
+              current_statement__ = 8;
               assign(p_real_3d_ar,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__),
@@ -6647,7 +6683,7 @@ class mother_model final : public model_base_crtp<mother_model> {
                   p_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)], 0,
                   lp__), "assigning variable p_real_3d_ar");
             } else {
-              current_statement__ = 6;
+              current_statement__ = 8;
               assign(p_real_3d_ar,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__),
@@ -6660,18 +6696,18 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_vec = Eigen::Matrix<local_scalar_t__, -1, 1>(N);
       stan::math::fill(p_vec, DUMMY_VAR__);
       
-      current_statement__ = 7;
+      current_statement__ = 9;
       p_vec = in__.vector(N);
-      current_statement__ = 7;
+      current_statement__ = 9;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 7;
+        current_statement__ = 9;
         if (jacobian__) {
-          current_statement__ = 7;
+          current_statement__ = 9;
           assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lb_constrain(p_vec[(sym1__ - 1)], 0, lp__),
             "assigning variable p_vec");
         } else {
-          current_statement__ = 7;
+          current_statement__ = 9;
           assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lb_constrain(p_vec[(sym1__ - 1)], 0),
             "assigning variable p_vec");
@@ -6680,22 +6716,22 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_1d_vec = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(N, Eigen::Matrix<local_scalar_t__, -1, 1>(N));
       stan::math::fill(p_1d_vec, DUMMY_VAR__);
       
-      current_statement__ = 8;
+      current_statement__ = 10;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 8;
+        current_statement__ = 10;
         assign(p_1d_vec, cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector(N), "assigning variable p_1d_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>> p_3d_vec;
       p_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(K, Eigen::Matrix<local_scalar_t__, -1, 1>(N))));
       stan::math::fill(p_3d_vec, DUMMY_VAR__);
       
-      current_statement__ = 9;
+      current_statement__ = 11;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 9;
+        current_statement__ = 11;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 9;
+          current_statement__ = 11;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 9;
+            current_statement__ = 11;
             assign(p_3d_vec,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
@@ -6705,28 +6741,28 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_row_vec = Eigen::Matrix<local_scalar_t__, 1, -1>(N);
       stan::math::fill(p_row_vec, DUMMY_VAR__);
       
-      current_statement__ = 10;
+      current_statement__ = 12;
       p_row_vec = in__.row_vector(N);
       std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>> p_1d_row_vec;
       p_1d_row_vec = std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(N, Eigen::Matrix<local_scalar_t__, 1, -1>(N));
       stan::math::fill(p_1d_row_vec, DUMMY_VAR__);
       
-      current_statement__ = 11;
+      current_statement__ = 13;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 11;
+        current_statement__ = 13;
         assign(p_1d_row_vec, cons_list(index_uni(sym1__), nil_index_list()),
           in__.row_vector(N), "assigning variable p_1d_row_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>> p_3d_row_vec;
       p_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>(M, std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(K, Eigen::Matrix<local_scalar_t__, 1, -1>(N))));
       stan::math::fill(p_3d_row_vec, DUMMY_VAR__);
       
-      current_statement__ = 12;
+      current_statement__ = 14;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 12;
+        current_statement__ = 14;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 12;
+          current_statement__ = 14;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 12;
+            current_statement__ = 14;
             assign(p_3d_row_vec,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
@@ -6736,26 +6772,26 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_ar_mat = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>>(4, std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>(5, Eigen::Matrix<local_scalar_t__, -1, -1>(2, 3)));
       stan::math::fill(p_ar_mat, DUMMY_VAR__);
       
-      current_statement__ = 13;
+      current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 13;
+        current_statement__ = 15;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 13;
+          current_statement__ = 15;
           assign(p_ar_mat,
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             in__.matrix(2, 3), "assigning variable p_ar_mat");}}
-      current_statement__ = 13;
+      current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 13;
+        current_statement__ = 15;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 13;
+          current_statement__ = 15;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 13;
+            current_statement__ = 15;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 13;
+              current_statement__ = 15;
               if (jacobian__) {
-                current_statement__ = 13;
+                current_statement__ = 15;
                 assign(p_ar_mat,
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__),
@@ -6769,7 +6805,7 @@ class mother_model final : public model_base_crtp<mother_model> {
                             cons_list(index_uni(sym4__), nil_index_list())))),
                       "p_ar_mat"), 0, 1, lp__), "assigning variable p_ar_mat");
               } else {
-                current_statement__ = 13;
+                current_statement__ = 15;
                 assign(p_ar_mat,
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__),
@@ -6791,16 +6827,16 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_simplex_in__ = Eigen::Matrix<local_scalar_t__, -1, 1>((N - 1));
       stan::math::fill(p_simplex_in__, DUMMY_VAR__);
       
-      current_statement__ = 14;
+      current_statement__ = 16;
       p_simplex_in__ = in__.vector((N - 1));
-      current_statement__ = 14;
+      current_statement__ = 16;
       if (jacobian__) {
-        current_statement__ = 14;
+        current_statement__ = 16;
         assign(p_simplex, nil_index_list(),
           stan::math::simplex_constrain(p_simplex_in__, lp__),
           "assigning variable p_simplex");
       } else {
-        current_statement__ = 14;
+        current_statement__ = 16;
         assign(p_simplex, nil_index_list(),
           stan::math::simplex_constrain(p_simplex_in__),
           "assigning variable p_simplex");
@@ -6814,23 +6850,23 @@ class mother_model final : public model_base_crtp<mother_model> {
         (N - 1)));
       stan::math::fill(p_1d_simplex_in__, DUMMY_VAR__);
       
-      current_statement__ = 15;
+      current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 15;
+        current_statement__ = 17;
         assign(p_1d_simplex_in__,
           cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector((N - 1)), "assigning variable p_1d_simplex_in__");}
-      current_statement__ = 15;
+      current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 15;
+        current_statement__ = 17;
         if (jacobian__) {
-          current_statement__ = 15;
+          current_statement__ = 17;
           assign(p_1d_simplex,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::simplex_constrain(p_1d_simplex_in__[(sym1__ - 1)],
               lp__), "assigning variable p_1d_simplex");
         } else {
-          current_statement__ = 15;
+          current_statement__ = 17;
           assign(p_1d_simplex,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::simplex_constrain(p_1d_simplex_in__[(sym1__ - 1)]),
@@ -6845,28 +6881,28 @@ class mother_model final : public model_base_crtp<mother_model> {
         (N - 1)))));
       stan::math::fill(p_3d_simplex_in__, DUMMY_VAR__);
       
-      current_statement__ = 16;
+      current_statement__ = 18;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 16;
+        current_statement__ = 18;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 16;
+          current_statement__ = 18;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 16;
+            current_statement__ = 18;
             assign(p_3d_simplex_in__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               in__.vector((N - 1)), "assigning variable p_3d_simplex_in__");}
         }}
-      current_statement__ = 16;
+      current_statement__ = 18;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 16;
+        current_statement__ = 18;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 16;
+          current_statement__ = 18;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 16;
+            current_statement__ = 18;
             if (jacobian__) {
-              current_statement__ = 16;
+              current_statement__ = 18;
               assign(p_3d_simplex,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__),
@@ -6875,7 +6911,7 @@ class mother_model final : public model_base_crtp<mother_model> {
                   p_3d_simplex_in__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                   lp__), "assigning variable p_3d_simplex");
             } else {
-              current_statement__ = 16;
+              current_statement__ = 18;
               assign(p_3d_simplex,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__),
@@ -6897,17 +6933,17 @@ class mother_model final : public model_base_crtp<mother_model> {
                                                                    4)));
       stan::math::fill(p_cfcov_54_in__, DUMMY_VAR__);
       
-      current_statement__ = 17;
+      current_statement__ = 19;
       p_cfcov_54_in__ = in__.vector(
                           ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)));
-      current_statement__ = 17;
+      current_statement__ = 19;
       if (jacobian__) {
-        current_statement__ = 17;
+        current_statement__ = 19;
         assign(p_cfcov_54, nil_index_list(),
           stan::math::cholesky_factor_constrain(p_cfcov_54_in__, 5, 4, lp__),
           "assigning variable p_cfcov_54");
       } else {
-        current_statement__ = 17;
+        current_statement__ = 19;
         assign(p_cfcov_54, nil_index_list(),
           stan::math::cholesky_factor_constrain(p_cfcov_54_in__, 5, 4),
           "assigning variable p_cfcov_54");
@@ -6925,17 +6961,17 @@ class mother_model final : public model_base_crtp<mother_model> {
                                                                    3)));
       stan::math::fill(p_cfcov_33_in__, DUMMY_VAR__);
       
-      current_statement__ = 18;
+      current_statement__ = 20;
       p_cfcov_33_in__ = in__.vector(
                           ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)));
-      current_statement__ = 18;
+      current_statement__ = 20;
       if (jacobian__) {
-        current_statement__ = 18;
+        current_statement__ = 20;
         assign(p_cfcov_33, nil_index_list(),
           stan::math::cholesky_factor_constrain(p_cfcov_33_in__, 3, 3, lp__),
           "assigning variable p_cfcov_33");
       } else {
-        current_statement__ = 18;
+        current_statement__ = 20;
         assign(p_cfcov_33, nil_index_list(),
           stan::math::cholesky_factor_constrain(p_cfcov_33_in__, 3, 3),
           "assigning variable p_cfcov_33");
@@ -6949,25 +6985,25 @@ class mother_model final : public model_base_crtp<mother_model> {
         ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))));
       stan::math::fill(p_cfcov_33_ar_in__, DUMMY_VAR__);
       
-      current_statement__ = 19;
+      current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 19;
+        current_statement__ = 21;
         assign(p_cfcov_33_ar_in__,
           cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector(((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))),
           "assigning variable p_cfcov_33_ar_in__");}
-      current_statement__ = 19;
+      current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 19;
+        current_statement__ = 21;
         if (jacobian__) {
-          current_statement__ = 19;
+          current_statement__ = 21;
           assign(p_cfcov_33_ar,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::cholesky_factor_constrain(
               p_cfcov_33_ar_in__[(sym1__ - 1)], 3, 3, lp__),
             "assigning variable p_cfcov_33_ar");
         } else {
-          current_statement__ = 19;
+          current_statement__ = 21;
           assign(p_cfcov_33_ar,
             cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::cholesky_factor_constrain(
@@ -6978,13 +7014,13 @@ class mother_model final : public model_base_crtp<mother_model> {
       x_p = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
       stan::math::fill(x_p, DUMMY_VAR__);
       
-      current_statement__ = 20;
+      current_statement__ = 22;
       x_p = in__.vector(2);
       Eigen::Matrix<local_scalar_t__, -1, 1> y_p;
       y_p = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
       stan::math::fill(y_p, DUMMY_VAR__);
       
-      current_statement__ = 21;
+      current_statement__ = 23;
       y_p = in__.vector(2);
       std::vector<local_scalar_t__> tp_real_1d_ar;
       tp_real_1d_ar = std::vector<local_scalar_t__>(N, DUMMY_VAR__);
@@ -7048,127 +7084,127 @@ class mother_model final : public model_base_crtp<mother_model> {
       theta_p = Eigen::Matrix<local_scalar_t__, -1, 1>(2);
       stan::math::fill(theta_p, DUMMY_VAR__);
       
-      current_statement__ = 38;
+      current_statement__ = 40;
       assign(tp_real_1d_ar, nil_index_list(), p_real_1d_ar,
         "assigning variable tp_real_1d_ar");
-      current_statement__ = 39;
+      current_statement__ = 41;
       assign(tp_real_3d_ar, nil_index_list(), p_real_3d_ar,
         "assigning variable tp_real_3d_ar");
-      current_statement__ = 40;
+      current_statement__ = 42;
       assign(tp_1d_vec, nil_index_list(), p_1d_vec,
         "assigning variable tp_1d_vec");
-      current_statement__ = 41;
+      current_statement__ = 43;
       assign(tp_3d_vec, nil_index_list(), p_3d_vec,
         "assigning variable tp_3d_vec");
-      current_statement__ = 42;
+      current_statement__ = 44;
       assign(tp_simplex, nil_index_list(), p_simplex,
         "assigning variable tp_simplex");
-      current_statement__ = 43;
+      current_statement__ = 45;
       assign(tp_1d_simplex, nil_index_list(), p_1d_simplex,
         "assigning variable tp_1d_simplex");
-      current_statement__ = 44;
+      current_statement__ = 46;
       assign(tp_3d_simplex, nil_index_list(), p_3d_simplex,
         "assigning variable tp_3d_simplex");
-      current_statement__ = 45;
+      current_statement__ = 47;
       assign(tp_cfcov_54, nil_index_list(), p_cfcov_54,
         "assigning variable tp_cfcov_54");
-      current_statement__ = 46;
+      current_statement__ = 48;
       assign(tp_cfcov_33, nil_index_list(), p_cfcov_33,
         "assigning variable tp_cfcov_33");
-      current_statement__ = 47;
+      current_statement__ = 49;
       assign(tp_cfcov_33_ar, nil_index_list(), p_cfcov_33_ar,
         "assigning variable tp_cfcov_33_ar");
-      current_statement__ = 56;
+      current_statement__ = 58;
       for (int i = 1; i <= 2; ++i) {
-        current_statement__ = 54;
+        current_statement__ = 56;
         for (int j = 1; j <= 3; ++j) {
-          current_statement__ = 52;
+          current_statement__ = 54;
           for (int m = 1; m <= 4; ++m) {
-            current_statement__ = 50;
+            current_statement__ = 52;
             for (int n = 1; n <= 5; ++n) {
-              current_statement__ = 48;
+              current_statement__ = 50;
               assign(tp_ar_mat,
                 cons_list(index_uni(m),
                   cons_list(index_uni(n),
                     cons_list(index_uni(i),
                       cons_list(index_uni(j), nil_index_list())))), 0.4,
                 "assigning variable tp_ar_mat");}}}}
-      current_statement__ = 58;
+      current_statement__ = 60;
       for (int i = 1; i <= N; ++i) {
-        current_statement__ = 57;
+        current_statement__ = 59;
         assign(tp_vec, cons_list(index_uni(i), nil_index_list()),
           (-1.0 * p_vec[(i - 1)]), "assigning variable tp_vec");}
-      current_statement__ = 59;
+      current_statement__ = 61;
       assign(tp_row_vec, nil_index_list(), transpose(tp_1d_vec[(1 - 1)]),
         "assigning variable tp_row_vec");
-      current_statement__ = 60;
+      current_statement__ = 62;
       assign(tp_1d_row_vec, nil_index_list(), p_1d_row_vec,
         "assigning variable tp_1d_row_vec");
-      current_statement__ = 61;
+      current_statement__ = 63;
       assign(tp_3d_row_vec, nil_index_list(), p_3d_row_vec,
         "assigning variable tp_3d_row_vec");
-      current_statement__ = 62;
+      current_statement__ = 64;
       assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x, y, dat, dat_int,
           pstream__), "assigning variable theta_p");
-      current_statement__ = 63;
+      current_statement__ = 65;
       assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x, y, dat, dat_int,
           pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
-      current_statement__ = 64;
+      current_statement__ = 66;
       assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x, y_p, dat, dat_int,
           pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
-      current_statement__ = 65;
-      assign(theta_p, nil_index_list(),
-        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
-          pstream__), "assigning variable theta_p");
-      current_statement__ = 66;
-      assign(theta_p, nil_index_list(),
-        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
-          pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
       current_statement__ = 67;
       assign(theta_p, nil_index_list(),
-        algebra_solver(algebra_system_functor__(), x_p, y_p, dat, dat_int,
+        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
           pstream__), "assigning variable theta_p");
       current_statement__ = 68;
       assign(theta_p, nil_index_list(),
+        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
+          pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
+      current_statement__ = 69;
+      assign(theta_p, nil_index_list(),
+        algebra_solver(algebra_system_functor__(), x_p, y_p, dat, dat_int,
+          pstream__), "assigning variable theta_p");
+      current_statement__ = 70;
+      assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x_p, y_p, dat, dat_int,
           pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
-      current_statement__ = 22;
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 22;
-        current_statement__ = 22;
-        check_greater_or_equal(function__, "tp_real_1d_ar[sym1__]",
-                               tp_real_1d_ar[(sym1__ - 1)], 0);}
-      current_statement__ = 23;
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 23;
-        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 23;
-          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 23;
-            current_statement__ = 23;
-            check_greater_or_equal(function__,
-                                   "tp_real_3d_ar[sym1__, sym2__, sym3__]",
-                                   tp_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][
-                                   (sym3__ - 1)], 0);}}}
       current_statement__ = 24;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 24;
         current_statement__ = 24;
+        check_greater_or_equal(function__, "tp_real_1d_ar[sym1__]",
+                               tp_real_1d_ar[(sym1__ - 1)], 0);}
+      current_statement__ = 25;
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        current_statement__ = 25;
+        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
+          current_statement__ = 25;
+          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
+            current_statement__ = 25;
+            current_statement__ = 25;
+            check_greater_or_equal(function__,
+                                   "tp_real_3d_ar[sym1__, sym2__, sym3__]",
+                                   tp_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][
+                                   (sym3__ - 1)], 0);}}}
+      current_statement__ = 26;
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        current_statement__ = 26;
+        current_statement__ = 26;
         check_less_or_equal(function__, "tp_vec[sym1__]",
                             tp_vec[(sym1__ - 1)], 0);}
-      current_statement__ = 30;
+      current_statement__ = 32;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 30;
+        current_statement__ = 32;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 30;
+          current_statement__ = 32;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 30;
+            current_statement__ = 32;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 30;
-              current_statement__ = 30;
+              current_statement__ = 32;
+              current_statement__ = 32;
               check_greater_or_equal(function__,
                                      "tp_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                      rvalue(tp_ar_mat,
@@ -7178,16 +7214,16 @@ class mother_model final : public model_base_crtp<mother_model> {
                                              cons_list(index_uni(sym4__),
                                                nil_index_list())))),
                                        "tp_ar_mat"), 0);}}}}
-      current_statement__ = 30;
+      current_statement__ = 32;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 30;
+        current_statement__ = 32;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 30;
+          current_statement__ = 32;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 30;
+            current_statement__ = 32;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 30;
-              current_statement__ = 30;
+              current_statement__ = 32;
+              current_statement__ = 32;
               check_less_or_equal(function__,
                                   "tp_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                   rvalue(tp_ar_mat,
@@ -7197,37 +7233,37 @@ class mother_model final : public model_base_crtp<mother_model> {
                                           cons_list(index_uni(sym4__),
                                             nil_index_list())))),
                                     "tp_ar_mat"), 1);}}}}
-      current_statement__ = 31;
-      current_statement__ = 31;
+      current_statement__ = 33;
+      current_statement__ = 33;
       check_simplex(function__, "tp_simplex", tp_simplex);
-      current_statement__ = 32;
+      current_statement__ = 34;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 32;
-        current_statement__ = 32;
+        current_statement__ = 34;
+        current_statement__ = 34;
         check_simplex(function__, "tp_1d_simplex[sym1__]",
                       tp_1d_simplex[(sym1__ - 1)]);}
-      current_statement__ = 33;
+      current_statement__ = 35;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 33;
+        current_statement__ = 35;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 33;
+          current_statement__ = 35;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 33;
-            current_statement__ = 33;
+            current_statement__ = 35;
+            current_statement__ = 35;
             check_simplex(function__,
                           "tp_3d_simplex[sym1__, sym2__, sym3__]",
                           tp_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ -
                                                                     1)]);}}}
-      current_statement__ = 34;
-      current_statement__ = 34;
-      check_cholesky_factor(function__, "tp_cfcov_54", tp_cfcov_54);
-      current_statement__ = 35;
-      current_statement__ = 35;
-      check_cholesky_factor(function__, "tp_cfcov_33", tp_cfcov_33);
       current_statement__ = 36;
+      current_statement__ = 36;
+      check_cholesky_factor(function__, "tp_cfcov_54", tp_cfcov_54);
+      current_statement__ = 37;
+      current_statement__ = 37;
+      check_cholesky_factor(function__, "tp_cfcov_33", tp_cfcov_33);
+      current_statement__ = 38;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 36;
-        current_statement__ = 36;
+        current_statement__ = 38;
+        current_statement__ = 38;
         check_cholesky_factor(function__, "tp_cfcov_33_ar[sym1__]",
                               tp_cfcov_33_ar[(sym1__ - 1)]);}
       {
@@ -7242,82 +7278,82 @@ class mother_model final : public model_base_crtp<mother_model> {
         local_scalar_t__ r1;
         r1 = DUMMY_VAR__;
         
-        current_statement__ = 147;
+        current_statement__ = 149;
         r1 = foo_bar1(p_real, pstream__);
         local_scalar_t__ r2;
         r2 = DUMMY_VAR__;
         
-        current_statement__ = 148;
-        r2 = foo_bar1(J, pstream__);
-        current_statement__ = 149;
-        lp_accum__.add(normal_lpdf<propto__>(p_real, 0, 1));
         current_statement__ = 150;
-        lp_accum__.add(normal_lpdf<propto__>(offset_multiplier, 0, 1));
+        r2 = foo_bar1(J, pstream__);
         current_statement__ = 151;
-        lp_accum__.add(normal_lpdf<propto__>(no_offset_multiplier, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(p_real, 0, 1));
         current_statement__ = 152;
-        lp_accum__.add(normal_lpdf<propto__>(offset_no_multiplier, 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(offset_multiplier, 0, 1));
         current_statement__ = 153;
+        lp_accum__.add(normal_lpdf<propto__>(no_offset_multiplier, 0, 1));
+        current_statement__ = 154;
+        lp_accum__.add(normal_lpdf<propto__>(offset_no_multiplier, 0, 1));
+        current_statement__ = 155;
         lp_accum__.add(normal_lpdf<propto__>(to_vector(p_real_1d_ar), 0, 1));
-        current_statement__ = 166;
+        current_statement__ = 168;
         for (int n = 1; n <= N; ++n) {
-          current_statement__ = 154;
-          lp_accum__.add(
-            normal_lpdf<propto__>(to_vector(p_1d_vec[(n - 1)]), 0, 1));
-          current_statement__ = 155;
-          lp_accum__.add(
-            normal_lpdf<propto__>(to_vector(p_1d_row_vec[(n - 1)]), 0, 1));
           current_statement__ = 156;
           lp_accum__.add(
+            normal_lpdf<propto__>(to_vector(p_1d_vec[(n - 1)]), 0, 1));
+          current_statement__ = 157;
+          lp_accum__.add(
+            normal_lpdf<propto__>(to_vector(p_1d_row_vec[(n - 1)]), 0, 1));
+          current_statement__ = 158;
+          lp_accum__.add(
             normal_lpdf<propto__>(to_vector(p_1d_simplex[(n - 1)]), 0, 1));
-          current_statement__ = 164;
+          current_statement__ = 166;
           for (int m = 1; m <= M; ++m) {
-            current_statement__ = 162;
+            current_statement__ = 164;
             for (int k = 1; k <= K; ++k) {
-              current_statement__ = 157;
+              current_statement__ = 159;
               lp_accum__.add(
                 normal_lpdf<propto__>(
                   to_vector(p_3d_vec[(n - 1)][(m - 1)][(k - 1)]),
                   d_3d_vec[(n - 1)][(m - 1)][(k - 1)], 1));
-              current_statement__ = 158;
+              current_statement__ = 160;
               lp_accum__.add(
                 normal_lpdf<propto__>(
                   to_vector(p_3d_row_vec[(n - 1)][(m - 1)][(k - 1)]),
                   d_3d_row_vec[(n - 1)][(m - 1)][(k - 1)], 1));
-              current_statement__ = 159;
+              current_statement__ = 161;
               lp_accum__.add(
                 normal_lpdf<propto__>(
                   to_vector(p_3d_simplex[(n - 1)][(m - 1)][(k - 1)]),
                   d_3d_simplex[(n - 1)][(m - 1)][(k - 1)], 1));
-              current_statement__ = 160;
+              current_statement__ = 162;
               lp_accum__.add(
                 normal_lpdf<propto__>(
                   p_real_3d_ar[(n - 1)][(m - 1)][(k - 1)],
                   p_real_3d_ar[(n - 1)][(m - 1)][(k - 1)], 1));}}}
-        current_statement__ = 171;
+        current_statement__ = 173;
         for (int i = 1; i <= 4; ++i) {
-          current_statement__ = 169;
+          current_statement__ = 171;
           for (int j = 1; j <= 5; ++j) {
-            current_statement__ = 167;
+            current_statement__ = 169;
             lp_accum__.add(
               normal_lpdf<propto__>(to_vector(p_ar_mat[(i - 1)][(j - 1)]), 0,
                 1));}}
-        current_statement__ = 174;
+        current_statement__ = 176;
         for (int k = 1; k <= K; ++k) {
-          current_statement__ = 172;
+          current_statement__ = 174;
           lp_accum__.add(
             normal_lpdf<propto__>(to_vector(p_cfcov_33_ar[(k - 1)]), 0, 1));}
-        current_statement__ = 175;
-        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_vec), d_vec, 1));
-        current_statement__ = 176;
-        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_row_vec), 0, 1));
         current_statement__ = 177;
-        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_simplex), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_vec), d_vec, 1));
         current_statement__ = 178;
-        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_cfcov_54), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_row_vec), 0, 1));
         current_statement__ = 179;
-        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_cfcov_33), 0, 1));
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_simplex), 0, 1));
         current_statement__ = 180;
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_cfcov_54), 0, 1));
+        current_statement__ = 181;
+        lp_accum__.add(normal_lpdf<propto__>(to_vector(p_cfcov_33), 0, 1));
+        current_statement__ = 182;
         lp_accum__.add(
           map_rect<1, binomialf_functor__>(tmp, tmp2, x_r, x_i, pstream__));
       }
@@ -7358,18 +7394,32 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       current_statement__ = 1;
       p_real = in__.scalar();
+      double p_upper;
+      p_upper = std::numeric_limits<double>::quiet_NaN();
+      
+      current_statement__ = 2;
+      p_upper = in__.scalar();
+      current_statement__ = 2;
+      p_upper = stan::math::lb_constrain(p_upper, p_real);
+      double p_lower;
+      p_lower = std::numeric_limits<double>::quiet_NaN();
+      
+      current_statement__ = 3;
+      p_lower = in__.scalar();
+      current_statement__ = 3;
+      p_lower = stan::math::ub_constrain(p_lower, p_upper);
       std::vector<double> offset_multiplier;
       offset_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 2;
+      current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 2;
+        current_statement__ = 4;
         assign(offset_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(),
           "assigning variable offset_multiplier");}
-      current_statement__ = 2;
+      current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 2;
+        current_statement__ = 4;
         assign(offset_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_constrain(
@@ -7378,15 +7428,15 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<double> no_offset_multiplier;
       no_offset_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 3;
+      current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 3;
+        current_statement__ = 5;
         assign(no_offset_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(),
           "assigning variable no_offset_multiplier");}
-      current_statement__ = 3;
+      current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 3;
+        current_statement__ = 5;
         assign(no_offset_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_constrain(
@@ -7395,15 +7445,15 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<double> offset_no_multiplier;
       offset_no_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 4;
+      current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 4;
+        current_statement__ = 6;
         assign(offset_no_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()), in__.scalar(),
           "assigning variable offset_no_multiplier");}
-      current_statement__ = 4;
+      current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 4;
+        current_statement__ = 6;
         assign(offset_no_multiplier,
           cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_constrain(
@@ -7412,39 +7462,39 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<double> p_real_1d_ar;
       p_real_1d_ar = std::vector<double>(N, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 5;
+      current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 5;
+        current_statement__ = 7;
         assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()),
           in__.scalar(), "assigning variable p_real_1d_ar");}
-      current_statement__ = 5;
+      current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 5;
+        current_statement__ = 7;
         assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_constrain(p_real_1d_ar[(sym1__ - 1)], 0),
           "assigning variable p_real_1d_ar");}
       std::vector<std::vector<std::vector<double>>> p_real_3d_ar;
       p_real_3d_ar = std::vector<std::vector<std::vector<double>>>(N, std::vector<std::vector<double>>(M, std::vector<double>(K, std::numeric_limits<double>::quiet_NaN())));
       
-      current_statement__ = 6;
+      current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 6;
+        current_statement__ = 8;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 6;
+          current_statement__ = 8;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 6;
+            current_statement__ = 8;
             assign(p_real_3d_ar,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               in__.scalar(), "assigning variable p_real_3d_ar");}}}
-      current_statement__ = 6;
+      current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 6;
+        current_statement__ = 8;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 6;
+          current_statement__ = 8;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 6;
+            current_statement__ = 8;
             assign(p_real_3d_ar,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
@@ -7456,11 +7506,11 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_vec = Eigen::Matrix<double, -1, 1>(N);
       stan::math::fill(p_vec, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 7;
+      current_statement__ = 9;
       p_vec = in__.vector(N);
-      current_statement__ = 7;
+      current_statement__ = 9;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 7;
+        current_statement__ = 9;
         assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_constrain(p_vec[(sym1__ - 1)], 0),
           "assigning variable p_vec");}
@@ -7468,22 +7518,22 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       stan::math::fill(p_1d_vec, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 8;
+      current_statement__ = 10;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 8;
+        current_statement__ = 10;
         assign(p_1d_vec, cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector(N), "assigning variable p_1d_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_vec;
       p_3d_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       stan::math::fill(p_3d_vec, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 9;
+      current_statement__ = 11;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 9;
+        current_statement__ = 11;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 9;
+          current_statement__ = 11;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 9;
+            current_statement__ = 11;
             assign(p_3d_vec,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
@@ -7493,28 +7543,28 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_row_vec = Eigen::Matrix<double, 1, -1>(N);
       stan::math::fill(p_row_vec, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 10;
+      current_statement__ = 12;
       p_row_vec = in__.row_vector(N);
       std::vector<Eigen::Matrix<double, 1, -1>> p_1d_row_vec;
       p_1d_row_vec = std::vector<Eigen::Matrix<double, 1, -1>>(N, Eigen::Matrix<double, 1, -1>(N));
       stan::math::fill(p_1d_row_vec, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 11;
+      current_statement__ = 13;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 11;
+        current_statement__ = 13;
         assign(p_1d_row_vec, cons_list(index_uni(sym1__), nil_index_list()),
           in__.row_vector(N), "assigning variable p_1d_row_vec");}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>> p_3d_row_vec;
       p_3d_row_vec = std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(M, std::vector<Eigen::Matrix<double, 1, -1>>(K, Eigen::Matrix<double, 1, -1>(N))));
       stan::math::fill(p_3d_row_vec, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 12;
+      current_statement__ = 14;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 12;
+        current_statement__ = 14;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 12;
+          current_statement__ = 14;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 12;
+            current_statement__ = 14;
             assign(p_3d_row_vec,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
@@ -7524,24 +7574,24 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_ar_mat = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
       stan::math::fill(p_ar_mat, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 13;
+      current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 13;
+        current_statement__ = 15;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 13;
+          current_statement__ = 15;
           assign(p_ar_mat,
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             in__.matrix(2, 3), "assigning variable p_ar_mat");}}
-      current_statement__ = 13;
+      current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 13;
+        current_statement__ = 15;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 13;
+          current_statement__ = 15;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 13;
+            current_statement__ = 15;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 13;
+              current_statement__ = 15;
               assign(p_ar_mat,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__),
@@ -7562,9 +7612,9 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_simplex_in__ = Eigen::Matrix<local_scalar_t__, -1, 1>((N - 1));
       stan::math::fill(p_simplex_in__, DUMMY_VAR__);
       
-      current_statement__ = 14;
+      current_statement__ = 16;
       p_simplex_in__ = in__.vector((N - 1));
-      current_statement__ = 14;
+      current_statement__ = 16;
       assign(p_simplex, nil_index_list(),
         stan::math::simplex_constrain(p_simplex_in__),
         "assigning variable p_simplex");
@@ -7577,15 +7627,15 @@ class mother_model final : public model_base_crtp<mother_model> {
         (N - 1)));
       stan::math::fill(p_1d_simplex_in__, DUMMY_VAR__);
       
-      current_statement__ = 15;
+      current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 15;
+        current_statement__ = 17;
         assign(p_1d_simplex_in__,
           cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector((N - 1)), "assigning variable p_1d_simplex_in__");}
-      current_statement__ = 15;
+      current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 15;
+        current_statement__ = 17;
         assign(p_1d_simplex, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::simplex_constrain(p_1d_simplex_in__[(sym1__ - 1)]),
           "assigning variable p_1d_simplex");}
@@ -7598,26 +7648,26 @@ class mother_model final : public model_base_crtp<mother_model> {
         (N - 1)))));
       stan::math::fill(p_3d_simplex_in__, DUMMY_VAR__);
       
-      current_statement__ = 16;
+      current_statement__ = 18;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 16;
+        current_statement__ = 18;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 16;
+          current_statement__ = 18;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 16;
+            current_statement__ = 18;
             assign(p_3d_simplex_in__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               in__.vector((N - 1)), "assigning variable p_3d_simplex_in__");}
         }}
-      current_statement__ = 16;
+      current_statement__ = 18;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 16;
+        current_statement__ = 18;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 16;
+          current_statement__ = 18;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 16;
+            current_statement__ = 18;
             assign(p_3d_simplex,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
@@ -7638,10 +7688,10 @@ class mother_model final : public model_base_crtp<mother_model> {
                                                                    4)));
       stan::math::fill(p_cfcov_54_in__, DUMMY_VAR__);
       
-      current_statement__ = 17;
+      current_statement__ = 19;
       p_cfcov_54_in__ = in__.vector(
                           ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)));
-      current_statement__ = 17;
+      current_statement__ = 19;
       assign(p_cfcov_54, nil_index_list(),
         stan::math::cholesky_factor_constrain(p_cfcov_54_in__, 5, 4),
         "assigning variable p_cfcov_54");
@@ -7658,10 +7708,10 @@ class mother_model final : public model_base_crtp<mother_model> {
                                                                    3)));
       stan::math::fill(p_cfcov_33_in__, DUMMY_VAR__);
       
-      current_statement__ = 18;
+      current_statement__ = 20;
       p_cfcov_33_in__ = in__.vector(
                           ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)));
-      current_statement__ = 18;
+      current_statement__ = 20;
       assign(p_cfcov_33, nil_index_list(),
         stan::math::cholesky_factor_constrain(p_cfcov_33_in__, 3, 3),
         "assigning variable p_cfcov_33");
@@ -7674,16 +7724,16 @@ class mother_model final : public model_base_crtp<mother_model> {
         ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))));
       stan::math::fill(p_cfcov_33_ar_in__, DUMMY_VAR__);
       
-      current_statement__ = 19;
+      current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 19;
+        current_statement__ = 21;
         assign(p_cfcov_33_ar_in__,
           cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector(((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))),
           "assigning variable p_cfcov_33_ar_in__");}
-      current_statement__ = 19;
+      current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 19;
+        current_statement__ = 21;
         assign(p_cfcov_33_ar, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::cholesky_factor_constrain(
             p_cfcov_33_ar_in__[(sym1__ - 1)], 3, 3),
@@ -7692,13 +7742,13 @@ class mother_model final : public model_base_crtp<mother_model> {
       x_p = Eigen::Matrix<double, -1, 1>(2);
       stan::math::fill(x_p, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 20;
+      current_statement__ = 22;
       x_p = in__.vector(2);
       Eigen::Matrix<double, -1, 1> y_p;
       y_p = Eigen::Matrix<double, -1, 1>(2);
       stan::math::fill(y_p, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 21;
+      current_statement__ = 23;
       y_p = in__.vector(2);
       std::vector<double> tp_real_1d_ar;
       tp_real_1d_ar = std::vector<double>(N, std::numeric_limits<double>::quiet_NaN());
@@ -7763,6 +7813,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       stan::math::fill(theta_p, std::numeric_limits<double>::quiet_NaN());
       
       vars__.emplace_back(p_real);
+      vars__.emplace_back(p_upper);
+      vars__.emplace_back(p_lower);
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
         vars__.emplace_back(offset_multiplier[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
@@ -7854,127 +7906,127 @@ class mother_model final : public model_base_crtp<mother_model> {
             primitive_value(emit_generated_quantities__)))) {
         return ;
       } 
-      current_statement__ = 38;
+      current_statement__ = 40;
       assign(tp_real_1d_ar, nil_index_list(), p_real_1d_ar,
         "assigning variable tp_real_1d_ar");
-      current_statement__ = 39;
+      current_statement__ = 41;
       assign(tp_real_3d_ar, nil_index_list(), p_real_3d_ar,
         "assigning variable tp_real_3d_ar");
-      current_statement__ = 40;
+      current_statement__ = 42;
       assign(tp_1d_vec, nil_index_list(), p_1d_vec,
         "assigning variable tp_1d_vec");
-      current_statement__ = 41;
+      current_statement__ = 43;
       assign(tp_3d_vec, nil_index_list(), p_3d_vec,
         "assigning variable tp_3d_vec");
-      current_statement__ = 42;
+      current_statement__ = 44;
       assign(tp_simplex, nil_index_list(), p_simplex,
         "assigning variable tp_simplex");
-      current_statement__ = 43;
+      current_statement__ = 45;
       assign(tp_1d_simplex, nil_index_list(), p_1d_simplex,
         "assigning variable tp_1d_simplex");
-      current_statement__ = 44;
+      current_statement__ = 46;
       assign(tp_3d_simplex, nil_index_list(), p_3d_simplex,
         "assigning variable tp_3d_simplex");
-      current_statement__ = 45;
+      current_statement__ = 47;
       assign(tp_cfcov_54, nil_index_list(), p_cfcov_54,
         "assigning variable tp_cfcov_54");
-      current_statement__ = 46;
+      current_statement__ = 48;
       assign(tp_cfcov_33, nil_index_list(), p_cfcov_33,
         "assigning variable tp_cfcov_33");
-      current_statement__ = 47;
+      current_statement__ = 49;
       assign(tp_cfcov_33_ar, nil_index_list(), p_cfcov_33_ar,
         "assigning variable tp_cfcov_33_ar");
-      current_statement__ = 56;
+      current_statement__ = 58;
       for (int i = 1; i <= 2; ++i) {
-        current_statement__ = 54;
+        current_statement__ = 56;
         for (int j = 1; j <= 3; ++j) {
-          current_statement__ = 52;
+          current_statement__ = 54;
           for (int m = 1; m <= 4; ++m) {
-            current_statement__ = 50;
+            current_statement__ = 52;
             for (int n = 1; n <= 5; ++n) {
-              current_statement__ = 48;
+              current_statement__ = 50;
               assign(tp_ar_mat,
                 cons_list(index_uni(m),
                   cons_list(index_uni(n),
                     cons_list(index_uni(i),
                       cons_list(index_uni(j), nil_index_list())))), 0.4,
                 "assigning variable tp_ar_mat");}}}}
-      current_statement__ = 58;
+      current_statement__ = 60;
       for (int i = 1; i <= N; ++i) {
-        current_statement__ = 57;
+        current_statement__ = 59;
         assign(tp_vec, cons_list(index_uni(i), nil_index_list()),
           (-1.0 * p_vec[(i - 1)]), "assigning variable tp_vec");}
-      current_statement__ = 59;
+      current_statement__ = 61;
       assign(tp_row_vec, nil_index_list(), transpose(tp_1d_vec[(1 - 1)]),
         "assigning variable tp_row_vec");
-      current_statement__ = 60;
+      current_statement__ = 62;
       assign(tp_1d_row_vec, nil_index_list(), p_1d_row_vec,
         "assigning variable tp_1d_row_vec");
-      current_statement__ = 61;
+      current_statement__ = 63;
       assign(tp_3d_row_vec, nil_index_list(), p_3d_row_vec,
         "assigning variable tp_3d_row_vec");
-      current_statement__ = 62;
+      current_statement__ = 64;
       assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x, y, dat, dat_int,
           pstream__), "assigning variable theta_p");
-      current_statement__ = 63;
+      current_statement__ = 65;
       assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x, y, dat, dat_int,
           pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
-      current_statement__ = 64;
+      current_statement__ = 66;
       assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x, y_p, dat, dat_int,
           pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
-      current_statement__ = 65;
-      assign(theta_p, nil_index_list(),
-        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
-          pstream__), "assigning variable theta_p");
-      current_statement__ = 66;
-      assign(theta_p, nil_index_list(),
-        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
-          pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
       current_statement__ = 67;
       assign(theta_p, nil_index_list(),
-        algebra_solver(algebra_system_functor__(), x_p, y_p, dat, dat_int,
+        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
           pstream__), "assigning variable theta_p");
       current_statement__ = 68;
       assign(theta_p, nil_index_list(),
+        algebra_solver(algebra_system_functor__(), x_p, y, dat, dat_int,
+          pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
+      current_statement__ = 69;
+      assign(theta_p, nil_index_list(),
+        algebra_solver(algebra_system_functor__(), x_p, y_p, dat, dat_int,
+          pstream__), "assigning variable theta_p");
+      current_statement__ = 70;
+      assign(theta_p, nil_index_list(),
         algebra_solver(algebra_system_functor__(), x_p, y_p, dat, dat_int,
           pstream__, 0.01, 0.01, 10), "assigning variable theta_p");
-      current_statement__ = 22;
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 22;
-        current_statement__ = 22;
-        check_greater_or_equal(function__, "tp_real_1d_ar[sym1__]",
-                               tp_real_1d_ar[(sym1__ - 1)], 0);}
-      current_statement__ = 23;
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 23;
-        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 23;
-          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 23;
-            current_statement__ = 23;
-            check_greater_or_equal(function__,
-                                   "tp_real_3d_ar[sym1__, sym2__, sym3__]",
-                                   tp_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][
-                                   (sym3__ - 1)], 0);}}}
       current_statement__ = 24;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 24;
         current_statement__ = 24;
+        check_greater_or_equal(function__, "tp_real_1d_ar[sym1__]",
+                               tp_real_1d_ar[(sym1__ - 1)], 0);}
+      current_statement__ = 25;
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        current_statement__ = 25;
+        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
+          current_statement__ = 25;
+          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
+            current_statement__ = 25;
+            current_statement__ = 25;
+            check_greater_or_equal(function__,
+                                   "tp_real_3d_ar[sym1__, sym2__, sym3__]",
+                                   tp_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][
+                                   (sym3__ - 1)], 0);}}}
+      current_statement__ = 26;
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        current_statement__ = 26;
+        current_statement__ = 26;
         check_less_or_equal(function__, "tp_vec[sym1__]",
                             tp_vec[(sym1__ - 1)], 0);}
-      current_statement__ = 30;
+      current_statement__ = 32;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 30;
+        current_statement__ = 32;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 30;
+          current_statement__ = 32;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 30;
+            current_statement__ = 32;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 30;
-              current_statement__ = 30;
+              current_statement__ = 32;
+              current_statement__ = 32;
               check_greater_or_equal(function__,
                                      "tp_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                      rvalue(tp_ar_mat,
@@ -7984,16 +8036,16 @@ class mother_model final : public model_base_crtp<mother_model> {
                                              cons_list(index_uni(sym4__),
                                                nil_index_list())))),
                                        "tp_ar_mat"), 0);}}}}
-      current_statement__ = 30;
+      current_statement__ = 32;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 30;
+        current_statement__ = 32;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 30;
+          current_statement__ = 32;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 30;
+            current_statement__ = 32;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 30;
-              current_statement__ = 30;
+              current_statement__ = 32;
+              current_statement__ = 32;
               check_less_or_equal(function__,
                                   "tp_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                   rvalue(tp_ar_mat,
@@ -8003,37 +8055,37 @@ class mother_model final : public model_base_crtp<mother_model> {
                                           cons_list(index_uni(sym4__),
                                             nil_index_list())))),
                                     "tp_ar_mat"), 1);}}}}
-      current_statement__ = 31;
-      current_statement__ = 31;
+      current_statement__ = 33;
+      current_statement__ = 33;
       check_simplex(function__, "tp_simplex", tp_simplex);
-      current_statement__ = 32;
+      current_statement__ = 34;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 32;
-        current_statement__ = 32;
+        current_statement__ = 34;
+        current_statement__ = 34;
         check_simplex(function__, "tp_1d_simplex[sym1__]",
                       tp_1d_simplex[(sym1__ - 1)]);}
-      current_statement__ = 33;
+      current_statement__ = 35;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 33;
+        current_statement__ = 35;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 33;
+          current_statement__ = 35;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 33;
-            current_statement__ = 33;
+            current_statement__ = 35;
+            current_statement__ = 35;
             check_simplex(function__,
                           "tp_3d_simplex[sym1__, sym2__, sym3__]",
                           tp_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ -
                                                                     1)]);}}}
-      current_statement__ = 34;
-      current_statement__ = 34;
-      check_cholesky_factor(function__, "tp_cfcov_54", tp_cfcov_54);
-      current_statement__ = 35;
-      current_statement__ = 35;
-      check_cholesky_factor(function__, "tp_cfcov_33", tp_cfcov_33);
       current_statement__ = 36;
+      current_statement__ = 36;
+      check_cholesky_factor(function__, "tp_cfcov_54", tp_cfcov_54);
+      current_statement__ = 37;
+      current_statement__ = 37;
+      check_cholesky_factor(function__, "tp_cfcov_33", tp_cfcov_33);
+      current_statement__ = 38;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 36;
-        current_statement__ = 36;
+        current_statement__ = 38;
+        current_statement__ = 38;
         check_cholesky_factor(function__, "tp_cfcov_33_ar[sym1__]",
                               tp_cfcov_33_ar[(sym1__ - 1)]);}
       if (emit_transformed_parameters__) {
@@ -8123,12 +8175,12 @@ class mother_model final : public model_base_crtp<mother_model> {
       double gq_r1;
       gq_r1 = std::numeric_limits<double>::quiet_NaN();
       
-      current_statement__ = 69;
+      current_statement__ = 71;
       gq_r1 = foo_bar1(p_real, pstream__);
       double gq_r2;
       gq_r2 = std::numeric_limits<double>::quiet_NaN();
       
-      current_statement__ = 70;
+      current_statement__ = 72;
       gq_r2 = foo_bar1(J, pstream__);
       std::vector<double> gq_real_1d_ar;
       gq_real_1d_ar = std::vector<double>(N, std::numeric_limits<double>::quiet_NaN());
@@ -8191,7 +8243,7 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<int> indices;
       indices = std::vector<int>(3, std::numeric_limits<int>::min());
       
-      current_statement__ = 86;
+      current_statement__ = 88;
       assign(indices, nil_index_list(), stan::math::array_builder<int>()
         .add(2).add(3).add(1).array(), "assigning variable indices");
       std::vector<Eigen::Matrix<double, -1, -1>> indexing_mat;
@@ -8230,88 +8282,88 @@ class mother_model final : public model_base_crtp<mother_model> {
       idx_res5 = std::vector<Eigen::Matrix<double, -1, 1>>(2, Eigen::Matrix<double, -1, 1>(2));
       stan::math::fill(idx_res5, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 96;
+      current_statement__ = 98;
       assign(gq_real_1d_ar, nil_index_list(),
         rvalue(p_1d_simplex,
           cons_list(index_omni(), cons_list(index_uni(1), nil_index_list())),
           "p_1d_simplex"), "assigning variable gq_real_1d_ar");
-      current_statement__ = 97;
+      current_statement__ = 99;
       assign(gq_real_3d_ar, nil_index_list(), p_real_3d_ar,
         "assigning variable gq_real_3d_ar");
-      current_statement__ = 98;
+      current_statement__ = 100;
       assign(gq_1d_vec, nil_index_list(), p_1d_vec,
         "assigning variable gq_1d_vec");
-      current_statement__ = 99;
+      current_statement__ = 101;
       assign(gq_3d_vec, nil_index_list(), p_3d_vec,
         "assigning variable gq_3d_vec");
-      current_statement__ = 100;
+      current_statement__ = 102;
       assign(gq_row_vec, nil_index_list(), p_row_vec,
         "assigning variable gq_row_vec");
-      current_statement__ = 101;
+      current_statement__ = 103;
       assign(gq_1d_row_vec, nil_index_list(), p_1d_row_vec,
         "assigning variable gq_1d_row_vec");
-      current_statement__ = 102;
+      current_statement__ = 104;
       assign(gq_3d_row_vec, nil_index_list(), p_3d_row_vec,
         "assigning variable gq_3d_row_vec");
-      current_statement__ = 103;
+      current_statement__ = 105;
       assign(gq_simplex, nil_index_list(),
         rvalue(p_1d_simplex,
           cons_list(index_uni(1),
             cons_list(index_min_max(1, N), nil_index_list())),
           "p_1d_simplex"), "assigning variable gq_simplex");
-      current_statement__ = 104;
+      current_statement__ = 106;
       assign(gq_1d_simplex, nil_index_list(), p_1d_simplex,
         "assigning variable gq_1d_simplex");
-      current_statement__ = 105;
+      current_statement__ = 107;
       assign(gq_3d_simplex, nil_index_list(), p_3d_simplex,
         "assigning variable gq_3d_simplex");
-      current_statement__ = 106;
+      current_statement__ = 108;
       assign(gq_cfcov_54, nil_index_list(), p_cfcov_54,
         "assigning variable gq_cfcov_54");
-      current_statement__ = 107;
+      current_statement__ = 109;
       assign(gq_cfcov_33, nil_index_list(), p_cfcov_33,
         "assigning variable gq_cfcov_33");
-      current_statement__ = 108;
+      current_statement__ = 110;
       assign(gq_cfcov_33_ar, nil_index_list(), p_cfcov_33_ar,
         "assigning variable gq_cfcov_33_ar");
-      current_statement__ = 117;
+      current_statement__ = 119;
       for (int i = 1; i <= 2; ++i) {
-        current_statement__ = 115;
+        current_statement__ = 117;
         for (int j = 1; j <= 3; ++j) {
-          current_statement__ = 113;
+          current_statement__ = 115;
           for (int m = 1; m <= 4; ++m) {
-            current_statement__ = 111;
+            current_statement__ = 113;
             for (int n = 1; n <= 5; ++n) {
-              current_statement__ = 109;
+              current_statement__ = 111;
               assign(gq_ar_mat,
                 cons_list(index_uni(m),
                   cons_list(index_uni(n),
                     cons_list(index_uni(i),
                       cons_list(index_uni(j), nil_index_list())))), 0.4,
                 "assigning variable gq_ar_mat");}}}}
-      current_statement__ = 119;
+      current_statement__ = 121;
       for (int i = 1; i <= N; ++i) {
-        current_statement__ = 118;
+        current_statement__ = 120;
         assign(gq_vec, cons_list(index_uni(i), nil_index_list()),
           (-1.0 * p_vec[(i - 1)]), "assigning variable gq_vec");}
-      current_statement__ = 123;
+      current_statement__ = 125;
       for (int i = 1; i <= 3; ++i) {
-        current_statement__ = 122;
+        current_statement__ = 124;
         for (int j = 1; j <= 4; ++j) {
-          current_statement__ = 121;
+          current_statement__ = 123;
           for (int k = 1; k <= 5; ++k) {
-            current_statement__ = 120;
+            current_statement__ = 122;
             assign(indexing_mat,
               cons_list(index_uni(k),
                 cons_list(index_uni(i),
                   cons_list(index_uni(j), nil_index_list()))),
               normal_rng(0, 1, base_rng__), "assigning variable indexing_mat");
           }}}
-      current_statement__ = 126;
+      current_statement__ = 128;
       for (int i = 1; i <= size(indices); ++i) {
-        current_statement__ = 125;
+        current_statement__ = 127;
         for (int j = 1; j <= size(indices); ++j) {
-          current_statement__ = 124;
+          current_statement__ = 126;
           assign(idx_res1,
             cons_list(index_uni(i),
               cons_list(index_uni(j), nil_index_list())),
@@ -8319,13 +8371,13 @@ class mother_model final : public model_base_crtp<mother_model> {
               cons_list(index_uni(indices[(i - 1)]),
                 cons_list(index_uni(indices[(j - 1)]), nil_index_list())),
               "indexing_mat"), "assigning variable idx_res1");}}
-      current_statement__ = 127;
+      current_statement__ = 129;
       assign(idx_res11, nil_index_list(),
         rvalue(indexing_mat,
           cons_list(index_multi(indices),
             cons_list(index_multi(indices), nil_index_list())),
           "indexing_mat"), "assigning variable idx_res11");
-      current_statement__ = 129;
+      current_statement__ = 131;
       if (logical_neq(
             rvalue(
               rvalue(indexing_mat,
@@ -8339,16 +8391,16 @@ class mother_model final : public model_base_crtp<mother_model> {
               cons_list(index_uni(2),
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list()))), "idx_res1"))) {
-        current_statement__ = 128;
+        current_statement__ = 130;
         std::stringstream errmsg_stream__;
         errmsg_stream__ << "indexing test 1 failed";
         throw std::domain_error(errmsg_stream__.str());
       } 
-      current_statement__ = 132;
+      current_statement__ = 134;
       for (int i = 1; i <= 5; ++i) {
-        current_statement__ = 131;
+        current_statement__ = 133;
         for (int j = 1; j <= size(indices); ++j) {
-          current_statement__ = 130;
+          current_statement__ = 132;
           assign(idx_res2,
             cons_list(index_uni(i),
               cons_list(index_uni(j), nil_index_list())),
@@ -8356,13 +8408,13 @@ class mother_model final : public model_base_crtp<mother_model> {
               cons_list(index_uni(i),
                 cons_list(index_uni(indices[(j - 1)]), nil_index_list())),
               "indexing_mat"), "assigning variable idx_res2");}}
-      current_statement__ = 133;
+      current_statement__ = 135;
       assign(idx_res21, nil_index_list(),
         rvalue(indexing_mat,
           cons_list(index_omni(),
             cons_list(index_multi(indices), nil_index_list())),
           "indexing_mat"), "assigning variable idx_res21");
-      current_statement__ = 135;
+      current_statement__ = 137;
       if (logical_neq(
             rvalue(
               rvalue(indexing_mat,
@@ -8376,18 +8428,18 @@ class mother_model final : public model_base_crtp<mother_model> {
               cons_list(index_uni(2),
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list()))), "idx_res2"))) {
-        current_statement__ = 134;
+        current_statement__ = 136;
         std::stringstream errmsg_stream__;
         errmsg_stream__ << "indexing test 2 failed";
         throw std::domain_error(errmsg_stream__.str());
       } 
-      current_statement__ = 139;
+      current_statement__ = 141;
       for (int i = 1; i <= size(indices); ++i) {
-        current_statement__ = 138;
+        current_statement__ = 140;
         for (int j = 1; j <= 3; ++j) {
-          current_statement__ = 137;
+          current_statement__ = 139;
           for (int k = 1; k <= size(indices); ++k) {
-            current_statement__ = 136;
+            current_statement__ = 138;
             assign(idx_res3,
               cons_list(index_uni(i),
                 cons_list(index_uni(j),
@@ -8397,14 +8449,14 @@ class mother_model final : public model_base_crtp<mother_model> {
                   cons_list(index_uni(j),
                     cons_list(index_uni(indices[(k - 1)]), nil_index_list()))),
                 "indexing_mat"), "assigning variable idx_res3");}}}
-      current_statement__ = 140;
+      current_statement__ = 142;
       assign(idx_res31, nil_index_list(),
         rvalue(indexing_mat,
           cons_list(index_multi(indices),
             cons_list(index_omni(),
               cons_list(index_multi(indices), nil_index_list()))),
           "indexing_mat"), "assigning variable idx_res31");
-      current_statement__ = 142;
+      current_statement__ = 144;
       if (logical_neq(
             rvalue(
               rvalue(indexing_mat,
@@ -8419,59 +8471,59 @@ class mother_model final : public model_base_crtp<mother_model> {
               cons_list(index_uni(2),
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list()))), "idx_res3"))) {
-        current_statement__ = 141;
+        current_statement__ = 143;
         std::stringstream errmsg_stream__;
         errmsg_stream__ << "indexing test 3 failed";
         throw std::domain_error(errmsg_stream__.str());
       } 
-      current_statement__ = 143;
+      current_statement__ = 145;
       assign(idx_res4, nil_index_list(),
         rvalue(indexing_mat,
           cons_list(index_min_max(1, 3),
             cons_list(index_uni(1),
               cons_list(index_omni(), nil_index_list()))), "indexing_mat"),
         "assigning variable idx_res4");
-      current_statement__ = 144;
+      current_statement__ = 146;
       assign(idx_res5, nil_index_list(),
         rvalue(indexing_mat,
           cons_list(index_min(4),
             cons_list(index_min_max(2, 3),
               cons_list(index_uni(1), nil_index_list()))), "indexing_mat"),
         "assigning variable idx_res5");
-      current_statement__ = 71;
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 71;
-        current_statement__ = 71;
-        check_greater_or_equal(function__, "gq_real_1d_ar[sym1__]",
-                               gq_real_1d_ar[(sym1__ - 1)], 0);}
-      current_statement__ = 72;
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 72;
-        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 72;
-          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 72;
-            current_statement__ = 72;
-            check_greater_or_equal(function__,
-                                   "gq_real_3d_ar[sym1__, sym2__, sym3__]",
-                                   gq_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][
-                                   (sym3__ - 1)], 0);}}}
       current_statement__ = 73;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         current_statement__ = 73;
         current_statement__ = 73;
+        check_greater_or_equal(function__, "gq_real_1d_ar[sym1__]",
+                               gq_real_1d_ar[(sym1__ - 1)], 0);}
+      current_statement__ = 74;
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        current_statement__ = 74;
+        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
+          current_statement__ = 74;
+          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
+            current_statement__ = 74;
+            current_statement__ = 74;
+            check_greater_or_equal(function__,
+                                   "gq_real_3d_ar[sym1__, sym2__, sym3__]",
+                                   gq_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][
+                                   (sym3__ - 1)], 0);}}}
+      current_statement__ = 75;
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        current_statement__ = 75;
+        current_statement__ = 75;
         check_less_or_equal(function__, "gq_vec[sym1__]",
                             gq_vec[(sym1__ - 1)], 1);}
-      current_statement__ = 79;
+      current_statement__ = 81;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 79;
+        current_statement__ = 81;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 79;
+          current_statement__ = 81;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 79;
+            current_statement__ = 81;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 79;
-              current_statement__ = 79;
+              current_statement__ = 81;
+              current_statement__ = 81;
               check_greater_or_equal(function__,
                                      "gq_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                      rvalue(gq_ar_mat,
@@ -8481,16 +8533,16 @@ class mother_model final : public model_base_crtp<mother_model> {
                                              cons_list(index_uni(sym4__),
                                                nil_index_list())))),
                                        "gq_ar_mat"), 0);}}}}
-      current_statement__ = 79;
+      current_statement__ = 81;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 79;
+        current_statement__ = 81;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 79;
+          current_statement__ = 81;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 79;
+            current_statement__ = 81;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 79;
-              current_statement__ = 79;
+              current_statement__ = 81;
+              current_statement__ = 81;
               check_less_or_equal(function__,
                                   "gq_ar_mat[sym1__, sym2__, sym3__, sym4__]",
                                   rvalue(gq_ar_mat,
@@ -8500,37 +8552,37 @@ class mother_model final : public model_base_crtp<mother_model> {
                                           cons_list(index_uni(sym4__),
                                             nil_index_list())))),
                                     "gq_ar_mat"), 1);}}}}
-      current_statement__ = 80;
-      current_statement__ = 80;
+      current_statement__ = 82;
+      current_statement__ = 82;
       check_simplex(function__, "gq_simplex", gq_simplex);
-      current_statement__ = 81;
+      current_statement__ = 83;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 81;
-        current_statement__ = 81;
+        current_statement__ = 83;
+        current_statement__ = 83;
         check_simplex(function__, "gq_1d_simplex[sym1__]",
                       gq_1d_simplex[(sym1__ - 1)]);}
-      current_statement__ = 82;
+      current_statement__ = 84;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 82;
+        current_statement__ = 84;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 82;
+          current_statement__ = 84;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 82;
-            current_statement__ = 82;
+            current_statement__ = 84;
+            current_statement__ = 84;
             check_simplex(function__,
                           "gq_3d_simplex[sym1__, sym2__, sym3__]",
                           gq_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ -
                                                                     1)]);}}}
-      current_statement__ = 83;
-      current_statement__ = 83;
-      check_cholesky_factor(function__, "gq_cfcov_54", gq_cfcov_54);
-      current_statement__ = 84;
-      current_statement__ = 84;
-      check_cholesky_factor(function__, "gq_cfcov_33", gq_cfcov_33);
       current_statement__ = 85;
+      current_statement__ = 85;
+      check_cholesky_factor(function__, "gq_cfcov_54", gq_cfcov_54);
+      current_statement__ = 86;
+      current_statement__ = 86;
+      check_cholesky_factor(function__, "gq_cfcov_33", gq_cfcov_33);
+      current_statement__ = 87;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 85;
-        current_statement__ = 85;
+        current_statement__ = 87;
+        current_statement__ = 87;
         check_cholesky_factor(function__, "gq_cfcov_33_ar[sym1__]",
                               gq_cfcov_33_ar[(sym1__ - 1)]);}
       vars__.emplace_back(gq_r1);
@@ -8709,149 +8761,189 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       current_statement__ = 1;
       p_real = context__.vals_r("p_real")[(1 - 1)];
+      double p_upper;
+      p_upper = std::numeric_limits<double>::quiet_NaN();
+      
+      current_statement__ = 2;
+      p_upper = context__.vals_r("p_upper")[(1 - 1)];
+      double p_upper_free__;
+      p_upper_free__ = std::numeric_limits<double>::quiet_NaN();
+      
+      current_statement__ = 2;
+      p_upper_free__ = stan::math::lb_free(p_upper, p_real);
+      double p_lower;
+      p_lower = std::numeric_limits<double>::quiet_NaN();
+      
+      current_statement__ = 3;
+      p_lower = context__.vals_r("p_lower")[(1 - 1)];
+      double p_lower_free__;
+      p_lower_free__ = std::numeric_limits<double>::quiet_NaN();
+      
+      current_statement__ = 3;
+      p_lower_free__ = stan::math::ub_free(p_lower, p_upper);
       std::vector<double> offset_multiplier;
       offset_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 2;
+      current_statement__ = 4;
       assign(offset_multiplier, nil_index_list(),
         context__.vals_r("offset_multiplier"),
         "assigning variable offset_multiplier");
-      current_statement__ = 2;
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 2;
-        assign(offset_multiplier,
-          cons_list(index_uni(sym1__), nil_index_list()),
-          stan::math::offset_multiplier_free(offset_multiplier[(sym1__ - 1)],
-            1, 2), "assigning variable offset_multiplier");}
-      std::vector<double> no_offset_multiplier;
-      no_offset_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
+      std::vector<double> offset_multiplier_free__;
+      offset_multiplier_free__ = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 3;
-      assign(no_offset_multiplier, nil_index_list(),
-        context__.vals_r("no_offset_multiplier"),
-        "assigning variable no_offset_multiplier");
-      current_statement__ = 3;
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        current_statement__ = 3;
-        assign(no_offset_multiplier,
-          cons_list(index_uni(sym1__), nil_index_list()),
-          stan::math::offset_multiplier_free(
-            no_offset_multiplier[(sym1__ - 1)], 0, 2),
-          "assigning variable no_offset_multiplier");}
-      std::vector<double> offset_no_multiplier;
-      offset_no_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
-      
-      current_statement__ = 4;
-      assign(offset_no_multiplier, nil_index_list(),
-        context__.vals_r("offset_no_multiplier"),
-        "assigning variable offset_no_multiplier");
       current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
         current_statement__ = 4;
-        assign(offset_no_multiplier,
+        assign(offset_multiplier_free__,
+          cons_list(index_uni(sym1__), nil_index_list()),
+          stan::math::offset_multiplier_free(offset_multiplier[(sym1__ - 1)],
+            1, 2), "assigning variable offset_multiplier_free__");}
+      std::vector<double> no_offset_multiplier;
+      no_offset_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 5;
+      assign(no_offset_multiplier, nil_index_list(),
+        context__.vals_r("no_offset_multiplier"),
+        "assigning variable no_offset_multiplier");
+      std::vector<double> no_offset_multiplier_free__;
+      no_offset_multiplier_free__ = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 5;
+      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+        current_statement__ = 5;
+        assign(no_offset_multiplier_free__,
+          cons_list(index_uni(sym1__), nil_index_list()),
+          stan::math::offset_multiplier_free(
+            no_offset_multiplier[(sym1__ - 1)], 0, 2),
+          "assigning variable no_offset_multiplier_free__");}
+      std::vector<double> offset_no_multiplier;
+      offset_no_multiplier = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 6;
+      assign(offset_no_multiplier, nil_index_list(),
+        context__.vals_r("offset_no_multiplier"),
+        "assigning variable offset_no_multiplier");
+      std::vector<double> offset_no_multiplier_free__;
+      offset_no_multiplier_free__ = std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 6;
+      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+        current_statement__ = 6;
+        assign(offset_no_multiplier_free__,
           cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_free(
             offset_no_multiplier[(sym1__ - 1)], 3, 1),
-          "assigning variable offset_no_multiplier");}
+          "assigning variable offset_no_multiplier_free__");}
       std::vector<double> p_real_1d_ar;
       p_real_1d_ar = std::vector<double>(N, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 5;
+      current_statement__ = 7;
       assign(p_real_1d_ar, nil_index_list(),
         context__.vals_r("p_real_1d_ar"), "assigning variable p_real_1d_ar");
-      current_statement__ = 5;
+      std::vector<double> p_real_1d_ar_free__;
+      p_real_1d_ar_free__ = std::vector<double>(N, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 5;
-        assign(p_real_1d_ar, cons_list(index_uni(sym1__), nil_index_list()),
+        current_statement__ = 7;
+        assign(p_real_1d_ar_free__,
+          cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_free(p_real_1d_ar[(sym1__ - 1)], 0),
-          "assigning variable p_real_1d_ar");}
+          "assigning variable p_real_1d_ar_free__");}
       std::vector<std::vector<std::vector<double>>> p_real_3d_ar;
       p_real_3d_ar = std::vector<std::vector<std::vector<double>>>(N, std::vector<std::vector<double>>(M, std::vector<double>(K, std::numeric_limits<double>::quiet_NaN())));
       
       {
         std::vector<local_scalar_t__> p_real_3d_ar_flat__;
-        current_statement__ = 6;
+        current_statement__ = 8;
         assign(p_real_3d_ar_flat__, nil_index_list(),
           context__.vals_r("p_real_3d_ar"),
           "assigning variable p_real_3d_ar_flat__");
-        current_statement__ = 6;
+        current_statement__ = 8;
         pos__ = 1;
-        current_statement__ = 6;
+        current_statement__ = 8;
         for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-          current_statement__ = 6;
+          current_statement__ = 8;
           for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-            current_statement__ = 6;
+            current_statement__ = 8;
             for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-              current_statement__ = 6;
+              current_statement__ = 8;
               assign(p_real_3d_ar,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 p_real_3d_ar_flat__[(pos__ - 1)],
                 "assigning variable p_real_3d_ar");
-              current_statement__ = 6;
+              current_statement__ = 8;
               pos__ = (pos__ + 1);}}}
       }
-      current_statement__ = 6;
+      std::vector<std::vector<std::vector<double>>> p_real_3d_ar_free__;
+      p_real_3d_ar_free__ = std::vector<std::vector<std::vector<double>>>(N, std::vector<std::vector<double>>(M, std::vector<double>(K, std::numeric_limits<double>::quiet_NaN())));
+      
+      current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 6;
+        current_statement__ = 8;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 6;
+          current_statement__ = 8;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 6;
-            assign(p_real_3d_ar,
+            current_statement__ = 8;
+            assign(p_real_3d_ar_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               stan::math::lb_free(
                 p_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)], 0),
-              "assigning variable p_real_3d_ar");}}}
+              "assigning variable p_real_3d_ar_free__");}}}
       Eigen::Matrix<double, -1, 1> p_vec;
       p_vec = Eigen::Matrix<double, -1, 1>(N);
       stan::math::fill(p_vec, std::numeric_limits<double>::quiet_NaN());
       
       {
         std::vector<local_scalar_t__> p_vec_flat__;
-        current_statement__ = 7;
+        current_statement__ = 9;
         assign(p_vec_flat__, nil_index_list(), context__.vals_r("p_vec"),
           "assigning variable p_vec_flat__");
-        current_statement__ = 7;
+        current_statement__ = 9;
         pos__ = 1;
-        current_statement__ = 7;
+        current_statement__ = 9;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 7;
+          current_statement__ = 9;
           assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()),
             p_vec_flat__[(pos__ - 1)], "assigning variable p_vec");
-          current_statement__ = 7;
+          current_statement__ = 9;
           pos__ = (pos__ + 1);}
       }
-      current_statement__ = 7;
+      Eigen::Matrix<double, -1, 1> p_vec_free__;
+      p_vec_free__ = Eigen::Matrix<double, -1, 1>(N);
+      stan::math::fill(p_vec_free__, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 9;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 7;
-        assign(p_vec, cons_list(index_uni(sym1__), nil_index_list()),
+        current_statement__ = 9;
+        assign(p_vec_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_free(p_vec[(sym1__ - 1)], 0),
-          "assigning variable p_vec");}
+          "assigning variable p_vec_free__");}
       std::vector<Eigen::Matrix<double, -1, 1>> p_1d_vec;
       p_1d_vec = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       stan::math::fill(p_1d_vec, std::numeric_limits<double>::quiet_NaN());
       
       {
         std::vector<local_scalar_t__> p_1d_vec_flat__;
-        current_statement__ = 8;
+        current_statement__ = 10;
         assign(p_1d_vec_flat__, nil_index_list(),
           context__.vals_r("p_1d_vec"), "assigning variable p_1d_vec_flat__");
-        current_statement__ = 8;
+        current_statement__ = 10;
         pos__ = 1;
-        current_statement__ = 8;
+        current_statement__ = 10;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 8;
+          current_statement__ = 10;
           for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-            current_statement__ = 8;
+            current_statement__ = 10;
             assign(p_1d_vec,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               p_1d_vec_flat__[(pos__ - 1)], "assigning variable p_1d_vec");
-            current_statement__ = 8;
+            current_statement__ = 10;
             pos__ = (pos__ + 1);}}
       }
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_vec;
@@ -8860,27 +8952,27 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> p_3d_vec_flat__;
-        current_statement__ = 9;
+        current_statement__ = 11;
         assign(p_3d_vec_flat__, nil_index_list(),
           context__.vals_r("p_3d_vec"), "assigning variable p_3d_vec_flat__");
-        current_statement__ = 9;
+        current_statement__ = 11;
         pos__ = 1;
-        current_statement__ = 9;
+        current_statement__ = 11;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 9;
+          current_statement__ = 11;
           for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-            current_statement__ = 9;
+            current_statement__ = 11;
             for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-              current_statement__ = 9;
+              current_statement__ = 11;
               for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-                current_statement__ = 9;
+                current_statement__ = 11;
                 assign(p_3d_vec,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
                       cons_list(index_uni(sym2__),
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   p_3d_vec_flat__[(pos__ - 1)], "assigning variable p_3d_vec");
-                current_statement__ = 9;
+                current_statement__ = 11;
                 pos__ = (pos__ + 1);}}}}
       }
       Eigen::Matrix<double, 1, -1> p_row_vec;
@@ -8889,18 +8981,18 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> p_row_vec_flat__;
-        current_statement__ = 10;
+        current_statement__ = 12;
         assign(p_row_vec_flat__, nil_index_list(),
           context__.vals_r("p_row_vec"),
           "assigning variable p_row_vec_flat__");
-        current_statement__ = 10;
+        current_statement__ = 12;
         pos__ = 1;
-        current_statement__ = 10;
+        current_statement__ = 12;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 10;
+          current_statement__ = 12;
           assign(p_row_vec, cons_list(index_uni(sym1__), nil_index_list()),
             p_row_vec_flat__[(pos__ - 1)], "assigning variable p_row_vec");
-          current_statement__ = 10;
+          current_statement__ = 12;
           pos__ = (pos__ + 1);}
       }
       std::vector<Eigen::Matrix<double, 1, -1>> p_1d_row_vec;
@@ -8909,23 +9001,23 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> p_1d_row_vec_flat__;
-        current_statement__ = 11;
+        current_statement__ = 13;
         assign(p_1d_row_vec_flat__, nil_index_list(),
           context__.vals_r("p_1d_row_vec"),
           "assigning variable p_1d_row_vec_flat__");
-        current_statement__ = 11;
+        current_statement__ = 13;
         pos__ = 1;
-        current_statement__ = 11;
+        current_statement__ = 13;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 11;
+          current_statement__ = 13;
           for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-            current_statement__ = 11;
+            current_statement__ = 13;
             assign(p_1d_row_vec,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               p_1d_row_vec_flat__[(pos__ - 1)],
               "assigning variable p_1d_row_vec");
-            current_statement__ = 11;
+            current_statement__ = 13;
             pos__ = (pos__ + 1);}}
       }
       std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>> p_3d_row_vec;
@@ -8934,21 +9026,21 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> p_3d_row_vec_flat__;
-        current_statement__ = 12;
+        current_statement__ = 14;
         assign(p_3d_row_vec_flat__, nil_index_list(),
           context__.vals_r("p_3d_row_vec"),
           "assigning variable p_3d_row_vec_flat__");
-        current_statement__ = 12;
+        current_statement__ = 14;
         pos__ = 1;
-        current_statement__ = 12;
+        current_statement__ = 14;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 12;
+          current_statement__ = 14;
           for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-            current_statement__ = 12;
+            current_statement__ = 14;
             for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-              current_statement__ = 12;
+              current_statement__ = 14;
               for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-                current_statement__ = 12;
+                current_statement__ = 14;
                 assign(p_3d_row_vec,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
@@ -8956,7 +9048,7 @@ class mother_model final : public model_base_crtp<mother_model> {
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   p_3d_row_vec_flat__[(pos__ - 1)],
                   "assigning variable p_3d_row_vec");
-                current_statement__ = 12;
+                current_statement__ = 14;
                 pos__ = (pos__ + 1);}}}}
       }
       std::vector<std::vector<Eigen::Matrix<double, -1, -1>>> p_ar_mat;
@@ -8965,39 +9057,43 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> p_ar_mat_flat__;
-        current_statement__ = 13;
+        current_statement__ = 15;
         assign(p_ar_mat_flat__, nil_index_list(),
           context__.vals_r("p_ar_mat"), "assigning variable p_ar_mat_flat__");
-        current_statement__ = 13;
+        current_statement__ = 15;
         pos__ = 1;
-        current_statement__ = 13;
+        current_statement__ = 15;
         for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-          current_statement__ = 13;
+          current_statement__ = 15;
           for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-            current_statement__ = 13;
+            current_statement__ = 15;
             for (int sym3__ = 1; sym3__ <= 5; ++sym3__) {
-              current_statement__ = 13;
+              current_statement__ = 15;
               for (int sym4__ = 1; sym4__ <= 4; ++sym4__) {
-                current_statement__ = 13;
+                current_statement__ = 15;
                 assign(p_ar_mat,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
                       cons_list(index_uni(sym2__),
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   p_ar_mat_flat__[(pos__ - 1)], "assigning variable p_ar_mat");
-                current_statement__ = 13;
+                current_statement__ = 15;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 13;
+      std::vector<std::vector<Eigen::Matrix<double, -1, -1>>> p_ar_mat_free__;
+      p_ar_mat_free__ = std::vector<std::vector<Eigen::Matrix<double, -1, -1>>>(4, std::vector<Eigen::Matrix<double, -1, -1>>(5, Eigen::Matrix<double, -1, -1>(2, 3)));
+      stan::math::fill(p_ar_mat_free__, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        current_statement__ = 13;
+        current_statement__ = 15;
         for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          current_statement__ = 13;
+          current_statement__ = 15;
           for (int sym3__ = 1; sym3__ <= 2; ++sym3__) {
-            current_statement__ = 13;
+            current_statement__ = 15;
             for (int sym4__ = 1; sym4__ <= 3; ++sym4__) {
-              current_statement__ = 13;
-              assign(p_ar_mat,
+              current_statement__ = 15;
+              assign(p_ar_mat_free__,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym3__),
@@ -9008,82 +9104,94 @@ class mother_model final : public model_base_crtp<mother_model> {
                       cons_list(index_uni(sym2__),
                         cons_list(index_uni(sym3__),
                           cons_list(index_uni(sym4__), nil_index_list())))),
-                    "p_ar_mat"), 0, 1), "assigning variable p_ar_mat");}}}}
+                    "p_ar_mat"), 0, 1), "assigning variable p_ar_mat_free__");
+            }}}}
       Eigen::Matrix<double, -1, 1> p_simplex;
       p_simplex = Eigen::Matrix<double, -1, 1>(N);
       stan::math::fill(p_simplex, std::numeric_limits<double>::quiet_NaN());
       
       {
         std::vector<local_scalar_t__> p_simplex_flat__;
-        current_statement__ = 14;
+        current_statement__ = 16;
         assign(p_simplex_flat__, nil_index_list(),
           context__.vals_r("p_simplex"),
           "assigning variable p_simplex_flat__");
-        current_statement__ = 14;
+        current_statement__ = 16;
         pos__ = 1;
-        current_statement__ = 14;
+        current_statement__ = 16;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 14;
+          current_statement__ = 16;
           assign(p_simplex, cons_list(index_uni(sym1__), nil_index_list()),
             p_simplex_flat__[(pos__ - 1)], "assigning variable p_simplex");
-          current_statement__ = 14;
+          current_statement__ = 16;
           pos__ = (pos__ + 1);}
       }
-      current_statement__ = 14;
-      assign(p_simplex, nil_index_list(),
-        stan::math::simplex_free(p_simplex), "assigning variable p_simplex");
+      Eigen::Matrix<double, -1, 1> p_simplex_free__;
+      p_simplex_free__ = Eigen::Matrix<double, -1, 1>((N - 1));
+      stan::math::fill(p_simplex_free__, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 16;
+      assign(p_simplex_free__, nil_index_list(),
+        stan::math::simplex_free(p_simplex),
+        "assigning variable p_simplex_free__");
       std::vector<Eigen::Matrix<double, -1, 1>> p_1d_simplex;
       p_1d_simplex = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(N));
       stan::math::fill(p_1d_simplex, std::numeric_limits<double>::quiet_NaN());
       
       {
         std::vector<local_scalar_t__> p_1d_simplex_flat__;
-        current_statement__ = 15;
+        current_statement__ = 17;
         assign(p_1d_simplex_flat__, nil_index_list(),
           context__.vals_r("p_1d_simplex"),
           "assigning variable p_1d_simplex_flat__");
-        current_statement__ = 15;
+        current_statement__ = 17;
         pos__ = 1;
-        current_statement__ = 15;
+        current_statement__ = 17;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 15;
+          current_statement__ = 17;
           for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-            current_statement__ = 15;
+            current_statement__ = 17;
             assign(p_1d_simplex,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               p_1d_simplex_flat__[(pos__ - 1)],
               "assigning variable p_1d_simplex");
-            current_statement__ = 15;
+            current_statement__ = 17;
             pos__ = (pos__ + 1);}}
       }
-      current_statement__ = 15;
+      std::vector<Eigen::Matrix<double, -1, 1>> p_1d_simplex_free__;
+      p_1d_simplex_free__ = std::vector<Eigen::Matrix<double, -1, 1>>(N, Eigen::Matrix<double, -1, 1>(
+        (N - 1)));
+      stan::math::fill(p_1d_simplex_free__, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 15;
-        assign(p_1d_simplex, cons_list(index_uni(sym1__), nil_index_list()),
+        current_statement__ = 17;
+        assign(p_1d_simplex_free__,
+          cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::simplex_free(p_1d_simplex[(sym1__ - 1)]),
-          "assigning variable p_1d_simplex");}
+          "assigning variable p_1d_simplex_free__");}
       std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_simplex;
       p_3d_simplex = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(N))));
       stan::math::fill(p_3d_simplex, std::numeric_limits<double>::quiet_NaN());
       
       {
         std::vector<local_scalar_t__> p_3d_simplex_flat__;
-        current_statement__ = 16;
+        current_statement__ = 18;
         assign(p_3d_simplex_flat__, nil_index_list(),
           context__.vals_r("p_3d_simplex"),
           "assigning variable p_3d_simplex_flat__");
-        current_statement__ = 16;
+        current_statement__ = 18;
         pos__ = 1;
-        current_statement__ = 16;
+        current_statement__ = 18;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-          current_statement__ = 16;
+          current_statement__ = 18;
           for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-            current_statement__ = 16;
+            current_statement__ = 18;
             for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-              current_statement__ = 16;
+              current_statement__ = 18;
               for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-                current_statement__ = 16;
+                current_statement__ = 18;
                 assign(p_3d_simplex,
                   cons_list(index_uni(sym4__),
                     cons_list(index_uni(sym3__),
@@ -9091,45 +9199,50 @@ class mother_model final : public model_base_crtp<mother_model> {
                         cons_list(index_uni(sym1__), nil_index_list())))),
                   p_3d_simplex_flat__[(pos__ - 1)],
                   "assigning variable p_3d_simplex");
-                current_statement__ = 16;
+                current_statement__ = 18;
                 pos__ = (pos__ + 1);}}}}
       }
-      current_statement__ = 16;
+      std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>> p_3d_simplex_free__;
+      p_3d_simplex_free__ = std::vector<std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>>(N, std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(M, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(
+        (N - 1)))));
+      stan::math::fill(p_3d_simplex_free__, std::numeric_limits<double>::quiet_NaN());
+      
+      current_statement__ = 18;
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        current_statement__ = 16;
+        current_statement__ = 18;
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          current_statement__ = 16;
+          current_statement__ = 18;
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            current_statement__ = 16;
-            assign(p_3d_simplex,
+            current_statement__ = 18;
+            assign(p_3d_simplex_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               stan::math::simplex_free(
                 p_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]),
-              "assigning variable p_3d_simplex");}}}
+              "assigning variable p_3d_simplex_free__");}}}
       Eigen::Matrix<double, -1, -1> p_cfcov_54;
       p_cfcov_54 = Eigen::Matrix<double, -1, -1>(5, 4);
       stan::math::fill(p_cfcov_54, std::numeric_limits<double>::quiet_NaN());
       
       {
         std::vector<local_scalar_t__> p_cfcov_54_flat__;
-        current_statement__ = 17;
+        current_statement__ = 19;
         assign(p_cfcov_54_flat__, nil_index_list(),
           context__.vals_r("p_cfcov_54"),
           "assigning variable p_cfcov_54_flat__");
-        current_statement__ = 17;
+        current_statement__ = 19;
         pos__ = 1;
-        current_statement__ = 17;
+        current_statement__ = 19;
         for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-          current_statement__ = 17;
+          current_statement__ = 19;
           for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-            current_statement__ = 17;
+            current_statement__ = 19;
             assign(p_cfcov_54,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               p_cfcov_54_flat__[(pos__ - 1)], "assigning variable p_cfcov_54");
-            current_statement__ = 17;
+            current_statement__ = 19;
             pos__ = (pos__ + 1);}}
       }
       Eigen::Matrix<double, -1, 1> p_cfcov_54_free__;
@@ -9138,7 +9251,7 @@ class mother_model final : public model_base_crtp<mother_model> {
                                                          ((5 - 4) * 4)));
       stan::math::fill(p_cfcov_54_free__, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 17;
+      current_statement__ = 19;
       assign(p_cfcov_54_free__, nil_index_list(),
         stan::math::cholesky_factor_free(p_cfcov_54),
         "assigning variable p_cfcov_54_free__");
@@ -9148,22 +9261,22 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> p_cfcov_33_flat__;
-        current_statement__ = 18;
+        current_statement__ = 20;
         assign(p_cfcov_33_flat__, nil_index_list(),
           context__.vals_r("p_cfcov_33"),
           "assigning variable p_cfcov_33_flat__");
-        current_statement__ = 18;
+        current_statement__ = 20;
         pos__ = 1;
-        current_statement__ = 18;
+        current_statement__ = 20;
         for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-          current_statement__ = 18;
+          current_statement__ = 20;
           for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-            current_statement__ = 18;
+            current_statement__ = 20;
             assign(p_cfcov_33,
               cons_list(index_uni(sym2__),
                 cons_list(index_uni(sym1__), nil_index_list())),
               p_cfcov_33_flat__[(pos__ - 1)], "assigning variable p_cfcov_33");
-            current_statement__ = 18;
+            current_statement__ = 20;
             pos__ = (pos__ + 1);}}
       }
       Eigen::Matrix<double, -1, 1> p_cfcov_33_free__;
@@ -9172,7 +9285,7 @@ class mother_model final : public model_base_crtp<mother_model> {
                                                          ((3 - 3) * 3)));
       stan::math::fill(p_cfcov_33_free__, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 18;
+      current_statement__ = 20;
       assign(p_cfcov_33_free__, nil_index_list(),
         stan::math::cholesky_factor_free(p_cfcov_33),
         "assigning variable p_cfcov_33_free__");
@@ -9182,26 +9295,26 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> p_cfcov_33_ar_flat__;
-        current_statement__ = 19;
+        current_statement__ = 21;
         assign(p_cfcov_33_ar_flat__, nil_index_list(),
           context__.vals_r("p_cfcov_33_ar"),
           "assigning variable p_cfcov_33_ar_flat__");
-        current_statement__ = 19;
+        current_statement__ = 21;
         pos__ = 1;
-        current_statement__ = 19;
+        current_statement__ = 21;
         for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-          current_statement__ = 19;
+          current_statement__ = 21;
           for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-            current_statement__ = 19;
+            current_statement__ = 21;
             for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-              current_statement__ = 19;
+              current_statement__ = 21;
               assign(p_cfcov_33_ar,
                 cons_list(index_uni(sym3__),
                   cons_list(index_uni(sym2__),
                     cons_list(index_uni(sym1__), nil_index_list()))),
                 p_cfcov_33_ar_flat__[(pos__ - 1)],
                 "assigning variable p_cfcov_33_ar");
-              current_statement__ = 19;
+              current_statement__ = 21;
               pos__ = (pos__ + 1);}}}
       }
       std::vector<Eigen::Matrix<double, -1, 1>> p_cfcov_33_ar_free__;
@@ -9209,9 +9322,9 @@ class mother_model final : public model_base_crtp<mother_model> {
         ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))));
       stan::math::fill(p_cfcov_33_ar_free__, std::numeric_limits<double>::quiet_NaN());
       
-      current_statement__ = 19;
+      current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        current_statement__ = 19;
+        current_statement__ = 21;
         assign(p_cfcov_33_ar_free__,
           cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::cholesky_factor_free(p_cfcov_33_ar[(sym1__ - 1)]),
@@ -9222,17 +9335,17 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> x_p_flat__;
-        current_statement__ = 20;
+        current_statement__ = 22;
         assign(x_p_flat__, nil_index_list(), context__.vals_r("x_p"),
           "assigning variable x_p_flat__");
-        current_statement__ = 20;
+        current_statement__ = 22;
         pos__ = 1;
-        current_statement__ = 20;
+        current_statement__ = 22;
         for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-          current_statement__ = 20;
+          current_statement__ = 22;
           assign(x_p, cons_list(index_uni(sym1__), nil_index_list()),
             x_p_flat__[(pos__ - 1)], "assigning variable x_p");
-          current_statement__ = 20;
+          current_statement__ = 22;
           pos__ = (pos__ + 1);}
       }
       Eigen::Matrix<double, -1, 1> y_p;
@@ -9241,35 +9354,38 @@ class mother_model final : public model_base_crtp<mother_model> {
       
       {
         std::vector<local_scalar_t__> y_p_flat__;
-        current_statement__ = 21;
+        current_statement__ = 23;
         assign(y_p_flat__, nil_index_list(), context__.vals_r("y_p"),
           "assigning variable y_p_flat__");
-        current_statement__ = 21;
+        current_statement__ = 23;
         pos__ = 1;
-        current_statement__ = 21;
+        current_statement__ = 23;
         for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-          current_statement__ = 21;
+          current_statement__ = 23;
           assign(y_p, cons_list(index_uni(sym1__), nil_index_list()),
             y_p_flat__[(pos__ - 1)], "assigning variable y_p");
-          current_statement__ = 21;
+          current_statement__ = 23;
           pos__ = (pos__ + 1);}
       }
       vars__.emplace_back(p_real);
+      vars__.emplace_back(p_upper_free__);
+      vars__.emplace_back(p_lower_free__);
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        vars__.emplace_back(offset_multiplier[(sym1__ - 1)]);}
+        vars__.emplace_back(offset_multiplier_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        vars__.emplace_back(no_offset_multiplier[(sym1__ - 1)]);}
+        vars__.emplace_back(no_offset_multiplier_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        vars__.emplace_back(offset_no_multiplier[(sym1__ - 1)]);}
+        vars__.emplace_back(offset_no_multiplier_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        vars__.emplace_back(p_real_1d_ar[(sym1__ - 1)]);}
+        vars__.emplace_back(p_real_1d_ar_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
             vars__.emplace_back(
-              p_real_3d_ar[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}}}
+              p_real_3d_ar_free__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);
+          }}}
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        vars__.emplace_back(p_vec[(sym1__ - 1)]);}
+        vars__.emplace_back(p_vec_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
           vars__.emplace_back(p_1d_vec[(sym1__ - 1)][(sym2__ - 1)]);}}
@@ -9297,23 +9413,24 @@ class mother_model final : public model_base_crtp<mother_model> {
           for (int sym3__ = 1; sym3__ <= 3; ++sym3__) {
             for (int sym4__ = 1; sym4__ <= 2; ++sym4__) {
               vars__.emplace_back(
-                rvalue(p_ar_mat,
+                rvalue(p_ar_mat_free__,
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__),
                       cons_list(index_uni(sym4__),
                         cons_list(index_uni(sym3__), nil_index_list())))),
-                  "p_ar_mat"));}}}}
+                  "p_ar_mat_free__"));}}}}
       for (int sym1__ = 1; sym1__ <= (N - 1); ++sym1__) {
-        vars__.emplace_back(p_simplex[(sym1__ - 1)]);}
+        vars__.emplace_back(p_simplex_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= (N - 1); ++sym2__) {
-          vars__.emplace_back(p_1d_simplex[(sym1__ - 1)][(sym2__ - 1)]);}}
+          vars__.emplace_back(
+            p_1d_simplex_free__[(sym1__ - 1)][(sym2__ - 1)]);}}
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
           for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
             for (int sym4__ = 1; sym4__ <= (N - 1); ++sym4__) {
               vars__.emplace_back(
-                p_3d_simplex[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)][
+                p_3d_simplex_free__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)][
                 (sym4__ - 1)]);}}}}
       for (int sym1__ = 1;
            sym1__ <= ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)); ++sym1__) {
@@ -9341,6 +9458,8 @@ class mother_model final : public model_base_crtp<mother_model> {
     
     names__.clear();
     names__.emplace_back("p_real");
+    names__.emplace_back("p_upper");
+    names__.emplace_back("p_lower");
     names__.emplace_back("offset_multiplier");
     names__.emplace_back("no_offset_multiplier");
     names__.emplace_back("offset_no_multiplier");
@@ -9409,6 +9528,10 @@ class mother_model final : public model_base_crtp<mother_model> {
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
     final {
     dimss__.clear();
+    dimss__.emplace_back(std::vector<size_t>{});
+    
+    dimss__.emplace_back(std::vector<size_t>{});
+    
     dimss__.emplace_back(std::vector<size_t>{});
     
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(5)});
@@ -9625,6 +9748,8 @@ class mother_model final : public model_base_crtp<mother_model> {
     final {
     
     param_names__.emplace_back(std::string() + "p_real");
+    param_names__.emplace_back(std::string() + "p_upper");
+    param_names__.emplace_back(std::string() + "p_lower");
     for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
       {
         param_names__.emplace_back(std::string() + "offset_multiplier" + '.' + std::to_string(sym1__));
@@ -10123,6 +10248,8 @@ class mother_model final : public model_base_crtp<mother_model> {
     final {
     
     param_names__.emplace_back(std::string() + "p_real");
+    param_names__.emplace_back(std::string() + "p_upper");
+    param_names__.emplace_back(std::string() + "p_lower");
     for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
       {
         param_names__.emplace_back(std::string() + "offset_multiplier" + '.' + std::to_string(sym1__));
@@ -10598,13 +10725,13 @@ class mother_model final : public model_base_crtp<mother_model> {
     
   inline std::string get_constrained_sizedtypes() const {
     stringstream s__;
-    s__ << "[{\"name\":\"p_real\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"no_offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"offset_no_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"parameters\"},{\"name\":\"p_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"parameters\"},{\"name\":\"p_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_cfcov_54\",\"type\":{\"name\":\"matrix\",\"rows\":" << 5 << ",\"cols\":" << 4 << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33\",\"type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"parameters\"},{\"name\":\"x_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"y_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"tp_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_54\",\"type\":{\"name\":\"matrix\",\"rows\":" << 5 << ",\"cols\":" << 4 << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33\",\"type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"transformed_parameters\"},{\"name\":\"theta_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"transformed_parameters\"},{\"name\":\"gq_r1\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_r2\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_54\",\"type\":{\"name\":\"matrix\",\"rows\":" << 5 << ",\"cols\":" << 4 << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33\",\"type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"indices\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"int\"}},\"block\":\"generated_quantities\"},{\"name\":\"indexing_mat\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res1\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res2\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res3\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res11\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res21\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res31\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res4\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res5\",\"type\":{\"name\":\"array\",\"length\":" << 2 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 2 << "}},\"block\":\"generated_quantities\"}]";
+    s__ << "[{\"name\":\"p_real\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"p_upper\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"p_lower\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"no_offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"offset_no_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"parameters\"},{\"name\":\"p_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"parameters\"},{\"name\":\"p_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_cfcov_54\",\"type\":{\"name\":\"matrix\",\"rows\":" << 5 << ",\"cols\":" << 4 << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33\",\"type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"parameters\"},{\"name\":\"x_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"y_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"tp_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_54\",\"type\":{\"name\":\"matrix\",\"rows\":" << 5 << ",\"cols\":" << 4 << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33\",\"type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"transformed_parameters\"},{\"name\":\"theta_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"transformed_parameters\"},{\"name\":\"gq_r1\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_r2\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_54\",\"type\":{\"name\":\"matrix\",\"rows\":" << 5 << ",\"cols\":" << 4 << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33\",\"type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"indices\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"int\"}},\"block\":\"generated_quantities\"},{\"name\":\"indexing_mat\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res1\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res2\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res3\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res11\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res21\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res31\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res4\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res5\",\"type\":{\"name\":\"array\",\"length\":" << 2 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 2 << "}},\"block\":\"generated_quantities\"}]";
     return s__.str();
     } // get_constrained_sizedtypes() 
     
   inline std::string get_unconstrained_sizedtypes() const {
     stringstream s__;
-    s__ << "[{\"name\":\"p_real\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"no_offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"offset_no_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"parameters\"},{\"name\":\"p_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"parameters\"},{\"name\":\"p_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "},\"block\":\"parameters\"},{\"name\":\"p_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}}}},\"block\":\"parameters\"},{\"name\":\"p_cfcov_54\",\"type\":{\"name\":\"vector\",\"length\":" << ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)) << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33\",\"type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "}},\"block\":\"parameters\"},{\"name\":\"x_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"y_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"tp_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_54\",\"type\":{\"name\":\"vector\",\"length\":" << ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)) << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33\",\"type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "}},\"block\":\"transformed_parameters\"},{\"name\":\"theta_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"transformed_parameters\"},{\"name\":\"gq_r1\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_r2\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_54\",\"type\":{\"name\":\"vector\",\"length\":" << ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)) << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33\",\"type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "}},\"block\":\"generated_quantities\"},{\"name\":\"indices\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"int\"}},\"block\":\"generated_quantities\"},{\"name\":\"indexing_mat\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res1\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res2\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res3\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res11\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res21\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res31\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res4\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res5\",\"type\":{\"name\":\"array\",\"length\":" << 2 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 2 << "}},\"block\":\"generated_quantities\"}]";
+    s__ << "[{\"name\":\"p_real\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"p_upper\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"p_lower\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"no_offset_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"offset_no_multiplier\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"parameters\"},{\"name\":\"p_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"parameters\"},{\"name\":\"p_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"parameters\"},{\"name\":\"p_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"parameters\"},{\"name\":\"p_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"parameters\"},{\"name\":\"p_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "},\"block\":\"parameters\"},{\"name\":\"p_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}},\"block\":\"parameters\"},{\"name\":\"p_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}}}},\"block\":\"parameters\"},{\"name\":\"p_cfcov_54\",\"type\":{\"name\":\"vector\",\"length\":" << ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)) << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33\",\"type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "},\"block\":\"parameters\"},{\"name\":\"p_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "}},\"block\":\"parameters\"},{\"name\":\"x_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"y_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"parameters\"},{\"name\":\"tp_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}}}},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_54\",\"type\":{\"name\":\"vector\",\"length\":" << ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)) << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33\",\"type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "},\"block\":\"transformed_parameters\"},{\"name\":\"tp_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "}},\"block\":\"transformed_parameters\"},{\"name\":\"theta_p\",\"type\":{\"name\":\"vector\",\"length\":" << 2 << "},\"block\":\"transformed_parameters\"},{\"name\":\"gq_r1\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_r2\",\"type\":{\"name\":\"real\"},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_1d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"real\"}},\"block\":\"generated_quantities\"},{\"name\":\"gq_real_3d_ar\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"real\"}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_row_vec\",\"type\":{\"name\":\"vector\",\"length\":" << N << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_row_vec\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << N << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_ar_mat\",\"type\":{\"name\":\"array\",\"length\":" << 4 << ",\"element_type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 2 << ",\"cols\":" << 3 << "}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_simplex\",\"type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_1d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}},\"block\":\"generated_quantities\"},{\"name\":\"gq_3d_simplex\",\"type\":{\"name\":\"array\",\"length\":" << N << ",\"element_type\":{\"name\":\"array\",\"length\":" << M << ",\"element_type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << (N - 1) << "}}}},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_54\",\"type\":{\"name\":\"vector\",\"length\":" << ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)) << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33\",\"type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "},\"block\":\"generated_quantities\"},{\"name\":\"gq_cfcov_33_ar\",\"type\":{\"name\":\"array\",\"length\":" << K << ",\"element_type\":{\"name\":\"vector\",\"length\":" << ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)) << "}},\"block\":\"generated_quantities\"},{\"name\":\"indices\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"int\"}},\"block\":\"generated_quantities\"},{\"name\":\"indexing_mat\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res1\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res2\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res3\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res11\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res21\",\"type\":{\"name\":\"array\",\"length\":" << 5 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res31\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"matrix\",\"rows\":" << 3 << ",\"cols\":" << 3 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res4\",\"type\":{\"name\":\"array\",\"length\":" << 3 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 4 << "}},\"block\":\"generated_quantities\"},{\"name\":\"idx_res5\",\"type\":{\"name\":\"array\",\"length\":" << 2 << ",\"element_type\":{\"name\":\"vector\",\"length\":" << 2 << "}},\"block\":\"generated_quantities\"}]";
     return s__.str();
     } // get_unconstrained_sizedtypes() 
     
@@ -17713,61 +17840,79 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       
       current_statement__ = 1;
       alpha = context__.vals_r("alpha")[(1 - 1)];
+      double alpha_free__;
+      alpha_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      alpha = stan::math::lb_free(alpha, 0);
+      alpha_free__ = stan::math::lb_free(alpha, 0);
       double beta;
       beta = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 2;
       beta = context__.vals_r("beta")[(1 - 1)];
+      double beta_free__;
+      beta_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      beta = stan::math::lb_free(beta, 0);
+      beta_free__ = stan::math::lb_free(beta, 0);
       double gamma;
       gamma = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 3;
       gamma = context__.vals_r("gamma")[(1 - 1)];
+      double gamma_free__;
+      gamma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 3;
-      gamma = stan::math::lb_free(gamma, 0);
+      gamma_free__ = stan::math::lb_free(gamma, 0);
       double delta;
       delta = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 4;
       delta = context__.vals_r("delta")[(1 - 1)];
+      double delta_free__;
+      delta_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      delta = stan::math::lb_free(delta, 0);
+      delta_free__ = stan::math::lb_free(delta, 0);
       std::vector<double> z_init;
       z_init = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
       
       current_statement__ = 5;
       assign(z_init, nil_index_list(), context__.vals_r("z_init"),
         "assigning variable z_init");
+      std::vector<double> z_init_free__;
+      z_init_free__ = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 5;
-        assign(z_init, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(z_init_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_free(z_init[(sym1__ - 1)], 0),
-          "assigning variable z_init");}
+          "assigning variable z_init_free__");}
       std::vector<double> sigma;
       sigma = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
       
       current_statement__ = 6;
       assign(sigma, nil_index_list(), context__.vals_r("sigma"),
         "assigning variable sigma");
+      std::vector<double> sigma_free__;
+      sigma_free__ = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
         current_statement__ = 6;
-        assign(sigma, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(sigma_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_free(sigma[(sym1__ - 1)], 0),
-          "assigning variable sigma");}
-      vars__.emplace_back(alpha);
-      vars__.emplace_back(beta);
-      vars__.emplace_back(gamma);
-      vars__.emplace_back(delta);
+          "assigning variable sigma_free__");}
+      vars__.emplace_back(alpha_free__);
+      vars__.emplace_back(beta_free__);
+      vars__.emplace_back(gamma_free__);
+      vars__.emplace_back(delta_free__);
       for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        vars__.emplace_back(z_init[(sym1__ - 1)]);}
+        vars__.emplace_back(z_init_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        vars__.emplace_back(sigma[(sym1__ - 1)]);}
+        vars__.emplace_back(sigma_free__[(sym1__ - 1)]);}
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -19297,8 +19442,11 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       
       current_statement__ = 4;
       sigma = context__.vals_r("sigma")[(1 - 1)];
+      double sigma_free__;
+      sigma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      sigma = stan::math::lb_free(sigma, 0);
+      sigma_free__ = stan::math::lb_free(sigma, 0);
       double alpha;
       alpha = std::numeric_limits<double>::quiet_NaN();
       
@@ -19380,7 +19528,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
         vars__.emplace_back(beta[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         vars__.emplace_back(cuts[(sym1__ - 1)]);}
-      vars__.emplace_back(sigma);
+      vars__.emplace_back(sigma_free__);
       vars__.emplace_back(alpha);
       vars__.emplace_back(phi);
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
@@ -27982,9 +28130,12 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
+      double x_free__;
+      x_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      x = stan::math::lb_free(x, 0);
-      vars__.emplace_back(x);
+      x_free__ = stan::math::lb_free(x, 0);
+      vars__.emplace_back(x_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -30568,12 +30719,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 1;
       check_matching_dims("constraint", "p_1", p_1, "lower",
                           ds[(1 - 1)][(1 - 1)]);
+      std::vector<double> p_1_free__;
+      p_1_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 1;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 1;
-        assign(p_1, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_1_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_free(p_1[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_1");}
+            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]),
+          "assigning variable p_1_free__");}
       std::vector<double> p_2;
       p_2 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30583,12 +30738,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 2;
       check_matching_dims("constraint", "p_2", p_2, "upper",
                           ds[(1 - 1)][(1 - 1)]);
+      std::vector<double> p_2_free__;
+      p_2_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 2;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 2;
-        assign(p_2, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_2_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::ub_free(p_2[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_2");}
+            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]),
+          "assigning variable p_2_free__");}
       std::vector<double> p_3;
       p_3 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30601,13 +30760,17 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 3;
       check_matching_dims("constraint", "p_3", p_3, "upper",
                           ds[(1 - 1)][(2 - 1)]);
+      std::vector<double> p_3_free__;
+      p_3_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 3;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 3;
-        assign(p_3, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_3_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(p_3[(sym1__ - 1)],
             ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_3");}
+            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
+          "assigning variable p_3_free__");}
       std::vector<double> p_4;
       p_4 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30617,12 +30780,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 4;
       check_matching_dims("constraint", "p_4", p_4, "upper",
                           ds[(1 - 1)][(2 - 1)]);
+      std::vector<double> p_4_free__;
+      p_4_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 4;
-        assign(p_4, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_4_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(p_4[(sym1__ - 1)], 0,
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_4");}
+            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
+          "assigning variable p_4_free__");}
       std::vector<double> p_5;
       p_5 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30632,13 +30799,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 5;
       check_matching_dims("constraint", "p_5", p_5, "lower",
                           ds[(1 - 1)][(1 - 1)]);
+      std::vector<double> p_5_free__;
+      p_5_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 5;
-        assign(p_5, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_5_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(p_5[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1), "assigning variable p_5");
-      }
+            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1),
+          "assigning variable p_5_free__");}
       std::vector<double> p_6;
       p_6 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30648,13 +30818,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 6;
       check_matching_dims("constraint", "p_6", p_6, "offset",
                           ds[(1 - 1)][(1 - 1)]);
+      std::vector<double> p_6_free__;
+      p_6_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 6;
-        assign(p_6, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_6_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_free(p_6[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1), "assigning variable p_6");
-      }
+            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1),
+          "assigning variable p_6_free__");}
       std::vector<double> p_7;
       p_7 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30664,12 +30837,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 7;
       check_matching_dims("constraint", "p_7", p_7, "multiplier",
                           ds[(1 - 1)][(1 - 1)]);
+      std::vector<double> p_7_free__;
+      p_7_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 7;
-        assign(p_7, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_7_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_free(p_7[(sym1__ - 1)], 0,
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_7");}
+            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]),
+          "assigning variable p_7_free__");}
       std::vector<double> p_8;
       p_8 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30682,13 +30859,17 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 8;
       check_matching_dims("constraint", "p_8", p_8, "multiplier",
                           ds[(1 - 1)][(2 - 1)]);
+      std::vector<double> p_8_free__;
+      p_8_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 8;
-        assign(p_8, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(p_8_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_free(p_8[(sym1__ - 1)],
             ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_8");}
+            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
+          "assigning variable p_8_free__");}
       std::vector<std::vector<double>> p_9;
       p_9 = std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN()));
       
@@ -30713,17 +30894,20 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 9;
       check_matching_dims("constraint", "p_9", p_9, "lower", ds[(1 - 1)]);
+      std::vector<std::vector<double>> p_9_free__;
+      p_9_free__ = std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN()));
+      
       current_statement__ = 9;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 9;
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
           current_statement__ = 9;
-          assign(p_9,
+          assign(p_9_free__,
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lub_free(p_9[(sym1__ - 1)][(sym2__ - 1)],
               ds[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)], 1),
-            "assigning variable p_9");}}
+            "assigning variable p_9_free__");}}
       std::vector<std::vector<std::vector<double>>> p_10;
       p_10 = std::vector<std::vector<std::vector<double>>>(n, std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN())));
       
@@ -30751,6 +30935,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 10;
       check_matching_dims("constraint", "p_10", p_10, "upper", ds);
+      std::vector<std::vector<std::vector<double>>> p_10_free__;
+      p_10_free__ = std::vector<std::vector<std::vector<double>>>(n, std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN())));
+      
       current_statement__ = 10;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 10;
@@ -30758,14 +30945,14 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 10;
           for (int sym3__ = 1; sym3__ <= k; ++sym3__) {
             current_statement__ = 10;
-            assign(p_10,
+            assign(p_10_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               stan::math::lub_free(
                 p_10[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)], 0,
                 ds[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]),
-              "assigning variable p_10");}}}
+              "assigning variable p_10_free__");}}}
       Eigen::Matrix<double, -1, 1> pv_1;
       pv_1 = Eigen::Matrix<double, -1, 1>(k);
       stan::math::fill(pv_1, std::numeric_limits<double>::quiet_NaN());
@@ -30791,13 +30978,18 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 11;
       check_matching_dims("constraint", "pv_1", pv_1, "upper",
                           dv[(1 - 1)][(2 - 1)]);
+      Eigen::Matrix<double, -1, 1> pv_1_free__;
+      pv_1_free__ = Eigen::Matrix<double, -1, 1>(k);
+      stan::math::fill(pv_1_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 11;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 11;
-        assign(pv_1, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(pv_1_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(pv_1[(sym1__ - 1)],
             dv[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            dv[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable pv_1");}
+            dv[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
+          "assigning variable pv_1_free__");}
       std::vector<Eigen::Matrix<double, -1, 1>> pv_2;
       pv_2 = std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k));
       stan::math::fill(pv_2, std::numeric_limits<double>::quiet_NaN());
@@ -30823,17 +31015,21 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 12;
       check_matching_dims("constraint", "pv_2", pv_2, "lower", dv[(1 - 1)]);
+      std::vector<Eigen::Matrix<double, -1, 1>> pv_2_free__;
+      pv_2_free__ = std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k));
+      stan::math::fill(pv_2_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 12;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 12;
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
           current_statement__ = 12;
-          assign(pv_2,
+          assign(pv_2_free__,
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lb_free(pv_2[(sym1__ - 1)][(sym2__ - 1)],
               dv[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-            "assigning variable pv_2");}}
+            "assigning variable pv_2_free__");}}
       std::vector<std::vector<Eigen::Matrix<double, -1, 1>>> pv_3;
       pv_3 = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(n, std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k)));
       stan::math::fill(pv_3, std::numeric_limits<double>::quiet_NaN());
@@ -30862,6 +31058,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 13;
       check_matching_dims("constraint", "pv_3", pv_3, "upper", dv);
+      std::vector<std::vector<Eigen::Matrix<double, -1, 1>>> pv_3_free__;
+      pv_3_free__ = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(n, std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k)));
+      stan::math::fill(pv_3_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 13;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 13;
@@ -30869,14 +31069,14 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 13;
           for (int sym3__ = 1; sym3__ <= k; ++sym3__) {
             current_statement__ = 13;
-            assign(pv_3,
+            assign(pv_3_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               stan::math::ub_free(
                 pv_3[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                 dv[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]),
-              "assigning variable pv_3");}}}
+              "assigning variable pv_3_free__");}}}
       Eigen::Matrix<double, 1, -1> pr_1;
       pr_1 = Eigen::Matrix<double, 1, -1>(k);
       stan::math::fill(pr_1, std::numeric_limits<double>::quiet_NaN());
@@ -30902,13 +31102,18 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 14;
       check_matching_dims("constraint", "pr_1", pr_1, "upper",
                           dr[(1 - 1)][(2 - 1)]);
+      Eigen::Matrix<double, 1, -1> pr_1_free__;
+      pr_1_free__ = Eigen::Matrix<double, 1, -1>(k);
+      stan::math::fill(pr_1_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 14;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 14;
-        assign(pr_1, cons_list(index_uni(sym1__), nil_index_list()),
+        assign(pr_1_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(pr_1[(sym1__ - 1)],
             dr[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            dr[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable pr_1");}
+            dr[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
+          "assigning variable pr_1_free__");}
       std::vector<Eigen::Matrix<double, 1, -1>> pr_2;
       pr_2 = std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k));
       stan::math::fill(pr_2, std::numeric_limits<double>::quiet_NaN());
@@ -30934,17 +31139,21 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 15;
       check_matching_dims("constraint", "pr_2", pr_2, "lower", dr[(1 - 1)]);
+      std::vector<Eigen::Matrix<double, 1, -1>> pr_2_free__;
+      pr_2_free__ = std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k));
+      stan::math::fill(pr_2_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 15;
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
           current_statement__ = 15;
-          assign(pr_2,
+          assign(pr_2_free__,
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lb_free(pr_2[(sym1__ - 1)][(sym2__ - 1)],
               dr[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-            "assigning variable pr_2");}}
+            "assigning variable pr_2_free__");}}
       std::vector<std::vector<Eigen::Matrix<double, 1, -1>>> pr_3;
       pr_3 = std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(n, std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k)));
       stan::math::fill(pr_3, std::numeric_limits<double>::quiet_NaN());
@@ -30973,6 +31182,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 16;
       check_matching_dims("constraint", "pr_3", pr_3, "upper", dr);
+      std::vector<std::vector<Eigen::Matrix<double, 1, -1>>> pr_3_free__;
+      pr_3_free__ = std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(n, std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k)));
+      stan::math::fill(pr_3_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 16;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 16;
@@ -30980,14 +31193,14 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 16;
           for (int sym3__ = 1; sym3__ <= k; ++sym3__) {
             current_statement__ = 16;
-            assign(pr_3,
+            assign(pr_3_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
               stan::math::ub_free(
                 pr_3[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)],
                 dr[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]),
-              "assigning variable pr_3");}}}
+              "assigning variable pr_3_free__");}}}
       Eigen::Matrix<double, -1, -1> pm_1;
       pm_1 = Eigen::Matrix<double, -1, -1>(m, k);
       stan::math::fill(pm_1, std::numeric_limits<double>::quiet_NaN());
@@ -31013,12 +31226,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 17;
       check_matching_dims("constraint", "pm_1", pm_1, "lower", dm[(1 - 1)]);
+      Eigen::Matrix<double, -1, -1> pm_1_free__;
+      pm_1_free__ = Eigen::Matrix<double, -1, -1>(m, k);
+      stan::math::fill(pm_1_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 17;
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
           current_statement__ = 17;
-          assign(pm_1,
+          assign(pm_1_free__,
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lb_free(
@@ -31028,7 +31245,7 @@ class transform_model final : public model_base_crtp<transform_model> {
               rvalue(dm[(1 - 1)],
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__), nil_index_list())), "dm[1]")),
-            "assigning variable pm_1");}}
+            "assigning variable pm_1_free__");}}
       std::vector<Eigen::Matrix<double, -1, -1>> pm_2;
       pm_2 = std::vector<Eigen::Matrix<double, -1, -1>>(n, Eigen::Matrix<double, -1, -1>(m, k));
       stan::math::fill(pm_2, std::numeric_limits<double>::quiet_NaN());
@@ -31057,6 +31274,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 18;
       check_matching_dims("constraint", "pm_2", pm_2, "upper", dm);
+      std::vector<Eigen::Matrix<double, -1, -1>> pm_2_free__;
+      pm_2_free__ = std::vector<Eigen::Matrix<double, -1, -1>>(n, Eigen::Matrix<double, -1, -1>(m, k));
+      stan::math::fill(pm_2_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 18;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 18;
@@ -31064,7 +31285,7 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 18;
           for (int sym3__ = 1; sym3__ <= k; ++sym3__) {
             current_statement__ = 18;
-            assign(pm_2,
+            assign(pm_2_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__),
                   cons_list(index_uni(sym3__), nil_index_list()))),
@@ -31078,66 +31299,67 @@ class transform_model final : public model_base_crtp<transform_model> {
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__),
                       cons_list(index_uni(sym3__), nil_index_list()))), "dm")),
-              "assigning variable pm_2");}}}
+              "assigning variable pm_2_free__");}}}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_1[(sym1__ - 1)]);}
+        vars__.emplace_back(p_1_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_2[(sym1__ - 1)]);}
+        vars__.emplace_back(p_2_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_3[(sym1__ - 1)]);}
+        vars__.emplace_back(p_3_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_4[(sym1__ - 1)]);}
+        vars__.emplace_back(p_4_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_5[(sym1__ - 1)]);}
+        vars__.emplace_back(p_5_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_6[(sym1__ - 1)]);}
+        vars__.emplace_back(p_6_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_7[(sym1__ - 1)]);}
+        vars__.emplace_back(p_7_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(p_8[(sym1__ - 1)]);}
+        vars__.emplace_back(p_8_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
-          vars__.emplace_back(p_9[(sym1__ - 1)][(sym2__ - 1)]);}}
+          vars__.emplace_back(p_9_free__[(sym1__ - 1)][(sym2__ - 1)]);}}
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
           for (int sym3__ = 1; sym3__ <= k; ++sym3__) {
             vars__.emplace_back(
-              p_10[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}}}
+              p_10_free__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}}}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(pv_1[(sym1__ - 1)]);}
+        vars__.emplace_back(pv_1_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
-          vars__.emplace_back(pv_2[(sym1__ - 1)][(sym2__ - 1)]);}}
+          vars__.emplace_back(pv_2_free__[(sym1__ - 1)][(sym2__ - 1)]);}}
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
           for (int sym3__ = 1; sym3__ <= k; ++sym3__) {
             vars__.emplace_back(
-              pv_3[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}}}
+              pv_3_free__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}}}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        vars__.emplace_back(pr_1[(sym1__ - 1)]);}
+        vars__.emplace_back(pr_1_free__[(sym1__ - 1)]);}
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
-          vars__.emplace_back(pr_2[(sym1__ - 1)][(sym2__ - 1)]);}}
+          vars__.emplace_back(pr_2_free__[(sym1__ - 1)][(sym2__ - 1)]);}}
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
           for (int sym3__ = 1; sym3__ <= k; ++sym3__) {
             vars__.emplace_back(
-              pr_3[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}}}
+              pr_3_free__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}}}
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
           vars__.emplace_back(
-            rvalue(pm_1,
+            rvalue(pm_1_free__,
               cons_list(index_uni(sym2__),
-                cons_list(index_uni(sym1__), nil_index_list())), "pm_1"));}}
+                cons_list(index_uni(sym1__), nil_index_list())),
+              "pm_1_free__"));}}
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= k; ++sym2__) {
           for (int sym3__ = 1; sym3__ <= m; ++sym3__) {
             vars__.emplace_back(
-              rvalue(pm_2,
+              rvalue(pm_2_free__,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym3__),
-                    cons_list(index_uni(sym2__), nil_index_list()))), "pm_2"));
-          }}}
+                    cons_list(index_uni(sym2__), nil_index_list()))),
+                "pm_2_free__"));}}}
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -32173,10 +32395,13 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       
       current_statement__ = 2;
       y = context__.vals_r("y")[(1 - 1)];
+      double y_free__;
+      y_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      y = stan::math::lb_free(y, 0);
+      y_free__ = stan::math::lb_free(y, 0);
       vars__.emplace_back(m);
-      vars__.emplace_back(y);
+      vars__.emplace_back(y_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -32936,9 +33161,12 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
+      double x_free__;
+      x_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      x = stan::math::lb_free(x, 0);
-      vars__.emplace_back(x);
+      x_free__ = stan::math::lb_free(x, 0);
+      vars__.emplace_back(x_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -7645,6 +7645,38 @@
       (decl_type (Sized SReal))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_upper)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_upper UReal ())
+      ((pattern
+        (FunApp CompilerInternal FnConstrain__
+         (((pattern (Var p_upper))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern (Lit Str lb))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var p_real))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_lower)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_lower UReal ())
+      ((pattern
+        (FunApp CompilerInternal FnConstrain__
+         (((pattern (Var p_lower))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+          ((pattern (Lit Str ub))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var p_upper))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+    (meta <opaque>))
+   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id offset_multiplier)
       (decl_type
        (Sized
@@ -10368,6 +10400,38 @@
  (generate_quantities
   (((pattern
      (Decl (decl_adtype DataOnly) (decl_id p_real) (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_upper)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_upper UReal ())
+      ((pattern
+        (FunApp CompilerInternal FnConstrain__
+         (((pattern (Var p_upper))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Str lb))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var p_real))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_lower)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_lower UReal ())
+      ((pattern
+        (FunApp CompilerInternal FnConstrain__
+         (((pattern (Var p_lower))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Str ub))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var p_upper))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
     (meta <opaque>))
    ((pattern
      (Decl (decl_adtype DataOnly) (decl_id offset_multiplier)
@@ -14001,7 +14065,55 @@
      (Decl (decl_adtype DataOnly) (decl_id p_real) (decl_type (Sized SReal))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_upper)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_upper_free__)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_upper_free__ UReal ())
+      ((pattern
+        (FunApp CompilerInternal FnUnconstrain__
+         (((pattern (Var p_upper))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Str lb))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var p_real))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_lower)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_lower_free__)
+      (decl_type (Sized SReal))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_lower_free__ UReal ())
+      ((pattern
+        (FunApp CompilerInternal FnUnconstrain__
+         (((pattern (Var p_lower))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Str ub))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var p_upper))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
      (Decl (decl_adtype DataOnly) (decl_id offset_multiplier)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id offset_multiplier_free__)
       (decl_type
        (Sized
         (SArray SReal
@@ -14021,7 +14133,7 @@
          (Block
           (((pattern
              (Assignment
-              (offset_multiplier (UArray UReal)
+              (offset_multiplier_free__ (UArray UReal)
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -14057,6 +14169,14 @@
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id no_offset_multiplier_free__)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
      (For (loopvar sym1__)
       (lower
        ((pattern (Lit Int 1))
@@ -14069,7 +14189,7 @@
          (Block
           (((pattern
              (Assignment
-              (no_offset_multiplier (UArray UReal)
+              (no_offset_multiplier_free__ (UArray UReal)
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -14105,6 +14225,14 @@
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id offset_no_multiplier_free__)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
      (For (loopvar sym1__)
       (lower
        ((pattern (Lit Int 1))
@@ -14117,7 +14245,7 @@
          (Block
           (((pattern
              (Assignment
-              (offset_no_multiplier (UArray UReal)
+              (offset_no_multiplier_free__ (UArray UReal)
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -14153,6 +14281,14 @@
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_real_1d_ar_free__)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
      (For (loopvar sym1__)
       (lower
        ((pattern (Lit Int 1))
@@ -14165,7 +14301,7 @@
          (Block
           (((pattern
              (Assignment
-              (p_real_1d_ar (UArray UReal)
+              (p_real_1d_ar_free__ (UArray UReal)
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -14192,6 +14328,20 @@
     (meta <opaque>))
    ((pattern
      (Decl (decl_adtype DataOnly) (decl_id p_real_3d_ar)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray SReal
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_real_3d_ar_free__)
       (decl_type
        (Sized
         (SArray
@@ -14241,7 +14391,8 @@
                          (Block
                           (((pattern
                              (Assignment
-                              (p_real_3d_ar (UArray (UArray (UArray UReal)))
+                              (p_real_3d_ar_free__
+                               (UArray (UArray (UArray UReal)))
                                ((Single
                                  ((pattern (Var sym1__))
                                   (meta
@@ -14311,6 +14462,14 @@
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_vec_free__)
+      (decl_type
+       (Sized
+        (SVector
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
      (For (loopvar sym1__)
       (lower
        ((pattern (Lit Int 1))
@@ -14323,7 +14482,7 @@
          (Block
           (((pattern
              (Assignment
-              (p_vec UVector
+              (p_vec_free__ UVector
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -14428,6 +14587,22 @@
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_ar_mat_free__)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SMatrix
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 4))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
      (For (loopvar sym1__)
       (lower
        ((pattern (Lit Int 1))
@@ -14479,7 +14654,8 @@
                                  (Block
                                   (((pattern
                                      (Assignment
-                                      (p_ar_mat (UArray (UArray UMatrix))
+                                      (p_ar_mat_free__
+                                       (UArray (UArray UMatrix))
                                        ((Single
                                          ((pattern (Var sym1__))
                                           (meta
@@ -14567,7 +14743,20 @@
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
     (meta <opaque>))
    ((pattern
-     (Assignment (p_simplex UVector ())
+     (Decl (decl_adtype DataOnly) (decl_id p_simplex_free__)
+      (decl_type
+       (Sized
+        (SVector
+         ((pattern
+           (FunApp StanLib Minus__
+            (((pattern (Var N))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_simplex_free__ UVector ())
       ((pattern
         (FunApp CompilerInternal FnUnconstrain__
          (((pattern (Var p_simplex))
@@ -14588,6 +14777,22 @@
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
     (meta <opaque>))
    ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_1d_simplex_free__)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector
+          ((pattern
+            (FunApp StanLib Minus__
+             (((pattern (Var N))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern (Lit Int 1))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
      (For (loopvar sym1__)
       (lower
        ((pattern (Lit Int 1))
@@ -14600,7 +14805,7 @@
          (Block
           (((pattern
              (Assignment
-              (p_1d_simplex (UArray UVector)
+              (p_1d_simplex_free__ (UArray UVector)
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -14632,6 +14837,28 @@
           (SArray
            (SVector
             ((pattern (Var N))
+             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype DataOnly) (decl_id p_3d_simplex_free__)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray
+           (SVector
+            ((pattern
+              (FunApp StanLib Minus__
+               (((pattern (Var N))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                ((pattern (Lit Int 1))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
@@ -14677,7 +14904,7 @@
                          (Block
                           (((pattern
                              (Assignment
-                              (p_3d_simplex
+                              (p_3d_simplex_free__
                                (UArray (UArray (UArray UVector)))
                                ((Single
                                  ((pattern (Var sym1__))
@@ -14998,6 +15225,20 @@
   ((p_real
     ((out_unconstrained_st SReal) (out_constrained_st SReal)
      (out_block Parameters) (out_trans Identity)))
+   (p_upper
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block Parameters)
+     (out_trans
+      (Lower
+       ((pattern (Var p_real))
+        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
+   (p_lower
+    ((out_unconstrained_st SReal) (out_constrained_st SReal)
+     (out_block Parameters)
+     (out_trans
+      (Upper
+       ((pattern (Var p_upper))
+        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))))
    (offset_multiplier
     ((out_unconstrained_st
       (SArray SReal

--- a/test/integration/good/code-gen/mother.stan
+++ b/test/integration/good/code-gen/mother.stan
@@ -544,6 +544,8 @@ transformed data {
 }
 parameters {
   real p_real;
+  real<lower=p_real> p_upper;
+  real<upper=p_upper> p_lower;
   real<offset=1, multiplier=2> offset_multiplier[5];
   real<multiplier=2> no_offset_multiplier[5];
   real<offset=3> offset_no_multiplier[5];

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -679,33 +679,45 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       
       current_statement__ = 1;
       beta = context__.vals_r("beta")[(1 - 1)];
+      double beta_free__;
+      beta_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      beta = stan::math::lb_free(beta, 0);
+      beta_free__ = stan::math::lb_free(beta, 0);
       double gamma;
       gamma = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 2;
       gamma = context__.vals_r("gamma")[(1 - 1)];
+      double gamma_free__;
+      gamma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      gamma = stan::math::lb_free(gamma, 0);
+      gamma_free__ = stan::math::lb_free(gamma, 0);
       double xi;
       xi = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 3;
       xi = context__.vals_r("xi")[(1 - 1)];
+      double xi_free__;
+      xi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 3;
-      xi = stan::math::lb_free(xi, 0);
+      xi_free__ = stan::math::lb_free(xi, 0);
       double delta;
       delta = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 4;
       delta = context__.vals_r("delta")[(1 - 1)];
+      double delta_free__;
+      delta_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      delta = stan::math::lb_free(delta, 0);
-      vars__.emplace_back(beta);
-      vars__.emplace_back(gamma);
-      vars__.emplace_back(xi);
-      vars__.emplace_back(delta);
+      delta_free__ = stan::math::lb_free(delta, 0);
+      vars__.emplace_back(beta_free__);
+      vars__.emplace_back(gamma_free__);
+      vars__.emplace_back(xi_free__);
+      vars__.emplace_back(delta_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -3229,6 +3241,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       double lcm_sym52__;
       double lcm_sym51__;
       double lcm_sym50__;
+      double lcm_sym49__;
+      double lcm_sym48__;
       int lcm_sym47__;
       int lcm_sym46__;
       int pos__;
@@ -3240,8 +3254,11 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       
       current_statement__ = 1;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      double mean_p_free__;
+      mean_p_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      mean_p = stan::math::lub_free(mean_p, 0, 1);
+      mean_p_free__ = stan::math::lub_free(mean_p, 0, 1);
       Eigen::Matrix<double, -1, 1> beta;
       beta = Eigen::Matrix<double, -1, 1>(max_age);
       stan::math::fill(beta, std::numeric_limits<double>::quiet_NaN());
@@ -3268,23 +3285,27 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             pos__ = (pos__ + 1);}
         } 
       }
+      Eigen::Matrix<double, -1, 1> beta_free__;
+      beta_free__ = Eigen::Matrix<double, -1, 1>(max_age);
+      stan::math::fill(beta_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 2;
       if (lcm_sym46__) {
         current_statement__ = 2;
-        assign(beta, cons_list(index_uni(1), nil_index_list()),
+        assign(beta_free__, cons_list(index_uni(1), nil_index_list()),
           stan::math::lub_free(beta[(1 - 1)], 0, 1),
-          "assigning variable beta");
+          "assigning variable beta_free__");
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
-          assign(beta, cons_list(index_uni(sym1__), nil_index_list()),
+          assign(beta_free__, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_free(beta[(sym1__ - 1)], 0, 1),
-            "assigning variable beta");}
+            "assigning variable beta_free__");}
       } 
-      vars__.emplace_back(mean_p);
+      vars__.emplace_back(mean_p_free__);
       if (lcm_sym46__) {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(beta_free__[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
-          vars__.emplace_back(beta[(sym1__ - 1)]);}
+          vars__.emplace_back(beta_free__[(sym1__ - 1)]);}
       } 
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4605,43 +4626,61 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       
       current_statement__ = 1;
       sigma = context__.vals_r("sigma")[(1 - 1)];
+      double sigma_free__;
+      sigma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      sigma = stan::math::lb_free(sigma, 0);
+      sigma_free__ = stan::math::lb_free(sigma, 0);
       double sigma_age;
       sigma_age = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 2;
       sigma_age = context__.vals_r("sigma_age")[(1 - 1)];
+      double sigma_age_free__;
+      sigma_age_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      sigma_age = stan::math::lb_free(sigma_age, 0);
+      sigma_age_free__ = stan::math::lb_free(sigma_age, 0);
       double sigma_edu;
       sigma_edu = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 3;
       sigma_edu = context__.vals_r("sigma_edu")[(1 - 1)];
+      double sigma_edu_free__;
+      sigma_edu_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 3;
-      sigma_edu = stan::math::lb_free(sigma_edu, 0);
+      sigma_edu_free__ = stan::math::lb_free(sigma_edu, 0);
       double sigma_state;
       sigma_state = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 4;
       sigma_state = context__.vals_r("sigma_state")[(1 - 1)];
+      double sigma_state_free__;
+      sigma_state_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      sigma_state = stan::math::lb_free(sigma_state, 0);
+      sigma_state_free__ = stan::math::lb_free(sigma_state, 0);
       double sigma_region;
       sigma_region = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 5;
       sigma_region = context__.vals_r("sigma_region")[(1 - 1)];
+      double sigma_region_free__;
+      sigma_region_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 5;
-      sigma_region = stan::math::lb_free(sigma_region, 0);
+      sigma_region_free__ = stan::math::lb_free(sigma_region, 0);
       double sigma_age_edu;
       sigma_age_edu = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 6;
       sigma_age_edu = context__.vals_r("sigma_age_edu")[(1 - 1)];
+      double sigma_age_edu_free__;
+      sigma_age_edu_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 6;
-      sigma_age_edu = stan::math::lb_free(sigma_age_edu, 0);
+      sigma_age_edu_free__ = stan::math::lb_free(sigma_age_edu, 0);
       double b_0;
       b_0 = std::numeric_limits<double>::quiet_NaN();
       
@@ -4825,12 +4864,12 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             pos__ = (pos__ + 1);}
         } 
       }
-      vars__.emplace_back(sigma);
-      vars__.emplace_back(sigma_age);
-      vars__.emplace_back(sigma_edu);
-      vars__.emplace_back(sigma_state);
-      vars__.emplace_back(sigma_region);
-      vars__.emplace_back(sigma_age_edu);
+      vars__.emplace_back(sigma_free__);
+      vars__.emplace_back(sigma_age_free__);
+      vars__.emplace_back(sigma_edu_free__);
+      vars__.emplace_back(sigma_state_free__);
+      vars__.emplace_back(sigma_region_free__);
+      vars__.emplace_back(sigma_age_edu_free__);
       vars__.emplace_back(b_0);
       vars__.emplace_back(b_female);
       vars__.emplace_back(b_black);
@@ -6258,6 +6297,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     try {
       double lcm_sym9__;
       double lcm_sym8__;
+      double lcm_sym3__;
+      double lcm_sym2__;
       double lcm_sym7__;
       double lcm_sym6__;
       double lcm_sym5__;
@@ -6293,24 +6334,32 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           }
         }
       }
+      Eigen::Matrix<double, -1, 1> mu_free__;
+      mu_free__ = Eigen::Matrix<double, -1, 1>(2);
+      stan::math::fill(mu_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 1;
-      assign(mu, nil_index_list(), stan::math::ordered_free(mu),
-        "assigning variable mu");
+      assign(mu_free__, nil_index_list(), stan::math::ordered_free(mu),
+        "assigning variable mu_free__");
       std::vector<double> sigma;
       sigma = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
       
       current_statement__ = 2;
       assign(sigma, nil_index_list(), context__.vals_r("sigma"),
         "assigning variable sigma");
+      std::vector<double> sigma_free__;
+      sigma_free__ = std::vector<double>(2, std::numeric_limits<double>::quiet_NaN());
+      
       {
         current_statement__ = 2;
-        assign(sigma, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lb_free(sigma[(1 - 1)], 0), "assigning variable sigma");
+        assign(sigma_free__, cons_list(index_uni(1), nil_index_list()),
+          stan::math::lb_free(sigma[(1 - 1)], 0),
+          "assigning variable sigma_free__");
         {
           current_statement__ = 2;
-          assign(sigma, cons_list(index_uni(2), nil_index_list()),
+          assign(sigma_free__, cons_list(index_uni(2), nil_index_list()),
             stan::math::lb_free(sigma[(2 - 1)], 0),
-            "assigning variable sigma");
+            "assigning variable sigma_free__");
         }
       }
       double theta;
@@ -6318,21 +6367,24 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       
       current_statement__ = 3;
       theta = context__.vals_r("theta")[(1 - 1)];
+      double theta_free__;
+      theta_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 3;
-      theta = stan::math::lub_free(theta, 0, 1);
+      theta_free__ = stan::math::lub_free(theta, 0, 1);
       {
-        vars__.emplace_back(mu[(1 - 1)]);
+        vars__.emplace_back(mu_free__[(1 - 1)]);
         {
-          vars__.emplace_back(mu[(2 - 1)]);
+          vars__.emplace_back(mu_free__[(2 - 1)]);
         }
       }
       {
-        vars__.emplace_back(sigma[(1 - 1)]);
+        vars__.emplace_back(sigma_free__[(1 - 1)]);
         {
-          vars__.emplace_back(sigma[(2 - 1)]);
+          vars__.emplace_back(sigma_free__[(2 - 1)]);
         }
       }
-      vars__.emplace_back(theta);
+      vars__.emplace_back(theta_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -6833,15 +6885,18 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       
       current_statement__ = 3;
       tau = context__.vals_r("tau")[(1 - 1)];
+      double tau_free__;
+      tau_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 3;
-      tau = stan::math::lb_free(tau, 0);
+      tau_free__ = stan::math::lb_free(tau, 0);
       vars__.emplace_back(mu);
       if (logical_gte(J, 1)) {
         vars__.emplace_back(theta[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(theta[(sym1__ - 1)]);}
       } 
-      vars__.emplace_back(tau);
+      vars__.emplace_back(tau_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -8251,36 +8306,51 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       
       current_statement__ = 7;
       sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      double sigma_a_free__;
+      sigma_a_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 7;
-      sigma_a = stan::math::lub_free(sigma_a, 0, 100);
+      sigma_a_free__ = stan::math::lub_free(sigma_a, 0, 100);
       double sigma_b;
       sigma_b = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 8;
       sigma_b = context__.vals_r("sigma_b")[(1 - 1)];
+      double sigma_b_free__;
+      sigma_b_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 8;
-      sigma_b = stan::math::lub_free(sigma_b, 0, 100);
+      sigma_b_free__ = stan::math::lub_free(sigma_b, 0, 100);
       double sigma_c;
       sigma_c = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 9;
       sigma_c = context__.vals_r("sigma_c")[(1 - 1)];
+      double sigma_c_free__;
+      sigma_c_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 9;
-      sigma_c = stan::math::lub_free(sigma_c, 0, 100);
+      sigma_c_free__ = stan::math::lub_free(sigma_c, 0, 100);
       double sigma_d;
       sigma_d = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 10;
       sigma_d = context__.vals_r("sigma_d")[(1 - 1)];
+      double sigma_d_free__;
+      sigma_d_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 10;
-      sigma_d = stan::math::lub_free(sigma_d, 0, 100);
+      sigma_d_free__ = stan::math::lub_free(sigma_d, 0, 100);
       double sigma_e;
       sigma_e = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 11;
       sigma_e = context__.vals_r("sigma_e")[(1 - 1)];
+      double sigma_e_free__;
+      sigma_e_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 11;
-      sigma_e = stan::math::lub_free(sigma_e, 0, 100);
+      sigma_e_free__ = stan::math::lub_free(sigma_e, 0, 100);
       if (lcm_sym1__) {
         vars__.emplace_back(a[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
@@ -8321,11 +8391,11 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
           vars__.emplace_back(beta[(5 - 1)]);
         }
       }
-      vars__.emplace_back(sigma_a);
-      vars__.emplace_back(sigma_b);
-      vars__.emplace_back(sigma_c);
-      vars__.emplace_back(sigma_d);
-      vars__.emplace_back(sigma_e);
+      vars__.emplace_back(sigma_a_free__);
+      vars__.emplace_back(sigma_b_free__);
+      vars__.emplace_back(sigma_c_free__);
+      vars__.emplace_back(sigma_d_free__);
+      vars__.emplace_back(sigma_e_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -9218,8 +9288,11 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       
       current_statement__ = 1;
       tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      double tau_phi_free__;
+      tau_phi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      tau_phi = stan::math::lb_free(tau_phi, 0);
+      tau_phi_free__ = stan::math::lb_free(tau_phi, 0);
       Eigen::Matrix<double, -1, 1> phi_std_raw;
       phi_std_raw = Eigen::Matrix<double, -1, 1>((N - 1));
       stan::math::fill(phi_std_raw, std::numeric_limits<double>::quiet_NaN());
@@ -9250,7 +9323,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
             pos__ = (pos__ + 1);}
         } 
       }
-      vars__.emplace_back(tau_phi);
+      vars__.emplace_back(tau_phi_free__);
       if (lcm_sym1__) {
         vars__.emplace_back(phi_std_raw[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= lcm_sym2__; ++sym1__) {
@@ -11731,15 +11804,21 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       
       current_statement__ = 1;
       mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      double mean_phi_free__;
+      mean_phi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      mean_phi = stan::math::lub_free(mean_phi, 0, 1);
+      mean_phi_free__ = stan::math::lub_free(mean_phi, 0, 1);
       double mean_p;
       mean_p = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 2;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      double mean_p_free__;
+      mean_p_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      mean_p = stan::math::lub_free(mean_p, 0, 1);
+      mean_p_free__ = stan::math::lub_free(mean_p, 0, 1);
       Eigen::Matrix<double, -1, 1> epsilon;
       epsilon = Eigen::Matrix<double, -1, 1>(nind);
       stan::math::fill(epsilon, std::numeric_limits<double>::quiet_NaN());
@@ -11771,16 +11850,19 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       
       current_statement__ = 4;
       sigma = context__.vals_r("sigma")[(1 - 1)];
+      double sigma_free__;
+      sigma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      sigma = stan::math::lub_free(sigma, 0, 5);
-      vars__.emplace_back(mean_phi);
-      vars__.emplace_back(mean_p);
+      sigma_free__ = stan::math::lub_free(sigma, 0, 5);
+      vars__.emplace_back(mean_phi_free__);
+      vars__.emplace_back(mean_p_free__);
       if (lcm_sym46__) {
         vars__.emplace_back(epsilon[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
-      vars__.emplace_back(sigma);
+      vars__.emplace_back(sigma_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -15855,6 +15937,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       double lcm_sym123__;
       double lcm_sym122__;
       double lcm_sym121__;
+      double lcm_sym120__;
+      double lcm_sym119__;
       int lcm_sym118__;
       int lcm_sym117__;
       int lcm_sym116__;
@@ -15867,22 +15951,31 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       
       current_statement__ = 1;
       mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      double mean_phi_free__;
+      mean_phi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      mean_phi = stan::math::lub_free(mean_phi, 0, 1);
+      mean_phi_free__ = stan::math::lub_free(mean_phi, 0, 1);
       double mean_p;
       mean_p = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 2;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      double mean_p_free__;
+      mean_p_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      mean_p = stan::math::lub_free(mean_p, 0, 1);
+      mean_p_free__ = stan::math::lub_free(mean_p, 0, 1);
       double psi;
       psi = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 3;
       psi = context__.vals_r("psi")[(1 - 1)];
+      double psi_free__;
+      psi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 3;
-      psi = stan::math::lub_free(psi, 0, 1);
+      psi_free__ = stan::math::lub_free(psi, 0, 1);
       Eigen::Matrix<double, -1, 1> beta;
       beta = Eigen::Matrix<double, -1, 1>(n_occasions);
       stan::math::fill(beta, std::numeric_limits<double>::quiet_NaN());
@@ -15909,16 +16002,21 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             pos__ = (pos__ + 1);}
         } 
       }
+      Eigen::Matrix<double, -1, 1> beta_free__;
+      beta_free__ = Eigen::Matrix<double, -1, 1>(n_occasions);
+      stan::math::fill(beta_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 4;
       if (lcm_sym117__) {
         current_statement__ = 4;
-        assign(beta, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lb_free(beta[(1 - 1)], 0), "assigning variable beta");
+        assign(beta_free__, cons_list(index_uni(1), nil_index_list()),
+          stan::math::lb_free(beta[(1 - 1)], 0),
+          "assigning variable beta_free__");
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 4;
-          assign(beta, cons_list(index_uni(sym1__), nil_index_list()),
+          assign(beta_free__, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lb_free(beta[(sym1__ - 1)], 0),
-            "assigning variable beta");}
+            "assigning variable beta_free__");}
       } 
       Eigen::Matrix<double, -1, 1> epsilon;
       epsilon = Eigen::Matrix<double, -1, 1>(M);
@@ -15951,22 +16049,25 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       
       current_statement__ = 6;
       sigma = context__.vals_r("sigma")[(1 - 1)];
+      double sigma_free__;
+      sigma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 6;
-      sigma = stan::math::lub_free(sigma, 0, 5);
-      vars__.emplace_back(mean_phi);
-      vars__.emplace_back(mean_p);
-      vars__.emplace_back(psi);
+      sigma_free__ = stan::math::lub_free(sigma, 0, 5);
+      vars__.emplace_back(mean_phi_free__);
+      vars__.emplace_back(mean_p_free__);
+      vars__.emplace_back(psi_free__);
       if (lcm_sym117__) {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(beta_free__[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          vars__.emplace_back(beta[(sym1__ - 1)]);}
+          vars__.emplace_back(beta_free__[(sym1__ - 1)]);}
       } 
       if (lcm_sym116__) {
         vars__.emplace_back(epsilon[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
-      vars__.emplace_back(sigma);
+      vars__.emplace_back(sigma_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -17348,15 +17449,15 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       double lcm_sym22__;
       double lcm_sym21__;
       double lcm_sym20__;
-      Eigen::Matrix<double, -1, 1> lcm_sym9__;
       double lcm_sym19__;
       double lcm_sym18__;
-      Eigen::Matrix<double, -1, 1> lcm_sym8__;
       double lcm_sym17__;
       double lcm_sym16__;
-      Eigen::Matrix<double, -1, 1> lcm_sym7__;
       double lcm_sym15__;
       double lcm_sym14__;
+      Eigen::Matrix<double, -1, 1> lcm_sym9__;
+      Eigen::Matrix<double, -1, 1> lcm_sym8__;
+      Eigen::Matrix<double, -1, 1> lcm_sym7__;
       Eigen::Matrix<double, -1, 1> lcm_sym6__;
       double lcm_sym13__;
       double lcm_sym12__;
@@ -17397,9 +17498,13 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             pos__ = (pos__ + 1);}
         } 
       }
+      Eigen::Matrix<double, -1, 1> pi_free__;
+      pi_free__ = Eigen::Matrix<double, -1, 1>((K - 1));
+      stan::math::fill(pi_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 1;
-      assign(pi, nil_index_list(), stan::math::simplex_free(pi),
-        "assigning variable pi");
+      assign(pi_free__, nil_index_list(), stan::math::simplex_free(pi),
+        "assigning variable pi_free__");
       std::vector<std::vector<Eigen::Matrix<double, -1, 1>>> theta;
       theta = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(J, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(K)));
       stan::math::fill(theta, std::numeric_limits<double>::quiet_NaN());
@@ -17512,79 +17617,87 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           lcm_sym1__ = logical_gte(J, 1);
         }
       }
+      std::vector<std::vector<Eigen::Matrix<double, -1, 1>>> theta_free__;
+      theta_free__ = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(J, std::vector<Eigen::Matrix<double, -1, 1>>(K, Eigen::Matrix<double, -1, 1>(
+        (K - 1))));
+      stan::math::fill(theta_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 2;
       if (lcm_sym1__) {
         current_statement__ = 2;
         if (lcm_sym2__) {
           current_statement__ = 2;
-          assign(theta,
+          assign(theta_free__,
             cons_list(index_uni(1),
               cons_list(index_uni(1), nil_index_list())),
             stan::math::simplex_free(theta[(1 - 1)][(1 - 1)]),
-            "assigning variable theta");
+            "assigning variable theta_free__");
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
             current_statement__ = 2;
-            assign(theta,
+            assign(theta_free__,
               cons_list(index_uni(1),
                 cons_list(index_uni(sym2__), nil_index_list())),
               stan::math::simplex_free(theta[(1 - 1)][(sym2__ - 1)]),
-              "assigning variable theta");}
+              "assigning variable theta_free__");}
         } 
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           current_statement__ = 2;
           if (lcm_sym2__) {
             current_statement__ = 2;
-            assign(theta,
+            assign(theta_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(1), nil_index_list())),
               stan::math::simplex_free(theta[(sym1__ - 1)][(1 - 1)]),
-              "assigning variable theta");
+              "assigning variable theta_free__");
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               current_statement__ = 2;
-              assign(theta,
+              assign(theta_free__,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__), nil_index_list())),
                 stan::math::simplex_free(theta[(sym1__ - 1)][(sym2__ - 1)]),
-                "assigning variable theta");}
+                "assigning variable theta_free__");}
           } }
       } 
       lcm_sym4__ = (K - 1);
       lcm_sym3__ = logical_gte(lcm_sym4__, 1);
       if (lcm_sym3__) {
-        vars__.emplace_back(pi[(1 - 1)]);
+        vars__.emplace_back(pi_free__[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= lcm_sym4__; ++sym1__) {
-          vars__.emplace_back(pi[(sym1__ - 1)]);}
+          vars__.emplace_back(pi_free__[(sym1__ - 1)]);}
       } 
       if (lcm_sym1__) {
         if (lcm_sym2__) {
           if (lcm_sym3__) {
-            vars__.emplace_back(theta[(1 - 1)][(1 - 1)][(1 - 1)]);
+            vars__.emplace_back(theta_free__[(1 - 1)][(1 - 1)][(1 - 1)]);
             for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
-              vars__.emplace_back(theta[(1 - 1)][(1 - 1)][(sym3__ - 1)]);}
+              vars__.emplace_back(
+                theta_free__[(1 - 1)][(1 - 1)][(sym3__ - 1)]);}
           } 
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
             if (lcm_sym3__) {
-              vars__.emplace_back(theta[(1 - 1)][(sym2__ - 1)][(1 - 1)]);
+              vars__.emplace_back(
+                theta_free__[(1 - 1)][(sym2__ - 1)][(1 - 1)]);
               for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
                 vars__.emplace_back(
-                  theta[(1 - 1)][(sym2__ - 1)][(sym3__ - 1)]);}
+                  theta_free__[(1 - 1)][(sym2__ - 1)][(sym3__ - 1)]);}
             } }
         } 
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           if (lcm_sym2__) {
             if (lcm_sym3__) {
-              vars__.emplace_back(theta[(sym1__ - 1)][(1 - 1)][(1 - 1)]);
+              vars__.emplace_back(
+                theta_free__[(sym1__ - 1)][(1 - 1)][(1 - 1)]);
               for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
                 vars__.emplace_back(
-                  theta[(sym1__ - 1)][(1 - 1)][(sym3__ - 1)]);}
+                  theta_free__[(sym1__ - 1)][(1 - 1)][(sym3__ - 1)]);}
             } 
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               if (lcm_sym3__) {
                 vars__.emplace_back(
-                  theta[(sym1__ - 1)][(sym2__ - 1)][(1 - 1)]);
+                  theta_free__[(sym1__ - 1)][(sym2__ - 1)][(1 - 1)]);
                 for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
                   vars__.emplace_back(
-                    theta[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}
+                    theta_free__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}
               } }
           } }
       } 
@@ -18341,15 +18454,21 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       
       current_statement__ = 3;
       tau_theta = context__.vals_r("tau_theta")[(1 - 1)];
+      double tau_theta_free__;
+      tau_theta_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 3;
-      tau_theta = stan::math::lb_free(tau_theta, 0);
+      tau_theta_free__ = stan::math::lb_free(tau_theta, 0);
       double tau_phi;
       tau_phi = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 4;
       tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      double tau_phi_free__;
+      tau_phi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      tau_phi = stan::math::lb_free(tau_phi, 0);
+      tau_phi_free__ = stan::math::lb_free(tau_phi, 0);
       Eigen::Matrix<double, -1, 1> theta_std;
       theta_std = Eigen::Matrix<double, -1, 1>(N);
       stan::math::fill(theta_std, std::numeric_limits<double>::quiet_NaN());
@@ -18408,8 +18527,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       }
       vars__.emplace_back(beta0);
       vars__.emplace_back(beta1);
-      vars__.emplace_back(tau_theta);
-      vars__.emplace_back(tau_phi);
+      vars__.emplace_back(tau_theta_free__);
+      vars__.emplace_back(tau_phi_free__);
       if (lcm_sym1__) {
         vars__.emplace_back(theta_std[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -20963,6 +21082,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       double lcm_sym52__;
       double lcm_sym51__;
       double lcm_sym50__;
+      double lcm_sym49__;
+      double lcm_sym48__;
       int lcm_sym47__;
       int lcm_sym46__;
       int pos__;
@@ -20974,8 +21095,11 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       
       current_statement__ = 1;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      double mean_p_free__;
+      mean_p_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      mean_p = stan::math::lub_free(mean_p, 0, 1);
+      mean_p_free__ = stan::math::lub_free(mean_p, 0, 1);
       Eigen::Matrix<double, -1, 1> beta;
       beta = Eigen::Matrix<double, -1, 1>(max_age);
       stan::math::fill(beta, std::numeric_limits<double>::quiet_NaN());
@@ -21002,23 +21126,27 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             pos__ = (pos__ + 1);}
         } 
       }
+      Eigen::Matrix<double, -1, 1> beta_free__;
+      beta_free__ = Eigen::Matrix<double, -1, 1>(max_age);
+      stan::math::fill(beta_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 2;
       if (lcm_sym46__) {
         current_statement__ = 2;
-        assign(beta, cons_list(index_uni(1), nil_index_list()),
+        assign(beta_free__, cons_list(index_uni(1), nil_index_list()),
           stan::math::lub_free(beta[(1 - 1)], 0, 1),
-          "assigning variable beta");
+          "assigning variable beta_free__");
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
-          assign(beta, cons_list(index_uni(sym1__), nil_index_list()),
+          assign(beta_free__, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_free(beta[(sym1__ - 1)], 0, 1),
-            "assigning variable beta");}
+            "assigning variable beta_free__");}
       } 
-      vars__.emplace_back(mean_p);
+      vars__.emplace_back(mean_p_free__);
       if (lcm_sym46__) {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(beta_free__[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
-          vars__.emplace_back(beta[(sym1__ - 1)]);}
+          vars__.emplace_back(beta_free__[(sym1__ - 1)]);}
       } 
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -24963,6 +25091,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       double lcm_sym141__;
       double lcm_sym140__;
       double lcm_sym139__;
+      double lcm_sym134__;
+      double lcm_sym133__;
       double lcm_sym138__;
       double lcm_sym137__;
       double lcm_sym136__;
@@ -24980,15 +25110,21 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       
       current_statement__ = 1;
       mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      double mean_phi_free__;
+      mean_phi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      mean_phi = stan::math::lub_free(mean_phi, 0, 1);
+      mean_phi_free__ = stan::math::lub_free(mean_phi, 0, 1);
       double mean_p;
       mean_p = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 2;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      double mean_p_free__;
+      mean_p_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      mean_p = stan::math::lub_free(mean_p, 0, 1);
+      mean_p_free__ = stan::math::lub_free(mean_p, 0, 1);
       Eigen::Matrix<double, -1, 1> gamma;
       gamma = Eigen::Matrix<double, -1, 1>(n_occasions);
       stan::math::fill(gamma, std::numeric_limits<double>::quiet_NaN());
@@ -25015,17 +25151,22 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             pos__ = (pos__ + 1);}
         } 
       }
+      Eigen::Matrix<double, -1, 1> gamma_free__;
+      gamma_free__ = Eigen::Matrix<double, -1, 1>(n_occasions);
+      stan::math::fill(gamma_free__, std::numeric_limits<double>::quiet_NaN());
+      
       current_statement__ = 3;
       if (lcm_sym129__) {
         current_statement__ = 3;
-        assign(gamma, cons_list(index_uni(1), nil_index_list()),
+        assign(gamma_free__, cons_list(index_uni(1), nil_index_list()),
           stan::math::lub_free(gamma[(1 - 1)], 0, 1),
-          "assigning variable gamma");
+          "assigning variable gamma_free__");
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 3;
-          assign(gamma, cons_list(index_uni(sym1__), nil_index_list()),
+          assign(gamma_free__,
+            cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_free(gamma[(sym1__ - 1)], 0, 1),
-            "assigning variable gamma");}
+            "assigning variable gamma_free__");}
       } 
       Eigen::Matrix<double, -1, 1> epsilon;
       epsilon = Eigen::Matrix<double, -1, 1>((n_occasions - 1));
@@ -25059,21 +25200,24 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       
       current_statement__ = 5;
       sigma = context__.vals_r("sigma")[(1 - 1)];
+      double sigma_free__;
+      sigma_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 5;
-      sigma = stan::math::lub_free(sigma, 0, 5);
-      vars__.emplace_back(mean_phi);
-      vars__.emplace_back(mean_p);
+      sigma_free__ = stan::math::lub_free(sigma, 0, 5);
+      vars__.emplace_back(mean_phi_free__);
+      vars__.emplace_back(mean_p_free__);
       if (lcm_sym129__) {
-        vars__.emplace_back(gamma[(1 - 1)]);
+        vars__.emplace_back(gamma_free__[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          vars__.emplace_back(gamma[(sym1__ - 1)]);}
+          vars__.emplace_back(gamma_free__[(sym1__ - 1)]);}
       } 
       if (lcm_sym130__) {
         vars__.emplace_back(epsilon[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= lcm_sym131__; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
-      vars__.emplace_back(sigma);
+      vars__.emplace_back(sigma_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -28651,17 +28795,23 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       
       current_statement__ = 1;
       mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      double mean_phi_free__;
+      mean_phi_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 1;
-      mean_phi = stan::math::lub_free(mean_phi, 0, 1);
+      mean_phi_free__ = stan::math::lub_free(mean_phi, 0, 1);
       double mean_p;
       mean_p = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 2;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      double mean_p_free__;
+      mean_p_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 2;
-      mean_p = stan::math::lub_free(mean_p, 0, 1);
-      vars__.emplace_back(mean_phi);
-      vars__.emplace_back(mean_p);
+      mean_p_free__ = stan::math::lub_free(mean_p, 0, 1);
+      vars__.emplace_back(mean_phi_free__);
+      vars__.emplace_back(mean_p_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -30658,22 +30808,31 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       
       current_statement__ = 6;
       sigma_a1 = context__.vals_r("sigma_a1")[(1 - 1)];
+      double sigma_a1_free__;
+      sigma_a1_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 6;
-      sigma_a1 = stan::math::lub_free(sigma_a1, 0, 100);
+      sigma_a1_free__ = stan::math::lub_free(sigma_a1, 0, 100);
       double sigma_a2;
       sigma_a2 = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 7;
       sigma_a2 = context__.vals_r("sigma_a2")[(1 - 1)];
+      double sigma_a2_free__;
+      sigma_a2_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 7;
-      sigma_a2 = stan::math::lub_free(sigma_a2, 0, 100);
+      sigma_a2_free__ = stan::math::lub_free(sigma_a2, 0, 100);
       double sigma_y;
       sigma_y = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 8;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
+      double sigma_y_free__;
+      sigma_y_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 8;
-      sigma_y = stan::math::lub_free(sigma_y, 0, 100);
+      sigma_y_free__ = stan::math::lub_free(sigma_y, 0, 100);
       vars__.emplace_back(beta);
       if (lcm_sym1__) {
         vars__.emplace_back(eta1[(1 - 1)]);
@@ -30687,9 +30846,9 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       } 
       vars__.emplace_back(mu_a1);
       vars__.emplace_back(mu_a2);
-      vars__.emplace_back(sigma_a1);
-      vars__.emplace_back(sigma_a2);
-      vars__.emplace_back(sigma_y);
+      vars__.emplace_back(sigma_a1_free__);
+      vars__.emplace_back(sigma_a2_free__);
+      vars__.emplace_back(sigma_y_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -33029,15 +33188,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       
       current_statement__ = 4;
       sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      double sigma_a_free__;
+      sigma_a_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 4;
-      sigma_a = stan::math::lub_free(sigma_a, 0, 100);
+      sigma_a_free__ = stan::math::lub_free(sigma_a, 0, 100);
       double sigma_y;
       sigma_y = std::numeric_limits<double>::quiet_NaN();
       
       current_statement__ = 5;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
+      double sigma_y_free__;
+      sigma_y_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 5;
-      sigma_y = stan::math::lub_free(sigma_y, 0, 100);
+      sigma_y_free__ = stan::math::lub_free(sigma_y, 0, 100);
       if (lcm_sym1__) {
         vars__.emplace_back(a[(1 - 1)]);
         for (int sym1__ = 2; sym1__ <= n_pair; ++sym1__) {
@@ -33050,8 +33215,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         }
       }
       vars__.emplace_back(mu_a);
-      vars__.emplace_back(sigma_a);
-      vars__.emplace_back(sigma_y);
+      vars__.emplace_back(sigma_a_free__);
+      vars__.emplace_back(sigma_y_free__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -33857,8 +34022,11 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       
       current_statement__ = 5;
       tau = context__.vals_r("tau")[(1 - 1)];
+      double tau_free__;
+      tau_free__ = std::numeric_limits<double>::quiet_NaN();
+      
       current_statement__ = 5;
-      tau = stan::math::lb_free(tau, 0);
+      tau_free__ = stan::math::lb_free(tau, 0);
       std::vector<Eigen::Matrix<double, -1, 1>> b;
       b = std::vector<Eigen::Matrix<double, -1, 1>>(I, Eigen::Matrix<double, -1, 1>(8));
       stan::math::fill(b, std::numeric_limits<double>::quiet_NaN());
@@ -34037,7 +34205,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       vars__.emplace_back(alpha1);
       vars__.emplace_back(alpha2);
       vars__.emplace_back(alpha12);
-      vars__.emplace_back(tau);
+      vars__.emplace_back(tau_free__);
       if (lcm_sym1__) {
         {
           vars__.emplace_back(b[(1 - 1)][(1 - 1)]);


### PR DESCRIPTION
Fixes issue with `transform_inits` when parameter constraints are parameters. [Discourse link](https://discourse.mc-stan.org/t/lub-free-error-possible-bug-when-initializing-parameters-bounded-by-other-parameters/17989).
For example
```stan
parameters {
  real<lower=0> x;
  real<lower=x> y;
}
```
Note that the lower bound for `y` is the _constrained_ `x`; in particular it is always positive. Constraining works fine and Stanc2 handled unconstraining correctly too. Unfortunately Stanc3's `transform_inits` would unconstrain `x` first and then use the _unconstrained_ value of `x` as the lower bound for `y`.

## Release notes
Fix parameter unconstraining bug when the constraints depend on other constrained parameters

## Copyright and Licensing
Copyright holder: Niko Huurre
By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
