### PR TITLE
Building ARM binaries in the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -281,7 +281,6 @@ pipeline {
 
                             opam update; opam install -y js_of_ocaml-compiler.3.4.0 js_of_ocaml-ppx.3.4.0 js_of_ocaml.3.4.0
                             opam update; bash -x scripts/install_build_deps.sh
-                            opam update; bash -x scripts/install_dev_deps.sh
                             opam update; bash -x scripts/install_js_deps.sh
                         """)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -289,12 +289,12 @@ pipeline {
                             dune subst
                             dune build @install --profile static
                         """)
-
+                        /*
                         echo runShell("""
                             eval \$(opam env)
                             time dune runtest --profile static --verbose
                         """)
-
+                        */
                         sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/linux-arm-stanc"
                         sh "mv _build/default/src/stan2tfp/stan2tfp.exe bin/linux-arm-stan2tfp"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,7 +278,7 @@ pipeline {
 
                         runShell("""
                             # Install and initialize ocaml
-                            bash -x install_ocaml.sh "--disable-sandboxing -y"
+                            bash -x scripts/install_ocaml.sh "--disable-sandboxing -y"
                             opam update; bash -x scripts/install_build_deps.sh
 
                             # Install build dependencies

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,14 +277,12 @@ pipeline {
                     steps {
 
                         runShell("""
-                            # Install and initialize ocaml
                             bash -x scripts/install_ocaml.sh "--disable-sandboxing -y"
+                            
                             opam update; bash -x scripts/install_build_deps.sh
 
-                            # Install build dependencies
                             opam update; bash -x scripts/install_dev_deps.sh
 
-                            # Install dev dependencies
                             opam update; opam install -y js_of_ocaml-compiler.3.4.0 js_of_ocaml-ppx.3.4.0 js_of_ocaml.3.4.0
 
                             opam update; bash -x scripts/install_js_deps.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,10 +275,6 @@ pipeline {
                 stage("Build & test a static Linux ARM binary") {
                     agent { label "arm-ec2" }
                     steps {
-                        script {
-                            checkoutRepository("sh")
-                        }
-
                         runShell("""
                             eval \$(opam env)
                             opam update || true
@@ -292,10 +288,10 @@ pipeline {
                             time dune runtest --verbose
                         """)
 
-                        sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/arm-stanc"
-                        sh "mv _build/default/src/stan2tfp/stan2tfp.exe bin/arm-stan2tfp"
+                        sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/linux-arm-stanc"
+                        sh "mv _build/default/src/stan2tfp/stan2tfp.exe bin/linux-arm-stan2tfp"
 
-                        stash name:'arm-exe', includes:'bin/*'
+                        stash name:'linux-arm-exe', includes:'bin/*'
                     }
                     post { always { runShell("rm -rf ./*") }}
                 }
@@ -341,7 +337,7 @@ pipeline {
                 unstash 'windows-exe'
                 unstash 'linux-exe'
                 unstash 'mac-exe'
-                unstash 'arm-exe'
+                unstash 'linux-arm-exe'
                 unstash 'js-exe'
                 runShell("""
                     wget https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,13 +278,10 @@ pipeline {
 
                         runShell("""
                             bash -x scripts/install_ocaml.sh "--disable-sandboxing -y"
-                            
-                            opam update; bash -x scripts/install_build_deps.sh
-
-                            opam update; bash -x scripts/install_dev_deps.sh
 
                             opam update; opam install -y js_of_ocaml-compiler.3.4.0 js_of_ocaml-ppx.3.4.0 js_of_ocaml.3.4.0
-
+                            opam update; bash -x scripts/install_build_deps.sh
+                            opam update; bash -x scripts/install_dev_deps.sh
                             opam update; bash -x scripts/install_js_deps.sh
                         """)
 


### PR DESCRIPTION
## Release notes

Added build stage for ARM in Jenkinsfile.  
I have added a new EC2 Fleet for ARM with 0 instances so it will spin up only when we need it, this way we can now easily build ARM for other projects too.  

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
