### PR TITLE
Make locations_array constexpr and move curr_statement__ to function scope

### DIFF
--- a/src/stan_math_backend/Locations.ml
+++ b/src/stan_math_backend/Locations.ml
@@ -40,9 +40,9 @@ let pp_globals ppf location_list =
   in
   let location_count = List.length location_list in
   Fmt.pf ppf
-    "@ stan::math::profile_map profiles__;@ \
-     static constexpr std::array<const char*, @[<hov>%d@]> locations_array__ = @ \
-     {@[<hov>%a@]};@ " location_count
+    "@ stan::math::profile_map profiles__;@ static constexpr std::array<const \
+     char*, @[<hov>%d@]> locations_array__ = @ {@[<hov>%a@]};@ "
+    location_count
     Fmt.(list ~sep:comma (fmt "%S"))
     location_list
 

--- a/src/stan_math_backend/Locations.ml
+++ b/src/stan_math_backend/Locations.ml
@@ -38,10 +38,11 @@ let pp_globals ppf location_list =
     :: ( List.filter ~f:(fun x -> x <> Location_span.empty) location_list
        |> List.map ~f:(fun x -> " (in " ^ Location_span.to_string x ^ ")") )
   in
+  let location_count = List.length location_list in
   Fmt.pf ppf
-    "@ stan::math::profile_map profiles__;@ static int current_statement__= \
-     0;@ static const std::vector<std::string> locations_array__ = @ \
-     {@[<hov>%a@]};@ "
+    "@ stan::math::profile_map profiles__;@ \
+     static constexpr std::array<const char*, @[<hov>%d@]> locations_array__ = @ \
+     {@[<hov>%a@]};@ " location_count
     Fmt.(list ~sep:comma (fmt "%S"))
     location_list
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -496,10 +496,10 @@ let pp_method_b ppf rt name params intro ?(outro = nop) ?(cv_attr = ["const"])
 let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
   pf ppf
     "template <typename RNG, typename VecR, typename VecI, typename VecVar, @ \
-     \x20 stan::require_vector_like_vt<std::is_floating_point, VecR>* = \
-     nullptr, @ \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = \
-     nullptr, @ \x20 stan::require_std_vector_vt<std::is_floating_point, \
-     VecVar>* = nullptr> @ " ;
+     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, @ \
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, @ \
+     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> \
+     @ " ;
   let params =
     [ "RNG& base_rng__"; "VecR& params_r__"; "VecI& params_i__"
     ; "VecVar& vars__"; "const bool emit_transformed_parameters__ = true"
@@ -641,8 +641,8 @@ let pp_unconstrained_param_names ppf {Program.output_vars; _} =
 (** Print the `transform_inits` method of the model class *)
 let pp_transform_inits ppf {Program.transform_inits; _} =
   pf ppf
-    "template <typename VecVar, typename VecI, @ \x20 \
-     stan::require_std_vector_t<VecVar>* = nullptr, @ \x20 \
+    "template <typename VecVar, typename VecI, @ \
+     stan::require_std_vector_t<VecVar>* = nullptr, @ \
      stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
   let params =
     [ "const stan::io::var_context& context__"; "VecI& params_i__"
@@ -662,7 +662,7 @@ let pp_transform_inits ppf {Program.transform_inits; _} =
 let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   pf ppf
     "template <bool propto__, bool jacobian__ , typename VecR, typename VecI, \
-     @ \x20 stan::require_vector_like_t<VecR>* = nullptr, @ \x20 \
+     @ stan::require_vector_like_t<VecR>* = nullptr, @ \
      stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
   let params =
     [ "VecR& params_r__"; "VecI& params_i__"

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -217,6 +217,7 @@ let pp_fun_def ppf Program.({fdrt; fdname; fdargs; fdbody; _})
   in
   let pp_body ppf (Stmt.Fixed.({pattern; _}) as fdbody) =
     pf ppf "@[<hv 8>using local_scalar_t__ = %a;@]@," pp_promoted_scalar fdargs ;
+    pf ppf "int current_statement__ = 0; @ " ;
     if List.exists ~f:(fun (_, _, t) -> UnsizedType.is_eigen_type t) fdargs
     then pp_eigen_arg_to_ref ppf fdargs ;
     if not (is_dist || is_lp) then (
@@ -397,7 +398,7 @@ let pp_ctor ppf p =
   in
   pp_block ppf
     ( (fun ppf {Program.prog_name; prepare_data; output_vars; _} ->
-        pf ppf "int current_statement__ = 0;@ ";
+        pf ppf "int current_statement__ = 0;@ " ;
         pf ppf "using local_scalar_t__ = double ;@ " ;
         pf ppf "boost::ecuyer1988 base_rng__ = @ " ;
         pf ppf "    stan::services::util::create_rng(random_seed__, 0);@ " ;
@@ -495,9 +496,10 @@ let pp_method_b ppf rt name params intro ?(outro = nop) ?(cv_attr = ["const"])
 let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
   pf ppf
     "template <typename RNG, typename VecR, typename VecI, typename VecVar, @ \
-     \x20 stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, @ \
-     \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, @ \
-     \x20 stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> @ " ;
+     \x20 stan::require_vector_like_vt<std::is_floating_point, VecR>* = \
+     nullptr, @ \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = \
+     nullptr, @ \x20 stan::require_std_vector_vt<std::is_floating_point, \
+     VecVar>* = nullptr> @ " ;
   let params =
     [ "RNG& base_rng__"; "VecR& params_r__"; "VecI& params_i__"
     ; "VecVar& vars__"; "const bool emit_transformed_parameters__ = true"
@@ -639,9 +641,9 @@ let pp_unconstrained_param_names ppf {Program.output_vars; _} =
 (** Print the `transform_inits` method of the model class *)
 let pp_transform_inits ppf {Program.transform_inits; _} =
   pf ppf
-    "template <typename VecVar, typename VecI, @ \
-     \x20 stan::require_std_vector_t<VecVar>* = nullptr, @ \
-     \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
+    "template <typename VecVar, typename VecI, @ \x20 \
+     stan::require_std_vector_t<VecVar>* = nullptr, @ \x20 \
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
   let params =
     [ "const stan::io::var_context& context__"; "VecI& params_i__"
     ; "VecVar& vars__"; "std::ostream* pstream__ = nullptr" ]
@@ -649,8 +651,8 @@ let pp_transform_inits ppf {Program.transform_inits; _} =
   let intro ppf () =
     pf ppf
       "using local_scalar_t__ = \
-       double;@,vars__.clear();@,vars__.reserve(num_params_r__);@ \
-       int current_statement__ = 0; "
+       double;@,vars__.clear();@,vars__.reserve(num_params_r__);@ int \
+       current_statement__ = 0; "
   in
   let cv_attr = ["const"] in
   pp_method_b ppf "void" "transform_inits_impl" params intro transform_inits
@@ -659,9 +661,9 @@ let pp_transform_inits ppf {Program.transform_inits; _} =
 (** Print the `log_prob` method of the model class *)
 let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   pf ppf
-    "template <bool propto__, bool jacobian__ , typename VecR, typename VecI, @ \
-     \x20 stan::require_vector_like_t<VecR>* = nullptr, @ \
-     \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
+    "template <bool propto__, bool jacobian__ , typename VecR, typename VecI, \
+     @ \x20 stan::require_vector_like_t<VecR>* = nullptr, @ \x20 \
+     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
   let params =
     [ "VecR& params_r__"; "VecI& params_i__"
     ; "std::ostream* pstream__ = nullptr" ]

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -44,7 +44,7 @@ let pp_unused = fmt "(void) %s;  // suppress unused var warning"
   @param fname Name of the function.
  *)
 let pp_function__ ppf (prog_name, fname) =
-  pf ppf {|@[<v>static const char* function__ = "%s_namespace::%s";@,%a@]|}
+  pf ppf {|@[<v>static constexpr char* function__ = "%s_namespace::%s";@,%a@]|}
     prog_name fname pp_unused "function__"
 
 (** Print the body of exception handling for functions *)
@@ -220,7 +220,7 @@ let pp_fun_def ppf Program.({fdrt; fdname; fdargs; fdbody; _})
     if List.exists ~f:(fun (_, _, t) -> UnsizedType.is_eigen_type t) fdargs
     then pp_eigen_arg_to_ref ppf fdargs ;
     if not (is_dist || is_lp) then (
-      pf ppf "%s@ " "const static bool propto__ = true;" ;
+      pf ppf "%s@ " "static constexpr bool propto__ = true;" ;
       pf ppf "%s@ " "(void) propto__;" ) ;
     pf ppf "%s@ "
       "local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());" ;
@@ -397,6 +397,7 @@ let pp_ctor ppf p =
   in
   pp_block ppf
     ( (fun ppf {Program.prog_name; prepare_data; output_vars; _} ->
+        pf ppf "int current_statement__ = 0;@ ";
         pf ppf "using local_scalar_t__ = double ;@ " ;
         pf ppf "boost::ecuyer1988 base_rng__ = @ " ;
         pf ppf "    stan::services::util::create_rng(random_seed__, 0);@ " ;
@@ -493,10 +494,10 @@ let pp_method_b ppf rt name params intro ?(outro = nop) ?(cv_attr = ["const"])
 (** Print the write_array method of the model class *)
 let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
   pf ppf
-    "template <typename RNG, typename VecR, typename VecI, typename VecVar, \
-     stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, \
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, \
-     stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>" ;
+    "template <typename RNG, typename VecR, typename VecI, typename VecVar, @ \
+     \x20 stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, @ \
+     \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, @ \
+     \x20 stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> @ " ;
   let params =
     [ "RNG& base_rng__"; "VecR& params_r__"; "VecI& params_i__"
     ; "VecVar& vars__"; "const bool emit_transformed_parameters__ = true"
@@ -509,6 +510,7 @@ let pp_write_array ppf {Program.prog_name; generate_quantities; _} =
       ; "stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);"
       ; "double lp__ = 0.0;"
       ; "(void) lp__;  // dummy to suppress unused var warning"
+      ; "int current_statement__ = 0; "
       ; "stan::math::accumulator<double> lp_accum__;"
       ; "local_scalar_t__ \
          DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());" ]
@@ -637,9 +639,9 @@ let pp_unconstrained_param_names ppf {Program.output_vars; _} =
 (** Print the `transform_inits` method of the model class *)
 let pp_transform_inits ppf {Program.transform_inits; _} =
   pf ppf
-    "template <typename VecVar, typename VecI, \
-     stan::require_std_vector_t<VecVar>* = nullptr, \
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>" ;
+    "template <typename VecVar, typename VecI, @ \
+     \x20 stan::require_std_vector_t<VecVar>* = nullptr, @ \
+     \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
   let params =
     [ "const stan::io::var_context& context__"; "VecI& params_i__"
     ; "VecVar& vars__"; "std::ostream* pstream__ = nullptr" ]
@@ -647,7 +649,8 @@ let pp_transform_inits ppf {Program.transform_inits; _} =
   let intro ppf () =
     pf ppf
       "using local_scalar_t__ = \
-       double;@,vars__.clear();@,vars__.reserve(num_params_r__);"
+       double;@,vars__.clear();@,vars__.reserve(num_params_r__);@ \
+       int current_statement__ = 0; "
   in
   let cv_attr = ["const"] in
   pp_method_b ppf "void" "transform_inits_impl" params intro transform_inits
@@ -656,9 +659,9 @@ let pp_transform_inits ppf {Program.transform_inits; _} =
 (** Print the `log_prob` method of the model class *)
 let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
   pf ppf
-    "template <bool propto__, bool jacobian__, typename VecR, typename VecI, \
-     stan::require_vector_like_t<VecR>* = nullptr, \
-     stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>" ;
+    "template <bool propto__, bool jacobian__ , typename VecR, typename VecI, @ \
+     \x20 stan::require_vector_like_t<VecR>* = nullptr, @ \
+     \x20 stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> @ " ;
   let params =
     [ "VecR& params_r__"; "VecI& params_i__"
     ; "std::ostream* pstream__ = nullptr" ]
@@ -669,6 +672,7 @@ let pp_log_prob ppf Program.({prog_name; log_prob; _}) =
       ; "using local_scalar_t__ = T__;"; "T__ lp__(0.0);"
       ; "stan::math::accumulator<T__> lp_accum__;"
       ; "stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);"
+      ; "int current_statement__ = 0;"
       ; "local_scalar_t__ \
          DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());" ]
       pp_unused "DUMMY_VAR__" pp_function__ (prog_name, "log_prob")

--- a/test/integration/cli-args/filename_good.expected
+++ b/test/integration/cli-args/filename_good.expected
@@ -83,8 +83,8 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -111,9 +111,9 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -147,8 +147,8 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/cli-args/filename_good.expected
+++ b/test/integration/cli-args/filename_good.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 3> locations_array__ = 
 {" (found before start of program)",
  " (in 'filename_good.stan', line 2, column 4 to column 11)",
  " (in 'filename_good.stan', line 3, column 4 to column 19)"};
@@ -46,11 +45,12 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
   filename_good_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
                       std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "filename_good_model_namespace::filename_good_model";
+    static constexpr char* function__ = "filename_good_model_namespace::filename_good_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -82,7 +82,9 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -91,9 +93,10 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "filename_good_model_namespace::log_prob";
+    static constexpr char* function__ = "filename_good_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -107,7 +110,10 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -118,10 +124,11 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "filename_good_model_namespace::write_array";
+    static constexpr char* function__ = "filename_good_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -139,13 +146,16 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -557,8 +557,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1274,9 +1274,9 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1387,8 +1387,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 217> locations_array__ = 
 {" (found before start of program)",
  " (in 'optimize_glm.stan', line 27, column 2 to column 20)",
  " (in 'optimize_glm.stan', line 28, column 2 to column 17)",
@@ -283,11 +282,12 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   optimize_glm_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,
                      std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
+    static constexpr char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -556,7 +556,9 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -565,9 +567,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "optimize_glm_model_namespace::log_prob";
+    static constexpr char* function__ = "optimize_glm_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1270,7 +1273,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1281,10 +1287,11 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "optimize_glm_model_namespace::write_array";
+    static constexpr char* function__ = "optimize_glm_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1379,13 +1386,16 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -2596,6 +2596,7 @@ foo(const int& n, std::ostream* pstream__) ;
 int
 foo(const int& n, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2638,6 +2639,7 @@ sho(const T0__& t, const std::vector<T1__>& y,
     const std::vector<T2__>& theta, const std::vector<double>& x,
     const std::vector<int>& x_int, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2678,6 +2680,7 @@ return sho(t, y, theta, x, x_int, pstream__);
 double
 foo_bar0(std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2705,6 +2708,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 foo_bar1(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2734,6 +2738,7 @@ stan::promote_args_t<T0__,
 T1__>
 foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2763,6 +2768,7 @@ template <bool propto__, typename T1__>
 stan::promote_args_t<T1__>
 foo_lpmf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T1__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -2789,6 +2795,7 @@ template <typename T1__>
 stan::promote_args_t<T1__>
 foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T1__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2817,6 +2824,7 @@ template <typename T1__>
 stan::promote_args_t<T1__>
 foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T1__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2847,6 +2855,7 @@ T1__>
 foo_rng(const T0__& mu, const T1__& sigma, RNG& base_rng__,
         std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2879,6 +2888,7 @@ void
 unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -2908,6 +2918,7 @@ return unit_normal_lp<propto__>(u, lp__, lp_accum__, pstream__);
 int
 foo_1(const int& a, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3154,6 +3165,7 @@ return foo_1(a, pstream__);
 int
 foo_2(const int& a, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3196,6 +3208,7 @@ template <typename T0__>
 std::vector<stan::promote_args_t<T0__>>
 foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3226,6 +3239,7 @@ stan::promote_args_t<T0__>
 foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
        std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -3254,6 +3268,7 @@ template <typename T0__>
 void
 foo_4(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3287,6 +3302,7 @@ T3__>
 relative_diff(const T0__& x, const T1__& y, const T2__& max_,
               const T3__& min_, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3355,6 +3371,7 @@ foo_5(const T0__& shared_params_arg__, const T1__& job_params_arg__,
       std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>>;
+  int current_statement__ = 0; 
   const auto& shared_params = to_ref(shared_params_arg__);
   const auto& job_params = to_ref(job_params_arg__);
   static constexpr bool propto__ = true;
@@ -3395,6 +3412,7 @@ foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
           T2__,
           T3__,
           T4__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3436,6 +3454,7 @@ foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
           T2__,
           T3__,
           T4__, stan::promote_args_t<T5__>>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -3469,6 +3488,7 @@ Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 covsqrt2corsqrt(const T0__& mat_arg__, const int& invert,
                 std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+  int current_statement__ = 0; 
   const auto& mat = to_ref(mat_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -3534,6 +3554,7 @@ f0(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -3593,6 +3614,7 @@ f1(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -3649,6 +3671,7 @@ f2(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -3705,6 +3728,7 @@ f3(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -3763,6 +3787,7 @@ f4(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -3823,6 +3848,7 @@ f5(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -3883,6 +3909,7 @@ f6(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -3943,6 +3970,7 @@ f7(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -4003,6 +4031,7 @@ f8(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -4063,6 +4092,7 @@ f9(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -4123,6 +4153,7 @@ f10(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -4183,6 +4214,7 @@ f11(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -4243,6 +4275,7 @@ f12(const int& a1, const std::vector<int>& a2,
           stan::value_type_t<T9__>,
           T10__,
           T11__>>;
+  int current_statement__ = 0; 
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
   static constexpr bool propto__ = true;
@@ -4284,6 +4317,7 @@ return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 void
 foo_6(std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -4327,6 +4361,7 @@ return foo_6(pstream__);
 Eigen::Matrix<double, -1, -1>
 matfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -4357,6 +4392,7 @@ return matfoo(pstream__);
 Eigen::Matrix<double, -1, 1>
 vecfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -4385,6 +4421,7 @@ template <typename T0__>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmufoo(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -4420,6 +4457,7 @@ template <typename T0__>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmubar(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -4463,6 +4501,7 @@ algebra_system(const T0__& x_arg__, const T1__& y_arg__,
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>,
           T2__>;
+  int current_statement__ = 0; 
   const auto& x = to_ref(x_arg__);
   const auto& y = to_ref(y_arg__);
   static constexpr bool propto__ = true;
@@ -4509,6 +4548,7 @@ binomialf(const T0__& phi_arg__, const T1__& theta_arg__,
           std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>>;
+  int current_statement__ = 0; 
   const auto& phi = to_ref(phi_arg__);
   const auto& theta = to_ref(theta_arg__);
   static constexpr bool propto__ = true;
@@ -11371,6 +11411,7 @@ sho(const T0__& t, const std::vector<T1__>& y,
     const std::vector<T2__>& theta, const std::vector<T3__>& x,
     const std::vector<int>& x_int, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -11415,6 +11456,7 @@ integrand(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
           const std::vector<T3__>& x_r, const std::vector<int>& x_i,
           std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -11451,6 +11493,7 @@ foo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>,
           T2__>;
+  int current_statement__ = 0; 
   const auto& shared_params = to_ref(shared_params_arg__);
   const auto& job_params = to_ref(job_params_arg__);
   static constexpr bool propto__ = true;
@@ -11489,6 +11532,7 @@ goo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>,
           T2__>;
+  int current_statement__ = 0; 
   const auto& shared_params = to_ref(shared_params_arg__);
   const auto& job_params = to_ref(job_params_arg__);
   static constexpr bool propto__ = true;
@@ -11522,6 +11566,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 map_rectfake(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -11555,6 +11600,7 @@ algebra_system(const T0__& x_arg__, const T1__& y_arg__,
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>,
           T2__>;
+  int current_statement__ = 0; 
   const auto& x = to_ref(x_arg__);
   const auto& y = to_ref(y_arg__);
   static constexpr bool propto__ = true;
@@ -13913,6 +13959,7 @@ f(const T0__& t, const T1__& z_arg__, const T2__& a, const T3__& b_arg__,
           stan::value_type_t<T1__>,
           T2__,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& z = to_ref(z_arg__);
   const auto& b = to_ref(b_arg__);
   static constexpr bool propto__ = true;
@@ -17757,6 +17804,7 @@ dz_dt(const T0__& t, const std::vector<T1__>& z,
       const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
       const std::vector<int>& x_i, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -20816,6 +20864,7 @@ stan::promote_args_t<T0__>
 g(const std::vector<T0__>& y_slice, const int& start, const int& end,
   std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -20864,6 +20913,7 @@ T3__>
 h(const std::vector<T0__>& y_slice, const int& start, const int& end,
   const std::vector<T3__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -20917,6 +20967,7 @@ stan::promote_args_t<T0__>
 foo_lpdf(const std::vector<T0__>& y_slice, const int& start, const int& end,
          std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -21583,6 +21634,7 @@ stan::promote_args_t<T0__>
 g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21624,6 +21676,7 @@ stan::promote_args_t<T0__>
 g2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21674,6 +21727,7 @@ stan::promote_args_t<T0__>
 g3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21724,6 +21778,7 @@ stan::promote_args_t<T0__>
 g4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21775,6 +21830,7 @@ stan::promote_args_t<T0__>
 g5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21828,6 +21884,7 @@ stan::promote_args_t<T0__>
 g6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21882,6 +21939,7 @@ stan::promote_args_t<T0__>
 g7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21936,6 +21994,7 @@ stan::promote_args_t<T0__>
 g8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21991,6 +22050,7 @@ T3__>
 h1(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<T3__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22038,6 +22098,7 @@ T3__>
 h2(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, 1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22093,6 +22154,7 @@ T3__>
 h3(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, 1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22148,6 +22210,7 @@ T3__>
 h4(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22204,6 +22267,7 @@ T3__>
 h5(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22261,6 +22325,7 @@ h6(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22321,6 +22386,7 @@ h7(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22381,6 +22447,7 @@ h8(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24455,6 +24522,7 @@ stan::promote_args_t<T0__>
 f1(const std::vector<T0__>& y_slice, const int& start, const int& end,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24496,6 +24564,7 @@ stan::promote_args_t<T0__>
 f1a(const std::vector<T0__>& y_slice, const int& start, const int& end,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24537,6 +24606,7 @@ stan::promote_args_t<T0__>
 f2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24578,6 +24648,7 @@ stan::promote_args_t<T0__>
 f3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24619,6 +24690,7 @@ stan::promote_args_t<T0__>
 f4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24660,6 +24732,7 @@ stan::promote_args_t<T0__>
 f5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24701,6 +24774,7 @@ stan::promote_args_t<T0__>
 f6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24742,6 +24816,7 @@ stan::promote_args_t<T0__>
 f7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24783,6 +24858,7 @@ stan::promote_args_t<T0__>
 f8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24823,6 +24899,7 @@ double
 f9(const std::vector<int>& y_slice, const int& start, const int& end,
    std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24861,6 +24938,7 @@ double
 f10(const std::vector<std::vector<int>>& y_slice, const int& start,
     const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24899,6 +24977,7 @@ double
 f11(const std::vector<std::vector<std::vector<int>>>& y_slice,
     const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24938,6 +25017,7 @@ stan::promote_args_t<T0__>
 f12(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
     const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -24980,6 +25060,7 @@ T3__>
 g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const T3__& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25025,6 +25106,7 @@ g2(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const T3__& a_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& a = to_ref(a_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -25071,6 +25153,7 @@ g3(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const T3__& a_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& a = to_ref(a_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -25117,6 +25200,7 @@ g4(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const T3__& a_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& a = to_ref(a_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -25162,6 +25246,7 @@ T3__>
 g5(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<T3__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25208,6 +25293,7 @@ T3__>
 g6(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, 1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25254,6 +25340,7 @@ T3__>
 g7(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, 1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25300,6 +25387,7 @@ T3__>
 g8(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25346,6 +25434,7 @@ T3__>
 g9(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25393,6 +25482,7 @@ g10(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25441,6 +25531,7 @@ g11(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25489,6 +25580,7 @@ g12(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -25565,6 +25657,7 @@ s(const std::vector<T0__>& y_slice, const int& start, const int& end,
           T16__,
           T17__,
           T19__>>>;
+  int current_statement__ = 0; 
   const auto& c = to_ref(c_arg__);
   const auto& d = to_ref(d_arg__);
   const auto& e = to_ref(e_arg__);
@@ -25649,6 +25742,7 @@ return s(y_slice, start + 1, end + 1, a, b, c, d, e, f, g, h, i, j, k, l, m,
 double
 r(std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -28328,6 +28422,7 @@ template <bool propto__>
 double
 foo0_log(const int& y, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -28354,6 +28449,7 @@ template <bool propto__>
 double
 foo1_lpmf(const int& y, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -28381,6 +28477,7 @@ double
 foo4_lp(const int& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
         std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -28408,6 +28505,7 @@ template <bool propto__, typename T0__>
 stan::promote_args_t<T0__>
 foo2_log(const T0__& y, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -28434,6 +28532,7 @@ template <bool propto__, typename T0__>
 stan::promote_args_t<T0__>
 foo3_lpdf(const T0__& y, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -28462,6 +28561,7 @@ stan::promote_args_t<T0__>
 foo5_lp(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
         std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -33409,6 +33509,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 normal(const T0__& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -33765,6 +33866,7 @@ stan::promote_args_t<T0__,
 T1__>
 lb_constrain(const T0__& x, const T1__& y, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 16> locations_array__ = 
 {" (found before start of program)",
  " (in '8_schools_ncp.stan', line 8, column 2 to column 10)",
  " (in '8_schools_ncp.stan', line 9, column 2 to column 20)",
@@ -60,11 +59,12 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
   _8_schools_ncp_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
                        std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "_8_schools_ncp_model_namespace::_8_schools_ncp_model";
+    static constexpr char* function__ = "_8_schools_ncp_model_namespace::_8_schools_ncp_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -130,7 +130,9 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -139,9 +141,10 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "_8_schools_ncp_model_namespace::log_prob";
+    static constexpr char* function__ = "_8_schools_ncp_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -195,7 +198,10 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -206,10 +212,11 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "_8_schools_ncp_model_namespace::write_array";
+    static constexpr char* function__ = "_8_schools_ncp_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -260,13 +267,16 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -508,8 +518,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 3> locations_array__ = 
 {" (found before start of program)",
  " (in '8start_with_number.stan', line 6, column 3 to column 12)",
  " (in '8start_with_number.stan', line 3, column 2 to column 17)"};
@@ -534,11 +543,12 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
   _8start_with_number_model(stan::io::var_context& context__,
                             unsigned int random_seed__ = 0,
                             std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "_8start_with_number_model_namespace::_8start_with_number_model";
+    static constexpr char* function__ = "_8start_with_number_model_namespace::_8start_with_number_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -569,7 +579,9 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -578,9 +590,10 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "_8start_with_number_model_namespace::log_prob";
+    static constexpr char* function__ = "_8start_with_number_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -598,7 +611,10 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -609,10 +625,11 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "_8start_with_number_model_namespace::write_array";
+    static constexpr char* function__ = "_8start_with_number_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -636,13 +653,16 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -827,8 +847,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 16> locations_array__ = 
 {" (found before start of program)",
  " (in 'eight_schools_ncp.stan', line 8, column 2 to column 10)",
  " (in 'eight_schools_ncp.stan', line 9, column 2 to column 20)",
@@ -868,11 +887,12 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
   eight_schools_ncp_model(stan::io::var_context& context__,
                           unsigned int random_seed__ = 0,
                           std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "eight_schools_ncp_model_namespace::eight_schools_ncp_model";
+    static constexpr char* function__ = "eight_schools_ncp_model_namespace::eight_schools_ncp_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -938,7 +958,9 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -947,9 +969,10 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "eight_schools_ncp_model_namespace::log_prob";
+    static constexpr char* function__ = "eight_schools_ncp_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1003,7 +1026,10 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1014,10 +1040,11 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "eight_schools_ncp_model_namespace::write_array";
+    static constexpr char* function__ = "eight_schools_ncp_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1068,13 +1095,16 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -1317,8 +1347,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 6> locations_array__ = 
 {" (found before start of program)",
  " (in 'mixed_type_arrays.stan', line 5, column 2 to column 13)",
  " (in 'mixed_type_arrays.stan', line 8, column 2 to column 26)",
@@ -1346,11 +1375,12 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
   mixed_type_arrays_model(stan::io::var_context& context__,
                           unsigned int random_seed__ = 0,
                           std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "mixed_type_arrays_model_namespace::mixed_type_arrays_model";
+    static constexpr char* function__ = "mixed_type_arrays_model_namespace::mixed_type_arrays_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1377,7 +1407,9 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1386,9 +1418,10 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "mixed_type_arrays_model_namespace::log_prob";
+    static constexpr char* function__ = "mixed_type_arrays_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1438,7 +1471,10 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1449,10 +1485,11 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "mixed_type_arrays_model_namespace::write_array";
+    static constexpr char* function__ = "mixed_type_arrays_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1520,13 +1557,16 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -1771,8 +1811,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 776> locations_array__ = 
 {" (found before start of program)",
  " (in 'mother.stan', line 549, column 2 to column 14)",
  " (in 'mother.stan', line 550, column 2 to column 29)",
@@ -2557,7 +2596,7 @@ foo(const int& n, std::ostream* pstream__) ;
 int
 foo(const int& n, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2599,7 +2638,7 @@ sho(const T0__& t, const std::vector<T1__>& y,
     const std::vector<T2__>& theta, const std::vector<double>& x,
     const std::vector<int>& x_int, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2639,7 +2678,7 @@ return sho(t, y, theta, x, x_int, pstream__);
 double
 foo_bar0(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2666,7 +2705,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 foo_bar1(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2695,7 +2734,7 @@ stan::promote_args_t<T0__,
 T1__>
 foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2750,7 +2789,7 @@ template <typename T1__>
 stan::promote_args_t<T1__>
 foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T1__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2778,7 +2817,7 @@ template <typename T1__>
 stan::promote_args_t<T1__>
 foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T1__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2808,7 +2847,7 @@ T1__>
 foo_rng(const T0__& mu, const T1__& sigma, RNG& base_rng__,
         std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -2869,7 +2908,7 @@ return unit_normal_lp<propto__>(u, lp__, lp_accum__, pstream__);
 int
 foo_1(const int& a, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3115,7 +3154,7 @@ return foo_1(a, pstream__);
 int
 foo_2(const int& a, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3157,7 +3196,7 @@ template <typename T0__>
 std::vector<stan::promote_args_t<T0__>>
 foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3215,7 +3254,7 @@ template <typename T0__>
 void
 foo_4(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3248,7 +3287,7 @@ T3__>
 relative_diff(const T0__& x, const T1__& y, const T2__& max_,
               const T3__& min_, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3318,7 +3357,7 @@ foo_5(const T0__& shared_params_arg__, const T1__& job_params_arg__,
           stan::value_type_t<T1__>>;
   const auto& shared_params = to_ref(shared_params_arg__);
   const auto& job_params = to_ref(job_params_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3356,7 +3395,7 @@ foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
           T2__,
           T3__,
           T4__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3431,7 +3470,7 @@ covsqrt2corsqrt(const T0__& mat_arg__, const int& invert,
                 std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
   const auto& mat = to_ref(mat_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3497,7 +3536,7 @@ f0(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3556,7 +3595,7 @@ f1(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3612,7 +3651,7 @@ f2(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3668,7 +3707,7 @@ f3(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3726,7 +3765,7 @@ f4(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3786,7 +3825,7 @@ f5(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3846,7 +3885,7 @@ f6(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3906,7 +3945,7 @@ f7(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3966,7 +4005,7 @@ f8(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4026,7 +4065,7 @@ f9(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4086,7 +4125,7 @@ f10(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4146,7 +4185,7 @@ f11(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4206,7 +4245,7 @@ f12(const int& a1, const std::vector<int>& a2,
           T11__>>;
   const auto& a7 = to_ref(a7_arg__);
   const auto& a10 = to_ref(a10_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4245,7 +4284,7 @@ return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 void
 foo_6(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4288,7 +4327,7 @@ return foo_6(pstream__);
 Eigen::Matrix<double, -1, -1>
 matfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4318,7 +4357,7 @@ return matfoo(pstream__);
 Eigen::Matrix<double, -1, 1>
 vecfoo(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4346,7 +4385,7 @@ template <typename T0__>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmufoo(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4381,7 +4420,7 @@ template <typename T0__>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmubar(const T0__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4426,7 +4465,7 @@ algebra_system(const T0__& x_arg__, const T1__& y_arg__,
           T2__>;
   const auto& x = to_ref(x_arg__);
   const auto& y = to_ref(y_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4472,7 +4511,7 @@ binomialf(const T0__& phi_arg__, const T1__& theta_arg__,
           stan::value_type_t<T1__>>;
   const auto& phi = to_ref(phi_arg__);
   const auto& theta = to_ref(theta_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4600,11 +4639,12 @@ class mother_model final : public model_base_crtp<mother_model> {
   mother_model(stan::io::var_context& context__,
                unsigned int random_seed__ = 0,
                std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "mother_model_namespace::mother_model";
+    static constexpr char* function__ = "mother_model_namespace::mother_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -6795,7 +6835,9 @@ class mother_model final : public model_base_crtp<mother_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6804,9 +6846,10 @@ class mother_model final : public model_base_crtp<mother_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "mother_model_namespace::log_prob";
+    static constexpr char* function__ = "mother_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -7668,7 +7711,10 @@ class mother_model final : public model_base_crtp<mother_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -7679,10 +7725,11 @@ class mother_model final : public model_base_crtp<mother_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "mother_model_namespace::write_array";
+    static constexpr char* function__ = "mother_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -9047,13 +9094,16 @@ class mother_model final : public model_base_crtp<mother_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -11153,8 +11203,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 158> locations_array__ = 
 {" (found before start of program)",
  " (in 'motherHOF.stan', line 52, column 2 to column 15)",
  " (in 'motherHOF.stan', line 53, column 2 to column 18)",
@@ -11322,7 +11371,7 @@ sho(const T0__& t, const std::vector<T1__>& y,
     const std::vector<T2__>& theta, const std::vector<T3__>& x,
     const std::vector<int>& x_int, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11366,7 +11415,7 @@ integrand(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
           const std::vector<T3__>& x_r, const std::vector<int>& x_i,
           std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11404,7 +11453,7 @@ foo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
           T2__>;
   const auto& shared_params = to_ref(shared_params_arg__);
   const auto& job_params = to_ref(job_params_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11442,7 +11491,7 @@ goo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
           T2__>;
   const auto& shared_params = to_ref(shared_params_arg__);
   const auto& job_params = to_ref(job_params_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11473,7 +11522,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 map_rectfake(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11508,7 +11557,7 @@ algebra_system(const T0__& x_arg__, const T1__& y_arg__,
           T2__>;
   const auto& x = to_ref(x_arg__);
   const auto& y = to_ref(y_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11574,11 +11623,12 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
   motherHOF_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
                   std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "motherHOF_model_namespace::motherHOF_model";
+    static constexpr char* function__ = "motherHOF_model_namespace::motherHOF_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11788,7 +11838,9 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -11797,9 +11849,10 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "motherHOF_model_namespace::log_prob";
+    static constexpr char* function__ = "motherHOF_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -12129,7 +12182,10 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -12140,10 +12196,11 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "motherHOF_model_namespace::write_array";
+    static constexpr char* function__ = "motherHOF_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -12570,13 +12627,16 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -13211,8 +13271,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 630> locations_array__ = 
 {" (found before start of program)",
  " (in 'new_integrate_interface.stan', line 31, column 2 to column 9)",
  " (in 'new_integrate_interface.stan', line 32, column 2 to column 13)",
@@ -13856,7 +13915,7 @@ f(const T0__& t, const T1__& z_arg__, const T2__& a, const T3__& b_arg__,
           stan::value_type_t<T3__>>;
   const auto& z = to_ref(z_arg__);
   const auto& b = to_ref(b_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -13917,11 +13976,12 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
   new_integrate_interface_model(stan::io::var_context& context__,
                                 unsigned int random_seed__ = 0,
                                 std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "new_integrate_interface_model_namespace::new_integrate_interface_model";
+    static constexpr char* function__ = "new_integrate_interface_model_namespace::new_integrate_interface_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -14069,7 +14129,9 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -14078,9 +14140,10 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "new_integrate_interface_model_namespace::log_prob";
+    static constexpr char* function__ = "new_integrate_interface_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -15712,7 +15775,10 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -15723,10 +15789,11 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "new_integrate_interface_model_namespace::write_array";
+    static constexpr char* function__ = "new_integrate_interface_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -17368,13 +17435,16 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -17642,8 +17712,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 35> locations_array__ = 
 {" (found before start of program)",
  " (in 'old_integrate_interface.stan', line 27, column 2 to column 24)",
  " (in 'old_integrate_interface.stan', line 28, column 2 to column 23)",
@@ -17688,7 +17757,7 @@ dz_dt(const T0__& t, const std::vector<T1__>& z,
       const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
       const std::vector<int>& x_i, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -17776,11 +17845,12 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
   old_integrate_interface_model(stan::io::var_context& context__,
                                 unsigned int random_seed__ = 0,
                                 std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "old_integrate_interface_model_namespace::old_integrate_interface_model";
+    static constexpr char* function__ = "old_integrate_interface_model_namespace::old_integrate_interface_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -17873,7 +17943,9 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -17882,9 +17954,10 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "old_integrate_interface_model_namespace::log_prob";
+    static constexpr char* function__ = "old_integrate_interface_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -18034,7 +18107,10 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -18045,10 +18121,11 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "old_integrate_interface_model_namespace::write_array";
+    static constexpr char* function__ = "old_integrate_interface_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -18144,13 +18221,16 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -18463,8 +18543,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 217> locations_array__ = 
 {" (found before start of program)",
  " (in 'optimize_glm.stan', line 27, column 2 to column 20)",
  " (in 'optimize_glm.stan', line 28, column 2 to column 17)",
@@ -18721,11 +18800,12 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   optimize_glm_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,
                      std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
+    static constexpr char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -18982,7 +19062,9 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -18991,9 +19073,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "optimize_glm_model_namespace::log_prob";
+    static constexpr char* function__ = "optimize_glm_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -19603,7 +19686,10 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -19614,10 +19700,11 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "optimize_glm_model_namespace::write_array";
+    static constexpr char* function__ = "optimize_glm_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -19712,13 +19799,16 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -20152,8 +20242,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 7> locations_array__ = 
 {" (found before start of program)",
  " (in 'param-constraint.stan', line 7, column 2 to column 38)",
  " (in 'param-constraint.stan', line 8, column 2 to column 38)",
@@ -20183,11 +20272,12 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
   param_constraint_model(stan::io::var_context& context__,
                          unsigned int random_seed__ = 0,
                          std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "param_constraint_model_namespace::param_constraint_model";
+    static constexpr char* function__ = "param_constraint_model_namespace::param_constraint_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -20230,7 +20320,9 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20239,9 +20331,10 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "param_constraint_model_namespace::log_prob";
+    static constexpr char* function__ = "param_constraint_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20311,7 +20404,10 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -20322,10 +20418,11 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "param_constraint_model_namespace::write_array";
+    static constexpr char* function__ = "param_constraint_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20391,13 +20488,16 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -20679,8 +20779,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 26> locations_array__ = 
 {" (found before start of program)",
  " (in 'reduce_sum_m1.stan', line 26, column 2 to column 13)",
  " (in 'reduce_sum_m1.stan', line 27, column 2 to column 13)",
@@ -20717,7 +20816,7 @@ stan::promote_args_t<T0__>
 g(const std::vector<T0__>& y_slice, const int& start, const int& end,
   std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -20765,7 +20864,7 @@ T3__>
 h(const std::vector<T0__>& y_slice, const int& start, const int& end,
   const std::vector<T3__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -20871,11 +20970,12 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
   reduce_sum_m1_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
                       std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m1_model_namespace::reduce_sum_m1_model";
+    static constexpr char* function__ = "reduce_sum_m1_model_namespace::reduce_sum_m1_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -20912,7 +21012,9 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20921,9 +21023,10 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m1_model_namespace::log_prob";
+    static constexpr char* function__ = "reduce_sum_m1_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20972,7 +21075,10 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -20983,10 +21089,11 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m1_model_namespace::write_array";
+    static constexpr char* function__ = "reduce_sum_m1_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -21034,13 +21141,16 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -21270,8 +21380,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 180> locations_array__ = 
 {" (found before start of program)",
  " (in 'reduce_sum_m2.stan', line 130, column 2 to column 24)",
  " (in 'reduce_sum_m2.stan', line 131, column 2 to column 25)",
@@ -21474,7 +21583,7 @@ stan::promote_args_t<T0__>
 g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21515,7 +21624,7 @@ stan::promote_args_t<T0__>
 g2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21565,7 +21674,7 @@ stan::promote_args_t<T0__>
 g3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21615,7 +21724,7 @@ stan::promote_args_t<T0__>
 g4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21666,7 +21775,7 @@ stan::promote_args_t<T0__>
 g5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21719,7 +21828,7 @@ stan::promote_args_t<T0__>
 g6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21773,7 +21882,7 @@ stan::promote_args_t<T0__>
 g7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21827,7 +21936,7 @@ stan::promote_args_t<T0__>
 g8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21882,7 +21991,7 @@ T3__>
 h1(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<T3__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21929,7 +22038,7 @@ T3__>
 h2(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, 1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21984,7 +22093,7 @@ T3__>
 h3(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, 1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22039,7 +22148,7 @@ T3__>
 h4(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22095,7 +22204,7 @@ T3__>
 h5(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22152,7 +22261,7 @@ h6(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22212,7 +22321,7 @@ h7(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22272,7 +22381,7 @@ h8(const std::vector<T0__>& y, const int& start, const int& end,
    const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22344,11 +22453,12 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
   reduce_sum_m2_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
                       std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m2_model_namespace::reduce_sum_m2_model";
+    static constexpr char* function__ = "reduce_sum_m2_model_namespace::reduce_sum_m2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22477,7 +22587,9 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -22486,9 +22598,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m2_model_namespace::log_prob";
+    static constexpr char* function__ = "reduce_sum_m2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -22707,7 +22820,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -22718,10 +22834,11 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m2_model_namespace::write_array";
+    static constexpr char* function__ = "reduce_sum_m2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -22993,13 +23110,16 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -23960,8 +24080,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 342> locations_array__ = 
 {" (found before start of program)",
  " (in 'reduce_sum_m3.stan', line 210, column 2 to column 13)",
  " (in 'reduce_sum_m3.stan', line 211, column 2 to column 18)",
@@ -24336,7 +24455,7 @@ stan::promote_args_t<T0__>
 f1(const std::vector<T0__>& y_slice, const int& start, const int& end,
    std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24377,7 +24496,7 @@ stan::promote_args_t<T0__>
 f1a(const std::vector<T0__>& y_slice, const int& start, const int& end,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24418,7 +24537,7 @@ stan::promote_args_t<T0__>
 f2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24459,7 +24578,7 @@ stan::promote_args_t<T0__>
 f3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24500,7 +24619,7 @@ stan::promote_args_t<T0__>
 f4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24541,7 +24660,7 @@ stan::promote_args_t<T0__>
 f5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
    const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24582,7 +24701,7 @@ stan::promote_args_t<T0__>
 f6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24623,7 +24742,7 @@ stan::promote_args_t<T0__>
 f7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24664,7 +24783,7 @@ stan::promote_args_t<T0__>
 f8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
    const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24704,7 +24823,7 @@ double
 f9(const std::vector<int>& y_slice, const int& start, const int& end,
    std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24742,7 +24861,7 @@ double
 f10(const std::vector<std::vector<int>>& y_slice, const int& start,
     const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24780,7 +24899,7 @@ double
 f11(const std::vector<std::vector<std::vector<int>>>& y_slice,
     const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24819,7 +24938,7 @@ stan::promote_args_t<T0__>
 f12(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
     const int& start, const int& end, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24861,7 +24980,7 @@ T3__>
 g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const T3__& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24907,7 +25026,7 @@ g2(const std::vector<T0__>& y_slice, const int& start, const int& end,
   using local_scalar_t__ = stan::promote_args_t<T0__,
           stan::value_type_t<T3__>>;
   const auto& a = to_ref(a_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24953,7 +25072,7 @@ g3(const std::vector<T0__>& y_slice, const int& start, const int& end,
   using local_scalar_t__ = stan::promote_args_t<T0__,
           stan::value_type_t<T3__>>;
   const auto& a = to_ref(a_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -24999,7 +25118,7 @@ g4(const std::vector<T0__>& y_slice, const int& start, const int& end,
   using local_scalar_t__ = stan::promote_args_t<T0__,
           stan::value_type_t<T3__>>;
   const auto& a = to_ref(a_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25043,7 +25162,7 @@ T3__>
 g5(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<T3__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25089,7 +25208,7 @@ T3__>
 g6(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, 1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25135,7 +25254,7 @@ T3__>
 g7(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, 1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25181,7 +25300,7 @@ T3__>
 g8(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<Eigen::Matrix<T3__, -1, -1>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25227,7 +25346,7 @@ T3__>
 g9(const std::vector<T0__>& y_slice, const int& start, const int& end,
    const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25274,7 +25393,7 @@ g10(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25322,7 +25441,7 @@ g11(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25370,7 +25489,7 @@ g12(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
     std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25449,7 +25568,7 @@ s(const std::vector<T0__>& y_slice, const int& start, const int& end,
   const auto& c = to_ref(c_arg__);
   const auto& d = to_ref(d_arg__);
   const auto& e = to_ref(e_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25530,7 +25649,7 @@ return s(y_slice, start + 1, end + 1, a, b, c, d, e, f, g, h, i, j, k, l, m,
 double
 r(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25977,11 +26096,12 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
   reduce_sum_m3_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
                       std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m3_model_namespace::reduce_sum_m3_model";
+    static constexpr char* function__ = "reduce_sum_m3_model_namespace::reduce_sum_m3_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -26641,7 +26761,9 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26650,9 +26772,10 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m3_model_namespace::log_prob";
+    static constexpr char* function__ = "reduce_sum_m3_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -26928,7 +27051,10 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26939,10 +27065,11 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "reduce_sum_m3_model_namespace::write_array";
+    static constexpr char* function__ = "reduce_sum_m3_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -27300,13 +27427,16 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -28178,8 +28308,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 13> locations_array__ = 
 {" (found before start of program)",
  " (in 'single-argument-lpmf.stan', line 3, column 4 to column 14)",
  " (in 'single-argument-lpmf.stan', line 2, column 23 to line 4, column 3)",
@@ -28375,11 +28504,12 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
   single_argument_lpmf_model(stan::io::var_context& context__,
                              unsigned int random_seed__ = 0,
                              std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "single_argument_lpmf_model_namespace::single_argument_lpmf_model";
+    static constexpr char* function__ = "single_argument_lpmf_model_namespace::single_argument_lpmf_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -28403,7 +28533,9 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28412,9 +28544,10 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "single_argument_lpmf_model_namespace::log_prob";
+    static constexpr char* function__ = "single_argument_lpmf_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28428,7 +28561,10 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28439,10 +28575,11 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "single_argument_lpmf_model_namespace::write_array";
+    static constexpr char* function__ = "single_argument_lpmf_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28460,13 +28597,16 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -28644,8 +28784,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 8> locations_array__ = 
 {" (found before start of program)",
  " (in 'tilde-block.stan', line 5, column 4 to column 20)",
  " (in 'tilde-block.stan', line 11, column 27 to column 28)",
@@ -28675,11 +28814,12 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
   tilde_block_model(stan::io::var_context& context__,
                     unsigned int random_seed__ = 0,
                     std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "tilde_block_model_namespace::tilde_block_model";
+    static constexpr char* function__ = "tilde_block_model_namespace::tilde_block_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -28710,7 +28850,9 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28719,9 +28861,10 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "tilde_block_model_namespace::log_prob";
+    static constexpr char* function__ = "tilde_block_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28773,7 +28916,10 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28784,10 +28930,11 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "tilde_block_model_namespace::write_array";
+    static constexpr char* function__ = "tilde_block_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28813,13 +28960,16 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -29008,8 +29158,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 116> locations_array__ = 
 {" (found before start of program)",
  " (in 'transform.stan', line 11, column 2 to column 29)",
  " (in 'transform.stan', line 12, column 2 to column 29)",
@@ -29153,11 +29302,12 @@ class transform_model final : public model_base_crtp<transform_model> {
   transform_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
                   std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "transform_model_namespace::transform_model";
+    static constexpr char* function__ = "transform_model_namespace::transform_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -29483,7 +29633,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -29492,9 +29644,10 @@ class transform_model final : public model_base_crtp<transform_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "transform_model_namespace::log_prob";
+    static constexpr char* function__ = "transform_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -30464,7 +30617,10 @@ class transform_model final : public model_base_crtp<transform_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -30475,10 +30631,11 @@ class transform_model final : public model_base_crtp<transform_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "transform_model_namespace::write_array";
+    static constexpr char* function__ = "transform_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -31372,13 +31529,16 @@ class transform_model final : public model_base_crtp<transform_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -32763,8 +32923,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 21> locations_array__ = 
 {" (found before start of program)",
  " (in 'truncate.stan', line 6, column 4 to column 11)",
  " (in 'truncate.stan', line 7, column 4 to column 20)",
@@ -32808,11 +32967,12 @@ class truncate_model final : public model_base_crtp<truncate_model> {
   truncate_model(stan::io::var_context& context__,
                  unsigned int random_seed__ = 0,
                  std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "truncate_model_namespace::truncate_model";
+    static constexpr char* function__ = "truncate_model_namespace::truncate_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -32851,7 +33011,9 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -32860,9 +33022,10 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "truncate_model_namespace::log_prob";
+    static constexpr char* function__ = "truncate_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -32975,7 +33138,10 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -32986,10 +33152,11 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "truncate_model_namespace::write_array";
+    static constexpr char* function__ = "truncate_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33021,13 +33188,16 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -33227,8 +33397,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 5> locations_array__ = 
 {" (found before start of program)",
  " (in 'udf_tilde_stmt_conflict.stan', line 7, column 4 to column 11)",
  " (in 'udf_tilde_stmt_conflict.stan', line 10, column 4 to column 20)",
@@ -33240,7 +33409,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 normal(const T0__& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33282,11 +33451,12 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
   udf_tilde_stmt_conflict_model(stan::io::var_context& context__,
                                 unsigned int random_seed__ = 0,
                                 std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "udf_tilde_stmt_conflict_model_namespace::udf_tilde_stmt_conflict_model";
+    static constexpr char* function__ = "udf_tilde_stmt_conflict_model_namespace::udf_tilde_stmt_conflict_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33310,7 +33480,9 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33319,9 +33491,10 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "udf_tilde_stmt_conflict_model_namespace::log_prob";
+    static constexpr char* function__ = "udf_tilde_stmt_conflict_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33343,7 +33516,10 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33354,10 +33530,11 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "udf_tilde_stmt_conflict_model_namespace::write_array";
+    static constexpr char* function__ = "udf_tilde_stmt_conflict_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33381,13 +33558,16 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -33572,8 +33752,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 5> locations_array__ = 
 {" (found before start of program)",
  " (in 'user_constrain.stan', line 7, column 2 to column 18)",
  " (in 'user_constrain.stan', line 10, column 2 to column 19)",
@@ -33586,7 +33765,7 @@ stan::promote_args_t<T0__,
 T1__>
 lb_constrain(const T0__& x, const T1__& y, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33629,11 +33808,12 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
   user_constrain_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
                        std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "user_constrain_model_namespace::user_constrain_model";
+    static constexpr char* function__ = "user_constrain_model_namespace::user_constrain_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33657,7 +33837,9 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33666,9 +33848,10 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "user_constrain_model_namespace::log_prob";
+    static constexpr char* function__ = "user_constrain_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33698,7 +33881,10 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33709,10 +33895,11 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "user_constrain_model_namespace::write_array";
+    static constexpr char* function__ = "user_constrain_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33738,13 +33925,16 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -131,8 +131,8 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -199,9 +199,9 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -268,8 +268,8 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -580,8 +580,8 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -612,9 +612,9 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -654,8 +654,8 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -959,8 +959,8 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1027,9 +1027,9 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1096,8 +1096,8 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -1408,8 +1408,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1472,9 +1472,9 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -1558,8 +1558,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6876,8 +6876,8 @@ class mother_model final : public model_base_crtp<mother_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -7752,9 +7752,9 @@ class mother_model final : public model_base_crtp<mother_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -9135,8 +9135,8 @@ class mother_model final : public model_base_crtp<mother_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -11885,8 +11885,8 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -12229,9 +12229,9 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -12674,8 +12674,8 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -14177,8 +14177,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -15823,9 +15823,9 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -17483,8 +17483,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -17992,8 +17992,8 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -18156,9 +18156,9 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -18270,8 +18270,8 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -19111,8 +19111,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -19735,9 +19735,9 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -19848,8 +19848,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -20369,8 +20369,8 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20453,9 +20453,9 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -20537,8 +20537,8 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -21064,8 +21064,8 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -21127,9 +21127,9 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -21193,8 +21193,8 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -22655,8 +22655,8 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -22888,9 +22888,9 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -23178,8 +23178,8 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26856,8 +26856,8 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -27146,9 +27146,9 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -27522,8 +27522,8 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -28634,8 +28634,8 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28662,9 +28662,9 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28698,8 +28698,8 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -28951,8 +28951,8 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -29017,9 +29017,9 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -29061,8 +29061,8 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -29734,8 +29734,8 @@ class transform_model final : public model_base_crtp<transform_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -30718,9 +30718,9 @@ class transform_model final : public model_base_crtp<transform_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -31630,8 +31630,8 @@ class transform_model final : public model_base_crtp<transform_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33112,8 +33112,8 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33239,9 +33239,9 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33289,8 +33289,8 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33582,8 +33582,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33618,9 +33618,9 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33660,8 +33660,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33940,8 +33940,8 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33984,9 +33984,9 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -34028,8 +34028,8 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 11> locations_array__ = 
 {" (found before start of program)",
  " (in 'simple_function.stan', line 13, column 4 to column 10)",
  " (in 'simple_function.stan', line 14, column 11 to column 12)",
@@ -50,7 +49,7 @@ foo1(const T0__& a, const int& b, const std::vector<T2__>& c,
   const auto& d = to_ref(d_arg__);
   const auto& e = to_ref(e_arg__);
   const auto& f = to_ref(f_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -89,7 +88,7 @@ foo2(const T0__& a_arg__, const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
           T1__,
           T2__>;
   const auto& a = to_ref(a_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -124,7 +123,7 @@ foo3(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
           stan::value_type_t<T1__>>;
   const auto& a = to_ref(a_arg__);
   const auto& b = to_ref(b_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -168,11 +167,12 @@ class simple_function_model final : public model_base_crtp<simple_function_model
   simple_function_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "simple_function_model_namespace::simple_function_model";
+    static constexpr char* function__ = "simple_function_model_namespace::simple_function_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -232,7 +232,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -241,9 +243,10 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "simple_function_model_namespace::log_prob";
+    static constexpr char* function__ = "simple_function_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -257,7 +260,10 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -268,10 +274,11 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "simple_function_model_namespace::write_array";
+    static constexpr char* function__ = "simple_function_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -289,13 +296,16 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -46,6 +46,7 @@ foo1(const T0__& a, const int& b, const std::vector<T2__>& c,
           stan::value_type_t<T3__>,
           stan::value_type_t<T4__>,
           stan::value_type_t<T5__>>;
+  int current_statement__ = 0; 
   const auto& d = to_ref(d_arg__);
   const auto& e = to_ref(e_arg__);
   const auto& f = to_ref(f_arg__);
@@ -87,6 +88,7 @@ foo2(const T0__& a_arg__, const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           T1__,
           T2__>;
+  int current_statement__ = 0; 
   const auto& a = to_ref(a_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -121,6 +123,7 @@ stan::value_type_t<T1__>>, -1, -1>
 foo3(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>>;
+  int current_statement__ = 0; 
   const auto& a = to_ref(a_arg__);
   const auto& b = to_ref(b_arg__);
   static constexpr bool propto__ = true;

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -236,8 +236,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -264,9 +264,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -300,8 +300,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -957,8 +957,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -3496,9 +3496,9 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6058,8 +6058,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6596,8 +6596,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6704,9 +6704,9 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6835,8 +6835,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 771> locations_array__ = 
 {" (found before start of program)",
  " (in 'distributions.stan', line 10, column 2 to column 14)",
  " (in 'distributions.stan', line 11, column 2 to column 27)",
@@ -822,11 +821,12 @@ class distributions_model final : public model_base_crtp<distributions_model> {
   distributions_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
                       std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "distributions_model_namespace::distributions_model";
+    static constexpr char* function__ = "distributions_model_namespace::distributions_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -956,7 +956,9 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -965,9 +967,10 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "distributions_model_namespace::log_prob";
+    static constexpr char* function__ = "distributions_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -3492,7 +3495,10 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -3503,10 +3509,11 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "distributions_model_namespace::write_array";
+    static constexpr char* function__ = "distributions_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6050,13 +6057,16 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -6388,8 +6398,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 40> locations_array__ = 
 {" (found before start of program)",
  " (in 'restricted.stan', line 10, column 2 to column 14)",
  " (in 'restricted.stan', line 11, column 2 to column 27)",
@@ -6457,11 +6466,12 @@ class restricted_model final : public model_base_crtp<restricted_model> {
   restricted_model(stan::io::var_context& context__,
                    unsigned int random_seed__ = 0,
                    std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "restricted_model_namespace::restricted_model";
+    static constexpr char* function__ = "restricted_model_namespace::restricted_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -6585,7 +6595,9 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6594,9 +6606,10 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "restricted_model_namespace::log_prob";
+    static constexpr char* function__ = "restricted_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6690,7 +6703,10 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6701,10 +6717,11 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "restricted_model_namespace::write_array";
+    static constexpr char* function__ = "restricted_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6817,13 +6834,16 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -158,8 +158,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -284,9 +284,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -344,8 +344,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 29> locations_array__ = 
 {" (found before start of program)",
  " (in 'simple_function.stan', line 14, column 2 to column 20)",
  " (in 'simple_function.stan', line 15, column 2 to column 22)",
@@ -74,11 +73,12 @@ class simple_function_model final : public model_base_crtp<simple_function_model
   simple_function_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "simple_function_model_namespace::simple_function_model";
+    static constexpr char* function__ = "simple_function_model_namespace::simple_function_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -157,7 +157,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -166,9 +168,10 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "simple_function_model_namespace::log_prob";
+    static constexpr char* function__ = "simple_function_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -280,7 +283,10 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -291,10 +297,11 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "simple_function_model_namespace::write_array";
+    static constexpr char* function__ = "simple_function_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -336,13 +343,16 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -47,6 +47,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 my_log1p_exp(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -75,6 +76,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -102,6 +104,7 @@ return array_fun(a, pstream__);
 double
 int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -129,6 +132,7 @@ template <typename T0__>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+  int current_statement__ = 0; 
   const auto& x = to_ref(x_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -166,6 +170,7 @@ return my_vector_mul_by_5(x, pstream__);
 int
 int_only_multiplication(const int& a, const int& b, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -193,6 +198,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 test_lgamma(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -223,6 +229,7 @@ void
 test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
         std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -251,6 +258,7 @@ template <typename T0__, typename RNG>
 stan::promote_args_t<T0__>
 test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -280,6 +288,7 @@ stan::promote_args_t<T0__,
 T1__>
 test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -416,6 +425,7 @@ template <typename T0__>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 integrand(const T0__& x_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+  int current_statement__ = 0; 
   const auto& x = to_ref(x_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -448,6 +458,7 @@ integrand_ode(const T0__& r, const std::vector<T1__>& f,
               const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
               const std::vector<int>& x_i, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -490,6 +501,7 @@ return integrand_ode(r, f, theta, x_r, x_i, pstream__);
 double
 ode_integrate(std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 21> locations_array__ = 
 {" (found before start of program)",
  " (in 'basic.stan', line 3, column 8 to column 28)",
  " (in 'basic.stan', line 2, column 30 to line 4, column 5)",
@@ -48,7 +47,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 my_log1p_exp(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -76,7 +75,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -103,7 +102,7 @@ return array_fun(a, pstream__);
 double
 int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -131,7 +130,7 @@ Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
   const auto& x = to_ref(x_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -167,7 +166,7 @@ return my_vector_mul_by_5(x, pstream__);
 int
 int_only_multiplication(const int& a, const int& b, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -194,7 +193,7 @@ template <typename T0__>
 stan::promote_args_t<T0__>
 test_lgamma(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -252,7 +251,7 @@ template <typename T0__, typename RNG>
 stan::promote_args_t<T0__>
 test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -399,8 +398,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 11> locations_array__ = 
 {" (found before start of program)",
  " (in 'integrate.stan', line 4, column 4 to column 27)",
  " (in 'integrate.stan', line 3, column 29 to line 5, column 3)",
@@ -419,7 +417,7 @@ Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 integrand(const T0__& x_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
   const auto& x = to_ref(x_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -450,7 +448,7 @@ integrand_ode(const T0__& r, const std::vector<T1__>& f,
               const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
               const std::vector<int>& x_i, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -492,7 +490,7 @@ return integrand_ode(r, f, theta, x_r, x_i, pstream__);
 double
 ode_integrate(std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -64,6 +64,7 @@ simple_SIR(const T0__& t, const std::vector<T1__>& y,
            const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
            const std::vector<int>& x_i, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -956,6 +957,7 @@ static constexpr std::array<const char*, 68> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1002,6 +1004,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -1062,6 +1065,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
                 const T3__& phi_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T2__>,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   static constexpr bool propto__ = true;
@@ -9497,6 +9501,7 @@ static constexpr std::array<const char*, 71> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -9543,6 +9548,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -9603,6 +9609,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
                 const T3__& phi_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T2__>,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   static constexpr bool propto__ = true;
@@ -12082,6 +12089,7 @@ static constexpr std::array<const char*, 147> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -12128,6 +12136,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -12188,6 +12197,7 @@ prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                 std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   static constexpr bool propto__ = true;
@@ -12404,6 +12414,7 @@ js_super_lp(const std::vector<std::vector<int>>& y,
           T5__,
           stan::value_type_t<T6__>,
           stan::value_type_t<T7__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   const auto& nu = to_ref(nu_arg__);
@@ -18596,6 +18607,7 @@ static constexpr std::array<const char*, 68> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -18642,6 +18654,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -18702,6 +18715,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
                 const T3__& phi_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T2__>,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   static constexpr bool propto__ = true;
@@ -21277,6 +21291,7 @@ static constexpr std::array<const char*, 145> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21323,6 +21338,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21383,6 +21399,7 @@ prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                 std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
           stan::value_type_t<T1__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   static constexpr bool propto__ = true;
@@ -21598,6 +21615,7 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
           stan::value_type_t<T4__>,
           stan::value_type_t<T5__>,
           stan::value_type_t<T6__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   const auto& gamma = to_ref(gamma_arg__);
@@ -22147,6 +22165,7 @@ template <typename T0__>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+  int current_statement__ = 0; 
   const auto& gamma = to_ref(gamma_arg__);
   static constexpr bool propto__ = true;
   (void) propto__;
@@ -26416,6 +26435,7 @@ static constexpr std::array<const char*, 64> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -26462,6 +26482,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -26522,6 +26543,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
                 const T3__& phi_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T2__>,
           stan::value_type_t<T3__>>;
+  int current_statement__ = 0; 
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
   static constexpr bool propto__ = true;
@@ -28722,6 +28744,7 @@ stan::promote_args_t<T0__,
 T1__>
 foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -28752,6 +28775,7 @@ template <bool propto__, typename T1__>
 stan::promote_args_t<T1__>
 bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T1__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -28781,6 +28805,7 @@ template <bool propto__, typename T0__>
 stan::promote_args_t<T0__>
 baz_lpdf(const T0__& x, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -31364,6 +31389,7 @@ void
 nrfun_lp(const T0__& x, const int& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__>;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {
@@ -31399,6 +31425,7 @@ return nrfun_lp<propto__>(x, y, lp__, lp_accum__, pstream__);
 int
 rfun(const int& y, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -31436,6 +31463,7 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__>
 int
 rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
   using local_scalar_t__ = double;
+  int current_statement__ = 0; 
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
   try {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -19,8 +19,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 35> locations_array__ = 
 {" (found before start of program)",
  " (in 'ad-level-failing.stan', line 45, column 2 to column 21)",
  " (in 'ad-level-failing.stan', line 46, column 2 to column 22)",
@@ -65,7 +64,7 @@ simple_SIR(const T0__& t, const std::vector<T1__>& y,
            const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
            const std::vector<int>& x_i, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -142,11 +141,12 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   ad_level_failing_model(stan::io::var_context& context__,
                          unsigned int random_seed__ = 0,
                          std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "ad_level_failing_model_namespace::ad_level_failing_model";
+    static constexpr char* function__ = "ad_level_failing_model_namespace::ad_level_failing_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -242,7 +242,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -251,9 +253,10 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "ad_level_failing_model_namespace::log_prob";
+    static constexpr char* function__ = "ad_level_failing_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -437,7 +440,10 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -448,10 +454,11 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "ad_level_failing_model_namespace::write_array";
+    static constexpr char* function__ = "ad_level_failing_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -610,13 +617,16 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -872,8 +882,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 68> locations_array__ = 
 {" (found before start of program)",
  " (in 'copy_fail.stan', line 71, column 2 to column 31)",
  " (in 'copy_fail.stan', line 72, column 2 to column 40)",
@@ -947,7 +956,7 @@ static const std::vector<std::string> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -993,7 +1002,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1055,7 +1064,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
           stan::value_type_t<T3__>>;
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1302,11 +1311,12 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   copy_fail_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
                   std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "copy_fail_model_namespace::copy_fail_model";
+    static constexpr char* function__ = "copy_fail_model_namespace::copy_fail_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1809,7 +1819,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -1818,9 +1830,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "copy_fail_model_namespace::log_prob";
+    static constexpr char* function__ = "copy_fail_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -2491,7 +2504,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -2502,10 +2518,11 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "copy_fail_model_namespace::write_array";
+    static constexpr char* function__ = "copy_fail_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -3151,13 +3168,16 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym53__;
@@ -3466,8 +3486,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 66> locations_array__ = 
 {" (found before start of program)",
  " (in 'dce-fail.stan', line 18, column 2 to column 22)",
  " (in 'dce-fail.stan', line 19, column 2 to column 26)",
@@ -3586,11 +3605,12 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   dce_fail_model(stan::io::var_context& context__,
                  unsigned int random_seed__ = 0,
                  std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "dce_fail_model_namespace::dce_fail_model";
+    static constexpr char* function__ = "dce_fail_model_namespace::dce_fail_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -3967,7 +3987,9 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -3976,9 +3998,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "dce_fail_model_namespace::log_prob";
+    static constexpr char* function__ = "dce_fail_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -4271,7 +4294,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -4282,10 +4308,11 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "dce_fail_model_namespace::write_array";
+    static constexpr char* function__ = "dce_fail_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -4478,13 +4505,16 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym27__;
@@ -5102,8 +5132,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 9> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-experiment.stan', line 2, column 2 to column 8)",
  " (in 'expr-prop-experiment.stan', line 5, column 2 to column 9)",
@@ -5139,11 +5168,12 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
   expr_prop_experiment_model(stan::io::var_context& context__,
                              unsigned int random_seed__ = 0,
                              std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_experiment_model_namespace::expr_prop_experiment_model";
+    static constexpr char* function__ = "expr_prop_experiment_model_namespace::expr_prop_experiment_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -5197,7 +5227,9 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5206,9 +5238,10 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_experiment_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_experiment_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5222,7 +5255,10 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5233,10 +5269,11 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_experiment_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_experiment_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5256,13 +5293,16 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -5440,8 +5480,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 8> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-experiment2.stan', line 2, column 2 to column 8)",
  " (in 'expr-prop-experiment2.stan', line 5, column 2 to column 13)",
@@ -5474,11 +5513,12 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   expr_prop_experiment2_model(stan::io::var_context& context__,
                               unsigned int random_seed__ = 0,
                               std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_experiment2_model_namespace::expr_prop_experiment2_model";
+    static constexpr char* function__ = "expr_prop_experiment2_model_namespace::expr_prop_experiment2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -5531,7 +5571,9 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5540,9 +5582,10 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_experiment2_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_experiment2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5556,7 +5599,10 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5567,10 +5613,11 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_experiment2_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_experiment2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5590,13 +5637,16 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -5774,8 +5824,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 12> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail.stan', line 7, column 2 to column 16)",
  " (in 'expr-prop-fail.stan', line 8, column 2 to column 25)",
@@ -5814,11 +5863,12 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   expr_prop_fail_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
                        std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail_model_namespace::expr_prop_fail_model";
+    static constexpr char* function__ = "expr_prop_fail_model_namespace::expr_prop_fail_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -5888,7 +5938,9 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5897,9 +5949,10 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6013,7 +6066,10 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6024,10 +6080,11 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6105,13 +6162,16 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym9__;
@@ -6397,8 +6457,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 12> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail2.stan', line 7, column 2 to column 10)",
  " (in 'expr-prop-fail2.stan', line 8, column 2 to column 16)",
@@ -6437,11 +6496,12 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   expr_prop_fail2_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail2_model_namespace::expr_prop_fail2_model";
+    static constexpr char* function__ = "expr_prop_fail2_model_namespace::expr_prop_fail2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -6513,7 +6573,9 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6522,9 +6584,10 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail2_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6577,7 +6640,10 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6588,10 +6654,11 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail2_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6646,13 +6713,16 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym3__;
@@ -6877,8 +6947,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 52> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail3.stan', line 19, column 2 to column 18)",
  " (in 'expr-prop-fail3.stan', line 20, column 2 to column 18)",
@@ -6990,11 +7059,12 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   expr_prop_fail3_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail3_model_namespace::expr_prop_fail3_model";
+    static constexpr char* function__ = "expr_prop_fail3_model_namespace::expr_prop_fail3_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -7458,7 +7528,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -7467,9 +7539,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail3_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail3_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -7639,7 +7712,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -7650,10 +7726,11 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail3_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail3_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -7848,13 +7925,16 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym30__;
@@ -8431,8 +8511,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 44> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail4.stan', line 12, column 2 to column 24)",
  " (in 'expr-prop-fail4.stan', line 13, column 2 to column 28)",
@@ -8517,11 +8596,12 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   expr_prop_fail4_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail4_model_namespace::expr_prop_fail4_model";
+    static constexpr char* function__ = "expr_prop_fail4_model_namespace::expr_prop_fail4_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -8710,7 +8790,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -8719,9 +8801,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail4_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail4_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -8794,7 +8877,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -8805,10 +8891,11 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail4_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail4_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -9004,13 +9091,16 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym7__;
@@ -9330,8 +9420,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 71> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail5.stan', line 71, column 2 to column 33)",
  " (in 'expr-prop-fail5.stan', line 72, column 2 to column 31)",
@@ -9408,7 +9497,7 @@ static const std::vector<std::string> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -9454,7 +9543,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -9516,7 +9605,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
           stan::value_type_t<T3__>>;
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -9754,11 +9843,12 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   expr_prop_fail5_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail5_model_namespace::expr_prop_fail5_model";
+    static constexpr char* function__ = "expr_prop_fail5_model_namespace::expr_prop_fail5_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -10133,7 +10223,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -10142,9 +10234,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail5_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail5_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -10815,7 +10908,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -10826,10 +10922,11 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail5_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail5_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -11492,13 +11589,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym51__;
@@ -11829,8 +11929,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 147> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail6.stan', line 163, column 2 to column 33)",
  " (in 'expr-prop-fail6.stan', line 164, column 2 to column 31)",
@@ -11983,7 +12082,7 @@ static const std::vector<std::string> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -12029,7 +12128,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -12091,7 +12190,7 @@ prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
           stan::value_type_t<T1__>>;
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -12906,11 +13005,12 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   expr_prop_fail6_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail6_model_namespace::expr_prop_fail6_model";
+    static constexpr char* function__ = "expr_prop_fail6_model_namespace::expr_prop_fail6_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -13301,7 +13401,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -13310,9 +13412,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail6_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail6_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -14499,7 +14602,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -14510,10 +14616,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail6_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail6_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -15603,13 +15710,16 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym128__;
@@ -16081,8 +16191,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 38> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail7.stan', line 20, column 2 to column 16)",
  " (in 'expr-prop-fail7.stan', line 21, column 2 to column 24)",
@@ -16167,11 +16276,12 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   expr_prop_fail7_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail7_model_namespace::expr_prop_fail7_model";
+    static constexpr char* function__ = "expr_prop_fail7_model_namespace::expr_prop_fail7_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -16502,7 +16612,9 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -16511,9 +16623,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail7_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail7_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -16799,7 +16912,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -16810,10 +16926,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail7_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail7_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -17093,13 +17210,16 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym23__;
@@ -17576,8 +17696,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 25> locations_array__ = 
 {" (found before start of program)",
  " (in 'expr-prop-fail8.stan', line 11, column 2 to column 13)",
  " (in 'expr-prop-fail8.stan', line 12, column 2 to column 13)",
@@ -17640,11 +17759,12 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   expr_prop_fail8_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail8_model_namespace::expr_prop_fail8_model";
+    static constexpr char* function__ = "expr_prop_fail8_model_namespace::expr_prop_fail8_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -17825,7 +17945,9 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -17834,9 +17956,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail8_model_namespace::log_prob";
+    static constexpr char* function__ = "expr_prop_fail8_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -17926,7 +18049,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -17937,10 +18063,11 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "expr_prop_fail8_model_namespace::write_array";
+    static constexpr char* function__ = "expr_prop_fail8_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -18047,13 +18174,16 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym10__;
@@ -18392,8 +18522,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 68> locations_array__ = 
 {" (found before start of program)",
  " (in 'fails-test.stan', line 71, column 2 to column 31)",
  " (in 'fails-test.stan', line 72, column 2 to column 40)",
@@ -18467,7 +18596,7 @@ static const std::vector<std::string> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -18513,7 +18642,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -18575,7 +18704,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
           stan::value_type_t<T3__>>;
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -18822,11 +18951,12 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   fails_test_model(stan::io::var_context& context__,
                    unsigned int random_seed__ = 0,
                    std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "fails_test_model_namespace::fails_test_model";
+    static constexpr char* function__ = "fails_test_model_namespace::fails_test_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -19329,7 +19459,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -19338,9 +19470,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "fails_test_model_namespace::log_prob";
+    static constexpr char* function__ = "fails_test_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20011,7 +20144,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -20022,10 +20158,11 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "fails_test_model_namespace::write_array";
+    static constexpr char* function__ = "fails_test_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20671,13 +20808,16 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym53__;
@@ -20986,8 +21126,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 145> locations_array__ = 
 {" (found before start of program)",
  " (in 'inlining-fail2.stan', line 177, column 2 to column 33)",
  " (in 'inlining-fail2.stan', line 178, column 2 to column 31)",
@@ -21138,7 +21277,7 @@ static const std::vector<std::string> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21184,7 +21323,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21246,7 +21385,7 @@ prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
           stan::value_type_t<T1__>>;
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22009,7 +22148,7 @@ Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
   using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
   const auto& gamma = to_ref(gamma_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22120,11 +22259,12 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   inlining_fail2_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
                        std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "inlining_fail2_model_namespace::inlining_fail2_model";
+    static constexpr char* function__ = "inlining_fail2_model_namespace::inlining_fail2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22517,7 +22657,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -22526,9 +22668,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "inlining_fail2_model_namespace::log_prob";
+    static constexpr char* function__ = "inlining_fail2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -23639,7 +23782,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -23650,10 +23796,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "inlining_fail2_model_namespace::write_array";
+    static constexpr char* function__ = "inlining_fail2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -24654,13 +24801,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym142__;
@@ -25115,8 +25265,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 7> locations_array__ = 
 {" (found before start of program)",
  " (in 'lcm-experiment.stan', line 2, column 2 to column 8)",
  " (in 'lcm-experiment.stan', line 5, column 2 to column 13)",
@@ -25149,11 +25298,12 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
   lcm_experiment_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
                        std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "lcm_experiment_model_namespace::lcm_experiment_model";
+    static constexpr char* function__ = "lcm_experiment_model_namespace::lcm_experiment_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25204,7 +25354,9 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -25213,9 +25365,10 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_experiment_model_namespace::log_prob";
+    static constexpr char* function__ = "lcm_experiment_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25229,7 +25382,10 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -25240,10 +25396,11 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_experiment_model_namespace::write_array";
+    static constexpr char* function__ = "lcm_experiment_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25263,13 +25420,16 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -25446,8 +25606,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 8> locations_array__ = 
 {" (found before start of program)",
  " (in 'lcm-experiment2.stan', line 2, column 2 to column 9)",
  " (in 'lcm-experiment2.stan', line 5, column 2 to column 18)",
@@ -25477,11 +25636,12 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   lcm_experiment2_model(stan::io::var_context& context__,
                         unsigned int random_seed__ = 0,
                         std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "lcm_experiment2_model_namespace::lcm_experiment2_model";
+    static constexpr char* function__ = "lcm_experiment2_model_namespace::lcm_experiment2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25505,7 +25665,9 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -25514,9 +25676,10 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_experiment2_model_namespace::log_prob";
+    static constexpr char* function__ = "lcm_experiment2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25553,7 +25716,10 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -25564,10 +25730,11 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_experiment2_model_namespace::write_array";
+    static constexpr char* function__ = "lcm_experiment2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25593,13 +25760,16 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -25783,8 +25953,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 7> locations_array__ = 
 {" (found before start of program)",
  " (in 'lcm-fails.stan', line 6, column 2 to column 16)",
  " (in 'lcm-fails.stan', line 9, column 2 to column 22)",
@@ -25814,11 +25983,12 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   lcm_fails_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
                   std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "lcm_fails_model_namespace::lcm_fails_model";
+    static constexpr char* function__ = "lcm_fails_model_namespace::lcm_fails_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25864,7 +26034,9 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -25873,9 +26045,10 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_fails_model_namespace::log_prob";
+    static constexpr char* function__ = "lcm_fails_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25907,7 +26080,10 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -25918,10 +26094,11 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_fails_model_namespace::write_array";
+    static constexpr char* function__ = "lcm_fails_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25962,13 +26139,16 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym3__;
@@ -26166,8 +26346,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 64> locations_array__ = 
 {" (found before start of program)",
  " (in 'lcm-fails2.stan', line 69, column 2 to column 33)",
  " (in 'lcm-fails2.stan', line 70, column 2 to column 31)",
@@ -26237,7 +26416,7 @@ static const std::vector<std::string> locations_array__ =
 int
 first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -26283,7 +26462,7 @@ return first_capture(y_i, pstream__);
 int
 last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -26345,7 +26524,7 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
           stan::value_type_t<T3__>>;
   const auto& p = to_ref(p_arg__);
   const auto& phi = to_ref(phi_arg__);
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -26583,11 +26762,12 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
   lcm_fails2_model(stan::io::var_context& context__,
                    unsigned int random_seed__ = 0,
                    std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "lcm_fails2_model_namespace::lcm_fails2_model";
+    static constexpr char* function__ = "lcm_fails2_model_namespace::lcm_fails2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -26958,7 +27138,9 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26967,9 +27149,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_fails2_model_namespace::log_prob";
+    static constexpr char* function__ = "lcm_fails2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -27610,7 +27793,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -27621,10 +27807,11 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lcm_fails2_model_namespace::write_array";
+    static constexpr char* function__ = "lcm_fails2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28246,13 +28433,16 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -28511,8 +28701,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 13> locations_array__ = 
 {" (found before start of program)",
  " (in 'lupdf-inlining.stan', line 16, column 4 to column 12)",
  " (in 'lupdf-inlining.stan', line 19, column 4 to column 32)",
@@ -28635,11 +28824,12 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
   lupdf_inlining_model(stan::io::var_context& context__,
                        unsigned int random_seed__ = 0,
                        std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "lupdf_inlining_model_namespace::lupdf_inlining_model";
+    static constexpr char* function__ = "lupdf_inlining_model_namespace::lupdf_inlining_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -28670,7 +28860,9 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28679,9 +28871,10 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lupdf_inlining_model_namespace::log_prob";
+    static constexpr char* function__ = "lupdf_inlining_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28743,7 +28936,10 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28754,10 +28950,11 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "lupdf_inlining_model_namespace::write_array";
+    static constexpr char* function__ = "lupdf_inlining_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28836,13 +29033,16 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -29037,8 +29237,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 52> locations_array__ = 
 {" (found before start of program)",
  " (in 'off-dce.stan', line 23, column 2 to column 17)",
  " (in 'off-dce.stan', line 24, column 2 to column 16)",
@@ -29134,11 +29333,12 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   off_dce_model(stan::io::var_context& context__,
                 unsigned int random_seed__ = 0,
                 std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "off_dce_model_namespace::off_dce_model";
+    static constexpr char* function__ = "off_dce_model_namespace::off_dce_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -29417,7 +29617,9 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -29426,9 +29628,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "off_dce_model_namespace::log_prob";
+    static constexpr char* function__ = "off_dce_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -29538,7 +29741,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -29549,10 +29755,11 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "off_dce_model_namespace::write_array";
+    static constexpr char* function__ = "off_dce_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -29788,13 +29995,16 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;
@@ -30063,8 +30273,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 35> locations_array__ = 
 {" (found before start of program)",
  " (in 'off-small.stan', line 10, column 2 to column 12)",
  " (in 'off-small.stan', line 11, column 2 to column 17)",
@@ -30136,11 +30345,12 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   off_small_model(stan::io::var_context& context__,
                   unsigned int random_seed__ = 0,
                   std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "off_small_model_namespace::off_small_model";
+    static constexpr char* function__ = "off_small_model_namespace::off_small_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -30335,7 +30545,9 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -30344,9 +30556,10 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "off_small_model_namespace::log_prob";
+    static constexpr char* function__ = "off_small_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -30487,7 +30700,10 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -30498,10 +30714,11 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "off_small_model_namespace::write_array";
+    static constexpr char* function__ = "off_small_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -30656,13 +30873,16 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym10__;
@@ -31041,8 +31261,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 94> locations_array__ = 
 {" (found before start of program)",
  " (in 'optimizations.stan', line 20, column 4 to column 15)",
  " (in 'optimizations.stan', line 21, column 4 to column 13)",
@@ -31180,7 +31399,7 @@ return nrfun_lp<propto__>(x, y, lp__, lp_accum__, pstream__);
 int
 rfun(const int& y, std::ostream* pstream__) {
   using local_scalar_t__ = double;
-  const static bool propto__ = true;
+  static constexpr bool propto__ = true;
   (void) propto__;
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   (void) DUMMY_VAR__;  // suppress unused var warning
@@ -31261,11 +31480,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   optimizations_model(stan::io::var_context& context__,
                       unsigned int random_seed__ = 0,
                       std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "optimizations_model_namespace::optimizations_model";
+    static constexpr char* function__ = "optimizations_model_namespace::optimizations_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -31293,7 +31513,9 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -31302,9 +31524,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "optimizations_model_namespace::log_prob";
+    static constexpr char* function__ = "optimizations_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -31869,7 +32092,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -31880,10 +32106,11 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "optimizations_model_namespace::write_array";
+    static constexpr char* function__ = "optimizations_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -32025,13 +32252,16 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym53__;
@@ -32495,8 +32725,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 25> locations_array__ = 
 {" (found before start of program)",
  " (in 'partial-eval.stan', line 10, column 2 to column 19)",
  " (in 'partial-eval.stan', line 11, column 2 to column 17)",
@@ -32560,11 +32789,12 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   partial_eval_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,
                      std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "partial_eval_model_namespace::partial_eval_model";
+    static constexpr char* function__ = "partial_eval_model_namespace::partial_eval_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -32775,7 +33005,9 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -32784,9 +33016,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "partial_eval_model_namespace::log_prob";
+    static constexpr char* function__ = "partial_eval_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -32877,7 +33110,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -32888,10 +33124,11 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "partial_eval_model_namespace::write_array";
+    static constexpr char* function__ = "partial_eval_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -32991,13 +33228,16 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym10__;
@@ -33317,8 +33557,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 33> locations_array__ = 
 {" (found before start of program)",
  " (in 'stalled1-failure.stan', line 30, column 4 to column 16)",
  " (in 'stalled1-failure.stan', line 31, column 4 to column 16)",
@@ -33390,11 +33629,12 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   stalled1_failure_model(stan::io::var_context& context__,
                          unsigned int random_seed__ = 0,
                          std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "stalled1_failure_model_namespace::stalled1_failure_model";
+    static constexpr char* function__ = "stalled1_failure_model_namespace::stalled1_failure_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33564,7 +33804,9 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33573,9 +33815,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "stalled1_failure_model_namespace::log_prob";
+    static constexpr char* function__ = "stalled1_failure_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33688,7 +33931,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33699,10 +33945,11 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "stalled1_failure_model_namespace::write_array";
+    static constexpr char* function__ = "stalled1_failure_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33838,13 +34085,16 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       double lcm_sym8__;
@@ -34344,8 +34594,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static int current_statement__= 0;
-static const std::vector<std::string> locations_array__ = 
+static constexpr std::array<const char*, 14> locations_array__ = 
 {" (found before start of program)",
  " (in 'unroll-limit.stan', line 2, column 2 to column 8)",
  " (in 'unroll-limit.stan', line 4, column 4 to column 15)",
@@ -34381,11 +34630,12 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   unroll_limit_model(stan::io::var_context& context__,
                      unsigned int random_seed__ = 0,
                      std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
     using local_scalar_t__ = double ;
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static const char* function__ = "unroll_limit_model_namespace::unroll_limit_model";
+    static constexpr char* function__ = "unroll_limit_model_namespace::unroll_limit_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34409,7 +34659,9 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***"); 
     }
   }
-  template <bool propto__, bool jacobian__, typename VecR, typename VecI, stan::require_vector_like_t<VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+    stan::require_vector_like_t<VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -34418,9 +34670,10 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     T__ lp__(0.0);
     stan::math::accumulator<T__> lp_accum__;
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "unroll_limit_model_namespace::log_prob";
+    static constexpr char* function__ = "unroll_limit_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -34434,7 +34687,10 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     return lp_accum__.sum();
     } // log_prob_impl() 
     
-  template <typename RNG, typename VecR, typename VecI, typename VecVar, stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr>
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -34445,10 +34701,11 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
     double lp__ = 0.0;
     (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static const char* function__ = "unroll_limit_model_namespace::write_array";
+    static constexpr char* function__ = "unroll_limit_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -34744,13 +35001,16 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     }
     } // write_array_impl() 
     
-  template <typename VecVar, typename VecI, stan::require_std_vector_t<VecVar>* = nullptr, stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
+  template <typename VecVar, typename VecI, 
+    stan::require_std_vector_t<VecVar>* = nullptr, 
+    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     vars__.clear();
     vars__.reserve(num_params_r__);
+    int current_statement__ = 0; 
     
     try {
       int pos__;

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -244,8 +244,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -442,9 +442,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -619,8 +619,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -1824,8 +1824,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -2509,9 +2509,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -3173,8 +3173,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -3992,8 +3992,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -4299,9 +4299,9 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -4510,8 +4510,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -5232,8 +5232,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5260,9 +5260,9 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5298,8 +5298,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -5576,8 +5576,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -5604,9 +5604,9 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -5642,8 +5642,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -5943,8 +5943,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6071,9 +6071,9 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6167,8 +6167,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -6578,8 +6578,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -6645,9 +6645,9 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -6718,8 +6718,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -7533,8 +7533,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -7717,9 +7717,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -7930,8 +7930,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -8795,8 +8795,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -8882,9 +8882,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -9096,8 +9096,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -10231,8 +10231,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -10916,9 +10916,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -11597,8 +11597,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -13413,8 +13413,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -14614,9 +14614,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -15722,8 +15722,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -16624,8 +16624,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -16924,9 +16924,9 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -17222,8 +17222,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -17957,8 +17957,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -18061,9 +18061,9 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -18186,8 +18186,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -19474,8 +19474,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -20159,9 +20159,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -20823,8 +20823,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -22677,8 +22677,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -23802,9 +23802,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -24821,8 +24821,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -25374,8 +25374,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -25402,9 +25402,9 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -25440,8 +25440,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -25685,8 +25685,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -25736,9 +25736,9 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -25780,8 +25780,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -26054,8 +26054,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -26100,9 +26100,9 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -26159,8 +26159,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -27161,8 +27161,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -27816,9 +27816,9 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -28456,8 +28456,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -28886,8 +28886,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -28962,9 +28962,9 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -29059,8 +29059,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -29643,8 +29643,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -29767,9 +29767,9 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -30021,8 +30021,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -30571,8 +30571,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -30726,9 +30726,9 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -30899,8 +30899,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -31542,8 +31542,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -32121,9 +32121,9 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -32281,8 +32281,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33034,8 +33034,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33139,9 +33139,9 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -33257,8 +33257,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -33833,8 +33833,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -33960,9 +33960,9 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -34114,8 +34114,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {
@@ -34688,8 +34688,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     }
   }
   template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
-    stan::require_vector_like_t<VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
                                                  VecI& params_i__,
                                                  std::ostream* pstream__ = nullptr) const {
@@ -34716,9 +34716,9 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     } // log_prob_impl() 
     
   template <typename RNG, typename VecR, typename VecI, typename VecVar, 
-    stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
-    stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
   inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
                                VecI& params_i__, VecVar& vars__,
                                const bool emit_transformed_parameters__ = true,
@@ -35030,8 +35030,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     } // write_array_impl() 
     
   template <typename VecVar, typename VecI, 
-    stan::require_std_vector_t<VecVar>* = nullptr, 
-    stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
   inline void transform_inits_impl(const stan::io::var_context& context__,
                                    VecI& params_i__, VecVar& vars__,
                                    std::ostream* pstream__ = nullptr) const {

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -31,7 +31,7 @@ let%expect_test "udf" =
               stan::value_type_t<T1__>>;
       const auto& x = to_ref(x_arg__);
       const auto& y = to_ref(y_arg__);
-      const static bool propto__ = true;
+      static constexpr bool propto__ = true;
       (void) propto__;
       local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
       (void) DUMMY_VAR__;  // suppress unused var warning
@@ -92,7 +92,7 @@ let%expect_test "udf-expressions" =
       const auto& x = to_ref(x_arg__);
       const auto& y = to_ref(y_arg__);
       const auto& z = to_ref(z_arg__);
-      const static bool propto__ = true;
+      static constexpr bool propto__ = true;
       (void) propto__;
       local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
       (void) DUMMY_VAR__;  // suppress unused var warning

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -29,6 +29,7 @@ let%expect_test "udf" =
     sars(const T0__& x_arg__, const T1__& y_arg__, std::ostream* pstream__) {
       using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>,
               stan::value_type_t<T1__>>;
+      int current_statement__ = 0;
       const auto& x = to_ref(x_arg__);
       const auto& y = to_ref(y_arg__);
       static constexpr bool propto__ = true;
@@ -89,6 +90,7 @@ let%expect_test "udf-expressions" =
               stan::value_type_t<T1__>,
               stan::value_type_t<T2__>,
               T3__>;
+      int current_statement__ = 0;
       const auto& x = to_ref(x_arg__);
       const auto& y = to_ref(y_arg__);
       const auto& z = to_ref(z_arg__);


### PR DESCRIPTION
## Summary

This does three things

1. Makes `locations_array__` into a `static constexpr std::array<const char*, {size_of_error_list}>`
2. Moves `current_statement__` to be created inside of local function scopes.
3. Adds spaces to the templates for the `_impl` functions so they are a little easier to read.

(1) is just a nice optimization. That array is only read from and we can deduce the size in the compiler so we just make it a `static constexpr` array of `const char*` so the compiler knows it's size and `static` so that it knows that global can only be accessed inside this file.

(2) is related to [#897](https://github.com/stan-dev/cmdstan/pull/987) which let's a Stan program run with multiple chains in one program. Having `current_statement__` as a global variable means that when we call log prob in that etc. in that PR we hit a bunch of weird race conditions since each thread can be at a different point in each function (or running seperate functions that update `current_statement__`. This also produces [false sharing](https://en.wikipedia.org/wiki/False_sharing) in loops. Like say a user wrote

```stan
for (i in 1:N) {
  lp[i] = log_mix(x, xx[i], yy[i]);
  lp2[i] = log_mix(x2, xx2[i], yy2[i]);
}
```

In the c++ that becomes
```cpp
// pseudocode
for (int sym1__ = 1; sym1__ <= N;  ++sym1__) {
  current_statement__ = 5;
  lp[i] = log_mix(x, xx[i], yy[i]);
  current_statement__ = 6;
  lp2[i] = log_mix(x2, xx2[i], yy2[i]);
}
```

Since we are writing to a global if `current_statement__`, if the scalars used in the function and `current_statement__` are used on the same cache line then the cpu marks that cache line as invalid and forces the entire cache line to be re-read back in from memory. By making it defined locally each thread has their own version of `curr_statement__` and so there is no false sharing

So we just make current statement locally above the try block for each function that uses it. ~Thinking now I need to see how this will work with user defined functions.~ I think I sorted that out by just making it locally in the udf

(3) is just a nice thing to be able to read the generated C++

## Release notes

Make locations_array constexpr and move curr_statement__ to function scope

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)

Copyright Holder: Steve Bronder