### PR TITLE
Add const to constexpr char* variables (Issue #844)

### DIFF
--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -44,7 +44,7 @@ let pp_unused = fmt "(void) %s;  // suppress unused var warning"
   @param fname Name of the function.
  *)
 let pp_function__ ppf (prog_name, fname) =
-  pf ppf {|@[<v>static constexpr char* function__ = "%s_namespace::%s";@,%a@]|}
+  pf ppf {|@[<v>static constexpr const char* function__ = "%s_namespace::%s";@,%a@]|}
     prog_name fname pp_unused "function__"
 
 (** Print the body of exception handling for functions *)

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -44,7 +44,8 @@ let pp_unused = fmt "(void) %s;  // suppress unused var warning"
   @param fname Name of the function.
  *)
 let pp_function__ ppf (prog_name, fname) =
-  pf ppf {|@[<v>static constexpr const char* function__ = "%s_namespace::%s";@,%a@]|}
+  pf ppf
+    {|@[<v>static constexpr const char* function__ = "%s_namespace::%s";@,%a@]|}
     prog_name fname pp_unused "function__"
 
 (** Print the body of exception handling for functions *)

--- a/test/integration/cli-args/filename_good.expected
+++ b/test/integration/cli-args/filename_good.expected
@@ -50,7 +50,7 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "filename_good_model_namespace::filename_good_model";
+    static constexpr const char* function__ = "filename_good_model_namespace::filename_good_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -96,7 +96,7 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "filename_good_model_namespace::log_prob";
+    static constexpr const char* function__ = "filename_good_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -128,7 +128,7 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "filename_good_model_namespace::write_array";
+    static constexpr const char* function__ = "filename_good_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -287,7 +287,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
+    static constexpr const char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -570,7 +570,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "optimize_glm_model_namespace::log_prob";
+    static constexpr const char* function__ = "optimize_glm_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1291,7 +1291,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "optimize_glm_model_namespace::write_array";
+    static constexpr const char* function__ = "optimize_glm_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -64,7 +64,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "_8_schools_ncp_model_namespace::_8_schools_ncp_model";
+    static constexpr const char* function__ = "_8_schools_ncp_model_namespace::_8_schools_ncp_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -144,7 +144,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "_8_schools_ncp_model_namespace::log_prob";
+    static constexpr const char* function__ = "_8_schools_ncp_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -216,7 +216,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "_8_schools_ncp_model_namespace::write_array";
+    static constexpr const char* function__ = "_8_schools_ncp_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -548,7 +548,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "_8start_with_number_model_namespace::_8start_with_number_model";
+    static constexpr const char* function__ = "_8start_with_number_model_namespace::_8start_with_number_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -593,7 +593,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "_8start_with_number_model_namespace::log_prob";
+    static constexpr const char* function__ = "_8start_with_number_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -629,7 +629,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "_8start_with_number_model_namespace::write_array";
+    static constexpr const char* function__ = "_8start_with_number_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -892,7 +892,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "eight_schools_ncp_model_namespace::eight_schools_ncp_model";
+    static constexpr const char* function__ = "eight_schools_ncp_model_namespace::eight_schools_ncp_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -972,7 +972,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "eight_schools_ncp_model_namespace::log_prob";
+    static constexpr const char* function__ = "eight_schools_ncp_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1044,7 +1044,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "eight_schools_ncp_model_namespace::write_array";
+    static constexpr const char* function__ = "eight_schools_ncp_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1380,7 +1380,7 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "mixed_type_arrays_model_namespace::mixed_type_arrays_model";
+    static constexpr const char* function__ = "mixed_type_arrays_model_namespace::mixed_type_arrays_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1421,7 +1421,7 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "mixed_type_arrays_model_namespace::log_prob";
+    static constexpr const char* function__ = "mixed_type_arrays_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1489,7 +1489,7 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "mixed_type_arrays_model_namespace::write_array";
+    static constexpr const char* function__ = "mixed_type_arrays_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -4684,7 +4684,7 @@ class mother_model final : public model_base_crtp<mother_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "mother_model_namespace::mother_model";
+    static constexpr const char* function__ = "mother_model_namespace::mother_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -6889,7 +6889,7 @@ class mother_model final : public model_base_crtp<mother_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "mother_model_namespace::log_prob";
+    static constexpr const char* function__ = "mother_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -7769,7 +7769,7 @@ class mother_model final : public model_base_crtp<mother_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "mother_model_namespace::write_array";
+    static constexpr const char* function__ = "mother_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -11674,7 +11674,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "motherHOF_model_namespace::motherHOF_model";
+    static constexpr const char* function__ = "motherHOF_model_namespace::motherHOF_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -11898,7 +11898,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "motherHOF_model_namespace::log_prob";
+    static constexpr const char* function__ = "motherHOF_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -12246,7 +12246,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "motherHOF_model_namespace::write_array";
+    static constexpr const char* function__ = "motherHOF_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -14028,7 +14028,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "new_integrate_interface_model_namespace::new_integrate_interface_model";
+    static constexpr const char* function__ = "new_integrate_interface_model_namespace::new_integrate_interface_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -14190,7 +14190,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "new_integrate_interface_model_namespace::log_prob";
+    static constexpr const char* function__ = "new_integrate_interface_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -15840,7 +15840,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "new_integrate_interface_model_namespace::write_array";
+    static constexpr const char* function__ = "new_integrate_interface_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -17898,7 +17898,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "old_integrate_interface_model_namespace::old_integrate_interface_model";
+    static constexpr const char* function__ = "old_integrate_interface_model_namespace::old_integrate_interface_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -18005,7 +18005,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "old_integrate_interface_model_namespace::log_prob";
+    static constexpr const char* function__ = "old_integrate_interface_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -18173,7 +18173,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "old_integrate_interface_model_namespace::write_array";
+    static constexpr const char* function__ = "old_integrate_interface_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -18853,7 +18853,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
+    static constexpr const char* function__ = "optimize_glm_model_namespace::optimize_glm_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -19124,7 +19124,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "optimize_glm_model_namespace::log_prob";
+    static constexpr const char* function__ = "optimize_glm_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -19752,7 +19752,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "optimize_glm_model_namespace::write_array";
+    static constexpr const char* function__ = "optimize_glm_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20325,7 +20325,7 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "param_constraint_model_namespace::param_constraint_model";
+    static constexpr const char* function__ = "param_constraint_model_namespace::param_constraint_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -20382,7 +20382,7 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "param_constraint_model_namespace::log_prob";
+    static constexpr const char* function__ = "param_constraint_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20470,7 +20470,7 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "param_constraint_model_namespace::write_array";
+    static constexpr const char* function__ = "param_constraint_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -21026,7 +21026,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m1_model_namespace::reduce_sum_m1_model";
+    static constexpr const char* function__ = "reduce_sum_m1_model_namespace::reduce_sum_m1_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -21077,7 +21077,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m1_model_namespace::log_prob";
+    static constexpr const char* function__ = "reduce_sum_m1_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -21144,7 +21144,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m1_model_namespace::write_array";
+    static constexpr const char* function__ = "reduce_sum_m1_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -22525,7 +22525,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m2_model_namespace::reduce_sum_m2_model";
+    static constexpr const char* function__ = "reduce_sum_m2_model_namespace::reduce_sum_m2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22668,7 +22668,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m2_model_namespace::log_prob";
+    static constexpr const char* function__ = "reduce_sum_m2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -22905,7 +22905,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m2_model_namespace::write_array";
+    static constexpr const char* function__ = "reduce_sum_m2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -26195,7 +26195,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m3_model_namespace::reduce_sum_m3_model";
+    static constexpr const char* function__ = "reduce_sum_m3_model_namespace::reduce_sum_m3_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -26869,7 +26869,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m3_model_namespace::log_prob";
+    static constexpr const char* function__ = "reduce_sum_m3_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -27163,7 +27163,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "reduce_sum_m3_model_namespace::write_array";
+    static constexpr const char* function__ = "reduce_sum_m3_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28609,7 +28609,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "single_argument_lpmf_model_namespace::single_argument_lpmf_model";
+    static constexpr const char* function__ = "single_argument_lpmf_model_namespace::single_argument_lpmf_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -28647,7 +28647,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "single_argument_lpmf_model_namespace::log_prob";
+    static constexpr const char* function__ = "single_argument_lpmf_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28679,7 +28679,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "single_argument_lpmf_model_namespace::write_array";
+    static constexpr const char* function__ = "single_argument_lpmf_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28919,7 +28919,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "tilde_block_model_namespace::tilde_block_model";
+    static constexpr const char* function__ = "tilde_block_model_namespace::tilde_block_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -28964,7 +28964,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "tilde_block_model_namespace::log_prob";
+    static constexpr const char* function__ = "tilde_block_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -29034,7 +29034,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "tilde_block_model_namespace::write_array";
+    static constexpr const char* function__ = "tilde_block_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -29407,7 +29407,7 @@ class transform_model final : public model_base_crtp<transform_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "transform_model_namespace::transform_model";
+    static constexpr const char* function__ = "transform_model_namespace::transform_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -29747,7 +29747,7 @@ class transform_model final : public model_base_crtp<transform_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "transform_model_namespace::log_prob";
+    static constexpr const char* function__ = "transform_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -30735,7 +30735,7 @@ class transform_model final : public model_base_crtp<transform_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "transform_model_namespace::write_array";
+    static constexpr const char* function__ = "transform_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33072,7 +33072,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "truncate_model_namespace::truncate_model";
+    static constexpr const char* function__ = "truncate_model_namespace::truncate_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33125,7 +33125,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "truncate_model_namespace::log_prob";
+    static constexpr const char* function__ = "truncate_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33256,7 +33256,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "truncate_model_namespace::write_array";
+    static constexpr const char* function__ = "truncate_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33557,7 +33557,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "udf_tilde_stmt_conflict_model_namespace::udf_tilde_stmt_conflict_model";
+    static constexpr const char* function__ = "udf_tilde_stmt_conflict_model_namespace::udf_tilde_stmt_conflict_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33595,7 +33595,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "udf_tilde_stmt_conflict_model_namespace::log_prob";
+    static constexpr const char* function__ = "udf_tilde_stmt_conflict_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33635,7 +33635,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "udf_tilde_stmt_conflict_model_namespace::write_array";
+    static constexpr const char* function__ = "udf_tilde_stmt_conflict_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33915,7 +33915,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "user_constrain_model_namespace::user_constrain_model";
+    static constexpr const char* function__ = "user_constrain_model_namespace::user_constrain_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33953,7 +33953,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "user_constrain_model_namespace::log_prob";
+    static constexpr const char* function__ = "user_constrain_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -34001,7 +34001,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "user_constrain_model_namespace::write_array";
+    static constexpr const char* function__ = "user_constrain_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -175,7 +175,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "simple_function_model_namespace::simple_function_model";
+    static constexpr const char* function__ = "simple_function_model_namespace::simple_function_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -249,7 +249,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "simple_function_model_namespace::log_prob";
+    static constexpr const char* function__ = "simple_function_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -281,7 +281,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "simple_function_model_namespace::write_array";
+    static constexpr const char* function__ = "simple_function_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -826,7 +826,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "distributions_model_namespace::distributions_model";
+    static constexpr const char* function__ = "distributions_model_namespace::distributions_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -970,7 +970,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "distributions_model_namespace::log_prob";
+    static constexpr const char* function__ = "distributions_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -3513,7 +3513,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "distributions_model_namespace::write_array";
+    static constexpr const char* function__ = "distributions_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6471,7 +6471,7 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "restricted_model_namespace::restricted_model";
+    static constexpr const char* function__ = "restricted_model_namespace::restricted_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -6609,7 +6609,7 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "restricted_model_namespace::log_prob";
+    static constexpr const char* function__ = "restricted_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6721,7 +6721,7 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "restricted_model_namespace::write_array";
+    static constexpr const char* function__ = "restricted_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -78,7 +78,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "simple_function_model_namespace::simple_function_model";
+    static constexpr const char* function__ = "simple_function_model_namespace::simple_function_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -171,7 +171,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "simple_function_model_namespace::log_prob";
+    static constexpr const char* function__ = "simple_function_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -301,7 +301,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "simple_function_model_namespace::write_array";
+    static constexpr const char* function__ = "simple_function_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -147,7 +147,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "ad_level_failing_model_namespace::ad_level_failing_model";
+    static constexpr const char* function__ = "ad_level_failing_model_namespace::ad_level_failing_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -257,7 +257,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "ad_level_failing_model_namespace::log_prob";
+    static constexpr const char* function__ = "ad_level_failing_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -459,7 +459,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "ad_level_failing_model_namespace::write_array";
+    static constexpr const char* function__ = "ad_level_failing_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -1320,7 +1320,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "copy_fail_model_namespace::copy_fail_model";
+    static constexpr const char* function__ = "copy_fail_model_namespace::copy_fail_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -1837,7 +1837,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "copy_fail_model_namespace::log_prob";
+    static constexpr const char* function__ = "copy_fail_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -2526,7 +2526,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "copy_fail_model_namespace::write_array";
+    static constexpr const char* function__ = "copy_fail_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -3614,7 +3614,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "dce_fail_model_namespace::dce_fail_model";
+    static constexpr const char* function__ = "dce_fail_model_namespace::dce_fail_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -4005,7 +4005,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "dce_fail_model_namespace::log_prob";
+    static constexpr const char* function__ = "dce_fail_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -4316,7 +4316,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "dce_fail_model_namespace::write_array";
+    static constexpr const char* function__ = "dce_fail_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5177,7 +5177,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_experiment_model_namespace::expr_prop_experiment_model";
+    static constexpr const char* function__ = "expr_prop_experiment_model_namespace::expr_prop_experiment_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -5245,7 +5245,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_experiment_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_experiment_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5277,7 +5277,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_experiment_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_experiment_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5522,7 +5522,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_experiment2_model_namespace::expr_prop_experiment2_model";
+    static constexpr const char* function__ = "expr_prop_experiment2_model_namespace::expr_prop_experiment2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -5589,7 +5589,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_experiment2_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_experiment2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5621,7 +5621,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_experiment2_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_experiment2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -5872,7 +5872,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail_model_namespace::expr_prop_fail_model";
+    static constexpr const char* function__ = "expr_prop_fail_model_namespace::expr_prop_fail_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -5956,7 +5956,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6088,7 +6088,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6505,7 +6505,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail2_model_namespace::expr_prop_fail2_model";
+    static constexpr const char* function__ = "expr_prop_fail2_model_namespace::expr_prop_fail2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -6591,7 +6591,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail2_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -6662,7 +6662,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail2_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -7068,7 +7068,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail3_model_namespace::expr_prop_fail3_model";
+    static constexpr const char* function__ = "expr_prop_fail3_model_namespace::expr_prop_fail3_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -7546,7 +7546,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail3_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail3_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -7734,7 +7734,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail3_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail3_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -8605,7 +8605,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail4_model_namespace::expr_prop_fail4_model";
+    static constexpr const char* function__ = "expr_prop_fail4_model_namespace::expr_prop_fail4_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -8808,7 +8808,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail4_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail4_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -8899,7 +8899,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail4_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail4_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -9855,7 +9855,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail5_model_namespace::expr_prop_fail5_model";
+    static constexpr const char* function__ = "expr_prop_fail5_model_namespace::expr_prop_fail5_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -10244,7 +10244,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail5_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail5_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -10933,7 +10933,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail5_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail5_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -13021,7 +13021,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail6_model_namespace::expr_prop_fail6_model";
+    static constexpr const char* function__ = "expr_prop_fail6_model_namespace::expr_prop_fail6_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -13426,7 +13426,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail6_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail6_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -14631,7 +14631,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail6_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail6_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -16292,7 +16292,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail7_model_namespace::expr_prop_fail7_model";
+    static constexpr const char* function__ = "expr_prop_fail7_model_namespace::expr_prop_fail7_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -16637,7 +16637,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail7_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail7_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -16941,7 +16941,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail7_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail7_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -17775,7 +17775,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail8_model_namespace::expr_prop_fail8_model";
+    static constexpr const char* function__ = "expr_prop_fail8_model_namespace::expr_prop_fail8_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -17970,7 +17970,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail8_model_namespace::log_prob";
+    static constexpr const char* function__ = "expr_prop_fail8_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -18078,7 +18078,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "expr_prop_fail8_model_namespace::write_array";
+    static constexpr const char* function__ = "expr_prop_fail8_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -18970,7 +18970,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "fails_test_model_namespace::fails_test_model";
+    static constexpr const char* function__ = "fails_test_model_namespace::fails_test_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -19487,7 +19487,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "fails_test_model_namespace::log_prob";
+    static constexpr const char* function__ = "fails_test_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -20176,7 +20176,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "fails_test_model_namespace::write_array";
+    static constexpr const char* function__ = "fails_test_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -22283,7 +22283,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "inlining_fail2_model_namespace::inlining_fail2_model";
+    static constexpr const char* function__ = "inlining_fail2_model_namespace::inlining_fail2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -22690,7 +22690,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "inlining_fail2_model_namespace::log_prob";
+    static constexpr const char* function__ = "inlining_fail2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -23819,7 +23819,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "inlining_fail2_model_namespace::write_array";
+    static constexpr const char* function__ = "inlining_fail2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25322,7 +25322,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_experiment_model_namespace::lcm_experiment_model";
+    static constexpr const char* function__ = "lcm_experiment_model_namespace::lcm_experiment_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25387,7 +25387,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_experiment_model_namespace::log_prob";
+    static constexpr const char* function__ = "lcm_experiment_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25419,7 +25419,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_experiment_model_namespace::write_array";
+    static constexpr const char* function__ = "lcm_experiment_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25660,7 +25660,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_experiment2_model_namespace::lcm_experiment2_model";
+    static constexpr const char* function__ = "lcm_experiment2_model_namespace::lcm_experiment2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25698,7 +25698,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_experiment2_model_namespace::log_prob";
+    static constexpr const char* function__ = "lcm_experiment2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -25753,7 +25753,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_experiment2_model_namespace::write_array";
+    static constexpr const char* function__ = "lcm_experiment2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -26007,7 +26007,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_fails_model_namespace::lcm_fails_model";
+    static constexpr const char* function__ = "lcm_fails_model_namespace::lcm_fails_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -26067,7 +26067,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_fails_model_namespace::log_prob";
+    static constexpr const char* function__ = "lcm_fails_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -26117,7 +26117,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_fails_model_namespace::write_array";
+    static constexpr const char* function__ = "lcm_fails_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -26789,7 +26789,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_fails2_model_namespace::lcm_fails2_model";
+    static constexpr const char* function__ = "lcm_fails2_model_namespace::lcm_fails2_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -27174,7 +27174,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_fails2_model_namespace::log_prob";
+    static constexpr const char* function__ = "lcm_fails2_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -27833,7 +27833,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lcm_fails2_model_namespace::write_array";
+    static constexpr const char* function__ = "lcm_fails2_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28854,7 +28854,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "lupdf_inlining_model_namespace::lupdf_inlining_model";
+    static constexpr const char* function__ = "lupdf_inlining_model_namespace::lupdf_inlining_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -28899,7 +28899,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lupdf_inlining_model_namespace::log_prob";
+    static constexpr const char* function__ = "lupdf_inlining_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -28979,7 +28979,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "lupdf_inlining_model_namespace::write_array";
+    static constexpr const char* function__ = "lupdf_inlining_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -29363,7 +29363,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "off_dce_model_namespace::off_dce_model";
+    static constexpr const char* function__ = "off_dce_model_namespace::off_dce_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -29656,7 +29656,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "off_dce_model_namespace::log_prob";
+    static constexpr const char* function__ = "off_dce_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -29784,7 +29784,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "off_dce_model_namespace::write_array";
+    static constexpr const char* function__ = "off_dce_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -30375,7 +30375,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "off_small_model_namespace::off_small_model";
+    static constexpr const char* function__ = "off_small_model_namespace::off_small_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -30584,7 +30584,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "off_small_model_namespace::log_prob";
+    static constexpr const char* function__ = "off_small_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -30743,7 +30743,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "off_small_model_namespace::write_array";
+    static constexpr const char* function__ = "off_small_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -31513,7 +31513,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "optimizations_model_namespace::optimizations_model";
+    static constexpr const char* function__ = "optimizations_model_namespace::optimizations_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -31555,7 +31555,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "optimizations_model_namespace::log_prob";
+    static constexpr const char* function__ = "optimizations_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -32138,7 +32138,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "optimizations_model_namespace::write_array";
+    static constexpr const char* function__ = "optimizations_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -32822,7 +32822,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "partial_eval_model_namespace::partial_eval_model";
+    static constexpr const char* function__ = "partial_eval_model_namespace::partial_eval_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33047,7 +33047,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "partial_eval_model_namespace::log_prob";
+    static constexpr const char* function__ = "partial_eval_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33156,7 +33156,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "partial_eval_model_namespace::write_array";
+    static constexpr const char* function__ = "partial_eval_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33662,7 +33662,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "stalled1_failure_model_namespace::stalled1_failure_model";
+    static constexpr const char* function__ = "stalled1_failure_model_namespace::stalled1_failure_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -33846,7 +33846,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "stalled1_failure_model_namespace::log_prob";
+    static constexpr const char* function__ = "stalled1_failure_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -33977,7 +33977,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "stalled1_failure_model_namespace::write_array";
+    static constexpr const char* function__ = "stalled1_failure_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -34663,7 +34663,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     boost::ecuyer1988 base_rng__ = 
         stan::services::util::create_rng(random_seed__, 0);
     (void) base_rng__;  // suppress unused var warning
-    static constexpr char* function__ = "unroll_limit_model_namespace::unroll_limit_model";
+    static constexpr const char* function__ = "unroll_limit_model_namespace::unroll_limit_model";
     (void) function__;  // suppress unused var warning
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34701,7 +34701,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "unroll_limit_model_namespace::log_prob";
+    static constexpr const char* function__ = "unroll_limit_model_namespace::log_prob";
     (void) function__;  // suppress unused var warning
     
     try {
@@ -34733,7 +34733,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     stan::math::accumulator<double> lp_accum__;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
-    static constexpr char* function__ = "unroll_limit_model_namespace::write_array";
+    static constexpr const char* function__ = "unroll_limit_model_namespace::write_array";
     (void) function__;  // suppress unused var warning
     
     try {


### PR DESCRIPTION
## Release notes

I was getting compiler errors with the line:
```cpp
static constexpr char* function__ = "gauss3D_model_namespace::gauss3D_model";
```

The warning is:
```
warning: ISO C++11 does not allow conversion from string literal to 'char *const' [-Wwritable-strings]
```

If I add another `const` then they go away:
```cpp
static constexpr const char* function__ = "gauss3D_model_namespace::gauss3D_model";
```

I guess constexpr does not imply const.

Fixes #844 hopefully

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
