### PR TITLE
allow lp functions in transformed parameters

### DIFF
--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -261,9 +261,7 @@ let semantic_check_unnormalized cf ~loc id =
   Validate.(
     if
       Utils.is_unnormalized_distribution id.name
-      && not
-           ( (cf.in_fun_def && (cf.in_udf_dist_def || cf.in_lp_fun_def))
-           || cf.current_block = Model )
+      && not ((cf.in_fun_def && cf.in_udf_dist_def) || cf.current_block = Model)
     then Semantic_error.invalid_unnormalized_fn loc |> error
     else ok ())
 

--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -234,7 +234,9 @@ let semantic_check_fn_target_plus_equals cf ~loc id =
   Validate.(
     if
       String.is_suffix id.name ~suffix:"_lp"
-      && not (cf.in_lp_fun_def || cf.current_block = Model)
+      && not
+           ( cf.in_lp_fun_def || cf.current_block = Model
+           || cf.current_block = TParam )
     then Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
     else ok ())
 

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -364,7 +364,7 @@ module ExpressionError = struct
         Fmt.pf ppf
           "Functions with names ending in _lupdf and _lupmf can only be used \
            in the model block or user-defined functions with names ending in \
-           _lpdf, _lpmf or _lp."
+           _lpdf or _lpmf."
     | InvalidUnnormalizedUDF fname ->
         Fmt.pf ppf
           "%s is an invalid user-defined function name. User-defined \

--- a/test/integration/bad/unnormalized/lupdf_in_lp.stan
+++ b/test/integration/bad/unnormalized/lupdf_in_lp.stan
@@ -1,0 +1,12 @@
+functions {
+    void foo_lp(real y1, real y2) {
+        target += normal_lupdf(y1| y2, y2);
+    }
+}
+parameters {
+    real y1;
+    real y2;
+}
+transformed parameters {
+   foo_lp(y1, y2);
+}

--- a/test/integration/bad/unnormalized/lupmf_in_lp.stan
+++ b/test/integration/bad/unnormalized/lupmf_in_lp.stan
@@ -1,0 +1,14 @@
+functions {
+    void foo_lp(int i1, real r1) {
+        target += poisson_lupmf(i1| r1);
+    }
+}
+data {
+    int i1;
+}
+parameters {
+    real r1;
+}
+transformed parameters {
+    foo_lp(i1, r1, m1, v1, ai1, rv1);
+}

--- a/test/integration/bad/unnormalized/stanc.expected
+++ b/test/integration/bad/unnormalized/stanc.expected
@@ -23,7 +23,7 @@ Semantic error in 'lupdf_in_functions.stan', line 3, column 15 to column 34:
      5:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupdf_in_gq.stan
 
@@ -36,7 +36,7 @@ Semantic error in 'lupdf_in_gq.stan', line 8, column 13 to column 34:
      9:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupdf_in_gq_rs.stan
 
@@ -49,7 +49,21 @@ Semantic error in 'lupdf_in_gq_rs.stan', line 14, column 24 to column 33:
     15:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
+
+  $ ../../../../../install/default/bin/stanc lupdf_in_lp.stan
+
+Semantic error in 'lupdf_in_lp.stan', line 3, column 18 to column 42:
+   -------------------------------------------------
+     1:  functions {
+     2:      void foo_lp(real y1, real y2) {
+     3:          target += normal_lupdf(y1| y2, y2);
+                           ^
+     4:      }
+     5:  }
+   -------------------------------------------------
+
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupdf_in_trans_data.stan
 
@@ -62,7 +76,7 @@ Semantic error in 'lupdf_in_trans_data.stan', line 3, column 13 to column 34:
      4:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupdf_in_trans_params.stan
 
@@ -75,7 +89,7 @@ Semantic error in 'lupdf_in_trans_params.stan', line 3, column 13 to column 34:
      4:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupdf_in_trans_params_rs.stan
 
@@ -88,7 +102,7 @@ Semantic error in 'lupdf_in_trans_params_rs.stan', line 9, column 24 to column 3
     10:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupmf_in_gq.stan
 
@@ -101,7 +115,21 @@ Semantic error in 'lupmf_in_gq.stan', line 11, column 13 to column 33:
     12:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
+
+  $ ../../../../../install/default/bin/stanc lupmf_in_lp.stan
+
+Semantic error in 'lupmf_in_lp.stan', line 3, column 18 to column 39:
+   -------------------------------------------------
+     1:  functions {
+     2:      void foo_lp(int i1, real r1) {
+     3:          target += poisson_lupmf(i1| r1);
+                           ^
+     4:      }
+     5:  }
+   -------------------------------------------------
+
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupmf_in_trans_data.stan
 
