### PR TITLE
Allow methods that use reader to accept Eigen types

### DIFF
--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -708,16 +708,16 @@ let pp_overloads ppf () =
     {|
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -725,46 +725,46 @@ let pp_overloads ppf () =
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const final  {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-                       std::ostream* pstream = nullptr) const final {
+                       std::ostream* pstream = nullptr) const {
       Eigen::Matrix<int, -1, 1> params_i;
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const final  {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const final {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const final {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 |}
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -661,7 +661,7 @@ let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
     ; "std::ostream* pstream__ = nullptr" ]
   in
   let intro =
-    [ "using T__ = scalar_type_t<VecR>;"; "using local_scalar_t__ = T__;"
+    [ "using T__ = stan::scalar_type_t<VecR>;"; "using local_scalar_t__ = T__;"
     ; "T__ lp__(0.0);"; "stan::math::accumulator<T__> lp_accum__;"
     ; strf "%a" pp_function__ (prog_name, "log_prob")
     ; "stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);"
@@ -670,7 +670,7 @@ let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   in
   let outro = ["lp_accum__.add(lp__);"; "return lp_accum__.sum();"] in
   let cv_attr = ["const"] in
-  pp_method_b ppf "scalar_type_t<VecR>" "log_prob_impl" params intro log_prob
+  pp_method_b ppf "stan::scalar_type_t<VecR>" "log_prob_impl" params intro log_prob
     ~outro ~cv_attr
 
 (** Print the body of the constrained and unconstrained sizedtype methods
@@ -730,13 +730,13 @@ let pp_overloads ppf () =
                             std::vector<double>& vars__,
                             bool emit_transformed_parameters__ = true,
                             bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
+                            std::ostream* pstream__ = nullptr) const final  {
       write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-                       std::ostream* pstream = nullptr) const {
+                       std::ostream* pstream = nullptr) const final {
       Eigen::Matrix<int, -1, 1> params_i;
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
@@ -744,14 +744,14 @@ let pp_overloads ppf () =
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r__,
                         std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
+                        std::ostream* pstream__ = nullptr) const final  {
       return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream__ = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream__);
@@ -824,7 +824,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; |}
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -491,10 +491,12 @@ let pp_method_b ppf rt name params intro ?(outro = []) ?(cv_attr = ["const"])
 (** Print the write_array method of the model class *)
 let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
   pf ppf
-    "template <typename RNG, typename VecR, typename VecI, typename VecVar, \n\
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, \n\
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, \n\
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@ " ;
+    "template <typename RNG, typename VecR, typename VecI, typename VecVar,\n\
+    \     stan::require_vector_like_vt<std::is_floating_point, VecR>* = \
+     nullptr,\n\
+    \     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,\n\
+    \     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = \
+     nullptr>@" ;
   let params =
     [ "RNG& base_rng__"; "VecR& params_r__"; "VecI& params_i__"
     ; "VecVar& vars__"; "const bool emit_transformed_parameters__ = true"
@@ -635,9 +637,9 @@ let pp_unconstrained_param_names ppf {Program.output_vars; _} =
 (** Print the `transform_inits` method of the model class *)
 let pp_transform_inits ppf {Program.transform_inits; _} =
   pf ppf
-    "template <typename VecVar, typename VecI, \n\
-     stan::require_std_vector_t<VecVar>* = nullptr, \n\
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
+    "template <typename VecVar, typename VecI,\n\
+    \     stan::require_std_vector_t<VecVar>* = nullptr,\n\
+    \     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
   let params =
     [ "const stan::io::var_context& context__"; "VecI& params_i__"
     ; "VecVar& vars__"; "std::ostream* pstream__ = nullptr" ]
@@ -653,9 +655,9 @@ let pp_transform_inits ppf {Program.transform_inits; _} =
 (** Print the `log_prob` method of the model class *)
 let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   pf ppf
-    "template <bool propto__, bool jacobian__, typename VecR, typename VecI, \n\
-    \ stan::require_vector_like_t<VecR>* = nullptr, \n\
-    \ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
+    "template <bool propto__, bool jacobian__, typename VecR, typename VecI,\n\
+    \     stan::require_vector_like_t<VecR>* = nullptr,\n\
+    \     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
   let params =
     [ "VecR& params_r__"; "VecI& params_i__"
     ; "std::ostream* pstream__ = nullptr" ]

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -477,7 +477,7 @@ let pp_get_dims ppf {Program.output_vars; _} =
              output_vars))
   in
   let params = ["std::vector<std::vector<size_t>>& dimss__"] in
-  let cv_attr = ["const"; "final"] in
+  let cv_attr = ["const"] in
   pp_method ppf "void" "get_dims" params ["dimss__.clear();"]
     (fun ppf -> pp_output_var ppf)
     ~cv_attr
@@ -490,12 +490,15 @@ let pp_method_b ppf rt name params intro ?(outro = []) ?(cv_attr = ["const"])
 
 (** Print the write_array method of the model class *)
 let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
-  pf ppf "template <typename RNG>@ " ;
+  pf ppf
+    "template <typename RNG, typename VecR, typename VecI, typename VecVar, \n\
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, \n\
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, \n\
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@ " ;
   let params =
-    [ "RNG& base_rng__"; "std::vector<double>& params_r__"
-    ; "std::vector<int>& params_i__"; "std::vector<double>& vars__"
-    ; "bool emit_transformed_parameters__ = true"
-    ; "bool emit_generated_quantities__ = true"
+    [ "RNG& base_rng__"; "VecR& params_r__"; "VecI& params_i__"
+    ; "VecVar& vars__"; "const bool emit_transformed_parameters__ = true"
+    ; "const bool emit_generated_quantities__ = true"
     ; "std::ostream* pstream__ = nullptr" ]
   in
   let intro =
@@ -509,7 +512,7 @@ let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
     ; "local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
     ; strf "%a" pp_unused "DUMMY_VAR__" ]
   in
-  pp_method_b ppf "void" "write_array" params intro generate_quantities
+  pp_method_b ppf "void" "write_array_impl" params intro generate_quantities
 
 (** Prints the for loop for `constrained_param_names`
     and `unconstrained_param_names`
@@ -631,28 +634,35 @@ let pp_unconstrained_param_names ppf {Program.output_vars; _} =
 
 (** Print the `transform_inits` method of the model class *)
 let pp_transform_inits ppf {Program.transform_inits; _} =
+  pf ppf
+    "template <typename VecVar, typename VecI, \n\
+     stan::require_std_vector_t<VecVar>* = nullptr, \n\
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
   let params =
-    [ "const stan::io::var_context& context__"; "std::vector<int>& params_i__"
-    ; "std::vector<double>& vars__"; "std::ostream* pstream__" ]
+    [ "const stan::io::var_context& context__"; "VecI& params_i__"
+    ; "VecVar& vars__"; "std::ostream* pstream__ = nullptr" ]
   in
   let intro =
     [ "using local_scalar_t__ = double;"; "vars__.clear();"
     ; "vars__.reserve(num_params_r__);" ]
   in
-  let cv_attr = ["const"; "final"] in
-  pp_method_b ppf "void" "transform_inits" params intro transform_inits
+  let cv_attr = ["const"] in
+  pp_method_b ppf "void" "transform_inits_impl" params intro transform_inits
     ~cv_attr
 
 (** Print the `log_prob` method of the model class *)
 let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
-  pf ppf "template <bool propto__, bool jacobian__, typename T__>@ " ;
+  pf ppf
+    "template <bool propto__, bool jacobian__, typename VecR, typename VecI, \n\
+    \ stan::require_vector_like_t<VecR>* = nullptr, \n\
+    \ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
   let params =
-    [ "std::vector<T__>& params_r__"; "std::vector<int>& params_i__"
+    [ "VecR& params_r__"; "VecI& params_i__"
     ; "std::ostream* pstream__ = nullptr" ]
   in
   let intro =
-    [ "using local_scalar_t__ = T__;"; "T__ lp__(0.0);"
-    ; "stan::math::accumulator<T__> lp_accum__;"
+    [ "using T__ = scalar_type_t<VecR>;"; "using local_scalar_t__ = T__;"
+    ; "T__ lp__(0.0);"; "stan::math::accumulator<T__> lp_accum__;"
     ; strf "%a" pp_function__ (prog_name, "log_prob")
     ; "stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);"
     ; "local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());"
@@ -660,7 +670,8 @@ let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   in
   let outro = ["lp_accum__.add(lp__);"; "return lp_accum__.sum();"] in
   let cv_attr = ["const"] in
-  pp_method_b ppf "T__" "log_prob" params intro log_prob ~outro ~cv_attr
+  pp_method_b ppf "scalar_type_t<VecR>" "log_prob_impl" params intro log_prob
+    ~outro ~cv_attr
 
 (** Print the body of the constrained and unconstrained sizedtype methods
  in the model class
@@ -698,44 +709,63 @@ let pp_overloads ppf () =
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 |}
 
 (** Print the public parts of the model class *)
@@ -761,17 +791,14 @@ let model_prefix = "model_"
 let pp_model ppf ({Program.prog_name; _} as p) =
   pf ppf "class %s final : public model_base_crtp<%s> {" prog_name prog_name ;
   pf ppf "@ @[<v 1>@ private:@ @[<v 1> %a@]@ " pp_model_private p ;
-  pf ppf "@ public:@ @[<v 1> ~%s() final { }" prog_name ;
-  pf ppf "@ @ std::string model_name() const final { return \"%s\"; }"
+  pf ppf "@ public:@ @[<v 1> ~%s() { }" prog_name ;
+  pf ppf "@ @ inline std::string model_name() const final { return \"%s\"; }"
     prog_name ;
   pf ppf
     {|
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %s");
-    stanc_info.push_back("stancflags = %s");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %s", "stancflags = %s"};
   }
   |}
     "%%NAME%%3 %%VERSION%%" stanc_args_to_print ;
@@ -797,6 +824,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; |}
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -670,8 +670,8 @@ let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   in
   let outro = ["lp_accum__.add(lp__);"; "return lp_accum__.sum();"] in
   let cv_attr = ["const"] in
-  pp_method_b ppf "stan::scalar_type_t<VecR>" "log_prob_impl" params intro log_prob
-    ~outro ~cv_attr
+  pp_method_b ppf "stan::scalar_type_t<VecR>" "log_prob_impl" params intro
+    log_prob ~outro ~cv_attr
 
 (** Print the body of the constrained and unconstrained sizedtype methods
  in the model class

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -491,12 +491,10 @@ let pp_method_b ppf rt name params intro ?(outro = []) ?(cv_attr = ["const"])
 (** Print the write_array method of the model class *)
 let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
   pf ppf
-    "template <typename RNG, typename VecR, typename VecI, typename VecVar,\n\
-    \     stan::require_vector_like_vt<std::is_floating_point, VecR>* = \
-     nullptr,\n\
-    \     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,\n\
-    \     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = \
-     nullptr>@" ;
+    "template <typename RNG, typename VecR, typename VecI, typename VecVar, \
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, \
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, \
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>" ;
   let params =
     [ "RNG& base_rng__"; "VecR& params_r__"; "VecI& params_i__"
     ; "VecVar& vars__"; "const bool emit_transformed_parameters__ = true"
@@ -637,9 +635,9 @@ let pp_unconstrained_param_names ppf {Program.output_vars; _} =
 (** Print the `transform_inits` method of the model class *)
 let pp_transform_inits ppf {Program.transform_inits; _} =
   pf ppf
-    "template <typename VecVar, typename VecI,\n\
-    \     stan::require_std_vector_t<VecVar>* = nullptr,\n\
-    \     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
+    "template <typename VecVar, typename VecI, \
+     stan::require_std_vector_t<VecVar>* = nullptr, \
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>" ;
   let params =
     [ "const stan::io::var_context& context__"; "VecI& params_i__"
     ; "VecVar& vars__"; "std::ostream* pstream__ = nullptr" ]
@@ -655,9 +653,9 @@ let pp_transform_inits ppf {Program.transform_inits; _} =
 (** Print the `log_prob` method of the model class *)
 let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   pf ppf
-    "template <bool propto__, bool jacobian__, typename VecR, typename VecI,\n\
-    \     stan::require_vector_like_t<VecR>* = nullptr,\n\
-    \     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>@ " ;
+    "template <bool propto__, bool jacobian__, typename VecR, typename VecI, \
+     stan::require_vector_like_t<VecR>* = nullptr, \
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>" ;
   let params =
     [ "VecR& params_r__"; "VecI& params_i__"
     ; "std::ostream* pstream__ = nullptr" ]

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -54,6 +54,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -308,15 +309,12 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   matrix_cl<double> y_vi_d_td_opencl__;
  
  public:
-  ~optimize_glm_model() final { }
+  ~optimize_glm_model() { }
   
-  std::string model_name() const final { return "optimize_glm_model"; }
+  inline std::string model_name() const final { return "optimize_glm_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp --use-opencl");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp --use-opencl"};
   }
   
   
@@ -597,10 +595,13 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -1310,15 +1311,17 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -1424,13 +1427,14 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -1611,7 +1615,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -1627,8 +1631,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     names__.emplace_back("X_rv_p");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(k)});
     
@@ -1766,44 +1769,63 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -594,9 +594,9 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1312,10 +1312,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1428,9 +1428,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1803,14 +1803,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -1822,7 +1822,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -594,9 +594,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1312,10 +1310,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1428,9 +1423,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -54,7 +54,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -598,10 +597,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -1768,16 +1767,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -1785,13 +1784,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -1802,29 +1801,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -54,6 +54,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -85,15 +86,12 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
   std::vector<double> sigma;
  
  public:
-  ~_8_schools_ncp_model() final { }
+  ~_8_schools_ncp_model() { }
   
-  std::string model_name() const final { return "_8_schools_ncp_model"; }
+  inline std::string model_name() const final { return "_8_schools_ncp_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -171,10 +169,13 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -235,15 +236,17 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -305,13 +308,14 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -365,7 +369,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -376,8 +380,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     names__.emplace_back("theta");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -455,44 +458,63 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -569,6 +591,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -585,15 +608,12 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
   int good_model;
  
  public:
-  ~_8start_with_number_model() final { }
+  ~_8start_with_number_model() { }
   
-  std::string model_name() const final { return "_8start_with_number_model"; }
+  inline std::string model_name() const final { return "_8start_with_number_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -636,10 +656,13 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -664,15 +687,17 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -707,13 +732,14 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -734,7 +760,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -742,8 +768,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     names__.emplace_back("bar");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -799,44 +824,63 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -914,6 +958,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -945,15 +990,12 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
   std::vector<double> sigma;
  
  public:
-  ~eight_schools_ncp_model() final { }
+  ~eight_schools_ncp_model() { }
   
-  std::string model_name() const final { return "eight_schools_ncp_model"; }
+  inline std::string model_name() const final { return "eight_schools_ncp_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -1031,10 +1073,13 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -1095,15 +1140,17 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -1165,13 +1212,14 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -1225,7 +1273,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -1236,8 +1284,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     names__.emplace_back("theta");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -1315,44 +1362,63 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -1430,6 +1496,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -4298,15 +4365,12 @@ class mother_model final : public model_base_crtp<mother_model> {
   std::vector<std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>> transformed_data_row_vector_array_3d;
  
  public:
-  ~mother_model() final { }
+  ~mother_model() { }
   
-  std::string model_name() const final { return "mother_model"; }
+  inline std::string model_name() const final { return "mother_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -6510,10 +6574,13 @@ class mother_model final : public model_base_crtp<mother_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -7382,15 +7449,17 @@ class mother_model final : public model_base_crtp<mother_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -8766,13 +8835,14 @@ class mother_model final : public model_base_crtp<mother_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -9478,7 +9548,7 @@ class mother_model final : public model_base_crtp<mother_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -9552,8 +9622,7 @@ class mother_model final : public model_base_crtp<mother_model> {
     names__.emplace_back("idx_res5");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -10770,44 +10839,63 @@ class mother_model final : public model_base_crtp<mother_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -10914,6 +11002,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -11333,15 +11422,12 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
   std::vector<std::vector<int>> data_i;
  
  public:
-  ~motherHOF_model() final { }
+  ~motherHOF_model() { }
   
-  std::string model_name() const final { return "motherHOF_model"; }
+  inline std::string model_name() const final { return "motherHOF_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -11563,10 +11649,13 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -11903,15 +11992,17 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -12349,13 +12440,14 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -12473,7 +12565,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -12505,8 +12597,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     names__.emplace_back("theta_dbl");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(2)});
     
@@ -12770,44 +12861,63 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -13044,6 +13154,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -13741,15 +13852,12 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
   std::vector<Eigen::Matrix<double, -1, 1>> zd;
  
  public:
-  ~new_integrate_interface_model() final { }
+  ~new_integrate_interface_model() { }
   
-  std::string model_name() const final { return "new_integrate_interface_model"; }
+  inline std::string model_name() const final { return "new_integrate_interface_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -13909,10 +14017,13 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -15551,15 +15662,17 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -17212,13 +17325,14 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -17268,7 +17382,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -17280,8 +17394,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     names__.emplace_back("zg");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -17387,44 +17500,63 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -17502,6 +17634,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -17628,15 +17761,12 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
   std::vector<std::vector<double>> y;
  
  public:
-  ~old_integrate_interface_model() final { }
+  ~old_integrate_interface_model() { }
   
-  std::string model_name() const final { return "old_integrate_interface_model"; }
+  inline std::string model_name() const final { return "old_integrate_interface_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -17741,10 +17871,13 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -17901,15 +18034,17 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -18016,13 +18151,14 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -18115,7 +18251,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -18129,8 +18265,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     names__.emplace_back("z");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -18233,44 +18368,63 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -18352,6 +18506,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -18600,15 +18755,12 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   double y_r_d_td;
  
  public:
-  ~optimize_glm_model() final { }
+  ~optimize_glm_model() { }
   
-  std::string model_name() const final { return "optimize_glm_model"; }
+  inline std::string model_name() const final { return "optimize_glm_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -18877,10 +19029,13 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -19497,15 +19652,17 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -19611,13 +19768,14 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -19798,7 +19956,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -19814,8 +19972,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     names__.emplace_back("X_rv_p");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(k)});
     
@@ -19953,44 +20110,63 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -20067,6 +20243,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -20252,15 +20429,12 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
   int N;
  
  public:
-  ~reduce_sum_m1_model() final { }
+  ~reduce_sum_m1_model() { }
   
-  std::string model_name() const final { return "reduce_sum_m1_model"; }
+  inline std::string model_name() const final { return "reduce_sum_m1_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -20309,10 +20483,13 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -20368,15 +20545,17 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -20435,13 +20614,14 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -20480,7 +20660,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -20490,8 +20670,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     names__.emplace_back("y3");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(N)});
     
@@ -20573,44 +20752,63 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -20687,6 +20885,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -21767,15 +21966,12 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
   std::vector<double> x;
  
  public:
-  ~reduce_sum_m2_model() final { }
+  ~reduce_sum_m2_model() { }
   
-  std::string model_name() const final { return "reduce_sum_m2_model"; }
+  inline std::string model_name() const final { return "reduce_sum_m2_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -21916,10 +22112,13 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -22145,15 +22344,17 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -22436,13 +22637,14 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -22901,7 +23103,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -22924,8 +23126,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     names__.emplace_back("y1");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(N),
                                              static_cast<size_t>(N),
@@ -23305,44 +23506,63 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -23419,6 +23639,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -25453,15 +25674,12 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
   double tsd;
  
  public:
-  ~reduce_sum_m3_model() final { }
+  ~reduce_sum_m3_model() { }
   
-  std::string model_name() const final { return "reduce_sum_m3_model"; }
+  inline std::string model_name() const final { return "reduce_sum_m3_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -26133,10 +26351,13 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -26419,15 +26640,17 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -26796,13 +27019,14 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -27146,7 +27370,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -27192,8 +27416,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     names__.emplace_back("tgs");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(N)});
     
@@ -27576,44 +27799,63 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -27690,6 +27932,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -27883,15 +28126,12 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
   
  
  public:
-  ~single_argument_lpmf_model() final { }
+  ~single_argument_lpmf_model() { }
   
-  std::string model_name() const final { return "single_argument_lpmf_model"; }
+  inline std::string model_name() const final { return "single_argument_lpmf_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -27927,10 +28167,13 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -27951,15 +28194,17 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -27988,13 +28233,14 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -28009,7 +28255,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -28017,8 +28263,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     
     } // get_dims() 
@@ -28073,44 +28318,63 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -28188,6 +28452,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -28209,15 +28474,12 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
   int t;
  
  public:
-  ~tilde_block_model() final { }
+  ~tilde_block_model() { }
   
-  std::string model_name() const final { return "tilde_block_model"; }
+  inline std::string model_name() const final { return "tilde_block_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -28260,10 +28522,13 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -28322,15 +28587,17 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -28367,13 +28634,14 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -28399,7 +28667,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -28407,8 +28675,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     names__.emplace_back("x");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -28464,44 +28731,63 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -28578,6 +28864,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -28713,15 +29000,12 @@ class transform_model final : public model_base_crtp<transform_model> {
   std::vector<Eigen::Matrix<double, -1, -1>> dm;
  
  public:
-  ~transform_model() final { }
+  ~transform_model() { }
   
-  std::string model_name() const final { return "transform_model"; }
+  inline std::string model_name() const final { return "transform_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -29059,10 +29343,13 @@ class transform_model final : public model_base_crtp<transform_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -30039,15 +30326,17 @@ class transform_model final : public model_base_crtp<transform_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -30952,13 +31241,14 @@ class transform_model final : public model_base_crtp<transform_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -31623,7 +31913,7 @@ class transform_model final : public model_base_crtp<transform_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -31666,8 +31956,7 @@ class transform_model final : public model_base_crtp<transform_model> {
     names__.emplace_back("tpm_2");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(k)});
     
@@ -32245,44 +32534,63 @@ class transform_model final : public model_base_crtp<transform_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -32359,6 +32667,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -32394,15 +32703,12 @@ class truncate_model final : public model_base_crtp<truncate_model> {
   double x;
  
  public:
-  ~truncate_model() final { }
+  ~truncate_model() { }
   
-  std::string model_name() const final { return "truncate_model"; }
+  inline std::string model_name() const final { return "truncate_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -32453,10 +32759,13 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -32576,15 +32885,17 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -32627,13 +32938,14 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -32665,7 +32977,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -32674,8 +32986,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     names__.emplace_back("y");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -32735,44 +33046,63 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -32849,6 +33179,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -32895,15 +33226,12 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
   
  
  public:
-  ~udf_tilde_stmt_conflict_model() final { }
+  ~udf_tilde_stmt_conflict_model() { }
   
-  std::string model_name() const final { return "udf_tilde_stmt_conflict_model"; }
+  inline std::string model_name() const final { return "udf_tilde_stmt_conflict_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -32939,10 +33267,13 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -32971,15 +33302,17 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -33014,13 +33347,14 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -33041,7 +33375,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -33049,8 +33383,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     names__.emplace_back("x");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -33106,44 +33439,63 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -33221,6 +33573,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -33269,15 +33622,12 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
   
  
  public:
-  ~user_constrain_model() final { }
+  ~user_constrain_model() { }
   
-  std::string model_name() const final { return "user_constrain_model"; }
+  inline std::string model_name() const final { return "user_constrain_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -33313,10 +33663,13 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -33353,15 +33706,17 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -33398,13 +33753,14 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -33430,7 +33786,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -33438,8 +33794,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     names__.emplace_back("x");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -33495,44 +33850,63 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -492,14 +492,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -511,7 +511,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -857,14 +857,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -876,7 +876,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -1394,14 +1394,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -1413,7 +1413,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -10870,14 +10870,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -10889,7 +10889,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -12891,14 +12891,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -12910,7 +12910,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -17529,14 +17529,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -17548,7 +17548,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -18396,14 +18396,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -18415,7 +18415,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -20137,14 +20137,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -20156,7 +20156,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -20778,14 +20778,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -20797,7 +20797,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -23531,14 +23531,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -23550,7 +23550,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -27823,14 +27823,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -27842,7 +27842,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -28341,14 +28341,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -28360,7 +28360,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -28753,14 +28753,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -28772,7 +28772,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -32555,14 +32555,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -32574,7 +32574,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -33066,14 +33066,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -33085,7 +33085,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -33458,14 +33458,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -33477,7 +33477,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -33868,14 +33868,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -33887,7 +33887,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -54,7 +54,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -172,10 +171,10 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -457,16 +456,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -474,13 +473,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -491,29 +490,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -591,7 +590,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -659,10 +657,10 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -823,16 +821,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -840,13 +838,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -857,29 +855,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -958,7 +956,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -1076,10 +1073,10 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -1361,16 +1358,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -1378,13 +1375,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -1395,29 +1392,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -1496,7 +1493,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -6577,10 +6573,10 @@ class mother_model final : public model_base_crtp<mother_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -10838,16 +10834,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -10855,13 +10851,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -10872,29 +10868,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -11002,7 +10998,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -11652,10 +11647,10 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -12860,16 +12855,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -12877,13 +12872,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -12894,29 +12889,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -13154,7 +13149,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -14020,10 +14014,10 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -17499,16 +17493,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -17516,13 +17510,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -17533,29 +17527,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -17634,7 +17628,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -17874,10 +17867,10 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -18367,16 +18360,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -18384,13 +18377,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -18401,29 +18394,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -18506,7 +18499,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -19032,10 +19024,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -20109,16 +20101,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -20126,13 +20118,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -20143,29 +20135,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -20243,7 +20235,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -20486,10 +20477,10 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -20751,16 +20742,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -20768,13 +20759,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -20785,29 +20776,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -20885,7 +20876,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -22115,10 +22105,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -23505,16 +23495,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -23522,13 +23512,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -23539,29 +23529,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -23639,7 +23629,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -26354,10 +26343,10 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -27798,16 +27787,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -27815,13 +27804,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -27832,29 +27821,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -27932,7 +27921,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -28170,10 +28158,10 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -28317,16 +28305,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -28334,13 +28322,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -28351,29 +28339,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -28452,7 +28440,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -28525,10 +28512,10 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -28730,16 +28717,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -28747,13 +28734,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -28764,29 +28751,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -28864,7 +28851,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -29346,10 +29332,10 @@ class transform_model final : public model_base_crtp<transform_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -32533,16 +32519,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -32550,13 +32536,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -32567,29 +32553,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -32667,7 +32653,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -32762,10 +32747,10 @@ class truncate_model final : public model_base_crtp<truncate_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -33045,16 +33030,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -33062,13 +33047,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -33079,29 +33064,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -33179,7 +33164,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -33270,10 +33254,10 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -33438,16 +33422,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -33455,13 +33439,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -33472,29 +33456,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -33573,7 +33557,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -33666,10 +33649,10 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -33849,16 +33832,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -33866,13 +33849,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -33883,29 +33866,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -168,9 +168,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -237,10 +235,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -309,9 +304,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -654,9 +647,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -687,10 +678,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -732,9 +720,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -1070,9 +1056,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1139,10 +1123,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1211,9 +1192,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6570,9 +6549,7 @@ class mother_model final : public model_base_crtp<mother_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -7447,10 +7424,7 @@ class mother_model final : public model_base_crtp<mother_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -8833,9 +8807,7 @@ class mother_model final : public model_base_crtp<mother_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -11644,9 +11616,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -11989,10 +11959,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -12437,9 +12404,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -14011,9 +13976,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -15658,10 +15621,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -17321,9 +17281,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -17864,9 +17822,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -18029,10 +17985,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -18146,9 +18099,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -19021,9 +18972,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -19646,10 +19595,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -19762,9 +19708,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -20474,9 +20418,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20538,10 +20480,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -20607,9 +20546,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -22102,9 +22039,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -22336,10 +22271,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -22629,9 +22561,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26340,9 +26270,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26631,10 +26559,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -27010,9 +26935,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -28155,9 +28078,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28184,10 +28105,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28223,9 +28141,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -28509,9 +28425,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28576,10 +28490,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28623,9 +28534,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -29329,9 +29238,7 @@ class transform_model final : public model_base_crtp<transform_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -30314,10 +30221,7 @@ class transform_model final : public model_base_crtp<transform_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -31229,9 +31133,7 @@ class transform_model final : public model_base_crtp<transform_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -32744,9 +32646,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -32872,10 +32772,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -32925,9 +32822,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33251,9 +33146,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33288,10 +33181,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33333,9 +33223,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33646,9 +33534,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33691,10 +33577,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33738,9 +33621,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -168,9 +168,9 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -237,10 +237,10 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -309,9 +309,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -654,9 +654,9 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -687,10 +687,10 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -732,9 +732,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -1070,9 +1070,9 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1139,10 +1139,10 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1211,9 +1211,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6570,9 +6570,9 @@ class mother_model final : public model_base_crtp<mother_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -7447,10 +7447,10 @@ class mother_model final : public model_base_crtp<mother_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -8833,9 +8833,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -11644,9 +11644,9 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -11989,10 +11989,10 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -12437,9 +12437,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -14011,9 +14011,9 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -15658,10 +15658,10 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -17321,9 +17321,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -17864,9 +17864,9 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -18029,10 +18029,10 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -18146,9 +18146,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -19021,9 +19021,9 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -19646,10 +19646,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -19762,9 +19762,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -20474,9 +20474,9 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20538,10 +20538,10 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -20607,9 +20607,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -22102,9 +22102,9 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -22336,10 +22336,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -22629,9 +22629,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26340,9 +26340,9 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26631,10 +26631,10 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -27010,9 +27010,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -28155,9 +28155,9 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28184,10 +28184,10 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28223,9 +28223,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -28509,9 +28509,9 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28576,10 +28576,10 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28623,9 +28623,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -29329,9 +29329,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -30314,10 +30314,10 @@ class transform_model final : public model_base_crtp<transform_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -31229,9 +31229,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -32744,9 +32744,9 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -32872,10 +32872,10 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -32925,9 +32925,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33251,9 +33251,9 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33288,10 +33288,10 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33333,9 +33333,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33646,9 +33646,9 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33691,10 +33691,10 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33738,9 +33738,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -273,9 +273,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -302,10 +302,10 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -341,9 +341,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -273,9 +273,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -302,10 +300,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -341,9 +336,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -54,6 +54,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -196,15 +197,12 @@ class simple_function_model final : public model_base_crtp<simple_function_model
   Eigen::Matrix<double, -1, -1> m;
  
  public:
-  ~simple_function_model() final { }
+  ~simple_function_model() { }
   
-  std::string model_name() const final { return "simple_function_model"; }
+  inline std::string model_name() const final { return "simple_function_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
   }
   
   
@@ -276,10 +274,13 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -300,15 +301,17 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -337,13 +340,14 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -358,7 +362,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -366,8 +370,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     
     } // get_dims() 
@@ -422,44 +425,63 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -459,14 +459,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -478,7 +478,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -54,7 +54,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -277,10 +276,10 @@ class simple_function_model final : public model_base_crtp<simple_function_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -424,16 +423,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -441,13 +440,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -458,29 +457,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -54,7 +54,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -481,7 +480,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -54,6 +54,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -480,6 +481,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -54,6 +54,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -168,15 +169,12 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   std::vector<int> x_i;
  
  public:
-  ~ad_level_failing_model() final { }
+  ~ad_level_failing_model() { }
   
-  std::string model_name() const final { return "ad_level_failing_model"; }
+  inline std::string model_name() const final { return "ad_level_failing_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -284,10 +282,13 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -479,15 +480,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -658,13 +661,14 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -723,7 +727,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -735,8 +739,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     names__.emplace_back("y");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -819,44 +822,63 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -937,6 +959,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -1360,15 +1383,12 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   std::vector<int> last;
  
  public:
-  ~copy_fail_model() final { }
+  ~copy_fail_model() { }
   
-  std::string model_name() const final { return "copy_fail_model"; }
+  inline std::string model_name() const final { return "copy_fail_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -1883,10 +1903,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -2564,15 +2587,17 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -3229,13 +3254,14 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -3316,7 +3342,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -3328,8 +3354,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     names__.emplace_back("chi");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -3446,44 +3471,63 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -3560,6 +3604,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -3670,15 +3715,12 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   Eigen::Matrix<double, -1, 1> v_prev;
  
  public:
-  ~dce_fail_model() final { }
+  ~dce_fail_model() { }
   
-  std::string model_name() const final { return "dce_fail_model"; }
+  inline std::string model_name() const final { return "dce_fail_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -4067,10 +4109,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -4370,15 +4415,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -4582,13 +4629,14 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -4931,7 +4979,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -4954,8 +5002,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     names__.emplace_back("b_hat");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -5108,44 +5155,63 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -5222,6 +5288,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -5249,15 +5316,12 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
   double i;
  
  public:
-  ~expr_prop_experiment_model() final { }
+  ~expr_prop_experiment_model() { }
   
-  std::string model_name() const final { return "expr_prop_experiment_model"; }
+  inline std::string model_name() const final { return "expr_prop_experiment_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -5323,10 +5387,13 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -5347,15 +5414,17 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -5386,13 +5455,14 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -5407,7 +5477,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -5415,8 +5485,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     
     } // get_dims() 
@@ -5471,44 +5540,63 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -5586,6 +5674,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -5610,15 +5699,12 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   double y;
  
  public:
-  ~expr_prop_experiment2_model() final { }
+  ~expr_prop_experiment2_model() { }
   
-  std::string model_name() const final { return "expr_prop_experiment2_model"; }
+  inline std::string model_name() const final { return "expr_prop_experiment2_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -5683,10 +5769,13 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -5707,15 +5796,17 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -5746,13 +5837,14 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -5767,7 +5859,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -5775,8 +5867,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     
     } // get_dims() 
@@ -5831,44 +5922,63 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -5946,6 +6056,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -5976,15 +6087,12 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   Eigen::Matrix<double, -1, 1> y;
  
  public:
-  ~expr_prop_fail_model() final { }
+  ~expr_prop_fail_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -6066,10 +6174,13 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -6190,15 +6301,17 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -6287,13 +6400,14 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -6394,7 +6508,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -6404,8 +6518,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     names__.emplace_back("theta");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(2)});
     
@@ -6481,44 +6594,63 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -6595,6 +6727,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -6625,15 +6758,12 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   std::vector<double> sigma;
  
  public:
-  ~expr_prop_fail2_model() final { }
+  ~expr_prop_fail2_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail2_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail2_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -6717,10 +6847,13 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -6780,15 +6913,17 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -6854,13 +6989,14 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -6906,7 +7042,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -6916,8 +7052,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     names__.emplace_back("tau");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -6987,44 +7122,63 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -7101,6 +7255,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -7204,15 +7359,12 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   std::vector<int> y;
  
  public:
-  ~expr_prop_fail3_model() final { }
+  ~expr_prop_fail3_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail3_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail3_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -7688,10 +7840,13 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -7868,15 +8023,17 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -8082,13 +8239,14 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -8405,7 +8563,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -8424,8 +8582,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     names__.emplace_back("y_hat");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(n_age)});
     
@@ -8567,44 +8724,63 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -8681,6 +8857,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -8757,15 +8934,12 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   int phi_std_raw_1dim__;
  
  public:
-  ~expr_prop_fail4_model() final { }
+  ~expr_prop_fail4_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail4_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail4_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -8966,10 +9140,13 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -9049,15 +9226,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -9264,13 +9443,14 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -9338,7 +9518,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -9357,8 +9537,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     names__.emplace_back("y");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -9492,44 +9671,63 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -9606,6 +9804,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -10023,15 +10222,12 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   std::vector<int> last;
  
  public:
-  ~expr_prop_fail5_model() final { }
+  ~expr_prop_fail5_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail5_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail5_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -10418,10 +10614,13 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -11099,15 +11298,17 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -11781,13 +11982,14 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -11872,7 +12074,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -11888,8 +12090,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     names__.emplace_back("sigma2");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -12020,44 +12221,63 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -12134,6 +12354,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -13205,15 +13426,12 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   int phi_2dim__;
  
  public:
-  ~expr_prop_fail6_model() final { }
+  ~expr_prop_fail6_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail6_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail6_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -13616,10 +13834,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -14813,15 +15034,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -15922,13 +16145,14 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -16078,7 +16302,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -16101,8 +16325,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     names__.emplace_back("z");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -16302,44 +16525,63 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -16416,6 +16658,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -16492,15 +16735,12 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   std::vector<Eigen::Matrix<double, -1, 1>> beta;
  
  public:
-  ~expr_prop_fail7_model() final { }
+  ~expr_prop_fail7_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail7_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail7_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -16843,10 +17083,13 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -17139,15 +17382,17 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -17438,13 +17683,14 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -17711,7 +17957,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -17721,8 +17967,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     names__.emplace_back("log_Pr_z");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(K)});
     
@@ -17823,44 +18068,63 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -17937,6 +18201,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -17991,15 +18256,12 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   Eigen::Matrix<double, -1, 1> x;
  
  public:
-  ~expr_prop_fail8_model() final { }
+  ~expr_prop_fail8_model() { }
   
-  std::string model_name() const final { return "expr_prop_fail8_model"; }
+  inline std::string model_name() const final { return "expr_prop_fail8_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -18192,10 +18454,13 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -18292,15 +18557,17 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -18418,13 +18685,14 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -18549,7 +18817,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -18564,8 +18832,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     names__.emplace_back("phi");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -18665,44 +18932,63 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -18779,6 +19065,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -19202,15 +19489,12 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   std::vector<int> last;
  
  public:
-  ~fails_test_model() final { }
+  ~fails_test_model() { }
   
-  std::string model_name() const final { return "fails_test_model"; }
+  inline std::string model_name() const final { return "fails_test_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -19725,10 +20009,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -20406,15 +20693,17 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -21071,13 +21360,14 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -21158,7 +21448,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -21170,8 +21460,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     names__.emplace_back("chi");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -21288,44 +21577,63 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -21402,6 +21710,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -22531,15 +22840,12 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   int phi_2dim__;
  
  public:
-  ~inlining_fail2_model() final { }
+  ~inlining_fail2_model() { }
   
-  std::string model_name() const final { return "inlining_fail2_model"; }
+  inline std::string model_name() const final { return "inlining_fail2_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -22944,10 +23250,13 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -24065,15 +24374,17 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -25085,13 +25396,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -25233,7 +25545,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -25255,8 +25567,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     names__.emplace_back("z");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -25448,44 +25759,63 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -25562,6 +25892,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -25586,15 +25917,12 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
   double i;
  
  public:
-  ~lcm_experiment_model() final { }
+  ~lcm_experiment_model() { }
   
-  std::string model_name() const final { return "lcm_experiment_model"; }
+  inline std::string model_name() const final { return "lcm_experiment_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -25657,10 +25985,13 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -25681,15 +26012,17 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -25720,13 +26053,14 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -25741,7 +26075,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -25749,8 +26083,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     
     } // get_dims() 
@@ -25805,44 +26138,63 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -25919,6 +26271,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -25940,15 +26293,12 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   
  
  public:
-  ~lcm_experiment2_model() final { }
+  ~lcm_experiment2_model() { }
   
-  std::string model_name() const final { return "lcm_experiment2_model"; }
+  inline std::string model_name() const final { return "lcm_experiment2_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -25984,10 +26334,13 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -26031,15 +26384,17 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -26076,13 +26431,14 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -26103,7 +26459,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -26111,8 +26467,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     names__.emplace_back("x");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -26168,44 +26523,63 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -26282,6 +26656,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -26303,15 +26678,12 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   std::vector<double> y;
  
  public:
-  ~lcm_fails_model() final { }
+  ~lcm_fails_model() { }
   
-  std::string model_name() const final { return "lcm_fails_model"; }
+  inline std::string model_name() const final { return "lcm_fails_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -26369,10 +26741,13 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -26411,15 +26786,17 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -26471,13 +26848,14 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -26506,7 +26884,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -26514,8 +26892,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     names__.emplace_back("theta");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(J)});
     
@@ -26577,44 +26954,63 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -26691,6 +27087,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -27101,15 +27498,12 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
   std::vector<int> last;
  
  public:
-  ~lcm_fails2_model() final { }
+  ~lcm_fails2_model() { }
   
-  std::string model_name() const final { return "lcm_fails2_model"; }
+  inline std::string model_name() const final { return "lcm_fails2_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -27492,10 +27886,13 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -28143,15 +28540,17 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -28784,13 +29183,14 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -28827,7 +29227,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -28839,8 +29239,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     names__.emplace_back("chi");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -28951,44 +29350,63 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -29065,6 +29483,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -29152,15 +29571,12 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   int occ_obs;
  
  public:
-  ~off_dce_model() final { }
+  ~off_dce_model() { }
   
-  std::string model_name() const final { return "off_dce_model"; }
+  inline std::string model_name() const final { return "off_dce_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -29451,10 +29867,13 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -29571,15 +29990,17 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -29826,13 +30247,14 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -29871,7 +30293,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -29887,8 +30309,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     names__.emplace_back("z");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -30003,44 +30424,63 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -30117,6 +30557,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -30180,15 +30621,12 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   Eigen::Matrix<double, -1, 1> y;
  
  public:
-  ~off_small_model() final { }
+  ~off_small_model() { }
   
-  std::string model_name() const final { return "off_small_model"; }
+  inline std::string model_name() const final { return "off_small_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -30395,10 +30833,13 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -30546,15 +30987,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -30720,13 +31163,14 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -30864,7 +31308,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -30882,8 +31326,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     names__.emplace_back("y_hat");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -31007,44 +31450,63 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -31121,6 +31583,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -31334,15 +31797,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   
  
  public:
-  ~optimizations_model() final { }
+  ~optimizations_model() { }
   
-  std::string model_name() const final { return "optimizations_model"; }
+  inline std::string model_name() const final { return "optimizations_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -31382,10 +31842,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -31957,15 +32420,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -32118,13 +32583,14 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -32376,7 +32842,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -32388,8 +32854,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     names__.emplace_back("x_cov");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -32490,44 +32955,63 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -32604,6 +33088,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -32659,15 +33144,12 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   Eigen::Matrix<double, -1, 1> y;
  
  public:
-  ~partial_eval_model() final { }
+  ~partial_eval_model() { }
   
-  std::string model_name() const final { return "partial_eval_model"; }
+  inline std::string model_name() const final { return "partial_eval_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -32890,10 +33372,13 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -32991,15 +33476,17 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -33110,13 +33597,14 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -33232,7 +33720,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -33245,8 +33733,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     names__.emplace_back("y_hat");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{static_cast<size_t>(n_pair)});
     
@@ -33338,44 +33825,63 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -33452,6 +33958,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -33515,15 +34022,12 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   Eigen::Matrix<double, -1, 1> x1x2;
  
  public:
-  ~stalled1_failure_model() final { }
+  ~stalled1_failure_model() { }
   
-  std::string model_name() const final { return "stalled1_failure_model"; }
+  inline std::string model_name() const final { return "stalled1_failure_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -33705,10 +34209,13 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -33828,15 +34335,17 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -33983,13 +34492,14 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -34272,7 +34782,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -34286,8 +34796,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     names__.emplace_back("sigma");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -34378,44 +34887,63 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }
@@ -34658,6 +35186,7 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
+using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -34685,15 +35214,12 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   
  
  public:
-  ~unroll_limit_model() final { }
+  ~unroll_limit_model() { }
   
-  std::string model_name() const final { return "unroll_limit_model"; }
+  inline std::string model_name() const final { return "unroll_limit_model"; }
 
-  std::vector<std::string> model_compile_info() const {
-    std::vector<std::string> stanc_info;
-    stanc_info.push_back("stanc_version = %%NAME%%3 %%VERSION%%");
-    stanc_info.push_back("stancflags = --O --print-cpp");
-    return stanc_info;
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --O --print-cpp"};
   }
   
   
@@ -34729,10 +35255,13 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename T__>
-  inline T__ log_prob(std::vector<T__>& params_r__,
-                      std::vector<int>& params_i__,
-                      std::ostream* pstream__ = nullptr) const {
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
+ stan::require_vector_like_t<VecR>* = nullptr, 
+ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                           VecI& params_i__,
+                                           std::ostream* pstream__ = nullptr) const {
+    using T__ = scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -34753,15 +35282,17 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
-    } // log_prob() 
+    } // log_prob_impl() 
     
-  template <typename RNG>
-  inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                          std::vector<int>& params_i__,
-                          std::vector<double>& vars__,
-                          bool emit_transformed_parameters__ = true,
-                          bool emit_generated_quantities__ = true,
-                          std::ostream* pstream__ = nullptr) const {
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.resize(0);
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
@@ -35068,13 +35599,14 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // write_array() 
+    } // write_array_impl() 
     
-  inline void transform_inits(const stan::io::var_context& context__,
-                              std::vector<int>& params_i__,
-                              std::vector<double>& vars__,
-                              std::ostream* pstream__) const
-    final {
+  template <typename VecVar, typename VecI, 
+stan::require_std_vector_t<VecVar>* = nullptr, 
+stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  inline void transform_inits_impl(const stan::io::var_context& context__,
+                                   VecI& params_i__, VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
@@ -35089,7 +35621,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       // Next line prevents compiler griping about no return
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
-    } // transform_inits() 
+    } // transform_inits_impl() 
     
   inline void get_param_names(std::vector<std::string>& names__) const {
     
@@ -35097,8 +35629,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     names__.emplace_back("x");
     } // get_param_names() 
     
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const
-    final {
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     dimss__.clear();
     dimss__.emplace_back(std::vector<size_t>{});
     
@@ -35154,44 +35685,63 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     // Begin method overload boilerplate
     template <typename RNG>
     inline void write_array(RNG& base_rng__,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
-                     Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                     bool emit_transformed_parameters__ = true,
-                     bool emit_generated_quantities__ = true,
-                     std::ostream* pstream = nullptr) const {
-      std::vector<double> params_r_vec(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r_vec[i] = params_r(i);
-      std::vector<double> vars_vec;
-      std::vector<int> params_i_vec;
-      write_array(base_rng__, params_r_vec, params_i_vec, vars_vec,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters__ = true,
+                            const bool emit_generated_quantities__ = true,
+                            std::ostream* pstream = nullptr) const {
+      std::vector<double> vars_vec(vars.size());
+      std::vector<int> params_i;
+      write_array_impl(base_rng__, params_r, params_i, vars_vec,
           emit_transformed_parameters__, emit_generated_quantities__, pstream);
       vars.resize(vars_vec.size());
-      for (int i = 0; i < vars.size(); ++i)
-        vars(i) = vars_vec[i];
+      for (int i = 0; i < vars.size(); ++i) {
+        vars.coeffRef(i) = vars_vec[i];
+      }
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
+                            std::vector<int>& params_i__,
+                            std::vector<double>& vars__,
+                            bool emit_transformed_parameters__ = true,
+                            bool emit_generated_quantities__ = true,
+                            std::ostream* pstream__ = nullptr) const {
+      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
     inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
-               std::ostream* pstream = nullptr) const {
-      std::vector<T_> vec_params_r;
-      vec_params_r.reserve(params_r.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        vec_params_r.push_back(params_r(i));
-      std::vector<int> vec_params_i;
-      return log_prob<propto__,jacobian__,T_>(vec_params_r, vec_params_i, pstream);
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r__,
+                        std::vector<int>& params_i__,
+                        std::ostream* pstream__ = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    }
+  
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
                          std::ostream* pstream__ = nullptr) const {
-      std::vector<double> params_r_vec;
-      std::vector<int> params_i_vec;
-      transform_inits(context, params_i_vec, params_r_vec, pstream__);
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits_impl(context, params_i, params_r_vec, pstream__);
       params_r.resize(params_r_vec.size());
-      for (int i = 0; i < params_r.size(); ++i)
-        params_r(i) = params_r_vec[i];
+      for (int i = 0; i < params_r.size(); ++i) {
+        params_r.coeffRef(i) = params_r_vec[i];
+      }
     }
+    inline void transform_inits(const stan::io::var_context& context__,
+                                std::vector<int>& params_i__,
+                                std::vector<double>& vars__,
+                                std::ostream* pstream__) const final {
+      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    }        
 
 };
 }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -281,9 +281,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -481,10 +481,10 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -662,9 +662,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -1901,9 +1901,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -2587,10 +2587,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -3254,9 +3254,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -4106,9 +4106,9 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -4414,10 +4414,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -4628,9 +4628,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -5383,9 +5383,9 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5412,10 +5412,10 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5453,9 +5453,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -5764,9 +5764,9 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5793,10 +5793,10 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5834,9 +5834,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6168,9 +6168,9 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6297,10 +6297,10 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6396,9 +6396,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6840,9 +6840,9 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6908,10 +6908,10 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6984,9 +6984,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -7832,9 +7832,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -8017,10 +8017,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -8233,9 +8233,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -9131,9 +9131,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -9219,10 +9219,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -9436,9 +9436,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -10604,9 +10604,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -11290,10 +11290,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -11974,9 +11974,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -13823,9 +13823,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -15025,10 +15025,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -16136,9 +16136,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -17071,9 +17071,9 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -17372,10 +17372,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -17673,9 +17673,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -18441,9 +18441,9 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -18546,10 +18546,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -18674,9 +18674,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -19995,9 +19995,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20681,10 +20681,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -21348,9 +21348,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -23235,9 +23235,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -24361,10 +24361,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -25383,9 +25383,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -25969,9 +25969,9 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -25998,10 +25998,10 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26039,9 +26039,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26317,9 +26317,9 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26369,10 +26369,10 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26416,9 +26416,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26723,9 +26723,9 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26770,10 +26770,10 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26832,9 +26832,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -27867,9 +27867,9 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28523,10 +28523,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -29166,9 +29166,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -29847,9 +29847,9 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -29972,10 +29972,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -30229,9 +30229,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -30812,9 +30812,9 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -30968,10 +30968,10 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -31144,9 +31144,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -31820,9 +31820,9 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -32400,10 +32400,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -32563,9 +32563,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33349,9 +33349,9 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33455,10 +33455,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33576,9 +33576,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -34185,9 +34185,9 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -34313,10 +34313,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -34470,9 +34470,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -35230,9 +35230,9 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
- stan::require_vector_like_t<VecR>* = nullptr, 
- stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
+     stan::require_vector_like_t<VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -35259,10 +35259,10 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar,
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -35576,9 +35576,9 @@ stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, 
-stan::require_std_vector_t<VecVar>* = nullptr, 
-stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI,
+     stan::require_std_vector_t<VecVar>* = nullptr,
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -856,14 +856,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -875,7 +875,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -3504,14 +3504,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -3523,7 +3523,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -5187,14 +5187,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -5206,7 +5206,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -5571,14 +5571,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -5590,7 +5590,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -5952,14 +5952,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -5971,7 +5971,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -6623,14 +6623,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -6642,7 +6642,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -7150,14 +7150,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -7169,7 +7169,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -8751,14 +8751,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -8770,7 +8770,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -9697,14 +9697,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -9716,7 +9716,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -12246,14 +12246,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -12265,7 +12265,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -16549,14 +16549,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -16568,7 +16568,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -18091,14 +18091,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -18110,7 +18110,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -18954,14 +18954,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -18973,7 +18973,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -21598,14 +21598,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -21617,7 +21617,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -25779,14 +25779,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -25798,7 +25798,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -26157,14 +26157,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -26176,7 +26176,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -26541,14 +26541,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -26560,7 +26560,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -26971,14 +26971,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -26990,7 +26990,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -29366,14 +29366,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -29385,7 +29385,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -30439,14 +30439,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -30458,7 +30458,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -31464,14 +31464,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -31483,7 +31483,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -32968,14 +32968,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -32987,7 +32987,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -33837,14 +33837,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -33856,7 +33856,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -34898,14 +34898,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -34917,7 +34917,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 
@@ -35695,14 +35695,14 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     template <bool propto__, bool jacobian__, typename T__>
     inline T__ log_prob(std::vector<T__>& params_r,
                         std::vector<int>& params_i,
-                        std::ostream* pstream = nullptr) const  {
+                        std::ostream* pstream = nullptr) const {
       return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream = nullptr) const {
+                         std::ostream* pstream = nullptr) const final {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
       transform_inits_impl(context, params_i, params_r_vec, pstream);
@@ -35714,7 +35714,7 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     inline void transform_inits(const stan::io::var_context& context,
                                 std::vector<int>& params_i,
                                 std::vector<double>& vars,
-                                std::ostream* pstream = nullptr) const {
+                                std::ostream* pstream = nullptr) const final {
       transform_inits_impl(context, params_i, vars, pstream);
     }        
 

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -54,7 +54,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -285,10 +284,10 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -821,16 +820,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -838,13 +837,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -855,29 +854,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -959,7 +958,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -1906,10 +1904,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -3470,16 +3468,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -3487,13 +3485,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -3504,29 +3502,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -3604,7 +3602,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -4112,10 +4109,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -5154,16 +5151,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -5171,13 +5168,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -5188,29 +5185,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -5288,7 +5285,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -5390,10 +5386,10 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -5539,16 +5535,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -5556,13 +5552,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -5573,29 +5569,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -5674,7 +5670,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -5772,10 +5767,10 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -5921,16 +5916,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -5938,13 +5933,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -5955,29 +5950,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -6056,7 +6051,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -6177,10 +6171,10 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -6593,16 +6587,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -6610,13 +6604,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -6627,29 +6621,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -6727,7 +6721,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -6850,10 +6843,10 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -7121,16 +7114,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -7138,13 +7131,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -7155,29 +7148,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -7255,7 +7248,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -7843,10 +7835,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -8723,16 +8715,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -8740,13 +8732,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -8757,29 +8749,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -8857,7 +8849,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -9143,10 +9134,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -9670,16 +9661,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -9687,13 +9678,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -9704,29 +9695,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -9804,7 +9795,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -10617,10 +10607,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -12220,16 +12210,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -12237,13 +12227,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -12254,29 +12244,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -12354,7 +12344,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -13837,10 +13826,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -16524,16 +16513,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -16541,13 +16530,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -16558,29 +16547,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -16658,7 +16647,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -17086,10 +17074,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -18067,16 +18055,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -18084,13 +18072,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -18101,29 +18089,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -18201,7 +18189,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -18457,10 +18444,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -18931,16 +18918,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -18948,13 +18935,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -18965,29 +18952,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -19065,7 +19052,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -20012,10 +19998,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -21576,16 +21562,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -21593,13 +21579,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -21610,29 +21596,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -21710,7 +21696,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -23253,10 +23238,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -25758,16 +25743,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -25775,13 +25760,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -25792,29 +25777,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -25892,7 +25877,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -25988,10 +25972,10 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -26137,16 +26121,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -26154,13 +26138,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -26171,29 +26155,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -26271,7 +26255,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -26337,10 +26320,10 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -26522,16 +26505,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -26539,13 +26522,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -26556,29 +26539,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -26656,7 +26639,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -26744,10 +26726,10 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -26953,16 +26935,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -26970,13 +26952,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -26987,29 +26969,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -27087,7 +27069,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -27889,10 +27870,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -29349,16 +29330,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -29366,13 +29347,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -29383,29 +29364,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -29483,7 +29464,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -29870,10 +29850,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -30423,16 +30403,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -30440,13 +30420,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -30457,29 +30437,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -30557,7 +30537,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -30836,10 +30815,10 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -31449,16 +31428,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -31466,13 +31445,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -31483,29 +31462,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -31583,7 +31562,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -31845,10 +31823,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -32954,16 +32932,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -32971,13 +32949,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -32988,29 +32966,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -33088,7 +33066,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -33375,10 +33352,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -33824,16 +33801,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -33841,13 +33818,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -33858,29 +33835,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -33958,7 +33935,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -34212,10 +34188,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -34886,16 +34862,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -34903,13 +34879,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -34920,29 +34896,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };
@@ -35186,7 +35162,6 @@ using stan::model::index_min_max;
 using stan::model::index_multi;
 using stan::model::index_omni;
 using stan::model::nil_index_list;
-using stan::scalar_type_t;
 using namespace stan::math;
 using stan::math::pow; 
 
@@ -35258,10 +35233,10 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   template <bool propto__, bool jacobian__, typename VecR, typename VecI, 
  stan::require_vector_like_t<VecR>* = nullptr, 
  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
-  inline scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
-                                           VecI& params_i__,
-                                           std::ostream* pstream__ = nullptr) const {
-    using T__ = scalar_type_t<VecR>;
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
     using local_scalar_t__ = T__;
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
@@ -35684,16 +35659,16 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   
     // Begin method overload boilerplate
     template <typename RNG>
-    inline void write_array(RNG& base_rng__,
+    inline void write_array(RNG& base_rng,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
                             Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
-                            const bool emit_transformed_parameters__ = true,
-                            const bool emit_generated_quantities__ = true,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       std::vector<double> vars_vec(vars.size());
       std::vector<int> params_i;
-      write_array_impl(base_rng__, params_r, params_i, vars_vec,
-          emit_transformed_parameters__, emit_generated_quantities__, pstream);
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
       vars.resize(vars_vec.size());
       for (int i = 0; i < vars.size(); ++i) {
         vars.coeffRef(i) = vars_vec[i];
@@ -35701,13 +35676,13 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <typename RNG>
-    inline void write_array(RNG& base_rng__, std::vector<double>& params_r__,
-                            std::vector<int>& params_i__,
-                            std::vector<double>& vars__,
-                            bool emit_transformed_parameters__ = true,
-                            bool emit_generated_quantities__ = true,
-                            std::ostream* pstream__ = nullptr) const {
-      write_array_impl(base_rng__, params_r__, params_i__, vars__, emit_transformed_parameters__, emit_generated_quantities__, pstream__);
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
     template <bool propto__, bool jacobian__, typename T_>
@@ -35718,29 +35693,29 @@ stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
     }
 
     template <bool propto__, bool jacobian__, typename T__>
-    inline T__ log_prob(std::vector<T__>& params_r__,
-                        std::vector<int>& params_i__,
-                        std::ostream* pstream__ = nullptr) const {
-      return log_prob_impl<propto__, jacobian__>(params_r__, params_i__, pstream__);
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const  {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
     }
   
 
     inline void transform_inits(const stan::io::var_context& context,
                          Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
-                         std::ostream* pstream__ = nullptr) const {
+                         std::ostream* pstream = nullptr) const {
       std::vector<double> params_r_vec(params_r.size());
       std::vector<int> params_i;
-      transform_inits_impl(context, params_i, params_r_vec, pstream__);
+      transform_inits_impl(context, params_i, params_r_vec, pstream);
       params_r.resize(params_r_vec.size());
       for (int i = 0; i < params_r.size(); ++i) {
         params_r.coeffRef(i) = params_r_vec[i];
       }
     }
-    inline void transform_inits(const stan::io::var_context& context__,
-                                std::vector<int>& params_i__,
-                                std::vector<double>& vars__,
-                                std::ostream* pstream__) const final {
-      transform_inits_impl(context__, params_i__, vars__, pstream__);
+    inline void transform_inits(const stan::io::var_context& context,
+                                std::vector<int>& params_i,
+                                std::vector<double>& vars,
+                                std::ostream* pstream = nullptr) const {
+      transform_inits_impl(context, params_i, vars, pstream);
     }        
 
 };

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -281,9 +281,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -481,10 +479,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -662,9 +657,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -1901,9 +1894,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -2587,10 +2578,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -3254,9 +3242,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -4106,9 +4092,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -4414,10 +4398,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -4628,9 +4609,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -5383,9 +5362,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5412,10 +5389,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5453,9 +5427,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -5764,9 +5736,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5793,10 +5763,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5834,9 +5801,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6168,9 +6133,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6297,10 +6260,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6396,9 +6356,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6840,9 +6798,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6908,10 +6864,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6984,9 +6937,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -7832,9 +7783,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -8017,10 +7966,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -8233,9 +8179,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -9131,9 +9075,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -9219,10 +9161,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -9436,9 +9375,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -10604,9 +10541,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -11290,10 +11225,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -11974,9 +11906,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -13823,9 +13753,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -15025,10 +14953,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -16136,9 +16061,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -17071,9 +16994,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -17372,10 +17293,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -17673,9 +17591,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -18441,9 +18357,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -18546,10 +18460,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -18674,9 +18585,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -19995,9 +19904,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20681,10 +20588,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -21348,9 +21252,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -23235,9 +23137,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -24361,10 +24261,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -25383,9 +25280,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -25969,9 +25864,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -25998,10 +25891,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26039,9 +25929,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26317,9 +26205,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26369,10 +26255,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26416,9 +26299,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26723,9 +26604,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26770,10 +26649,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26832,9 +26708,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -27867,9 +27741,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28523,10 +28395,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -29166,9 +29035,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -29847,9 +29714,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -29972,10 +29837,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -30229,9 +30091,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -30812,9 +30672,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -30968,10 +30826,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -31144,9 +30999,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -31820,9 +31673,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -32400,10 +32251,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -32563,9 +32411,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33349,9 +33195,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33455,10 +33299,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33576,9 +33417,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -34185,9 +34024,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -34313,10 +34150,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -34470,9 +34304,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -35230,9 +35062,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI,
-     stan::require_vector_like_t<VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -35259,10 +35089,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar,
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr,
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>@
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -35576,9 +35403,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI,
-     stan::require_std_vector_t<VecVar>* = nullptr,
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {


### PR DESCRIPTION
The [`reader<>`](https://github.com/stan-dev/stan/blob/develop/src/stan/io/reader.hpp#L37) class was recently update so that it could accept Eigen matrices. This PR updates the generated model code so we still preserve the virtual methods for `write_array()`, `log_prob()`, and `transform_inits()`, but underneath the hood they just call a `*_impl` method. This is nice because now that `reader` can accept an Eigen type we don't have to make temporary `std::vector<>`s and copy back and forth from  eigen vectors to std vectors.

## Release notes

Allows `write_array()`, `log_prob()`, and `transform_inits()` to avoid a vector copy and read/write 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
