### PR TITLE
Small Nix installation fix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,4 @@ ocamlPackages.buildDunePackage rec {
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ rybern ];
   };
-
-  inherit pkgs;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,13 @@
 let derivation = import ./default.nix; in
 
-with derivation.pkgs;
+with (import (builtins.fetchTarball {
+  name = "nixpkgs-19.09";
+  # Tarball of tagged release of Nixpkgs 19.09
+  url = "https://github.com/NixOS/nixpkgs/archive/19.09.tar.gz";
+  # Tarball hash obtained using `nix-prefetch-url --unpack <url>`
+  sha256 = "0mhqhq21y5vrr1f30qd2bvydv4bbbslvyzclhw0kdxmkgg3z4c92";
+}) {});
+
 stdenv.mkDerivation rec {
   name = "stanc-env";
 


### PR DESCRIPTION
Fixing an issue with Nix installation that came up here: https://discourse.mc-stan.org/t/cmdstan-on-arm-error/18485/3

The issue occurred because of a workaround I added to simplify the shell.nix file, but it wasn't necessary so I reverted it.