@@ -114,7 +142,7 @@ Semantic error in 'lupmf_in_trans_data.stan', line 7, column 13 to column 33:
      8:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc lupmf_in_trans_params.stan
 
@@ -127,7 +155,7 @@ Semantic error in 'lupmf_in_trans_params.stan', line 6, column 13 to column 33:
      7:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf, _lpmf or _lp.
+Functions with names ending in _lupdf and _lupmf can only be used in the model block or user-defined functions with names ending in _lpdf or _lpmf.
 
   $ ../../../../../install/default/bin/stanc udf_lupdf.stan
 

--- a/test/integration/good/lp_transformed_param.stan
+++ b/test/integration/good/lp_transformed_param.stan
@@ -1,0 +1,15 @@
+functions { 
+  real test_lp(real r) {
+    target += normal_lpdf(r | 0, 1);
+    return r;
+  }
+}
+parameters { 
+  real y; 
+}
+transformed parameters { 
+  real alpha = test_lp(5.0);
+}
+model {
+  y ~ normal(0, 1); 
+}

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -4499,6 +4499,23 @@ get_lp() function is deprecated. It will be removed in a future release. Use tar
 
 
 Warning: in 'lp_in_fun.stan', line 3, column 21 to column 29: The no-argument function `get_lp()` is deprecated. Use the no-argument function `target()` instead.
