### PR TITLE
typo fix in a semantic error message

### DIFF
--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -372,7 +372,7 @@ module ExpressionError = struct
            _lcdf, _lccdf can make use of conditional notation."
     | ConditioningRequired ->
         Fmt.pf ppf
-          "Probabilty functions with suffixes _lpdf, _lupdf, _lpmf, _lupmf, \
+          "Probability functions with suffixes _lpdf, _lupdf, _lpmf, _lupmf, \
            _lcdf and _lccdf, require a vertical bar (|) between the first two \
            arguments."
     | NotPrintable -> Fmt.pf ppf "Functions cannot be printed."

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2058,7 +2058,7 @@ Semantic error in 'prob-fun-args-no-bar.stan', line 5, column 12 to column 32:
      6:  }
    -------------------------------------------------
 
-Probabilty functions with suffixes _lpdf, _lupdf, _lpmf, _lupmf, _lcdf and _lccdf, require a vertical bar (|) between the first two arguments.
+Probability functions with suffixes _lpdf, _lupdf, _lpmf, _lupmf, _lcdf and _lccdf, require a vertical bar (|) between the first two arguments.
 
   $ ../../../../install/default/bin/stanc prob-poisson_log-trunc-both.stan
 

--- a/test/integration/example-models/knitr/curse-dims/curse-dims.Rmd
+++ b/test/integration/example-models/knitr/curse-dims/curse-dims.Rmd
@@ -1140,7 +1140,7 @@ illustrate how atypical the all-success draw is.
 
 1.  The smallest set by volume that contains $1 - \epsilon$ of the
 probability mass is called the highest probability set.  In a
-univariate, unimodal density, the highest probabilty set is the
+univariate, unimodal density, the highest probability set is the
 highest density interval (HDI).  Show that the probability of a random
 draw falling in the difference between these sets (typical set and
 highest probability set) quickly converges to zero.


### PR DESCRIPTION
Typo fix in a semantic error message (+ corresponding test)
Probabilty -> Probability
No functional effect.
