### PR TITLE
Fix install instructions and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ The AST intends to keep very close to Stan-level semantics and syntax in every w
 ## Getting development on stanc3 up and running locally
 
 ### Using Opam+Make+Dune to build, test, and run
-To be able to build the project, make sure you have GNU make installed.
+To be able to build the project, make sure you have `GNU make`.
 
-To install OCaml and the dependencies we need to build and do development, run `scripts/setup_dev_env.sh`.
+To install OCaml and the dependencies we need to build and do development run the following from the stanc3 directory:
+
+```
+cd scripts
+bash -x setup_dev_env.sh
+```
+Note that `curl` and `m4` are prerequisites to run the install script.
 
 To build `stanc.exe`, run `make`. The binary will be built in `_build/default`.
 

--- a/scripts/install_dev_deps.sh
+++ b/scripts/install_dev_deps.sh
@@ -2,4 +2,5 @@
 
 # Merlin, utop, ocp-indent, ocamlformat, and patdiff are all for developer assistance
 opam pin -y ocamlformat 0.8
-opam install -y ocamlformat.0.8 merlin utop ocp-indent patdiff
+opam pin -y merlin 3.4.1
+opam install -y ocamlformat.0.8 merlin.3.4.1 utop ocp-indent patdiff


### PR DESCRIPTION
Clarifies what the prerequisites are, that you need to run the install script from the scripts folders and pins merlin to version 3.4.1.

See #749 for a report and I also tried installing on a clean Ubuntu install and it failed with the 3.4.2 merlin and builds fine with 3.4.1.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
