### PR TITLE
Fix deprecation message for cov_exp_quad

### DIFF
--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -6,7 +6,7 @@ let deprecated_functions =
   String.Map.of_alist_exn
     [ ("multiply_log", "lmultiply")
     ; ("binomial_coefficient_log", "lchoose")
-    ; ("cov_exp_quad", "gp_cov_exp_quad") ]
+    ; ("cov_exp_quad", "gp_exp_quad_cov") ]
 
 let deprecated_odes =
   String.Map.of_alist_exn

--- a/test/integration/canonicalize/canonical.expected
+++ b/test/integration/canonicalize/canonical.expected
@@ -29,7 +29,7 @@ transformed data {
   real d = fabs(b);
   array[0] int x_i;
   array[0] real x_r;
-  matrix[N, N] K = gp_cov_exp_quad(x_quad, 1.0, 1.0);
+  matrix[N, N] K = gp_exp_quad_cov(x_quad, 1.0, 1.0);
 }
 parameters {
   real x;
@@ -77,7 +77,7 @@ Warning: in 'deprecated.stan', line 14, column 24 to column 42: multiply_log is 
 
 Warning: in 'deprecated.stan', line 27, column 11 to column 17: Use of the `abs` function with real-valued arguments is deprecated; use functions `fabs` instead.
 
-Warning: in 'deprecated.stan', line 30, column 19 to column 49: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'deprecated.stan', line 30, column 19 to column 49: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
 Warning: in 'deprecated.stan', line 37, column 11 to column 46: The function `if_else` is deprecated. Use the conditional operator (x ? y : z) instead.
 

--- a/test/integration/example-models/knitr/pest-control/stan_programs/pretty.expected
+++ b/test/integration/example-models/knitr/pest-control/stan_programs/pretty.expected
@@ -318,7 +318,7 @@ generated quantities {
 }
 
 
-Warning: in 'hier_NB_regression_ncp_slopes_mod_mos_gp.stan', line 54, column 21 to column 62: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'hier_NB_regression_ncp_slopes_mod_mos_gp.stan', line 54, column 21 to column 62: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../../install/default/bin/stanc --auto-format hier_NB_regression_ncp_slopes_mod_mos_predict.stan
 functions {
   int neg_binomial_2_log_safe_rng(real eta, real phi) {

--- a/test/integration/example-models/misc/gaussian-process/pretty.expected
+++ b/test/integration/example-models/misc/gaussian-process/pretty.expected
@@ -78,7 +78,7 @@ model {
 }
 
 
-Warning: in 'gp-fit-latent.stan', line 22, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-fit-latent.stan', line 22, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-fit-logit.stan
 data {
   int<lower=1> N;
@@ -112,7 +112,7 @@ model {
 }
 
 
-Warning: in 'gp-fit-logit.stan', line 22, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-fit-logit.stan', line 22, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-fit-multi-output.stan
 data {
   int<lower=1> N;
@@ -153,7 +153,7 @@ generated quantities {
 }
 
 
-Warning: in 'gp-fit-multi-output.stan', line 22, column 21 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-fit-multi-output.stan', line 22, column 21 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-fit-pois.stan
 data {
   int<lower=1> N;
@@ -187,7 +187,7 @@ model {
 }
 
 
-Warning: in 'gp-fit-pois.stan', line 22, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-fit-pois.stan', line 22, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-fit.stan
 data {
   int<lower=1> N;
@@ -216,7 +216,7 @@ model {
 }
 
 
-Warning: in 'gp-fit.stan', line 19, column 19 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-fit.stan', line 19, column 19 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-predict-analytic.stan
 functions {
   vector gp_pred_rng(array[] real x2, vector y1, array[] real x1, real alpha,
@@ -287,13 +287,13 @@ generated quantities {
 }
 
 
-Warning: in 'gp-predict-analytic.stan', line 24, column 12 to column 40: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-predict-analytic.stan', line 24, column 12 to column 40: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'gp-predict-analytic.stan', line 29, column 18 to column 50: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-predict-analytic.stan', line 29, column 18 to column 50: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'gp-predict-analytic.stan', line 32, column 17 to column 45: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-predict-analytic.stan', line 32, column 17 to column 45: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'gp-predict-analytic.stan', line 59, column 23 to column 51: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-predict-analytic.stan', line 59, column 23 to column 51: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-predict-logit.stan
 data {
   int<lower=1> N1;
@@ -342,7 +342,7 @@ generated quantities {
 }
 
 
-Warning: in 'gp-predict-logit.stan', line 29, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-predict-logit.stan', line 29, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-predict.stan
 data {
   int<lower=1> N1;
@@ -391,7 +391,7 @@ generated quantities {
 }
 
 
-Warning: in 'gp-predict.stan', line 29, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-predict.stan', line 29, column 21 to column 48: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-sim-cholesky.stan
 data {
   int<lower=1> N;
@@ -419,7 +419,7 @@ generated quantities {
 }
 
 
-Warning: in 'gp-sim-cholesky.stan', line 14, column 21 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-sim-cholesky.stan', line 14, column 21 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-sim-multi-output.stan
 data {
   int<lower=1> N;
@@ -457,7 +457,7 @@ generated quantities {
 }
 
 
-Warning: in 'gp-sim-multi-output.stan', line 23, column 21 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-sim-multi-output.stan', line 23, column 21 to column 46: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-sim-multi.stan
 data {
   int<lower=1> N;
@@ -478,7 +478,7 @@ model {
 }
 
 
-Warning: in 'gp-sim-multi.stan', line 11, column 19 to column 44: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-sim-multi.stan', line 11, column 19 to column 44: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../install/default/bin/stanc --auto-format gp-sim-naive.stan
 data {
   int<lower=1> N;
@@ -522,4 +522,4 @@ model {
 }
 
 
-Warning: in 'gp-sim.stan', line 10, column 19 to column 44: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp-sim.stan', line 10, column 19 to column 44: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.

--- a/test/integration/good/function-signatures/math/matrix/pretty.expected
+++ b/test/integration/good/function-signatures/math/matrix/pretty.expected
@@ -4296,133 +4296,133 @@ model {
 }
 
 
-Warning: in 'cov_exp_quad.stan', line 18, column 28 to column 65: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 18, column 28 to column 65: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 19, column 28 to column 74: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 19, column 28 to column 74: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 20, column 28 to column 65: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 20, column 28 to column 65: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 21, column 28 to column 74: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 21, column 28 to column 74: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 22, column 28 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 22, column 28 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 23, column 28 to column 76: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 23, column 28 to column 76: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 39, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 39, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 40, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 40, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 41, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 41, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 42, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 42, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 44, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 44, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 45, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 45, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 46, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 46, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 47, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 47, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 49, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 49, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 50, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 50, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 51, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 51, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 52, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 52, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 54, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 54, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 55, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 55, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 56, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 56, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 57, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 57, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 59, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 59, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 60, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 60, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 61, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 61, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 62, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 62, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 64, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 64, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 65, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 65, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 66, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 66, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 67, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 67, column 29 to column 66: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 69, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 69, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 70, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 70, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 71, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 71, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 72, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 72, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 74, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 74, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 75, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 75, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 76, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 76, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 77, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 77, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 79, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 79, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 80, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 80, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 81, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 81, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 83, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 83, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 84, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 84, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 85, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 85, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 86, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 86, column 29 to column 75: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 88, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 88, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 89, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 89, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 90, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 90, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 91, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 91, column 29 to column 67: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 93, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 93, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 94, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 94, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 95, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 95, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 96, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 96, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 98, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 98, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 99, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 99, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 100, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 100, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 101, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 101, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 103, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 103, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 104, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 104, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 105, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 105, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 107, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 107, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 108, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 108, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 109, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 109, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
 
-Warning: in 'cov_exp_quad.stan', line 110, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'cov_exp_quad.stan', line 110, column 29 to column 77: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../../../install/default/bin/stanc --auto-format crossprod.stan
 data {
   int d_int;

--- a/test/integration/good/stat_comp_benchmarks_models/pretty.expected
+++ b/test/integration/good/stat_comp_benchmarks_models/pretty.expected
@@ -123,7 +123,7 @@ generated quantities {
 }
 
 
-Warning: in 'gen_gp_data.stan', line 16, column 25 to column 52: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gen_gp_data.stan', line 16, column 25 to column 52: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../install/default/bin/stanc --auto-format gp_pois_regr.stan
 data {
   int<lower=1> N;
@@ -152,7 +152,7 @@ model {
 }
 
 
-Warning: in 'gp_pois_regr.stan', line 16, column 25 to column 52: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp_pois_regr.stan', line 16, column 25 to column 52: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../install/default/bin/stanc --auto-format gp_regr.stan
 data {
   int<lower=1> N;
@@ -175,7 +175,7 @@ model {
 }
 
 
-Warning: in 'gp_regr.stan', line 14, column 23 to column 50: cov_exp_quad is deprecated and will be removed in the future. Use gp_cov_exp_quad instead.
+Warning: in 'gp_regr.stan', line 14, column 23 to column 50: cov_exp_quad is deprecated and will be removed in the future. Use gp_exp_quad_cov instead.
   $ ../../../../../install/default/bin/stanc --auto-format irt_2pl.stan
 data {
   int<lower=0> I;


### PR DESCRIPTION
Minor fix: deprecation warning for cov_exp_quad suggestes using gp_cov_exp_quad. It should suggest gp_exp_quad_cov. The former one does not exist.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