+  $ ../../../../install/default/bin/stanc --auto-format lp_transformed_param.stan
+functions {
+  real test_lp(real r) {
+    target += normal_lpdf(r| 0, 1);
+    return r;
+  }
+}
+parameters {
+  real y;
+}
+transformed parameters {
+  real alpha = test_lp(5.0);
+}
+model {
+  y ~ normal(0, 1);
+}
+
   $ ../../../../install/default/bin/stanc --auto-format map_rect.stan
 functions {
   vector foo(vector shared_params, vector job_params, array[] real data_r,

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -5388,49 +5388,6 @@ functions {
     r += wishart_lupdf(my1| y2, my2);
     return r;
   }
-  void goo_lp(real y1, real y2, vector vy1, vector vy2, matrix my1,
-              matrix my2, array[] real ay1) {
-    target += beta_lupdf(y1| y2, y2);
-    target += beta_proportion_lupdf(y1| y2, y2);
-    target += cauchy_lupdf(y1| y2, y2);
-    target += chi_square_lupdf(y1| y2);
-    target += dirichlet_lupdf(vy1| vy2);
-    target += double_exponential_lupdf(y1| y2, y2);
-    target += exp_mod_normal_lupdf(y1| y2, y2, y2);
-    target += exponential_lupdf(y1| y2);
-    target += frechet_lupdf(y1| y2, y2);
-    target += gamma_lupdf(y1| y2, y2);
-    target += gaussian_dlm_obs_lupdf(my1| my2, my2, vy2, my2, vy2, my2);
-    target += gumbel_lupdf(y1| y2, y2);
-    target += inv_chi_square_lupdf(y1| y2);
-    target += inv_gamma_lupdf(y1| y2, y2);
-    target += inv_wishart_lupdf(my1| y2, my2);
-    target += lkj_corr_cholesky_lupdf(my1| y2);
-    target += lkj_corr_lupdf(my1| y2);
-    target += logistic_lupdf(y1| y2, y2);
-    target += lognormal_lupdf(y1| y2, y2);
-    target += multi_gp_cholesky_lupdf(my1| my2, vy2);
-    target += multi_gp_lupdf(my1| my2, vy2);
-    target += multi_normal_cholesky_lupdf(vy1| vy2, my2);
-    target += multi_normal_lupdf(vy1| vy2, my2);
-    target += multi_normal_prec_lupdf(vy1| vy2, my2);
-    target += multi_student_t_lupdf(vy1| y2, vy2, my2);
-    target += normal_id_glm_lupdf(y1| my2, y2, vy2, vy2);
-    target += normal_lupdf(y1| y2, y2);
-    target += normal_lupdf(ay1| y2, y2);
-    target += pareto_lupdf(y1| y2, y2);
-    target += pareto_type_2_lupdf(y1| y2, y2, y2);
-    target += rayleigh_lupdf(y1| y2);
-    target += scaled_inv_chi_square_lupdf(y1| y2, y2);
-    target += skew_normal_lupdf(y1| y2, y2, y2);
-    target += std_normal_lupdf(y1| );
-    target += student_t_lupdf(y1| y2, y2, y2);
-    target += uniform_lupdf(y1| y2, y2);
-    target += von_mises_lupdf(y1| y2, y2);
-    target += weibull_lupdf(y1| y2, y2);
-    target += wiener_lupdf(y1| y2, y2, y2, y2);
-    target += wishart_lupdf(my1| y2, my2);
-  }
 }
 parameters {
   real y1;
@@ -5484,7 +5441,6 @@ model {
   r += wiener_lupdf(y1| y2, y2, y2, y2);
   r += wishart_lupdf(my1| y2, my2);
   r += foo_lupdf(y1| y2, vy1, vy2, my1, my2, ay1);
-  goo_lp(y1, y2, vy1, vy2, my1, my2, ay1);
 }
 
   $ ../../../../install/default/bin/stanc --auto-format unnormalized_math_fun_lpmf.stan
@@ -5514,30 +5470,6 @@ functions {
     r += poisson_log_lupmf(i1| r1);
     r += poisson_lupmf(i1| r1);
     return r;
-  }
-  void goo_lp(int i1, real r1, matrix m1, vector v1, array[] int ai1,
-              row_vector rv1) {
-    target += bernoulli_logit_glm_lupmf(i1| m1, r1, v1);
-    target += bernoulli_logit_lupmf(i1| r1);
-    target += bernoulli_lupmf(i1| r1);
-    target += beta_binomial_lupmf(i1| i1, r1, r1);
-    target += binomial_logit_lupmf(i1| i1, r1);
-    target += binomial_lupmf(i1| i1, r1);
-    target += categorical_logit_glm_lupmf(i1| rv1, v1, m1);
-    target += categorical_logit_lupmf(i1| v1);
-    target += categorical_lupmf(i1| v1);
-    target += hypergeometric_lupmf(i1| i1, i1, i1);
-    target += multinomial_lupmf(ai1| v1);
-    target += neg_binomial_2_log_glm_lupmf(i1| m1, r1, v1, r1);
-    target += neg_binomial_2_log_lupmf(i1| r1, r1);
-    target += neg_binomial_2_lupmf(i1| r1, r1);
-    target += neg_binomial_lupmf(i1| r1, r1);
-    target += ordered_logistic_glm_lupmf(i1| rv1, v1, v1);
-    target += ordered_logistic_lupmf(i1| r1, v1);
-    target += ordered_probit_lupmf(i1| r1, v1);
-    target += poisson_log_glm_lupmf(i1| m1, r1, v1);
-    target += poisson_log_lupmf(i1| r1);
-    target += poisson_lupmf(i1| r1);
   }
 }
 data {
@@ -5574,7 +5506,6 @@ model {
   r += poisson_log_lupmf(i1| r1);
   r += poisson_lupmf(i1| r1);
   r += foo_lupmf(i1| r1, m1, v1, ai1, rv1);
-  goo_lp(i1, r1, m1, v1, ai1, rv1);
 }
 
   $ ../../../../install/default/bin/stanc --auto-format unreserved-array-keyword.stan

--- a/test/integration/good/unnormalized_math_fun_lpdf.stan
+++ b/test/integration/good/unnormalized_math_fun_lpdf.stan
@@ -43,48 +43,6 @@ functions {
         r += wishart_lupdf(my1| y2, my2);
         return r;
     }
-    void goo_lp(real y1, real y2, vector vy1, vector vy2, matrix my1, matrix my2, real[] ay1) {
-        target += beta_lupdf(y1| y2, y2);
-        target += beta_proportion_lupdf(y1| y2, y2);
-        target += cauchy_lupdf(y1| y2, y2);
-        target += chi_square_lupdf(y1| y2);
-        target += dirichlet_lupdf(vy1| vy2);
-        target += double_exponential_lupdf(y1| y2, y2);
-        target += exp_mod_normal_lupdf(y1| y2, y2, y2);
-        target += exponential_lupdf(y1| y2);
-        target += frechet_lupdf(y1| y2, y2);
-        target += gamma_lupdf(y1| y2, y2);
-        target += gaussian_dlm_obs_lupdf(my1| my2, my2, vy2, my2, vy2, my2);
-        target += gumbel_lupdf(y1| y2, y2);
-        target += inv_chi_square_lupdf(y1| y2);
-        target += inv_gamma_lupdf(y1| y2, y2);
-        target += inv_wishart_lupdf(my1| y2, my2);
-        target += lkj_corr_cholesky_lupdf(my1| y2);
-        target += lkj_corr_lupdf(my1| y2);
-        target += logistic_lupdf(y1| y2, y2);
-        target += lognormal_lupdf(y1| y2, y2);
-        target += multi_gp_cholesky_lupdf(my1| my2, vy2);
-        target += multi_gp_lupdf(my1| my2, vy2);
-        target += multi_normal_cholesky_lupdf(vy1| vy2, my2);
-        target += multi_normal_lupdf(vy1| vy2, my2);
-        target += multi_normal_prec_lupdf(vy1| vy2, my2);
-        target += multi_student_t_lupdf(vy1| y2, vy2, my2);
-        target += normal_id_glm_lupdf(y1| my2, y2, vy2, vy2);
-        target += normal_lupdf(y1| y2, y2);
-        target += normal_lupdf(ay1| y2, y2);
-        target += pareto_lupdf(y1| y2, y2);
-        target += pareto_type_2_lupdf(y1| y2, y2, y2);
-        target += rayleigh_lupdf(y1| y2);
-        target += scaled_inv_chi_square_lupdf(y1| y2, y2);
-        target += skew_normal_lupdf(y1| y2, y2, y2);
-        target += std_normal_lupdf(y1|);
-        target += student_t_lupdf(y1| y2, y2, y2);
-        target += uniform_lupdf(y1| y2, y2);
-        target += von_mises_lupdf(y1| y2, y2);
-        target += weibull_lupdf(y1| y2, y2);
-        target += wiener_lupdf(y1| y2, y2, y2, y2);
-        target += wishart_lupdf(my1| y2, my2);
-    }
 }
 parameters {
     real y1;
@@ -138,5 +96,4 @@ model {
     r += wiener_lupdf(y1| y2, y2, y2, y2);
     r += wishart_lupdf(my1| y2, my2);
     r += foo_lupdf(y1| y2, vy1, vy2, my1, my2, ay1);
-    goo_lp(y1, y2, vy1, vy2, my1, my2, ay1);
 }

--- a/test/integration/good/unnormalized_math_fun_lpmf.stan
+++ b/test/integration/good/unnormalized_math_fun_lpmf.stan
@@ -24,29 +24,6 @@ functions {
         r += poisson_lupmf(i1| r1);
         return r;
     }
-    void goo_lp(int i1, real r1, matrix m1, vector v1, int[] ai1, row_vector rv1) {
-        target += bernoulli_logit_glm_lupmf(i1| m1, r1, v1);
-        target += bernoulli_logit_lupmf(i1| r1);
-        target += bernoulli_lupmf(i1| r1);
-        target += beta_binomial_lupmf(i1| i1, r1, r1);
-        target += binomial_logit_lupmf(i1| i1, r1);
-        target += binomial_lupmf(i1| i1, r1);
-        target += categorical_logit_glm_lupmf(i1| rv1, v1, m1);
-        target += categorical_logit_lupmf(i1| v1);
-        target += categorical_lupmf(i1| v1);
-        target += hypergeometric_lupmf(i1| i1, i1, i1);
-        target += multinomial_lupmf(ai1| v1);
-        target += neg_binomial_2_log_glm_lupmf(i1| m1, r1, v1, r1);
-        target += neg_binomial_2_log_lupmf(i1| r1, r1);
-        target += neg_binomial_2_lupmf(i1| r1, r1);
-        target += neg_binomial_lupmf(i1| r1, r1);
-        target += ordered_logistic_glm_lupmf(i1| rv1, v1, v1);
-        target += ordered_logistic_lupmf(i1| r1, v1);
-        target += ordered_probit_lupmf(i1| r1, v1);
-        target += poisson_log_glm_lupmf(i1| m1, r1, v1);
-        target += poisson_log_lupmf(i1| r1);
-        target += poisson_lupmf(i1| r1);
-    }
 }
 data {
     int i1;
@@ -82,5 +59,4 @@ model {
     r += poisson_log_lupmf(i1| r1);
     r += poisson_lupmf(i1| r1);
     r += foo_lupmf(i1| r1, m1, v1, ai1, rv1);
-    goo_lp(i1, r1, m1, v1, ai1, rv1);
 }


### PR DESCRIPTION
Prompted by issue #748 
One line change because `write_array()` method already had `lp_accum__` variable. The fact that it's not needed for anything other than `_lp` functions suggest that this may have been intented all along.

In any case, this is a backwards compatibility gotcha and [per discussion on the forum](https://discourse.mc-stan.org/t/accessing-target-in-transformed-parameters-stanc2-vs-stanc3/19432/3) something like this is needed.

## Release notes

Allow calling lp functions in transformed parameters block.

## Copyright and Licensing

Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
