### PR TITLE
Change agents for Jenkins-test-binaries

### DIFF
--- a/Jenkinsfile-test-binaries
+++ b/Jenkinsfile-test-binaries
@@ -45,7 +45,7 @@ def checkoutRepository(os_type) {
 pipeline {
     agent none
     parameters {
-        string(defaultValue: 'master', name: 'git_branch',
+        string(defaultValue: 'PR-829', name: 'git_branch',
                description: "Please specify a git branch ( develop ), git hash ( aace72b6ccecbb750431c46f418879b325416c7d ), pull request ( PR-123 ), pull request from fork ( PR-123 )")
     }
     environment {
@@ -58,6 +58,7 @@ pipeline {
                 dockerfile {
                     filename 'docker/debian/Dockerfile'
                     args "-u root --entrypoint=\'\'"
+                    label 'linux-ec2'
                 }
             }
             steps {
@@ -111,6 +112,7 @@ pipeline {
                             filename 'docker/debian/Dockerfile'
                             //Forces image to ignore entrypoint
                             args "-u root --entrypoint=\'\'"
+                            label 'linux-ec2'
                         }
                     }
                     steps {
@@ -136,6 +138,7 @@ pipeline {
                             filename 'docker/static/Dockerfile'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\'"
+                            label 'linux-ec2'
                         }
                     }
                     steps {

--- a/Jenkinsfile-test-binaries
+++ b/Jenkinsfile-test-binaries
@@ -45,7 +45,7 @@ def checkoutRepository(os_type) {
 pipeline {
     agent none
     parameters {
-        string(defaultValue: 'PR-829', name: 'git_branch',
+        string(defaultValue: 'master', name: 'git_branch',
                description: "Please specify a git branch ( develop ), git hash ( aace72b6ccecbb750431c46f418879b325416c7d ), pull request ( PR-123 ), pull request from fork ( PR-123 )")
     }
     environment {


### PR DESCRIPTION
Moved part of the jobs to 'linux-ec2' label to avoid erroring out on gelman-linux because of not being able to remove a path.


## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
