### PR TITLE
Do not print stdout and stderr in stanc.js

### DIFF
--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -54,7 +54,7 @@ let stan2cpp model_name model_string flags =
     |> Result.map ~f:(fun typed_ast ->
            if is_flag_set "print-canonical" then
              Pretty_printing.pretty_print_typed_program
-                 (Canonicalize.canonicalize_program typed_ast)
+               (Canonicalize.canonicalize_program typed_ast)
            else if is_flag_set "auto-format" then
              match ast with
              | Result.Ok f -> Pretty_printing.pretty_print_program f
@@ -71,7 +71,7 @@ let stan2cpp model_name model_string flags =
                Pedantic_analysis.print_warn_uninitialized mir ;
              if is_flag_set "warn-pedantic" then
                Pedantic_analysis.print_warn_pedantic mir ;
-             cpp)
+             cpp )
 
 let stanc_stdout = ref ""
 let stanc_stderr = ref ""
@@ -80,19 +80,17 @@ let wrap_result = function
   | Result.Ok s ->
       Js.Unsafe.obj
         [| ("result", Js.Unsafe.inject (Js.string s))
-         ; ( "warnings"
-           , Js.Unsafe.inject (Js.string !stanc_stderr)
-               ) |]
+         ; ("warnings", Js.Unsafe.inject (Js.string !stanc_stderr)) |]
   | Error e ->
       Js.Unsafe.obj
         [| ("errors", Js.Unsafe.inject (Array.map ~f:Js.string [|e|]))
          ; ("warnings", Js.Unsafe.inject (Js.string !stanc_stderr)) |]
 
 let stan2cpp_wrapped name code (flags : Js.string_array Js.t Js.opt) =
-  stanc_stdout := "";
-  stanc_stderr := "";
-  Sys_js.set_channel_flusher stdout (fun s -> (stanc_stdout := !stanc_stdout ^ s));
-  Sys_js.set_channel_flusher stderr (fun s -> (stanc_stderr := !stanc_stderr ^ s));
+  stanc_stdout := "" ;
+  stanc_stderr := "" ;
+  Sys_js.set_channel_flusher stdout (fun s -> stanc_stdout := !stanc_stdout ^ s) ;
+  Sys_js.set_channel_flusher stderr (fun s -> stanc_stderr := !stanc_stderr ^ s) ;
   stan2cpp (Js.to_string name) (Js.to_string code)
     Js.(
       Opt.map flags (fun a ->

--- a/test/stancjs/pedantic.js
+++ b/test/stancjs/pedantic.js
@@ -11,9 +11,14 @@ model {
 }
 `
 var pedantic_test = stanc.stanc("pedantic", pedantic_model, ["warn-pedantic"]);
+if (pedantic_test.warnings) {
+    console.log(pedantic_test.warnings)
+}
 
 var pedantic_test = stanc.stanc("pedantic", pedantic_model);
-
+if (pedantic_test.warnings) {
+    console.log(pedantic_test.warnings)
+}
 var warn_uninit_model = `
 transformed data { 
     real tt;
@@ -21,5 +26,11 @@ transformed data {
 }
 `
 var warn_uninit_test = stanc.stanc("uninit", warn_uninit_model, ["warn-uninitialized"]);
+if (warn_uninit_test.warnings) {
+    console.log(warn_uninit_test.warnings)
+}
 
 var warn_uninit_test = stanc.stanc("uninit", warn_uninit_model);
+if (warn_uninit_test.warnings) {
+    console.log(warn_uninit_test.warnings)
+}

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -44,11 +44,20 @@ Warning:
 Warning at 'string', line 7, column 17 to column 22:
   Argument 10000 suggests there may be parameters that are not unit scale;
   consider rescaling with a multiplier (see manual section 22.12).
+
 Warning at 'string', line 4, column 9 to column 11:
   The variable tt may not have been assigned a value before its use.
+
 $ node standalone-functions.js
 
 $ node version.js
 %%NAME%% %%VERSION%%
 %%NAME%% %%VERSION%%
 %%NAME%% %%VERSION%%
+$ node warnings.js
+
+Warning: deprecated language construct used in 'string', line 4, column 4:
+
+Comments beginning with # are deprecated. Please use // in place of # for line comments.
+
+

--- a/test/stancjs/warnings.js
+++ b/test/stancjs/warnings.js
@@ -1,0 +1,14 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+var deprecated_model = `
+parameters {
+    real y;
+    # hash comment is deprecated
+}
+model {
+    y ~ normal(0,1);
+}
+`
+var deprecated_test = stanc.stanc("deprecated", deprecated_model);
+console.log(deprecated_test.warnings)


### PR DESCRIPTION
Fixes #741 

Stdout and stderr in stanc.js are rerouted to a ref (is there a more Ocamlish solution?) and the contents of stderr are returned as the warnings element of the return object. Stdout is ignored.

I think this is the more Javascript way of doing it and for use in Rstan we have to avoid printing anyways (see issue).
Currently, in order to [print pedantic warnings](https://rok-cesnovar.github.io/stanc3js-demo/pedantic.html) in a browser, I had to reroute windows.console.error which is not how we want our API to work.

## Release notes

Removed stdout and stderr in stanc.js.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
