### PR TITLE
Fix map_rect arg check

### DIFF
--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -78,6 +78,7 @@ let check_of_same_type_mod_conv name t1 t2 =
     | UReal, UInt -> true
     | UFun (l1, rt1), UFun (l2, rt2) ->
         rt1 = rt2
+        && List.length l1 = List.length l2
         && List.for_all
              ~f:(fun x -> x = true)
              (List.map2_exn

--- a/test/integration/bad/map_rect/bad_not_enough_args.stan
+++ b/test/integration/bad/map_rect/bad_not_enough_args.stan
@@ -1,0 +1,14 @@
+functions {
+  vector foo(vector shared_params, vector job_params,
+             real[] data_r) {
+    return [1, 2, 3]';
+  }
+}
+transformed data {
+  vector[3] shared_params_d;
+  vector[3] job_params_d[3];
+  real data_r[3, 3];
+  int data_i[3, 3];
+  vector[3] y_hat_tp1
+      = map_rect(foo, shared_params_d, job_params_d, data_r, data_i);
+}

--- a/test/integration/bad/map_rect/stanc.expected
+++ b/test/integration/bad/map_rect/stanc.expected
@@ -102,6 +102,21 @@ Semantic error in 'bad_lp_fn.stan', line 22, column 16 to column 52:
 
 Mapped function cannot be an _rng or _lp function, found function name: lr_lp
 
+  $ ../../../../../install/default/bin/stanc bad_not_enough_args.stan
+
+Semantic error in 'bad_not_enough_args.stan', line 13, column 8 to column 68:
+   -------------------------------------------------
+    11:    int data_i[3, 3];
+    12:    vector[3] y_hat_tp1
+    13:        = map_rect(foo, shared_params_d, job_params_d, data_r, data_i);
+                 ^
+    14:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to function 'map_rect'. Available signatures: 
+((vector, vector, data real[], data int[]) => vector, vector, vector[], data real[,], data int[,]) => vector
+Instead supplied arguments of incompatible type: (vector, vector, real[]) => vector, vector, vector[], real[,], int[,].
+
   $ ../../../../../install/default/bin/stanc bad_rng_fn.stan
 
 Semantic error in 'bad_rng_fn.stan', line 22, column 19 to column 56:


### PR DESCRIPTION
Fixes #804

## Release notes

Fixed a bug with arguments check for `map_rect`.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
