### PR TITLE
Fix _lp functions in transformed params

### DIFF
--- a/src/frontend/Semantic_check.ml
+++ b/src/frontend/Semantic_check.ml
@@ -947,7 +947,9 @@ let semantic_check_nrfn_target ~loc ~cf id =
   Validate.(
     if
       String.is_suffix id.name ~suffix:"_lp"
-      && not (cf.in_lp_fun_def || cf.current_block = Model)
+      && not
+           ( cf.in_lp_fun_def || cf.current_block = Model
+           || cf.current_block = TParam )
     then Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
     else ok ())
 

--- a/test/integration/good/lp_transformed_param.stan
+++ b/test/integration/good/lp_transformed_param.stan
@@ -3,12 +3,16 @@ functions {
     target += normal_lpdf(r | 0, 1);
     return r;
   }
+  void nr_test_lp(real r) {
+    target += normal_lpdf(r | 0, 1);
+  }
 }
 parameters { 
   real y; 
 }
 transformed parameters { 
   real alpha = test_lp(5.0);
+  nr_test_lp(5.0);
 }
 model {
   y ~ normal(0, 1); 

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -3772,12 +3772,16 @@ functions {
     target += normal_lpdf(r| 0, 1);
     return r;
   }
+  void nr_test_lp(real r) {
+    target += normal_lpdf(r| 0, 1);
+  }
 }
 parameters {
   real y;
 }
 transformed parameters {
   real alpha = test_lp(5.0);
+  nr_test_lp(5.0);
 }
 model {
   y ~ normal(0, 1);


### PR DESCRIPTION
Fix #815 

## Release notes

Allow user-defined _lp functions in transformed parameters block.

## Copyright and Licensing

Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
