### PR TITLE
Adding back in rvalue checks on 1d indexes

### DIFF
--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -56,6 +56,11 @@ let minus_one e =
 
 let is_single_index = function Index.Single _ -> true | _ -> false
 
+let dont_need_range_check = function
+  | Index.Single Expr.Fixed.({pattern= Var id; _}) ->
+      not (Utils.is_user_ident id)
+  | _ -> false
+
 let promote_adtype =
   List.fold
     ~f:(fun accum expr ->
@@ -499,7 +504,7 @@ and pp_expr ppf Expr.Fixed.({pattern; meta} as e) =
       when Some Internal_fun.FnReadData = Internal_fun.of_string_opt f ->
         pp_indexed_simple ppf (strf "%a" pp_expr e, idx)
     | _
-      when List.for_all ~f:is_single_index idx
+      when List.for_all ~f:dont_need_range_check idx
            && not (UnsizedType.is_indexing_matrix (Expr.Typed.type_of e, idx))
       ->
         pp_indexed_simple ppf (strf "%a" pp_expr e, idx)

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1258,11 +1258,15 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
         current_statement__ = 174;
         lp_accum__.add(
           normal_id_glm_lpdf<false>(y_v_d_opencl__,
-            to_matrix_cl(X_d_a[(1 - 1)]), alpha, to_matrix_cl(beta), sigma));
+            to_matrix_cl(
+              rvalue(X_d_a, cons_list(index_uni(1), nil_index_list()),
+                "X_d_a")), alpha, to_matrix_cl(beta), sigma));
         current_statement__ = 175;
         lp_accum__.add(
           normal_id_glm_lpdf<propto__>(y_v_d_opencl__,
-            to_matrix_cl(X_d_a[(1 - 1)]), alpha, to_matrix_cl(beta), sigma));
+            to_matrix_cl(
+              rvalue(X_d_a, cons_list(index_uni(1), nil_index_list()),
+                "X_d_a")), alpha, to_matrix_cl(beta), sigma));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -2649,11 +2649,14 @@ sho(const T0__& t, const std::vector<T1__>& y,
     dydt = std::vector<local_scalar_t__>(2, DUMMY_VAR__);
     
     current_statement__ = 586;
-    assign(dydt, cons_list(index_uni(1), nil_index_list()), y[(2 - 1)],
+    assign(dydt, cons_list(index_uni(1), nil_index_list()),
+      rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"),
       "assigning variable dydt");
     current_statement__ = 587;
     assign(dydt, cons_list(index_uni(2), nil_index_list()),
-      (-y[(1 - 1)] - (theta[(1 - 1)] * y[(2 - 1)])),
+      (-rvalue(y, cons_list(index_uni(1), nil_index_list()), "y") -
+        (rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta") *
+          rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"))),
       "assigning variable dydt");
     current_statement__ = 588;
     return dydt;
@@ -4515,10 +4518,14 @@ algebra_system(const T0__& x_arg__, const T1__& y_arg__,
     
     current_statement__ = 768;
     assign(f_x, cons_list(index_uni(1), nil_index_list()),
-      (x[(1 - 1)] - y[(1 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(1), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 769;
     assign(f_x, cons_list(index_uni(2), nil_index_list()),
-      (x[(2 - 1)] - y[(2 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(2), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(2), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 770;
     return f_x;
   } catch (const std::exception& e) {
@@ -6006,7 +6013,10 @@ class mother_model final : public model_base_crtp<mother_model> {
           stan::math::fill(l_mat, std::numeric_limits<double>::quiet_NaN());
           
           current_statement__ = 337;
-          assign(l_mat, nil_index_list(), d_ar_mat[(i - 1)][(j - 1)],
+          assign(l_mat, nil_index_list(),
+            rvalue(d_ar_mat,
+              cons_list(index_uni(i),
+                cons_list(index_uni(j), nil_index_list())), "d_ar_mat"),
             "assigning variable l_mat");
           current_statement__ = 338;
           if (pstream__) {
@@ -7514,10 +7524,14 @@ class mother_model final : public model_base_crtp<mother_model> {
       for (int i = 1; i <= N; ++i) {
         current_statement__ = 60;
         assign(tp_vec, cons_list(index_uni(i), nil_index_list()),
-          (-1.0 * p_vec[(i - 1)]), "assigning variable tp_vec");}
+          (-1.0 *
+            rvalue(p_vec, cons_list(index_uni(i), nil_index_list()), "p_vec")),
+          "assigning variable tp_vec");}
       current_statement__ = 62;
-      assign(tp_row_vec, nil_index_list(), transpose(tp_1d_vec[(1 - 1)]),
-        "assigning variable tp_row_vec");
+      assign(tp_row_vec, nil_index_list(),
+        transpose(
+          rvalue(tp_1d_vec, cons_list(index_uni(1), nil_index_list()),
+            "tp_1d_vec")), "assigning variable tp_row_vec");
       current_statement__ = 63;
       assign(tp_1d_row_vec, nil_index_list(), p_1d_row_vec,
         "assigning variable tp_1d_row_vec");
@@ -7684,13 +7698,24 @@ class mother_model final : public model_base_crtp<mother_model> {
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 159;
           lp_accum__.add(
-            normal_lpdf<propto__>(to_vector(p_1d_vec[(n - 1)]), 0, 1));
+            normal_lpdf<propto__>(
+              to_vector(
+                rvalue(p_1d_vec, cons_list(index_uni(n), nil_index_list()),
+                  "p_1d_vec")), 0, 1));
           current_statement__ = 160;
           lp_accum__.add(
-            normal_lpdf<propto__>(to_vector(p_1d_row_vec[(n - 1)]), 0, 1));
+            normal_lpdf<propto__>(
+              to_vector(
+                rvalue(p_1d_row_vec,
+                  cons_list(index_uni(n), nil_index_list()), "p_1d_row_vec")),
+              0, 1));
           current_statement__ = 161;
           lp_accum__.add(
-            normal_lpdf<propto__>(to_vector(p_1d_simplex[(n - 1)]), 0, 1));
+            normal_lpdf<propto__>(
+              to_vector(
+                rvalue(p_1d_simplex,
+                  cons_list(index_uni(n), nil_index_list()), "p_1d_simplex")),
+              0, 1));
           current_statement__ = 169;
           for (int m = 1; m <= M; ++m) {
             current_statement__ = 167;
@@ -7698,36 +7723,79 @@ class mother_model final : public model_base_crtp<mother_model> {
               current_statement__ = 162;
               lp_accum__.add(
                 normal_lpdf<propto__>(
-                  to_vector(p_3d_vec[(n - 1)][(m - 1)][(k - 1)]),
-                  d_3d_vec[(n - 1)][(m - 1)][(k - 1)], 1));
+                  to_vector(
+                    rvalue(p_3d_vec,
+                      cons_list(index_uni(n),
+                        cons_list(index_uni(m),
+                          cons_list(index_uni(k), nil_index_list()))),
+                      "p_3d_vec")),
+                  rvalue(d_3d_vec,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "d_3d_vec"), 1));
               current_statement__ = 163;
               lp_accum__.add(
                 normal_lpdf<propto__>(
-                  to_vector(p_3d_row_vec[(n - 1)][(m - 1)][(k - 1)]),
-                  d_3d_row_vec[(n - 1)][(m - 1)][(k - 1)], 1));
+                  to_vector(
+                    rvalue(p_3d_row_vec,
+                      cons_list(index_uni(n),
+                        cons_list(index_uni(m),
+                          cons_list(index_uni(k), nil_index_list()))),
+                      "p_3d_row_vec")),
+                  rvalue(d_3d_row_vec,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "d_3d_row_vec"), 1));
               current_statement__ = 164;
               lp_accum__.add(
                 normal_lpdf<propto__>(
-                  to_vector(p_3d_simplex[(n - 1)][(m - 1)][(k - 1)]),
-                  d_3d_simplex[(n - 1)][(m - 1)][(k - 1)], 1));
+                  to_vector(
+                    rvalue(p_3d_simplex,
+                      cons_list(index_uni(n),
+                        cons_list(index_uni(m),
+                          cons_list(index_uni(k), nil_index_list()))),
+                      "p_3d_simplex")),
+                  rvalue(d_3d_simplex,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "d_3d_simplex"), 1));
               current_statement__ = 165;
               lp_accum__.add(
                 normal_lpdf<propto__>(
-                  p_real_3d_ar[(n - 1)][(m - 1)][(k - 1)],
-                  p_real_3d_ar[(n - 1)][(m - 1)][(k - 1)], 1));}}}
+                  rvalue(p_real_3d_ar,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "p_real_3d_ar"),
+                  rvalue(p_real_3d_ar,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(m),
+                        cons_list(index_uni(k), nil_index_list()))),
+                    "p_real_3d_ar"), 1));}}}
         current_statement__ = 176;
         for (int i = 1; i <= 4; ++i) {
           current_statement__ = 174;
           for (int j = 1; j <= 5; ++j) {
             current_statement__ = 172;
             lp_accum__.add(
-              normal_lpdf<propto__>(to_vector(p_ar_mat[(i - 1)][(j - 1)]), 0,
-                1));}}
+              normal_lpdf<propto__>(
+                to_vector(
+                  rvalue(p_ar_mat,
+                    cons_list(index_uni(i),
+                      cons_list(index_uni(j), nil_index_list())), "p_ar_mat")),
+                0, 1));}}
         current_statement__ = 179;
         for (int k = 1; k <= K; ++k) {
           current_statement__ = 177;
           lp_accum__.add(
-            normal_lpdf<propto__>(to_vector(p_cfcov_33_ar[(k - 1)]), 0, 1));}
+            normal_lpdf<propto__>(
+              to_vector(
+                rvalue(p_cfcov_33_ar,
+                  cons_list(index_uni(k), nil_index_list()), "p_cfcov_33_ar")),
+              0, 1));}
         current_statement__ = 180;
         lp_accum__.add(normal_lpdf<propto__>(to_vector(p_vec), d_vec, 1));
         current_statement__ = 181;
@@ -8342,10 +8410,14 @@ class mother_model final : public model_base_crtp<mother_model> {
       for (int i = 1; i <= N; ++i) {
         current_statement__ = 60;
         assign(tp_vec, cons_list(index_uni(i), nil_index_list()),
-          (-1.0 * p_vec[(i - 1)]), "assigning variable tp_vec");}
+          (-1.0 *
+            rvalue(p_vec, cons_list(index_uni(i), nil_index_list()), "p_vec")),
+          "assigning variable tp_vec");}
       current_statement__ = 62;
-      assign(tp_row_vec, nil_index_list(), transpose(tp_1d_vec[(1 - 1)]),
-        "assigning variable tp_row_vec");
+      assign(tp_row_vec, nil_index_list(),
+        transpose(
+          rvalue(tp_1d_vec, cons_list(index_uni(1), nil_index_list()),
+            "tp_1d_vec")), "assigning variable tp_row_vec");
       current_statement__ = 63;
       assign(tp_1d_row_vec, nil_index_list(), p_1d_row_vec,
         "assigning variable tp_1d_row_vec");
@@ -8737,7 +8809,9 @@ class mother_model final : public model_base_crtp<mother_model> {
       for (int i = 1; i <= N; ++i) {
         current_statement__ = 123;
         assign(gq_vec, cons_list(index_uni(i), nil_index_list()),
-          (-1.0 * p_vec[(i - 1)]), "assigning variable gq_vec");}
+          (-1.0 *
+            rvalue(p_vec, cons_list(index_uni(i), nil_index_list()), "p_vec")),
+          "assigning variable gq_vec");}
       current_statement__ = 128;
       for (int i = 1; i <= 3; ++i) {
         current_statement__ = 127;
@@ -8760,8 +8834,14 @@ class mother_model final : public model_base_crtp<mother_model> {
             cons_list(index_uni(i),
               cons_list(index_uni(j), nil_index_list())),
             rvalue(indexing_mat,
-              cons_list(index_uni(indices[(i - 1)]),
-                cons_list(index_uni(indices[(j - 1)]), nil_index_list())),
+              cons_list(
+                index_uni(rvalue(indices,
+                            cons_list(index_uni(i), nil_index_list()),
+                            "indices")),
+                cons_list(
+                  index_uni(rvalue(indices,
+                              cons_list(index_uni(j), nil_index_list()),
+                              "indices")), nil_index_list())),
               "indexing_mat"), "assigning variable idx_res1");}}
       current_statement__ = 132;
       assign(idx_res11, nil_index_list(),
@@ -8798,7 +8878,10 @@ class mother_model final : public model_base_crtp<mother_model> {
               cons_list(index_uni(j), nil_index_list())),
             rvalue(indexing_mat,
               cons_list(index_uni(i),
-                cons_list(index_uni(indices[(j - 1)]), nil_index_list())),
+                cons_list(
+                  index_uni(rvalue(indices,
+                              cons_list(index_uni(j), nil_index_list()),
+                              "indices")), nil_index_list())),
               "indexing_mat"), "assigning variable idx_res2");}}
       current_statement__ = 138;
       assign(idx_res21, nil_index_list(),
@@ -8837,9 +8920,15 @@ class mother_model final : public model_base_crtp<mother_model> {
                 cons_list(index_uni(j),
                   cons_list(index_uni(k), nil_index_list()))),
               rvalue(indexing_mat,
-                cons_list(index_uni(indices[(i - 1)]),
+                cons_list(
+                  index_uni(rvalue(indices,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "indices")),
                   cons_list(index_uni(j),
-                    cons_list(index_uni(indices[(k - 1)]), nil_index_list()))),
+                    cons_list(
+                      index_uni(rvalue(indices,
+                                  cons_list(index_uni(k), nil_index_list()),
+                                  "indices")), nil_index_list()))),
                 "indexing_mat"), "assigning variable idx_res3");}}}
       current_statement__ = 145;
       assign(idx_res31, nil_index_list(),
@@ -11421,11 +11510,14 @@ sho(const T0__& t, const std::vector<T1__>& y,
     dydt = std::vector<local_scalar_t__>(2, DUMMY_VAR__);
     
     current_statement__ = 141;
-    assign(dydt, cons_list(index_uni(1), nil_index_list()), y[(2 - 1)],
+    assign(dydt, cons_list(index_uni(1), nil_index_list()),
+      rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"),
       "assigning variable dydt");
     current_statement__ = 142;
     assign(dydt, cons_list(index_uni(2), nil_index_list()),
-      (-y[(1 - 1)] - (theta[(1 - 1)] * y[(2 - 1)])),
+      (-rvalue(y, cons_list(index_uni(1), nil_index_list()), "y") -
+        (rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta") *
+          rvalue(y, cons_list(index_uni(2), nil_index_list()), "y"))),
       "assigning variable dydt");
     current_statement__ = 143;
     return dydt;
@@ -11614,10 +11706,14 @@ algebra_system(const T0__& x_arg__, const T1__& y_arg__,
     
     current_statement__ = 154;
     assign(f_x, cons_list(index_uni(1), nil_index_list()),
-      (x[(1 - 1)] - y[(1 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(1), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 155;
     assign(f_x, cons_list(index_uni(2), nil_index_list()),
-      (x[(2 - 1)] - y[(2 - 1)]), "assigning variable f_x");
+      (rvalue(x, cons_list(index_uni(2), nil_index_list()), "x") -
+        rvalue(y, cons_list(index_uni(2), nil_index_list()), "y")),
+      "assigning variable f_x");
     current_statement__ = 156;
     return f_x;
   } catch (const std::exception& e) {
@@ -17814,32 +17910,32 @@ dz_dt(const T0__& t, const std::vector<T1__>& z,
     u = DUMMY_VAR__;
     
     current_statement__ = 25;
-    u = z[(1 - 1)];
+    u = rvalue(z, cons_list(index_uni(1), nil_index_list()), "z");
     local_scalar_t__ v;
     v = DUMMY_VAR__;
     
     current_statement__ = 26;
-    v = z[(2 - 1)];
+    v = rvalue(z, cons_list(index_uni(2), nil_index_list()), "z");
     local_scalar_t__ alpha;
     alpha = DUMMY_VAR__;
     
     current_statement__ = 27;
-    alpha = theta[(1 - 1)];
+    alpha = rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta");
     local_scalar_t__ beta;
     beta = DUMMY_VAR__;
     
     current_statement__ = 28;
-    beta = theta[(2 - 1)];
+    beta = rvalue(theta, cons_list(index_uni(2), nil_index_list()), "theta");
     local_scalar_t__ gamma;
     gamma = DUMMY_VAR__;
     
     current_statement__ = 29;
-    gamma = theta[(3 - 1)];
+    gamma = rvalue(theta, cons_list(index_uni(3), nil_index_list()), "theta");
     local_scalar_t__ delta;
     delta = DUMMY_VAR__;
     
     current_statement__ = 30;
-    delta = theta[(4 - 1)];
+    delta = rvalue(theta, cons_list(index_uni(4), nil_index_list()), "theta");
     local_scalar_t__ du_dt;
     du_dt = DUMMY_VAR__;
     
@@ -18132,8 +18228,14 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
         for (int k = 1; k <= 2; ++k) {
           current_statement__ = 14;
           lp_accum__.add(
-            lognormal_lpdf<propto__>(y_init[(k - 1)],
-              stan::math::log(z_init[(k - 1)]), sigma[(k - 1)]));
+            lognormal_lpdf<propto__>(
+              rvalue(y_init, cons_list(index_uni(k), nil_index_list()),
+                "y_init"),
+              stan::math::log(
+                rvalue(z_init, cons_list(index_uni(k), nil_index_list()),
+                  "z_init")),
+              rvalue(sigma, cons_list(index_uni(k), nil_index_list()),
+                "sigma")));
           current_statement__ = 15;
           lp_accum__.add(
             lognormal_lpdf<propto__>(
@@ -18144,7 +18246,8 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
                 rvalue(z,
                   cons_list(index_omni(),
                     cons_list(index_uni(k), nil_index_list())), "z")),
-              sigma[(k - 1)]));}
+              rvalue(sigma, cons_list(index_uni(k), nil_index_list()),
+                "sigma")));}
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -19718,12 +19821,14 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
             beta_m));
         current_statement__ = 174;
         lp_accum__.add(
-          normal_id_glm_lpdf<false>(y_v_d, X_d_a[(1 - 1)], alpha, beta,
-            sigma));
+          normal_id_glm_lpdf<false>(y_v_d,
+            rvalue(X_d_a, cons_list(index_uni(1), nil_index_list()), "X_d_a"),
+            alpha, beta, sigma));
         current_statement__ = 175;
         lp_accum__.add(
-          normal_id_glm_lpdf<propto__>(y_v_d, X_d_a[(1 - 1)], alpha, beta,
-            sigma));
+          normal_id_glm_lpdf<propto__>(y_v_d,
+            rvalue(X_d_a, cons_list(index_uni(1), nil_index_list()), "X_d_a"),
+            alpha, beta, sigma));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21690,7 +21795,11 @@ g2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice, const int& start,
     current_statement__ = 81;
     for (int n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 79;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(y_slice[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(y_slice,
+                       cons_list(index_uni(n), nil_index_list()), "y_slice"),
+                     0, 1));}
     current_statement__ = 82;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -21741,7 +21850,11 @@ g3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice, const int& start,
     current_statement__ = 87;
     for (int n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 85;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(y_slice[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(y_slice,
+                       cons_list(index_uni(n), nil_index_list()), "y_slice"),
+                     0, 1));}
     current_statement__ = 88;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -21793,7 +21906,11 @@ g4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice, const int& start,
     for (int n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 91;
       sum_lpdf = (sum_lpdf +
-                   normal_lpdf<false>(to_vector(y_slice[(n - 1)]), 0, 1));}
+                   normal_lpdf<false>(
+                     to_vector(
+                       rvalue(y_slice,
+                         cons_list(index_uni(n), nil_index_list()),
+                         "y_slice")), 0, 1));}
     current_statement__ = 94;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -21844,10 +21961,17 @@ g5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
     current_statement__ = 101;
     for (int n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 99;
-      for (int m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 97;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(y_slice[(n - 1)][(m - 1)], 0, 1));}}
+                     normal_lpdf<false>(
+                       rvalue(y_slice,
+                         cons_list(index_uni(n),
+                           cons_list(index_uni(m), nil_index_list())),
+                         "y_slice"), 0, 1));}}
     current_statement__ = 102;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -21898,11 +22022,18 @@ g6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
     current_statement__ = 109;
     for (int n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 107;
-      for (int m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 105;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(y_slice[(n - 1)][(m - 1)]),
-                       0, 1));}}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(y_slice,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())),
+                           "y_slice")), 0, 1));}}
     current_statement__ = 110;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -21953,11 +22084,18 @@ g7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
     current_statement__ = 117;
     for (int n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 115;
-      for (int m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 113;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(y_slice[(n - 1)][(m - 1)]),
-                       0, 1));}}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(y_slice,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())),
+                           "y_slice")), 0, 1));}}
     current_statement__ = 118;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22008,11 +22146,18 @@ g8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
     current_statement__ = 125;
     for (int n = 1; n <= size(y_slice); ++n) {
       current_statement__ = 123;
-      for (int m = 1; m <= size(y_slice[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(y_slice, cons_list(index_uni(n), nil_index_list()),
+                    "y_slice")); ++m) {
         current_statement__ = 121;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(y_slice[(n - 1)][(m - 1)]),
-                       0, 1));}}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(y_slice,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())),
+                           "y_slice")), 0, 1));}}
     current_statement__ = 126;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22112,7 +22257,10 @@ h2(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 133;
     for (int n = start; n <= end; ++n) {
       current_statement__ = 131;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(a[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(a, cons_list(index_uni(n), nil_index_list()),
+                       "a"), 0, 1));}
     current_statement__ = 134;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22168,7 +22316,10 @@ h3(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 139;
     for (int n = start; n <= end; ++n) {
       current_statement__ = 137;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(a[(n - 1)], 0, 1));}
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     rvalue(a, cons_list(index_uni(n), nil_index_list()),
+                       "a"), 0, 1));}
     current_statement__ = 140;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22224,8 +22375,11 @@ h4(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 145;
     for (int n = start; n <= end; ++n) {
       current_statement__ = 143;
-      sum_lpdf = (sum_lpdf + normal_lpdf<false>(to_vector(a[(n - 1)]), 0, 1));
-    }
+      sum_lpdf = (sum_lpdf +
+                   normal_lpdf<false>(
+                     to_vector(
+                       rvalue(a, cons_list(index_uni(n), nil_index_list()),
+                         "a")), 0, 1));}
     current_statement__ = 146;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22281,10 +22435,17 @@ h5(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 153;
     for (int n = start; n <= end; ++n) {
       current_statement__ = 151;
-      for (int m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 149;
-        sum_lpdf = (sum_lpdf + normal_lpdf<false>(a[(n - 1)][(m - 1)], 0, 1));
-      }}
+        sum_lpdf = (sum_lpdf +
+                     normal_lpdf<false>(
+                       rvalue(a,
+                         cons_list(index_uni(n),
+                           cons_list(index_uni(m), nil_index_list())), "a"),
+                       0, 1));}}
     current_statement__ = 154;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22339,11 +22500,18 @@ h6(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 161;
     for (int n = start; n <= end; ++n) {
       current_statement__ = 159;
-      for (int m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 157;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(a[(n - 1)][(m - 1)]), 0, 1));
-      }}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(a,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())), "a")),
+                       0, 1));}}
     current_statement__ = 162;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22400,11 +22568,18 @@ h7(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 169;
     for (int n = start; n <= end; ++n) {
       current_statement__ = 167;
-      for (int m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 165;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(a[(n - 1)][(m - 1)]), 0, 1));
-      }}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(a,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())), "a")),
+                       0, 1));}}
     current_statement__ = 170;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -22461,11 +22636,18 @@ h8(const std::vector<T0__>& y, const int& start, const int& end,
     current_statement__ = 177;
     for (int n = start; n <= end; ++n) {
       current_statement__ = 175;
-      for (int m = 1; m <= size(a[(n - 1)]); ++m) {
+      for (int m = 1;
+           m <= size(
+                  rvalue(a, cons_list(index_uni(n), nil_index_list()), "a"));
+           ++m) {
         current_statement__ = 173;
         sum_lpdf = (sum_lpdf +
-                     normal_lpdf<false>(to_vector(a[(n - 1)][(m - 1)]), 0, 1));
-      }}
+                     normal_lpdf<false>(
+                       to_vector(
+                         rvalue(a,
+                           cons_list(index_uni(n),
+                             cons_list(index_uni(m), nil_index_list())), "a")),
+                       0, 1));}}
     current_statement__ = 178;
     return sum_lpdf;
   } catch (const std::exception& e) {
@@ -29761,7 +29943,10 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_1");}
       current_statement__ = 1;
       check_matching_dims("constraint", "p_1", p_1, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 1;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 1;
@@ -29769,13 +29954,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 1;
           assign(p_1, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lb_constrain(p_1[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable p_1");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)], lp__), "assigning variable p_1");
         } else {
           current_statement__ = 1;
           assign(p_1, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lb_constrain(p_1[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_1");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)]), "assigning variable p_1");
         }}
       std::vector<local_scalar_t__> p_2;
       p_2 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
@@ -29787,7 +29975,10 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_2");}
       current_statement__ = 2;
       check_matching_dims("constraint", "p_2", p_2, "upper",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 2;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 2;
@@ -29795,13 +29986,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 2;
           assign(p_2, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::ub_constrain(p_2[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable p_2");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)], lp__), "assigning variable p_2");
         } else {
           current_statement__ = 2;
           assign(p_2, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::ub_constrain(p_2[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_2");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)]), "assigning variable p_2");
         }}
       std::vector<local_scalar_t__> p_3;
       p_3 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
@@ -29813,10 +30007,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_3");}
       current_statement__ = 3;
       check_matching_dims("constraint", "p_3", p_3, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 3;
       check_matching_dims("constraint", "p_3", p_3, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 3;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 3;
@@ -29824,15 +30024,22 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 3;
           assign(p_3, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(p_3[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              ds[(1 - 1)][(2 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable p_3");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)],
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+              (sym1__ - 1)], lp__), "assigning variable p_3");
         } else {
           current_statement__ = 3;
           assign(p_3, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(p_3[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_3");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)],
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+              (sym1__ - 1)]), "assigning variable p_3");
         }}
       std::vector<local_scalar_t__> p_4;
       p_4 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
@@ -29844,7 +30051,10 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_4");}
       current_statement__ = 4;
       check_matching_dims("constraint", "p_4", p_4, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 4;
@@ -29852,13 +30062,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 4;
           assign(p_4, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(p_4[(sym1__ - 1)], 0,
-              ds[(1 - 1)][(2 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable p_4");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+              (sym1__ - 1)], lp__), "assigning variable p_4");
         } else {
           current_statement__ = 4;
           assign(p_4, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(p_4[(sym1__ - 1)], 0,
-              ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_4");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+              (sym1__ - 1)]), "assigning variable p_4");
         }}
       std::vector<local_scalar_t__> p_5;
       p_5 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
@@ -29870,7 +30083,10 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_5");}
       current_statement__ = 5;
       check_matching_dims("constraint", "p_5", p_5, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 5;
@@ -29878,14 +30094,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 5;
           assign(p_5, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(p_5[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1, lp__),
-            "assigning variable p_5");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)], 1, lp__), "assigning variable p_5");
         } else {
           current_statement__ = 5;
           assign(p_5, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(p_5[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1),
-            "assigning variable p_5");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)], 1), "assigning variable p_5");
         }}
       std::vector<local_scalar_t__> p_6;
       p_6 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
@@ -29897,7 +30115,10 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_6");}
       current_statement__ = 6;
       check_matching_dims("constraint", "p_6", p_6, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 6;
@@ -29905,14 +30126,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 6;
           assign(p_6, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(p_6[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1, lp__),
-            "assigning variable p_6");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)], 1, lp__), "assigning variable p_6");
         } else {
           current_statement__ = 6;
           assign(p_6, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(p_6[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1),
-            "assigning variable p_6");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)], 1), "assigning variable p_6");
         }}
       std::vector<local_scalar_t__> p_7;
       p_7 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
@@ -29924,7 +30147,10 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_7");}
       current_statement__ = 7;
       check_matching_dims("constraint", "p_7", p_7, "multiplier",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 7;
@@ -29932,13 +30158,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 7;
           assign(p_7, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(p_7[(sym1__ - 1)], 0,
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable p_7");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)], lp__), "assigning variable p_7");
         } else {
           current_statement__ = 7;
           assign(p_7, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(p_7[(sym1__ - 1)], 0,
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_7");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)]), "assigning variable p_7");
         }}
       std::vector<local_scalar_t__> p_8;
       p_8 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
@@ -29950,10 +30179,16 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_8");}
       current_statement__ = 8;
       check_matching_dims("constraint", "p_8", p_8, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 8;
       check_matching_dims("constraint", "p_8", p_8, "multiplier",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 8;
@@ -29961,15 +30196,22 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 8;
           assign(p_8, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(p_8[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              ds[(1 - 1)][(2 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable p_8");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)],
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+              (sym1__ - 1)], lp__), "assigning variable p_8");
         } else {
           current_statement__ = 8;
           assign(p_8, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::offset_multiplier_constrain(p_8[(sym1__ - 1)],
-              ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_8");
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+              (sym1__ - 1)],
+              rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+              (sym1__ - 1)]), "assigning variable p_8");
         }}
       std::vector<std::vector<local_scalar_t__>> p_9;
       p_9 = std::vector<std::vector<local_scalar_t__>>(m, std::vector<local_scalar_t__>(k, DUMMY_VAR__));
@@ -29984,7 +30226,9 @@ class transform_model final : public model_base_crtp<transform_model> {
               cons_list(index_uni(sym2__), nil_index_list())), in__.scalar(),
             "assigning variable p_9");}}
       current_statement__ = 9;
-      check_matching_dims("constraint", "p_9", p_9, "lower", ds[(1 - 1)]);
+      check_matching_dims("constraint", "p_9", p_9, "lower",
+                          rvalue(ds,
+                            cons_list(index_uni(1), nil_index_list()), "ds"));
       current_statement__ = 9;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 9;
@@ -29996,7 +30240,8 @@ class transform_model final : public model_base_crtp<transform_model> {
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__), nil_index_list())),
               stan::math::lub_constrain(p_9[(sym1__ - 1)][(sym2__ - 1)],
-                ds[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)], 1, lp__),
+                rvalue(ds, cons_list(index_uni(1), nil_index_list()), "ds")[
+                (sym1__ - 1)][(sym2__ - 1)], 1, lp__),
               "assigning variable p_9");
           } else {
             current_statement__ = 9;
@@ -30004,8 +30249,8 @@ class transform_model final : public model_base_crtp<transform_model> {
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__), nil_index_list())),
               stan::math::lub_constrain(p_9[(sym1__ - 1)][(sym2__ - 1)],
-                ds[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)], 1),
-              "assigning variable p_9");
+                rvalue(ds, cons_list(index_uni(1), nil_index_list()), "ds")[
+                (sym1__ - 1)][(sym2__ - 1)], 1), "assigning variable p_9");
           }}}
       std::vector<std::vector<std::vector<local_scalar_t__>>> p_10;
       p_10 = std::vector<std::vector<std::vector<local_scalar_t__>>>(n, std::vector<std::vector<local_scalar_t__>>(m, std::vector<local_scalar_t__>(k, DUMMY_VAR__)));
@@ -30060,10 +30305,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       pv_1 = in__.vector(k);
       current_statement__ = 11;
       check_matching_dims("constraint", "pv_1", pv_1, "lower",
-                          dv[(1 - 1)][(1 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dv"));
       current_statement__ = 11;
       check_matching_dims("constraint", "pv_1", pv_1, "upper",
-                          dv[(1 - 1)][(2 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dv"));
       current_statement__ = 11;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 11;
@@ -30071,15 +30322,22 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 11;
           assign(pv_1, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(pv_1[(sym1__ - 1)],
-              dv[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              dv[(1 - 1)][(2 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable pv_1");
+              rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dv")[
+              (sym1__ - 1)],
+              rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dv")[
+              (sym1__ - 1)], lp__), "assigning variable pv_1");
         } else {
           current_statement__ = 11;
           assign(pv_1, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(pv_1[(sym1__ - 1)],
-              dv[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              dv[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable pv_1");
+              rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dv")[
+              (sym1__ - 1)],
+              rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dv")[
+              (sym1__ - 1)]), "assigning variable pv_1");
         }}
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> pv_2;
       pv_2 = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(m, Eigen::Matrix<local_scalar_t__, -1, 1>(k));
@@ -30091,7 +30349,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         assign(pv_2, cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector(k), "assigning variable pv_2");}
       current_statement__ = 12;
-      check_matching_dims("constraint", "pv_2", pv_2, "lower", dv[(1 - 1)]);
+      check_matching_dims("constraint", "pv_2", pv_2, "lower",
+                          rvalue(dv,
+                            cons_list(index_uni(1), nil_index_list()), "dv"));
       current_statement__ = 12;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 12;
@@ -30103,16 +30363,16 @@ class transform_model final : public model_base_crtp<transform_model> {
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__), nil_index_list())),
               stan::math::lb_constrain(pv_2[(sym1__ - 1)][(sym2__ - 1)],
-                dv[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)], lp__),
-              "assigning variable pv_2");
+                rvalue(dv, cons_list(index_uni(1), nil_index_list()), "dv")[
+                (sym1__ - 1)][(sym2__ - 1)], lp__), "assigning variable pv_2");
           } else {
             current_statement__ = 12;
             assign(pv_2,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__), nil_index_list())),
               stan::math::lb_constrain(pv_2[(sym1__ - 1)][(sym2__ - 1)],
-                dv[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-              "assigning variable pv_2");
+                rvalue(dv, cons_list(index_uni(1), nil_index_list()), "dv")[
+                (sym1__ - 1)][(sym2__ - 1)]), "assigning variable pv_2");
           }}}
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>> pv_3;
       pv_3 = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(n, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(m, Eigen::Matrix<local_scalar_t__, -1, 1>(k)));
@@ -30165,10 +30425,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       pr_1 = in__.row_vector(k);
       current_statement__ = 14;
       check_matching_dims("constraint", "pr_1", pr_1, "lower",
-                          dr[(1 - 1)][(1 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dr"));
       current_statement__ = 14;
       check_matching_dims("constraint", "pr_1", pr_1, "upper",
-                          dr[(1 - 1)][(2 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dr"));
       current_statement__ = 14;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 14;
@@ -30176,15 +30442,22 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 14;
           assign(pr_1, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(pr_1[(sym1__ - 1)],
-              dr[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              dr[(1 - 1)][(2 - 1)][(sym1__ - 1)], lp__),
-            "assigning variable pr_1");
+              rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dr")[
+              (sym1__ - 1)],
+              rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dr")[
+              (sym1__ - 1)], lp__), "assigning variable pr_1");
         } else {
           current_statement__ = 14;
           assign(pr_1, cons_list(index_uni(sym1__), nil_index_list()),
             stan::math::lub_constrain(pr_1[(sym1__ - 1)],
-              dr[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-              dr[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable pr_1");
+              rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dr")[
+              (sym1__ - 1)],
+              rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dr")[
+              (sym1__ - 1)]), "assigning variable pr_1");
         }}
       std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>> pr_2;
       pr_2 = std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(m, Eigen::Matrix<local_scalar_t__, 1, -1>(k));
@@ -30196,7 +30469,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         assign(pr_2, cons_list(index_uni(sym1__), nil_index_list()),
           in__.row_vector(k), "assigning variable pr_2");}
       current_statement__ = 15;
-      check_matching_dims("constraint", "pr_2", pr_2, "lower", dr[(1 - 1)]);
+      check_matching_dims("constraint", "pr_2", pr_2, "lower",
+                          rvalue(dr,
+                            cons_list(index_uni(1), nil_index_list()), "dr"));
       current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 15;
@@ -30208,16 +30483,16 @@ class transform_model final : public model_base_crtp<transform_model> {
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__), nil_index_list())),
               stan::math::lb_constrain(pr_2[(sym1__ - 1)][(sym2__ - 1)],
-                dr[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)], lp__),
-              "assigning variable pr_2");
+                rvalue(dr, cons_list(index_uni(1), nil_index_list()), "dr")[
+                (sym1__ - 1)][(sym2__ - 1)], lp__), "assigning variable pr_2");
           } else {
             current_statement__ = 15;
             assign(pr_2,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(sym2__), nil_index_list())),
               stan::math::lb_constrain(pr_2[(sym1__ - 1)][(sym2__ - 1)],
-                dr[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-              "assigning variable pr_2");
+                rvalue(dr, cons_list(index_uni(1), nil_index_list()), "dr")[
+                (sym1__ - 1)][(sym2__ - 1)]), "assigning variable pr_2");
           }}}
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>> pr_3;
       pr_3 = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>(n, std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(m, Eigen::Matrix<local_scalar_t__, 1, -1>(k)));
@@ -30269,7 +30544,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 17;
       pm_1 = in__.matrix(m, k);
       current_statement__ = 17;
-      check_matching_dims("constraint", "pm_1", pm_1, "lower", dm[(1 - 1)]);
+      check_matching_dims("constraint", "pm_1", pm_1, "lower",
+                          rvalue(dm,
+                            cons_list(index_uni(1), nil_index_list()), "dm"));
       current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 17;
@@ -30284,7 +30561,8 @@ class transform_model final : public model_base_crtp<transform_model> {
                 rvalue(pm_1,
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__), nil_index_list())), "pm_1"),
-                rvalue(dm[(1 - 1)],
+                rvalue(
+                  rvalue(dm, cons_list(index_uni(1), nil_index_list()), "dm"),
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__), nil_index_list())), "dm[1]"),
                 lp__), "assigning variable pm_1");
@@ -30297,7 +30575,8 @@ class transform_model final : public model_base_crtp<transform_model> {
                 rvalue(pm_1,
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__), nil_index_list())), "pm_1"),
-                rvalue(dm[(1 - 1)],
+                rvalue(
+                  rvalue(dm, cons_list(index_uni(1), nil_index_list()), "dm"),
                   cons_list(index_uni(sym1__),
                     cons_list(index_uni(sym2__), nil_index_list())), "dm[1]")),
               "assigning variable pm_1");
@@ -30362,7 +30641,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_1, nil_index_list(), p_1, "assigning variable tp_1");
       current_statement__ = 19;
       check_matching_dims("constraint", "tp_1", tp_1, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<local_scalar_t__> tp_2;
       tp_2 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       
@@ -30370,7 +30652,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_2, nil_index_list(), p_2, "assigning variable tp_2");
       current_statement__ = 20;
       check_matching_dims("constraint", "tp_2", tp_2, "upper",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<local_scalar_t__> tp_3;
       tp_3 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       
@@ -30378,10 +30663,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_3, nil_index_list(), p_3, "assigning variable tp_3");
       current_statement__ = 21;
       check_matching_dims("constraint", "tp_3", tp_3, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 21;
       check_matching_dims("constraint", "tp_3", tp_3, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       std::vector<local_scalar_t__> tp_4;
       tp_4 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       
@@ -30389,7 +30680,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_4, nil_index_list(), p_4, "assigning variable tp_4");
       current_statement__ = 22;
       check_matching_dims("constraint", "tp_4", tp_4, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       std::vector<local_scalar_t__> tp_5;
       tp_5 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       
@@ -30397,7 +30691,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_5, nil_index_list(), p_5, "assigning variable tp_5");
       current_statement__ = 23;
       check_matching_dims("constraint", "tp_5", tp_5, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<local_scalar_t__> tp_6;
       tp_6 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       
@@ -30405,7 +30702,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_6, nil_index_list(), p_6, "assigning variable tp_6");
       current_statement__ = 24;
       check_matching_dims("constraint", "tp_6", tp_6, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<local_scalar_t__> tp_7;
       tp_7 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       
@@ -30413,7 +30713,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_7, nil_index_list(), p_7, "assigning variable tp_7");
       current_statement__ = 25;
       check_matching_dims("constraint", "tp_7", tp_7, "multiplier",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<local_scalar_t__> tp_8;
       tp_8 = std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       
@@ -30421,17 +30724,25 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_8, nil_index_list(), p_8, "assigning variable tp_8");
       current_statement__ = 26;
       check_matching_dims("constraint", "tp_8", tp_8, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 26;
       check_matching_dims("constraint", "tp_8", tp_8, "multiplier",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       std::vector<std::vector<local_scalar_t__>> tp_9;
       tp_9 = std::vector<std::vector<local_scalar_t__>>(m, std::vector<local_scalar_t__>(k, DUMMY_VAR__));
       
       current_statement__ = 27;
       assign(tp_9, nil_index_list(), p_9, "assigning variable tp_9");
       current_statement__ = 27;
-      check_matching_dims("constraint", "tp_9", tp_9, "lower", ds[(1 - 1)]);
+      check_matching_dims("constraint", "tp_9", tp_9, "lower",
+                          rvalue(ds,
+                            cons_list(index_uni(1), nil_index_list()), "ds"));
       std::vector<std::vector<std::vector<local_scalar_t__>>> tp_10;
       tp_10 = std::vector<std::vector<std::vector<local_scalar_t__>>>(n, std::vector<std::vector<local_scalar_t__>>(m, std::vector<local_scalar_t__>(k, DUMMY_VAR__)));
       
@@ -30447,10 +30758,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tpv_1, nil_index_list(), pv_1, "assigning variable tpv_1");
       current_statement__ = 29;
       check_matching_dims("constraint", "tpv_1", tpv_1, "lower",
-                          dv[(1 - 1)][(1 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dv"));
       current_statement__ = 29;
       check_matching_dims("constraint", "tpv_1", tpv_1, "upper",
-                          dv[(1 - 1)][(2 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dv"));
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> tpv_2;
       tpv_2 = std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(m, Eigen::Matrix<local_scalar_t__, -1, 1>(k));
       stan::math::fill(tpv_2, DUMMY_VAR__);
@@ -30458,7 +30775,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 30;
       assign(tpv_2, nil_index_list(), pv_2, "assigning variable tpv_2");
       current_statement__ = 30;
-      check_matching_dims("constraint", "tpv_2", tpv_2, "lower", dv[(1 - 1)]);
+      check_matching_dims("constraint", "tpv_2", tpv_2, "lower",
+                          rvalue(dv,
+                            cons_list(index_uni(1), nil_index_list()), "dv"));
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>> tpv_3;
       tpv_3 = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>>(n, std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(m, Eigen::Matrix<local_scalar_t__, -1, 1>(k)));
       stan::math::fill(tpv_3, DUMMY_VAR__);
@@ -30475,10 +30794,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tpr_1, nil_index_list(), pr_1, "assigning variable tpr_1");
       current_statement__ = 32;
       check_matching_dims("constraint", "tpr_1", tpr_1, "lower",
-                          dr[(1 - 1)][(1 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dr"));
       current_statement__ = 32;
       check_matching_dims("constraint", "tpr_1", tpr_1, "upper",
-                          dr[(1 - 1)][(2 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dr"));
       std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>> tpr_2;
       tpr_2 = std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(m, Eigen::Matrix<local_scalar_t__, 1, -1>(k));
       stan::math::fill(tpr_2, DUMMY_VAR__);
@@ -30486,7 +30811,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 33;
       assign(tpr_2, nil_index_list(), pr_2, "assigning variable tpr_2");
       current_statement__ = 33;
-      check_matching_dims("constraint", "tpr_2", tpr_2, "lower", dr[(1 - 1)]);
+      check_matching_dims("constraint", "tpr_2", tpr_2, "lower",
+                          rvalue(dr,
+                            cons_list(index_uni(1), nil_index_list()), "dr"));
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>> tpr_3;
       tpr_3 = std::vector<std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>>(n, std::vector<Eigen::Matrix<local_scalar_t__, 1, -1>>(m, Eigen::Matrix<local_scalar_t__, 1, -1>(k)));
       stan::math::fill(tpr_3, DUMMY_VAR__);
@@ -30502,7 +30829,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 35;
       assign(tpm_1, nil_index_list(), pm_1, "assigning variable tpm_1");
       current_statement__ = 35;
-      check_matching_dims("constraint", "tpm_1", tpm_1, "lower", dm[(1 - 1)]);
+      check_matching_dims("constraint", "tpm_1", tpm_1, "lower",
+                          rvalue(dm,
+                            cons_list(index_uni(1), nil_index_list()), "dm"));
       std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>> tpm_2;
       tpm_2 = std::vector<Eigen::Matrix<local_scalar_t__, -1, -1>>(n, Eigen::Matrix<local_scalar_t__, -1, -1>(m, k));
       stan::math::fill(tpm_2, DUMMY_VAR__);
@@ -30517,26 +30846,34 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 19;
         check_greater_or_equal(function__, "tp_1[sym1__]",
                                tp_1[(sym1__ - 1)],
-                               ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                               (sym1__ - 1)]);}
       current_statement__ = 20;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 20;
         current_statement__ = 20;
         check_less_or_equal(function__, "tp_2[sym1__]", tp_2[(sym1__ - 1)],
-                            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                            (sym1__ - 1)]);}
       current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 21;
         current_statement__ = 21;
         check_greater_or_equal(function__, "tp_3[sym1__]",
                                tp_3[(sym1__ - 1)],
-                               ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                               (sym1__ - 1)]);}
       current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 21;
         current_statement__ = 21;
         check_less_or_equal(function__, "tp_3[sym1__]", tp_3[(sym1__ - 1)],
-                            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+                            (sym1__ - 1)]);}
       current_statement__ = 22;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 22;
@@ -30548,14 +30885,18 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 22;
         current_statement__ = 22;
         check_less_or_equal(function__, "tp_4[sym1__]", tp_4[(sym1__ - 1)],
-                            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+                            (sym1__ - 1)]);}
       current_statement__ = 23;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 23;
         current_statement__ = 23;
         check_greater_or_equal(function__, "tp_5[sym1__]",
                                tp_5[(sym1__ - 1)],
-                               ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                               (sym1__ - 1)]);}
       current_statement__ = 23;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 23;
@@ -30570,7 +30911,8 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 27;
           check_greater_or_equal(function__, "tp_9[sym1__, sym2__]",
                                  tp_9[(sym1__ - 1)][(sym2__ - 1)],
-                                 ds[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]);}}
+                                 rvalue(ds, cons_list(index_uni(1), nil_index_list()), "ds")[
+                                 (sym1__ - 1)][(sym2__ - 1)]);}}
       current_statement__ = 27;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 27;
@@ -30610,13 +30952,17 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 29;
         check_greater_or_equal(function__, "tpv_1[sym1__]",
                                tpv_1[(sym1__ - 1)],
-                               dv[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dv")[
+                               (sym1__ - 1)]);}
       current_statement__ = 29;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 29;
         current_statement__ = 29;
         check_less_or_equal(function__, "tpv_1[sym1__]", tpv_1[(sym1__ - 1)],
-                            dv[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dv")[
+                            (sym1__ - 1)]);}
       current_statement__ = 30;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 30;
@@ -30625,7 +30971,8 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 30;
           check_greater_or_equal(function__, "tpv_2[sym1__, sym2__]",
                                  tpv_2[(sym1__ - 1)][(sym2__ - 1)],
-                                 dv[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]);}}
+                                 rvalue(dv, cons_list(index_uni(1), nil_index_list()), "dv")[
+                                 (sym1__ - 1)][(sym2__ - 1)]);}}
       current_statement__ = 31;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 31;
@@ -30645,13 +30992,17 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 32;
         check_greater_or_equal(function__, "tpr_1[sym1__]",
                                tpr_1[(sym1__ - 1)],
-                               dr[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dr")[
+                               (sym1__ - 1)]);}
       current_statement__ = 32;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 32;
         current_statement__ = 32;
         check_less_or_equal(function__, "tpr_1[sym1__]", tpr_1[(sym1__ - 1)],
-                            dr[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dr")[
+                            (sym1__ - 1)]);}
       current_statement__ = 33;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 33;
@@ -30660,7 +31011,8 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 33;
           check_greater_or_equal(function__, "tpr_2[sym1__, sym2__]",
                                  tpr_2[(sym1__ - 1)][(sym2__ - 1)],
-                                 dr[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]);}}
+                                 rvalue(dr, cons_list(index_uni(1), nil_index_list()), "dr")[
+                                 (sym1__ - 1)][(sym2__ - 1)]);}}
       current_statement__ = 34;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 34;
@@ -30685,7 +31037,8 @@ class transform_model final : public model_base_crtp<transform_model> {
                                    cons_list(index_uni(sym1__),
                                      cons_list(index_uni(sym2__),
                                        nil_index_list())), "tpm_1"),
-                                 rvalue(dm[(1 - 1)],
+                                 rvalue(
+                                   rvalue(dm, cons_list(index_uni(1), nil_index_list()), "dm"),
                                    cons_list(index_uni(sym1__),
                                      cons_list(index_uni(sym2__),
                                        nil_index_list())), "dm[1]"));}}
@@ -30749,13 +31102,18 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_1");}
       current_statement__ = 1;
       check_matching_dims("constraint", "p_1", p_1, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 1;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 1;
         assign(p_1, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_constrain(p_1[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_1");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_1");}
       std::vector<double> p_2;
       p_2 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30766,13 +31124,18 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_2");}
       current_statement__ = 2;
       check_matching_dims("constraint", "p_2", p_2, "upper",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 2;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 2;
         assign(p_2, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::ub_constrain(p_2[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_2");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_2");}
       std::vector<double> p_3;
       p_3 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30783,17 +31146,27 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_3");}
       current_statement__ = 3;
       check_matching_dims("constraint", "p_3", p_3, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 3;
       check_matching_dims("constraint", "p_3", p_3, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 3;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 3;
         assign(p_3, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_constrain(p_3[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_3");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)],
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_3");}
       std::vector<double> p_4;
       p_4 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30804,13 +31177,18 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_4");}
       current_statement__ = 4;
       check_matching_dims("constraint", "p_4", p_4, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 4;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 4;
         assign(p_4, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_constrain(p_4[(sym1__ - 1)], 0,
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_4");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_4");}
       std::vector<double> p_5;
       p_5 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30821,14 +31199,18 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_5");}
       current_statement__ = 5;
       check_matching_dims("constraint", "p_5", p_5, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 5;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 5;
         assign(p_5, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_constrain(p_5[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1), "assigning variable p_5");
-      }
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)], 1), "assigning variable p_5");}
       std::vector<double> p_6;
       p_6 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30839,14 +31221,18 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_6");}
       current_statement__ = 6;
       check_matching_dims("constraint", "p_6", p_6, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 6;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 6;
         assign(p_6, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_constrain(p_6[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1), "assigning variable p_6");
-      }
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)], 1), "assigning variable p_6");}
       std::vector<double> p_7;
       p_7 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30857,13 +31243,18 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_7");}
       current_statement__ = 7;
       check_matching_dims("constraint", "p_7", p_7, "multiplier",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 7;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 7;
         assign(p_7, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_constrain(p_7[(sym1__ - 1)], 0,
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]), "assigning variable p_7");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_7");}
       std::vector<double> p_8;
       p_8 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -30874,17 +31265,27 @@ class transform_model final : public model_base_crtp<transform_model> {
           in__.scalar(), "assigning variable p_8");}
       current_statement__ = 8;
       check_matching_dims("constraint", "p_8", p_8, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 8;
       check_matching_dims("constraint", "p_8", p_8, "multiplier",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 8;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 8;
         assign(p_8, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_constrain(p_8[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable p_8");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)],
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_8");}
       std::vector<std::vector<double>> p_9;
       p_9 = std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN()));
       
@@ -30898,7 +31299,9 @@ class transform_model final : public model_base_crtp<transform_model> {
               cons_list(index_uni(sym2__), nil_index_list())), in__.scalar(),
             "assigning variable p_9");}}
       current_statement__ = 9;
-      check_matching_dims("constraint", "p_9", p_9, "lower", ds[(1 - 1)]);
+      check_matching_dims("constraint", "p_9", p_9, "lower",
+                          rvalue(ds,
+                            cons_list(index_uni(1), nil_index_list()), "ds"));
       current_statement__ = 9;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 9;
@@ -30908,8 +31311,8 @@ class transform_model final : public model_base_crtp<transform_model> {
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lub_constrain(p_9[(sym1__ - 1)][(sym2__ - 1)],
-              ds[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)], 1),
-            "assigning variable p_9");}}
+              rvalue(ds, cons_list(index_uni(1), nil_index_list()), "ds")[
+              (sym1__ - 1)][(sym2__ - 1)], 1), "assigning variable p_9");}}
       std::vector<std::vector<std::vector<double>>> p_10;
       p_10 = std::vector<std::vector<std::vector<double>>>(n, std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN())));
       
@@ -30950,17 +31353,27 @@ class transform_model final : public model_base_crtp<transform_model> {
       pv_1 = in__.vector(k);
       current_statement__ = 11;
       check_matching_dims("constraint", "pv_1", pv_1, "lower",
-                          dv[(1 - 1)][(1 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dv"));
       current_statement__ = 11;
       check_matching_dims("constraint", "pv_1", pv_1, "upper",
-                          dv[(1 - 1)][(2 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dv"));
       current_statement__ = 11;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 11;
         assign(pv_1, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_constrain(pv_1[(sym1__ - 1)],
-            dv[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            dv[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable pv_1");}
+            rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dv")[
+            (sym1__ - 1)],
+            rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dv")[
+            (sym1__ - 1)]), "assigning variable pv_1");}
       std::vector<Eigen::Matrix<double, -1, 1>> pv_2;
       pv_2 = std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k));
       stan::math::fill(pv_2, std::numeric_limits<double>::quiet_NaN());
@@ -30971,7 +31384,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         assign(pv_2, cons_list(index_uni(sym1__), nil_index_list()),
           in__.vector(k), "assigning variable pv_2");}
       current_statement__ = 12;
-      check_matching_dims("constraint", "pv_2", pv_2, "lower", dv[(1 - 1)]);
+      check_matching_dims("constraint", "pv_2", pv_2, "lower",
+                          rvalue(dv,
+                            cons_list(index_uni(1), nil_index_list()), "dv"));
       current_statement__ = 12;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 12;
@@ -30981,8 +31396,8 @@ class transform_model final : public model_base_crtp<transform_model> {
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lb_constrain(pv_2[(sym1__ - 1)][(sym2__ - 1)],
-              dv[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-            "assigning variable pv_2");}}
+              rvalue(dv, cons_list(index_uni(1), nil_index_list()), "dv")[
+              (sym1__ - 1)][(sym2__ - 1)]), "assigning variable pv_2");}}
       std::vector<std::vector<Eigen::Matrix<double, -1, 1>>> pv_3;
       pv_3 = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(n, std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k)));
       stan::math::fill(pv_3, std::numeric_limits<double>::quiet_NaN());
@@ -31021,17 +31436,27 @@ class transform_model final : public model_base_crtp<transform_model> {
       pr_1 = in__.row_vector(k);
       current_statement__ = 14;
       check_matching_dims("constraint", "pr_1", pr_1, "lower",
-                          dr[(1 - 1)][(1 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dr"));
       current_statement__ = 14;
       check_matching_dims("constraint", "pr_1", pr_1, "upper",
-                          dr[(1 - 1)][(2 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dr"));
       current_statement__ = 14;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 14;
         assign(pr_1, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_constrain(pr_1[(sym1__ - 1)],
-            dr[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            dr[(1 - 1)][(2 - 1)][(sym1__ - 1)]), "assigning variable pr_1");}
+            rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dr")[
+            (sym1__ - 1)],
+            rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dr")[
+            (sym1__ - 1)]), "assigning variable pr_1");}
       std::vector<Eigen::Matrix<double, 1, -1>> pr_2;
       pr_2 = std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k));
       stan::math::fill(pr_2, std::numeric_limits<double>::quiet_NaN());
@@ -31042,7 +31467,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         assign(pr_2, cons_list(index_uni(sym1__), nil_index_list()),
           in__.row_vector(k), "assigning variable pr_2");}
       current_statement__ = 15;
-      check_matching_dims("constraint", "pr_2", pr_2, "lower", dr[(1 - 1)]);
+      check_matching_dims("constraint", "pr_2", pr_2, "lower",
+                          rvalue(dr,
+                            cons_list(index_uni(1), nil_index_list()), "dr"));
       current_statement__ = 15;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 15;
@@ -31052,8 +31479,8 @@ class transform_model final : public model_base_crtp<transform_model> {
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lb_constrain(pr_2[(sym1__ - 1)][(sym2__ - 1)],
-              dr[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-            "assigning variable pr_2");}}
+              rvalue(dr, cons_list(index_uni(1), nil_index_list()), "dr")[
+              (sym1__ - 1)][(sym2__ - 1)]), "assigning variable pr_2");}}
       std::vector<std::vector<Eigen::Matrix<double, 1, -1>>> pr_3;
       pr_3 = std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(n, std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k)));
       stan::math::fill(pr_3, std::numeric_limits<double>::quiet_NaN());
@@ -31091,7 +31518,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 17;
       pm_1 = in__.matrix(m, k);
       current_statement__ = 17;
-      check_matching_dims("constraint", "pm_1", pm_1, "lower", dm[(1 - 1)]);
+      check_matching_dims("constraint", "pm_1", pm_1, "lower",
+                          rvalue(dm,
+                            cons_list(index_uni(1), nil_index_list()), "dm"));
       current_statement__ = 17;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 17;
@@ -31104,7 +31533,8 @@ class transform_model final : public model_base_crtp<transform_model> {
               rvalue(pm_1,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__), nil_index_list())), "pm_1"),
-              rvalue(dm[(1 - 1)],
+              rvalue(
+                rvalue(dm, cons_list(index_uni(1), nil_index_list()), "dm"),
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__), nil_index_list())), "dm[1]")),
             "assigning variable pm_1");}}
@@ -31270,52 +31700,84 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tp_1, nil_index_list(), p_1, "assigning variable tp_1");
       current_statement__ = 19;
       check_matching_dims("constraint", "tp_1", tp_1, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 20;
       assign(tp_2, nil_index_list(), p_2, "assigning variable tp_2");
       current_statement__ = 20;
       check_matching_dims("constraint", "tp_2", tp_2, "upper",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 21;
       assign(tp_3, nil_index_list(), p_3, "assigning variable tp_3");
       current_statement__ = 21;
       check_matching_dims("constraint", "tp_3", tp_3, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 21;
       check_matching_dims("constraint", "tp_3", tp_3, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 22;
       assign(tp_4, nil_index_list(), p_4, "assigning variable tp_4");
       current_statement__ = 22;
       check_matching_dims("constraint", "tp_4", tp_4, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 23;
       assign(tp_5, nil_index_list(), p_5, "assigning variable tp_5");
       current_statement__ = 23;
       check_matching_dims("constraint", "tp_5", tp_5, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 24;
       assign(tp_6, nil_index_list(), p_6, "assigning variable tp_6");
       current_statement__ = 24;
       check_matching_dims("constraint", "tp_6", tp_6, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 25;
       assign(tp_7, nil_index_list(), p_7, "assigning variable tp_7");
       current_statement__ = 25;
       check_matching_dims("constraint", "tp_7", tp_7, "multiplier",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 26;
       assign(tp_8, nil_index_list(), p_8, "assigning variable tp_8");
       current_statement__ = 26;
       check_matching_dims("constraint", "tp_8", tp_8, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 26;
       check_matching_dims("constraint", "tp_8", tp_8, "multiplier",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       current_statement__ = 27;
       assign(tp_9, nil_index_list(), p_9, "assigning variable tp_9");
       current_statement__ = 27;
-      check_matching_dims("constraint", "tp_9", tp_9, "lower", ds[(1 - 1)]);
+      check_matching_dims("constraint", "tp_9", tp_9, "lower",
+                          rvalue(ds,
+                            cons_list(index_uni(1), nil_index_list()), "ds"));
       current_statement__ = 28;
       assign(tp_10, nil_index_list(), p_10, "assigning variable tp_10");
       current_statement__ = 28;
@@ -31324,14 +31786,22 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tpv_1, nil_index_list(), pv_1, "assigning variable tpv_1");
       current_statement__ = 29;
       check_matching_dims("constraint", "tpv_1", tpv_1, "lower",
-                          dv[(1 - 1)][(1 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dv"));
       current_statement__ = 29;
       check_matching_dims("constraint", "tpv_1", tpv_1, "upper",
-                          dv[(1 - 1)][(2 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dv"));
       current_statement__ = 30;
       assign(tpv_2, nil_index_list(), pv_2, "assigning variable tpv_2");
       current_statement__ = 30;
-      check_matching_dims("constraint", "tpv_2", tpv_2, "lower", dv[(1 - 1)]);
+      check_matching_dims("constraint", "tpv_2", tpv_2, "lower",
+                          rvalue(dv,
+                            cons_list(index_uni(1), nil_index_list()), "dv"));
       current_statement__ = 31;
       assign(tpv_3, nil_index_list(), pv_3, "assigning variable tpv_3");
       current_statement__ = 31;
@@ -31340,14 +31810,22 @@ class transform_model final : public model_base_crtp<transform_model> {
       assign(tpr_1, nil_index_list(), pr_1, "assigning variable tpr_1");
       current_statement__ = 32;
       check_matching_dims("constraint", "tpr_1", tpr_1, "lower",
-                          dr[(1 - 1)][(1 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dr"));
       current_statement__ = 32;
       check_matching_dims("constraint", "tpr_1", tpr_1, "upper",
-                          dr[(1 - 1)][(2 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dr"));
       current_statement__ = 33;
       assign(tpr_2, nil_index_list(), pr_2, "assigning variable tpr_2");
       current_statement__ = 33;
-      check_matching_dims("constraint", "tpr_2", tpr_2, "lower", dr[(1 - 1)]);
+      check_matching_dims("constraint", "tpr_2", tpr_2, "lower",
+                          rvalue(dr,
+                            cons_list(index_uni(1), nil_index_list()), "dr"));
       current_statement__ = 34;
       assign(tpr_3, nil_index_list(), pr_3, "assigning variable tpr_3");
       current_statement__ = 34;
@@ -31355,7 +31833,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       current_statement__ = 35;
       assign(tpm_1, nil_index_list(), pm_1, "assigning variable tpm_1");
       current_statement__ = 35;
-      check_matching_dims("constraint", "tpm_1", tpm_1, "lower", dm[(1 - 1)]);
+      check_matching_dims("constraint", "tpm_1", tpm_1, "lower",
+                          rvalue(dm,
+                            cons_list(index_uni(1), nil_index_list()), "dm"));
       current_statement__ = 36;
       assign(tpm_2, nil_index_list(), pm_2, "assigning variable tpm_2");
       current_statement__ = 36;
@@ -31366,26 +31846,34 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 19;
         check_greater_or_equal(function__, "tp_1[sym1__]",
                                tp_1[(sym1__ - 1)],
-                               ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                               (sym1__ - 1)]);}
       current_statement__ = 20;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 20;
         current_statement__ = 20;
         check_less_or_equal(function__, "tp_2[sym1__]", tp_2[(sym1__ - 1)],
-                            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                            (sym1__ - 1)]);}
       current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 21;
         current_statement__ = 21;
         check_greater_or_equal(function__, "tp_3[sym1__]",
                                tp_3[(sym1__ - 1)],
-                               ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                               (sym1__ - 1)]);}
       current_statement__ = 21;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 21;
         current_statement__ = 21;
         check_less_or_equal(function__, "tp_3[sym1__]", tp_3[(sym1__ - 1)],
-                            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+                            (sym1__ - 1)]);}
       current_statement__ = 22;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 22;
@@ -31397,14 +31885,18 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 22;
         current_statement__ = 22;
         check_less_or_equal(function__, "tp_4[sym1__]", tp_4[(sym1__ - 1)],
-                            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+                            (sym1__ - 1)]);}
       current_statement__ = 23;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 23;
         current_statement__ = 23;
         check_greater_or_equal(function__, "tp_5[sym1__]",
                                tp_5[(sym1__ - 1)],
-                               ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+                               (sym1__ - 1)]);}
       current_statement__ = 23;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 23;
@@ -31419,7 +31911,8 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 27;
           check_greater_or_equal(function__, "tp_9[sym1__, sym2__]",
                                  tp_9[(sym1__ - 1)][(sym2__ - 1)],
-                                 ds[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]);}}
+                                 rvalue(ds, cons_list(index_uni(1), nil_index_list()), "ds")[
+                                 (sym1__ - 1)][(sym2__ - 1)]);}}
       current_statement__ = 27;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 27;
@@ -31459,13 +31952,17 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 29;
         check_greater_or_equal(function__, "tpv_1[sym1__]",
                                tpv_1[(sym1__ - 1)],
-                               dv[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dv")[
+                               (sym1__ - 1)]);}
       current_statement__ = 29;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 29;
         current_statement__ = 29;
         check_less_or_equal(function__, "tpv_1[sym1__]", tpv_1[(sym1__ - 1)],
-                            dv[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dv")[
+                            (sym1__ - 1)]);}
       current_statement__ = 30;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 30;
@@ -31474,7 +31971,8 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 30;
           check_greater_or_equal(function__, "tpv_2[sym1__, sym2__]",
                                  tpv_2[(sym1__ - 1)][(sym2__ - 1)],
-                                 dv[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]);}}
+                                 rvalue(dv, cons_list(index_uni(1), nil_index_list()), "dv")[
+                                 (sym1__ - 1)][(sym2__ - 1)]);}}
       current_statement__ = 31;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 31;
@@ -31494,13 +31992,17 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 32;
         check_greater_or_equal(function__, "tpr_1[sym1__]",
                                tpr_1[(sym1__ - 1)],
-                               dr[(1 - 1)][(1 - 1)][(sym1__ - 1)]);}
+                               rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dr")[
+                               (sym1__ - 1)]);}
       current_statement__ = 32;
       for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
         current_statement__ = 32;
         current_statement__ = 32;
         check_less_or_equal(function__, "tpr_1[sym1__]", tpr_1[(sym1__ - 1)],
-                            dr[(1 - 1)][(2 - 1)][(sym1__ - 1)]);}
+                            rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dr")[
+                            (sym1__ - 1)]);}
       current_statement__ = 33;
       for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
         current_statement__ = 33;
@@ -31509,7 +32011,8 @@ class transform_model final : public model_base_crtp<transform_model> {
           current_statement__ = 33;
           check_greater_or_equal(function__, "tpr_2[sym1__, sym2__]",
                                  tpr_2[(sym1__ - 1)][(sym2__ - 1)],
-                                 dr[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]);}}
+                                 rvalue(dr, cons_list(index_uni(1), nil_index_list()), "dr")[
+                                 (sym1__ - 1)][(sym2__ - 1)]);}}
       current_statement__ = 34;
       for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
         current_statement__ = 34;
@@ -31534,7 +32037,8 @@ class transform_model final : public model_base_crtp<transform_model> {
                                    cons_list(index_uni(sym1__),
                                      cons_list(index_uni(sym2__),
                                        nil_index_list())), "tpm_1"),
-                                 rvalue(dm[(1 - 1)],
+                                 rvalue(
+                                   rvalue(dm, cons_list(index_uni(1), nil_index_list()), "dm"),
                                    cons_list(index_uni(sym1__),
                                      cons_list(index_uni(sym2__),
                                        nil_index_list())), "dm[1]"));}}
@@ -31653,7 +32157,10 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_1");
       current_statement__ = 1;
       check_matching_dims("constraint", "p_1", p_1, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<double> p_1_free__;
       p_1_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31662,8 +32169,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 1;
         assign(p_1_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lb_free(p_1[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]),
-          "assigning variable p_1_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_1_free__");}
       std::vector<double> p_2;
       p_2 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31672,7 +32180,10 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_2");
       current_statement__ = 2;
       check_matching_dims("constraint", "p_2", p_2, "upper",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<double> p_2_free__;
       p_2_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31681,8 +32192,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 2;
         assign(p_2_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::ub_free(p_2[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]),
-          "assigning variable p_2_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_2_free__");}
       std::vector<double> p_3;
       p_3 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31691,10 +32203,16 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_3");
       current_statement__ = 3;
       check_matching_dims("constraint", "p_3", p_3, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 3;
       check_matching_dims("constraint", "p_3", p_3, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       std::vector<double> p_3_free__;
       p_3_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31703,9 +32221,12 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 3;
         assign(p_3_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(p_3[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
-          "assigning variable p_3_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)],
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_3_free__");}
       std::vector<double> p_4;
       p_4 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31714,7 +32235,10 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_4");
       current_statement__ = 4;
       check_matching_dims("constraint", "p_4", p_4, "upper",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       std::vector<double> p_4_free__;
       p_4_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31723,8 +32247,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 4;
         assign(p_4_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(p_4[(sym1__ - 1)], 0,
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
-          "assigning variable p_4_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_4_free__");}
       std::vector<double> p_5;
       p_5 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31733,7 +32258,10 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_5");
       current_statement__ = 5;
       check_matching_dims("constraint", "p_5", p_5, "lower",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<double> p_5_free__;
       p_5_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31742,8 +32270,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 5;
         assign(p_5_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(p_5[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1),
-          "assigning variable p_5_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)], 1), "assigning variable p_5_free__");}
       std::vector<double> p_6;
       p_6 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31752,7 +32281,10 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_6");
       current_statement__ = 6;
       check_matching_dims("constraint", "p_6", p_6, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<double> p_6_free__;
       p_6_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31761,8 +32293,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 6;
         assign(p_6_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_free(p_6[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)], 1),
-          "assigning variable p_6_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)], 1), "assigning variable p_6_free__");}
       std::vector<double> p_7;
       p_7 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31771,7 +32304,10 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_7");
       current_statement__ = 7;
       check_matching_dims("constraint", "p_7", p_7, "multiplier",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       std::vector<double> p_7_free__;
       p_7_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31780,8 +32316,9 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 7;
         assign(p_7_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_free(p_7[(sym1__ - 1)], 0,
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)]),
-          "assigning variable p_7_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_7_free__");}
       std::vector<double> p_8;
       p_8 = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31790,10 +32327,16 @@ class transform_model final : public model_base_crtp<transform_model> {
         "assigning variable p_8");
       current_statement__ = 8;
       check_matching_dims("constraint", "p_8", p_8, "offset",
-                          ds[(1 - 1)][(1 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "ds"));
       current_statement__ = 8;
       check_matching_dims("constraint", "p_8", p_8, "multiplier",
-                          ds[(1 - 1)][(2 - 1)]);
+                          rvalue(ds,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "ds"));
       std::vector<double> p_8_free__;
       p_8_free__ = std::vector<double>(k, std::numeric_limits<double>::quiet_NaN());
       
@@ -31802,9 +32345,12 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 8;
         assign(p_8_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::offset_multiplier_free(p_8[(sym1__ - 1)],
-            ds[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            ds[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
-          "assigning variable p_8_free__");}
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "ds")[
+            (sym1__ - 1)],
+            rvalue(ds,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "ds")[
+            (sym1__ - 1)]), "assigning variable p_8_free__");}
       std::vector<std::vector<double>> p_9;
       p_9 = std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN()));
       
@@ -31828,7 +32374,9 @@ class transform_model final : public model_base_crtp<transform_model> {
             pos__ = (pos__ + 1);}}
       }
       current_statement__ = 9;
-      check_matching_dims("constraint", "p_9", p_9, "lower", ds[(1 - 1)]);
+      check_matching_dims("constraint", "p_9", p_9, "lower",
+                          rvalue(ds,
+                            cons_list(index_uni(1), nil_index_list()), "ds"));
       std::vector<std::vector<double>> p_9_free__;
       p_9_free__ = std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN()));
       
@@ -31841,7 +32389,8 @@ class transform_model final : public model_base_crtp<transform_model> {
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lub_free(p_9[(sym1__ - 1)][(sym2__ - 1)],
-              ds[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)], 1),
+              rvalue(ds, cons_list(index_uni(1), nil_index_list()), "ds")[
+              (sym1__ - 1)][(sym2__ - 1)], 1),
             "assigning variable p_9_free__");}}
       std::vector<std::vector<std::vector<double>>> p_10;
       p_10 = std::vector<std::vector<std::vector<double>>>(n, std::vector<std::vector<double>>(m, std::vector<double>(k, std::numeric_limits<double>::quiet_NaN())));
@@ -31909,10 +32458,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 11;
       check_matching_dims("constraint", "pv_1", pv_1, "lower",
-                          dv[(1 - 1)][(1 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dv"));
       current_statement__ = 11;
       check_matching_dims("constraint", "pv_1", pv_1, "upper",
-                          dv[(1 - 1)][(2 - 1)]);
+                          rvalue(dv,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dv"));
       Eigen::Matrix<double, -1, 1> pv_1_free__;
       pv_1_free__ = Eigen::Matrix<double, -1, 1>(k);
       stan::math::fill(pv_1_free__, std::numeric_limits<double>::quiet_NaN());
@@ -31922,9 +32477,12 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 11;
         assign(pv_1_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(pv_1[(sym1__ - 1)],
-            dv[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            dv[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
-          "assigning variable pv_1_free__");}
+            rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dv")[
+            (sym1__ - 1)],
+            rvalue(dv,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dv")[
+            (sym1__ - 1)]), "assigning variable pv_1_free__");}
       std::vector<Eigen::Matrix<double, -1, 1>> pv_2;
       pv_2 = std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k));
       stan::math::fill(pv_2, std::numeric_limits<double>::quiet_NaN());
@@ -31949,7 +32507,9 @@ class transform_model final : public model_base_crtp<transform_model> {
             pos__ = (pos__ + 1);}}
       }
       current_statement__ = 12;
-      check_matching_dims("constraint", "pv_2", pv_2, "lower", dv[(1 - 1)]);
+      check_matching_dims("constraint", "pv_2", pv_2, "lower",
+                          rvalue(dv,
+                            cons_list(index_uni(1), nil_index_list()), "dv"));
       std::vector<Eigen::Matrix<double, -1, 1>> pv_2_free__;
       pv_2_free__ = std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k));
       stan::math::fill(pv_2_free__, std::numeric_limits<double>::quiet_NaN());
@@ -31963,8 +32523,9 @@ class transform_model final : public model_base_crtp<transform_model> {
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lb_free(pv_2[(sym1__ - 1)][(sym2__ - 1)],
-              dv[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-            "assigning variable pv_2_free__");}}
+              rvalue(dv, cons_list(index_uni(1), nil_index_list()), "dv")[
+              (sym1__ - 1)][(sym2__ - 1)]), "assigning variable pv_2_free__");
+        }}
       std::vector<std::vector<Eigen::Matrix<double, -1, 1>>> pv_3;
       pv_3 = std::vector<std::vector<Eigen::Matrix<double, -1, 1>>>(n, std::vector<Eigen::Matrix<double, -1, 1>>(m, Eigen::Matrix<double, -1, 1>(k)));
       stan::math::fill(pv_3, std::numeric_limits<double>::quiet_NaN());
@@ -32033,10 +32594,16 @@ class transform_model final : public model_base_crtp<transform_model> {
       }
       current_statement__ = 14;
       check_matching_dims("constraint", "pr_1", pr_1, "lower",
-                          dr[(1 - 1)][(1 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(1), nil_index_list())),
+                            "dr"));
       current_statement__ = 14;
       check_matching_dims("constraint", "pr_1", pr_1, "upper",
-                          dr[(1 - 1)][(2 - 1)]);
+                          rvalue(dr,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(2), nil_index_list())),
+                            "dr"));
       Eigen::Matrix<double, 1, -1> pr_1_free__;
       pr_1_free__ = Eigen::Matrix<double, 1, -1>(k);
       stan::math::fill(pr_1_free__, std::numeric_limits<double>::quiet_NaN());
@@ -32046,9 +32613,12 @@ class transform_model final : public model_base_crtp<transform_model> {
         current_statement__ = 14;
         assign(pr_1_free__, cons_list(index_uni(sym1__), nil_index_list()),
           stan::math::lub_free(pr_1[(sym1__ - 1)],
-            dr[(1 - 1)][(1 - 1)][(sym1__ - 1)],
-            dr[(1 - 1)][(2 - 1)][(sym1__ - 1)]),
-          "assigning variable pr_1_free__");}
+            rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())), "dr")[
+            (sym1__ - 1)],
+            rvalue(dr,
+  cons_list(index_uni(1), cons_list(index_uni(2), nil_index_list())), "dr")[
+            (sym1__ - 1)]), "assigning variable pr_1_free__");}
       std::vector<Eigen::Matrix<double, 1, -1>> pr_2;
       pr_2 = std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k));
       stan::math::fill(pr_2, std::numeric_limits<double>::quiet_NaN());
@@ -32073,7 +32643,9 @@ class transform_model final : public model_base_crtp<transform_model> {
             pos__ = (pos__ + 1);}}
       }
       current_statement__ = 15;
-      check_matching_dims("constraint", "pr_2", pr_2, "lower", dr[(1 - 1)]);
+      check_matching_dims("constraint", "pr_2", pr_2, "lower",
+                          rvalue(dr,
+                            cons_list(index_uni(1), nil_index_list()), "dr"));
       std::vector<Eigen::Matrix<double, 1, -1>> pr_2_free__;
       pr_2_free__ = std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k));
       stan::math::fill(pr_2_free__, std::numeric_limits<double>::quiet_NaN());
@@ -32087,8 +32659,9 @@ class transform_model final : public model_base_crtp<transform_model> {
             cons_list(index_uni(sym1__),
               cons_list(index_uni(sym2__), nil_index_list())),
             stan::math::lb_free(pr_2[(sym1__ - 1)][(sym2__ - 1)],
-              dr[(1 - 1)][(sym1__ - 1)][(sym2__ - 1)]),
-            "assigning variable pr_2_free__");}}
+              rvalue(dr, cons_list(index_uni(1), nil_index_list()), "dr")[
+              (sym1__ - 1)][(sym2__ - 1)]), "assigning variable pr_2_free__");
+        }}
       std::vector<std::vector<Eigen::Matrix<double, 1, -1>>> pr_3;
       pr_3 = std::vector<std::vector<Eigen::Matrix<double, 1, -1>>>(n, std::vector<Eigen::Matrix<double, 1, -1>>(m, Eigen::Matrix<double, 1, -1>(k)));
       stan::math::fill(pr_3, std::numeric_limits<double>::quiet_NaN());
@@ -32160,7 +32733,9 @@ class transform_model final : public model_base_crtp<transform_model> {
             pos__ = (pos__ + 1);}}
       }
       current_statement__ = 17;
-      check_matching_dims("constraint", "pm_1", pm_1, "lower", dm[(1 - 1)]);
+      check_matching_dims("constraint", "pm_1", pm_1, "lower",
+                          rvalue(dm,
+                            cons_list(index_uni(1), nil_index_list()), "dm"));
       Eigen::Matrix<double, -1, -1> pm_1_free__;
       pm_1_free__ = Eigen::Matrix<double, -1, -1>(m, k);
       stan::math::fill(pm_1_free__, std::numeric_limits<double>::quiet_NaN());
@@ -32177,7 +32752,8 @@ class transform_model final : public model_base_crtp<transform_model> {
               rvalue(pm_1,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__), nil_index_list())), "pm_1"),
-              rvalue(dm[(1 - 1)],
+              rvalue(
+                rvalue(dm, cons_list(index_uni(1), nil_index_list()), "dm"),
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(sym2__), nil_index_list())), "dm[1]")),
             "assigning variable pm_1_free__");}}

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -511,10 +511,13 @@ ode_integrate(std::ostream* pstream__) {
     x_i = std::vector<int>(0, std::numeric_limits<int>::min());
     
     current_statement__ = 9;
-    return integrate_ode_bdf(integrand_ode_functor__(), rep_array(0.0, 1), 1E-5,
+    return rvalue(
+             integrate_ode_bdf(integrand_ode_functor__(), rep_array(0.0, 1), 1E-5,
   rep_array((1.0 - 1E-5), 1), rep_array(0.0, 0), rep_array(0.0, 0), x_i,
-  pstream__)[
-        (1 - 1)][(1 - 1)];
+  pstream__),
+             cons_list(index_uni(1),
+               cons_list(index_uni(1), nil_index_list())),
+             "integrate_ode_bdf(integrand_ode, rep_array(0.0, 1), 1E-5,\n                  rep_array((1.0 - 1E-5), 1), rep_array(0.0, 0),\n                  rep_array(0.0, 0), x_i)");
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -80,18 +80,34 @@ simple_SIR(const T0__& t, const std::vector<T1__>& y,
       
       current_statement__ = 30;
       assign(dydt, cons_list(index_uni(1), nil_index_list()),
-        (((-theta[(1 - 1)] * y[(4 - 1)]) / (y[(4 - 1)] + theta[(2 - 1)])) *
-          y[(1 - 1)]), "assigning variable dydt");
-      lcm_sym4__ = (theta[(3 - 1)] * y[(2 - 1)]);
+        (((-rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta")
+            * rvalue(y, cons_list(index_uni(4), nil_index_list()), "y")) /
+           (rvalue(y, cons_list(index_uni(4), nil_index_list()), "y") +
+             rvalue(theta, cons_list(index_uni(2), nil_index_list()),
+               "theta"))) *
+          rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")),
+        "assigning variable dydt");
+      lcm_sym4__ = (rvalue(theta, cons_list(index_uni(3), nil_index_list()),
+                      "theta") *
+                     rvalue(y, cons_list(index_uni(2), nil_index_list()),
+                       "y"));
       assign(dydt, cons_list(index_uni(2), nil_index_list()),
-        ((((theta[(1 - 1)] * y[(4 - 1)]) / (y[(4 - 1)] + theta[(2 - 1)])) *
-           y[(1 - 1)]) - lcm_sym4__), "assigning variable dydt");
+        ((((rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta")
+             * rvalue(y, cons_list(index_uni(4), nil_index_list()), "y")) /
+            (rvalue(y, cons_list(index_uni(4), nil_index_list()), "y") +
+              rvalue(theta, cons_list(index_uni(2), nil_index_list()),
+                "theta"))) *
+           rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")) -
+          lcm_sym4__), "assigning variable dydt");
       current_statement__ = 31;
       assign(dydt, cons_list(index_uni(3), nil_index_list()), lcm_sym4__,
         "assigning variable dydt");
       current_statement__ = 32;
       assign(dydt, cons_list(index_uni(4), nil_index_list()),
-        ((theta[(4 - 1)] * y[(2 - 1)]) - (theta[(5 - 1)] * y[(4 - 1)])),
+        ((rvalue(theta, cons_list(index_uni(4), nil_index_list()), "theta") *
+           rvalue(y, cons_list(index_uni(2), nil_index_list()), "y")) -
+          (rvalue(theta, cons_list(index_uni(5), nil_index_list()), "theta")
+            * rvalue(y, cons_list(index_uni(4), nil_index_list()), "y"))),
         "assigning variable dydt");
       current_statement__ = 33;
       return dydt;
@@ -349,26 +365,41 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         {
           {
             {
-              lcm_sym32__ = lcm_sym23__[(1 - 1)][(1 - 1)];
+              lcm_sym32__ = rvalue(lcm_sym23__,
+                              cons_list(index_uni(1),
+                                cons_list(index_uni(1), nil_index_list())),
+                              "lcm_sym23__");
               check_greater_or_equal(function__, "y[sym1__, sym2__]",
                                      lcm_sym32__, 0);
               {
                 current_statement__ = 5;
                 current_statement__ = 5;
                 check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                       lcm_sym23__[(1 - 1)][(2 - 1)], 0);
+                                       rvalue(lcm_sym23__,
+                                         cons_list(index_uni(1),
+                                           cons_list(index_uni(2),
+                                             nil_index_list())),
+                                         "lcm_sym23__"), 0);
               }
               {
                 current_statement__ = 5;
                 current_statement__ = 5;
                 check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                       lcm_sym23__[(1 - 1)][(3 - 1)], 0);
+                                       rvalue(lcm_sym23__,
+                                         cons_list(index_uni(1),
+                                           cons_list(index_uni(3),
+                                             nil_index_list())),
+                                         "lcm_sym23__"), 0);
               }
               {
                 current_statement__ = 5;
                 current_statement__ = 5;
                 check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                       lcm_sym23__[(1 - 1)][(4 - 1)], 0);
+                                       rvalue(lcm_sym23__,
+                                         cons_list(index_uni(1),
+                                           cons_list(index_uni(4),
+                                             nil_index_list())),
+                                         "lcm_sym23__"), 0);
               }
             }
           }
@@ -377,29 +408,48 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
               current_statement__ = 5;
               current_statement__ = 5;
               check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                     lcm_sym23__[(sym1__ - 1)][(1 - 1)], 0);
+                                     rvalue(lcm_sym23__,
+                                       cons_list(index_uni(sym1__),
+                                         cons_list(index_uni(1),
+                                           nil_index_list())), "lcm_sym23__"),
+                                     0);
               {
                 current_statement__ = 5;
                 current_statement__ = 5;
                 check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                       lcm_sym23__[(sym1__ - 1)][(2 - 1)], 0);
+                                       rvalue(lcm_sym23__,
+                                         cons_list(index_uni(sym1__),
+                                           cons_list(index_uni(2),
+                                             nil_index_list())),
+                                         "lcm_sym23__"), 0);
               }
               {
                 current_statement__ = 5;
                 current_statement__ = 5;
                 check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                       lcm_sym23__[(sym1__ - 1)][(3 - 1)], 0);
+                                       rvalue(lcm_sym23__,
+                                         cons_list(index_uni(sym1__),
+                                           cons_list(index_uni(3),
+                                             nil_index_list())),
+                                         "lcm_sym23__"), 0);
               }
               {
                 current_statement__ = 5;
                 current_statement__ = 5;
                 check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                       lcm_sym23__[(sym1__ - 1)][(4 - 1)], 0);
+                                       rvalue(lcm_sym23__,
+                                         cons_list(index_uni(sym1__),
+                                           cons_list(index_uni(4),
+                                             nil_index_list())),
+                                         "lcm_sym23__"), 0);
               }
             }}
         }
       } else {
-        lcm_sym32__ = lcm_sym23__[(1 - 1)][(1 - 1)];
+        lcm_sym32__ = rvalue(lcm_sym23__,
+                        cons_list(index_uni(1),
+                          cons_list(index_uni(1), nil_index_list())),
+                        "lcm_sym23__");
       }
       {
         current_statement__ = 8;
@@ -412,20 +462,37 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         lp_accum__.add(cauchy_lpdf<propto__>(delta, 0, 1));
         current_statement__ = 12;
         lp_accum__.add(
-          poisson_lpmf<propto__>(stoi_hat[(1 - 1)],
-            (y0[(1 - 1)] - lcm_sym32__)));
+          poisson_lpmf<propto__>(
+            rvalue(stoi_hat, cons_list(index_uni(1), nil_index_list()),
+              "stoi_hat"),
+            (rvalue(y0, cons_list(index_uni(1), nil_index_list()), "y0") -
+              lcm_sym32__)));
         current_statement__ = 14;
         if (logical_gte(N_t, 2)) {
           current_statement__ = 13;
           lp_accum__.add(
-            poisson_lpmf<propto__>(stoi_hat[(2 - 1)],
-              (lcm_sym32__ - lcm_sym23__[(2 - 1)][(1 - 1)])));
+            poisson_lpmf<propto__>(
+              rvalue(stoi_hat, cons_list(index_uni(2), nil_index_list()),
+                "stoi_hat"),
+              (lcm_sym32__ -
+                rvalue(lcm_sym23__,
+                  cons_list(index_uni(2),
+                    cons_list(index_uni(1), nil_index_list())),
+                  "lcm_sym23__"))));
           for (int n = 3; n <= N_t; ++n) {
             current_statement__ = 13;
             lp_accum__.add(
-              poisson_lpmf<propto__>(stoi_hat[(n - 1)],
-                (lcm_sym23__[((n - 1) - 1)][(1 - 1)] -
-                  lcm_sym23__[(n - 1)][(1 - 1)])));}
+              poisson_lpmf<propto__>(
+                rvalue(stoi_hat, cons_list(index_uni(n), nil_index_list()),
+                  "stoi_hat"),
+                (rvalue(lcm_sym23__,
+                   cons_list(index_uni((n - 1)),
+                     cons_list(index_uni(1), nil_index_list())),
+                   "lcm_sym23__") -
+                  rvalue(lcm_sym23__,
+                    cons_list(index_uni(n),
+                      cons_list(index_uni(1), nil_index_list())),
+                    "lcm_sym23__"))));}
         } 
         current_statement__ = 15;
         lp_accum__.add(
@@ -532,24 +599,36 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
           current_statement__ = 5;
           current_statement__ = 5;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 lcm_sym8__[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(lcm_sym8__,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "lcm_sym8__"), 0);
           {
             current_statement__ = 5;
             current_statement__ = 5;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   lcm_sym8__[(1 - 1)][(2 - 1)], 0);
+                                   rvalue(lcm_sym8__,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(2),
+                                         nil_index_list())), "lcm_sym8__"), 0);
           }
           {
             current_statement__ = 5;
             current_statement__ = 5;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   lcm_sym8__[(1 - 1)][(3 - 1)], 0);
+                                   rvalue(lcm_sym8__,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(3),
+                                         nil_index_list())), "lcm_sym8__"), 0);
           }
           {
             current_statement__ = 5;
             current_statement__ = 5;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   lcm_sym8__[(1 - 1)][(4 - 1)], 0);
+                                   rvalue(lcm_sym8__,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(4),
+                                         nil_index_list())), "lcm_sym8__"), 0);
           }
         }
         for (int sym1__ = 2; sym1__ <= N_t; ++sym1__) {
@@ -557,53 +636,96 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
             current_statement__ = 5;
             current_statement__ = 5;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   lcm_sym8__[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(lcm_sym8__,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "lcm_sym8__"), 0);
             {
               current_statement__ = 5;
               current_statement__ = 5;
               check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                     lcm_sym8__[(sym1__ - 1)][(2 - 1)], 0);
+                                     rvalue(lcm_sym8__,
+                                       cons_list(index_uni(sym1__),
+                                         cons_list(index_uni(2),
+                                           nil_index_list())), "lcm_sym8__"),
+                                     0);
             }
             {
               current_statement__ = 5;
               current_statement__ = 5;
               check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                     lcm_sym8__[(sym1__ - 1)][(3 - 1)], 0);
+                                     rvalue(lcm_sym8__,
+                                       cons_list(index_uni(sym1__),
+                                         cons_list(index_uni(3),
+                                           nil_index_list())), "lcm_sym8__"),
+                                     0);
             }
             {
               current_statement__ = 5;
               current_statement__ = 5;
               check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                     lcm_sym8__[(sym1__ - 1)][(4 - 1)], 0);
+                                     rvalue(lcm_sym8__,
+                                       cons_list(index_uni(sym1__),
+                                         cons_list(index_uni(4),
+                                           nil_index_list())), "lcm_sym8__"),
+                                     0);
             }
           }}
       } 
       if (emit_transformed_parameters__) {
         {
           if (lcm_sym5__) {
-            vars__.emplace_back(lcm_sym8__[(1 - 1)][(1 - 1)]);
+            vars__.emplace_back(
+              rvalue(lcm_sym8__,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(1), nil_index_list())), "lcm_sym8__"));
             for (int sym2__ = 2; sym2__ <= N_t; ++sym2__) {
-              vars__.emplace_back(lcm_sym8__[(sym2__ - 1)][(1 - 1)]);}
+              vars__.emplace_back(
+                rvalue(lcm_sym8__,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(1), nil_index_list())), "lcm_sym8__"));
+            }
           } 
           {
             if (lcm_sym5__) {
-              vars__.emplace_back(lcm_sym8__[(1 - 1)][(2 - 1)]);
+              vars__.emplace_back(
+                rvalue(lcm_sym8__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(2), nil_index_list())), "lcm_sym8__"));
               for (int sym2__ = 2; sym2__ <= N_t; ++sym2__) {
-                vars__.emplace_back(lcm_sym8__[(sym2__ - 1)][(2 - 1)]);}
+                vars__.emplace_back(
+                  rvalue(lcm_sym8__,
+                    cons_list(index_uni(sym2__),
+                      cons_list(index_uni(2), nil_index_list())),
+                    "lcm_sym8__"));}
             } 
           }
           {
             if (lcm_sym5__) {
-              vars__.emplace_back(lcm_sym8__[(1 - 1)][(3 - 1)]);
+              vars__.emplace_back(
+                rvalue(lcm_sym8__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(3), nil_index_list())), "lcm_sym8__"));
               for (int sym2__ = 2; sym2__ <= N_t; ++sym2__) {
-                vars__.emplace_back(lcm_sym8__[(sym2__ - 1)][(3 - 1)]);}
+                vars__.emplace_back(
+                  rvalue(lcm_sym8__,
+                    cons_list(index_uni(sym2__),
+                      cons_list(index_uni(3), nil_index_list())),
+                    "lcm_sym8__"));}
             } 
           }
           {
             if (lcm_sym5__) {
-              vars__.emplace_back(lcm_sym8__[(1 - 1)][(4 - 1)]);
+              vars__.emplace_back(
+                rvalue(lcm_sym8__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(4), nil_index_list())), "lcm_sym8__"));
               for (int sym2__ = 2; sym2__ <= N_t; ++sym2__) {
-                vars__.emplace_back(lcm_sym8__[(sym2__ - 1)][(4 - 1)]);}
+                vars__.emplace_back(
+                  rvalue(lcm_sym8__,
+                    cons_list(index_uni(sym2__),
+                      cons_list(index_uni(4), nil_index_list())),
+                    "lcm_sym8__"));}
             } 
           }
         }
@@ -971,13 +1093,13 @@ first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       lcm_sym27__ = size(y_i);
       if (logical_gte(lcm_sym27__, 1)) {
         current_statement__ = 45;
-        if (y_i[(1 - 1)]) {
+        if (rvalue(y_i, cons_list(index_uni(1), nil_index_list()), "y_i")) {
           current_statement__ = 44;
           return 1;
         } 
         for (int k = 2; k <= lcm_sym27__; ++k) {
           current_statement__ = 45;
-          if (y_i[(k - 1)]) {
+          if (rvalue(y_i, cons_list(index_uni(k), nil_index_list()), "y_i")) {
             current_statement__ = 44;
             return k;
           } }
@@ -1405,7 +1527,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 35;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= nind; ++sym2__) {
@@ -1448,12 +1571,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 0);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 35;
@@ -1461,7 +1590,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 0);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -1476,12 +1608,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], 1);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), 1);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 35;
@@ -1489,7 +1627,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), 1);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -1531,7 +1672,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             assign(x,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              x_flat__[(1 - 1)], "assigning variable x");
+              rvalue(x_flat__, cons_list(index_uni(1), nil_index_list()),
+                "x_flat__"), "assigning variable x");
             current_statement__ = 38;
             pos__ = 2;
             for (int sym2__ = 2; sym2__ <= nind; ++sym2__) {
@@ -1571,12 +1713,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           current_statement__ = 38;
           current_statement__ = 38;
           check_greater_or_equal(function__, "x[sym1__, sym2__]",
-                                 x[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(x,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "x"), 0);
           for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
             current_statement__ = 38;
             current_statement__ = 38;
             check_greater_or_equal(function__, "x[sym1__, sym2__]",
-                                   x[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(x,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "x"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 38;
@@ -1584,7 +1732,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             current_statement__ = 38;
             current_statement__ = 38;
             check_greater_or_equal(function__, "x[sym1__, sym2__]",
-                                   x[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(x,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "x"), 0);
             for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
               current_statement__ = 38;
               current_statement__ = 38;
@@ -1599,12 +1750,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           current_statement__ = 38;
           current_statement__ = 38;
           check_less_or_equal(function__, "x[sym1__, sym2__]",
-                              x[(1 - 1)][(1 - 1)], max_age);
+                              rvalue(x,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "x"), max_age);
           for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
             current_statement__ = 38;
             current_statement__ = 38;
             check_less_or_equal(function__, "x[sym1__, sym2__]",
-                                x[(1 - 1)][(sym2__ - 1)], max_age);}
+                                rvalue(x,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "x"), max_age);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 38;
@@ -1612,7 +1769,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             current_statement__ = 38;
             current_statement__ = 38;
             check_less_or_equal(function__, "x[sym1__, sym2__]",
-                                x[(sym1__ - 1)][(1 - 1)], max_age);
+                                rvalue(x,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "x"), max_age);
             for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
               current_statement__ = 38;
               current_statement__ = 38;
@@ -1643,11 +1803,14 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym173__ = size(y[(1 - 1)]);
+          lcm_sym173__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym173__;
                ++inline_sym18__) {
             current_statement__ = 45;
-            if (y[(1 - 1)][(inline_sym18__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (inline_sym18__ - 1)]) {
               inline_sym19__ = 1;
               inline_sym17__ = inline_sym18__;
               break;
@@ -1667,11 +1830,15 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym172__ = size(y[(i - 1)]);
+            lcm_sym172__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym172__;
                  ++inline_sym18__) {
               current_statement__ = 45;
-              if (y[(i - 1)][(inline_sym18__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (inline_sym18__ - 1)]) {
                 inline_sym19__ = 1;
                 inline_sym17__ = inline_sym18__;
                 break;
@@ -1693,7 +1860,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym173__ = size(y[(1 - 1)]);
+          lcm_sym173__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           lcm_sym170__ = (lcm_sym173__ - 1);
           for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym170__;
                ++inline_sym23__) {
@@ -1703,7 +1872,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             lcm_sym169__ = (lcm_sym173__ - inline_sym23__);
             inline_sym22__ = lcm_sym169__;
             current_statement__ = 51;
-            if (y[(1 - 1)][(lcm_sym169__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (lcm_sym169__ - 1)]) {
               inline_sym24__ = 1;
               inline_sym21__ = lcm_sym169__;
               break;
@@ -1723,7 +1893,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym172__ = size(y[(i - 1)]);
+            lcm_sym172__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             lcm_sym168__ = (lcm_sym172__ - 1);
             for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym168__;
                  ++inline_sym23__) {
@@ -1733,7 +1906,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               lcm_sym167__ = (lcm_sym172__ - inline_sym23__);
               inline_sym22__ = lcm_sym167__;
               current_statement__ = 51;
-              if (y[(i - 1)][(lcm_sym167__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (lcm_sym167__ - 1)]) {
                 inline_sym24__ = 1;
                 inline_sym21__ = lcm_sym167__;
                 break;
@@ -1751,7 +1925,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       if (lcm_sym164__) {
         current_statement__ = 41;
         current_statement__ = 41;
-        check_greater_or_equal(function__, "first[sym1__]", first[(1 - 1)], 0);
+        check_greater_or_equal(function__, "first[sym1__]",
+                               rvalue(first,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "first"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 41;
           current_statement__ = 41;
@@ -1762,8 +1939,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       if (lcm_sym164__) {
         current_statement__ = 41;
         current_statement__ = 41;
-        check_less_or_equal(function__, "first[sym1__]", first[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "first[sym1__]",
+                            rvalue(first,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "first"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 41;
           current_statement__ = 41;
@@ -1774,7 +1953,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       if (lcm_sym164__) {
         current_statement__ = 43;
         current_statement__ = 43;
-        check_greater_or_equal(function__, "last[sym1__]", last[(1 - 1)], 0);
+        check_greater_or_equal(function__, "last[sym1__]",
+                               rvalue(last,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "last"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 43;
           current_statement__ = 43;
@@ -1785,8 +1967,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       if (lcm_sym164__) {
         current_statement__ = 43;
         current_statement__ = 43;
-        check_less_or_equal(function__, "last[sym1__]", last[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "last[sym1__]",
+                            rvalue(last,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "last"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 43;
           current_statement__ = 43;
@@ -1922,13 +2106,15 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         if (jacobian__) {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lub_constrain(beta[(1 - 1)], 0, 1, lp__),
-            "assigning variable beta");
+            stan::math::lub_constrain(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              0, 1, lp__), "assigning variable beta");
         } else {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lub_constrain(beta[(1 - 1)], 0, 1),
-            "assigning variable beta");
+            stan::math::lub_constrain(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              0, 1), "assigning variable beta");
         }
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
@@ -1958,7 +2144,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       
       lcm_sym107__ = logical_gte(nind, 1);
       if (lcm_sym107__) {
-        lcm_sym148__ = first[(1 - 1)];
+        lcm_sym148__ = rvalue(first,
+                         cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym120__ = (lcm_sym148__ - 1);
         if (logical_gte(lcm_sym120__, 1)) {
           current_statement__ = 6;
@@ -1989,8 +2176,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           assign(phi,
             cons_list(index_uni(1),
               cons_list(index_uni(lcm_sym148__), nil_index_list())),
-            beta[(x[(1 - 1)][(lcm_sym148__ - 1)] - 1)],
-            "assigning variable phi");
+            rvalue(beta,
+              cons_list(
+                index_uni(rvalue(x,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(lcm_sym148__),
+                                nil_index_list())), "x")), nil_index_list()),
+              "beta"), "assigning variable phi");
           lcm_sym126__ = (lcm_sym148__ + 1);
           assign(p,
             cons_list(index_uni(1),
@@ -2001,7 +2193,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             assign(phi,
               cons_list(index_uni(1),
                 cons_list(index_uni(t), nil_index_list())),
-              beta[(x[(1 - 1)][(t - 1)] - 1)], "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(1),
+                                cons_list(index_uni(t), nil_index_list())),
+                              "x")), nil_index_list()), "beta"),
+              "assigning variable phi");
             current_statement__ = 10;
             assign(p,
               cons_list(index_uni(1),
@@ -2009,7 +2207,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym147__ = first[(i - 1)];
+          lcm_sym147__ = rvalue(first,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "first");
           lcm_sym119__ = (lcm_sym147__ - 1);
           if (logical_gte(lcm_sym119__, 1)) {
             current_statement__ = 6;
@@ -2040,8 +2240,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             assign(phi,
               cons_list(index_uni(i),
                 cons_list(index_uni(lcm_sym147__), nil_index_list())),
-              beta[(x[(i - 1)][(lcm_sym147__ - 1)] - 1)],
-              "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(i),
+                                cons_list(index_uni(lcm_sym147__),
+                                  nil_index_list())), "x")),
+                  nil_index_list()), "beta"), "assigning variable phi");
             lcm_sym125__ = (lcm_sym147__ + 1);
             assign(p,
               cons_list(index_uni(i),
@@ -2052,7 +2257,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               assign(phi,
                 cons_list(index_uni(i),
                   cons_list(index_uni(t), nil_index_list())),
-                beta[(x[(i - 1)][(t - 1)] - 1)], "assigning variable phi");
+                rvalue(beta,
+                  cons_list(
+                    index_uni(rvalue(x,
+                                cons_list(index_uni(i),
+                                  cons_list(index_uni(t), nil_index_list())),
+                                "x")), nil_index_list()), "beta"),
+                "assigning variable phi");
               current_statement__ = 10;
               assign(p,
                 cons_list(index_uni(i),
@@ -2410,9 +2621,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       {
         current_statement__ = 30;
         if (lcm_sym107__) {
-          lcm_sym148__ = first[(1 - 1)];
+          lcm_sym148__ = rvalue(first,
+                           cons_list(index_uni(1), nil_index_list()),
+                           "first");
           if (logical_gt(lcm_sym148__, 0)) {
-            lcm_sym154__ = last[(1 - 1)];
+            lcm_sym154__ = rvalue(last,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "last");
             lcm_sym126__ = (lcm_sym148__ + 1);
             if (logical_gte(lcm_sym154__, lcm_sym126__)) {
               current_statement__ = 24;
@@ -2424,7 +2639,11 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                         nil_index_list())), "phi")));
               lcm_sym124__ = (lcm_sym126__ + 1);
               lp_accum__.add(
-                bernoulli_lpmf<propto__>(y[(1 - 1)][(lcm_sym126__ - 1)],
+                bernoulli_lpmf<propto__>(
+                  rvalue(y,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(lcm_sym126__), nil_index_list())),
+                    "y"),
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym126__ - 1)),
@@ -2439,7 +2658,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                       "phi")));
                 current_statement__ = 25;
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(1 - 1)][(t - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni(t), nil_index_list())), "y"),
                     rvalue(p,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
@@ -2454,9 +2676,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                   "inline_sym9__")));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym147__ = first[(i - 1)];
+            lcm_sym147__ = rvalue(first,
+                             cons_list(index_uni(i), nil_index_list()),
+                             "first");
             if (logical_gt(lcm_sym147__, 0)) {
-              lcm_sym153__ = last[(i - 1)];
+              lcm_sym153__ = rvalue(last,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "last");
               lcm_sym125__ = (lcm_sym147__ + 1);
               if (logical_gte(lcm_sym153__, lcm_sym125__)) {
                 current_statement__ = 24;
@@ -2468,7 +2694,11 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                           nil_index_list())), "phi")));
                 lcm_sym123__ = (lcm_sym125__ + 1);
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(i - 1)][(lcm_sym125__ - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(lcm_sym125__), nil_index_list())),
+                      "y"),
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym125__ - 1)),
@@ -2483,7 +2713,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                         "phi")));
                   current_statement__ = 25;
                   lp_accum__.add(
-                    bernoulli_lpmf<propto__>(y[(i - 1)][(t - 1)],
+                    bernoulli_lpmf<propto__>(
+                      rvalue(y,
+                        cons_list(index_uni(i),
+                          cons_list(index_uni(t), nil_index_list())), "y"),
                       rvalue(p,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
@@ -2596,8 +2829,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       if (lcm_sym54__) {
         current_statement__ = 2;
         assign(beta, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lub_constrain(beta[(1 - 1)], 0, 1),
-          "assigning variable beta");
+          stan::math::lub_constrain(
+            rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+            0, 1), "assigning variable beta");
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(sym1__), nil_index_list()),
@@ -2618,7 +2852,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       
       vars__.emplace_back(mean_p);
       if (lcm_sym54__) {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"));
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           vars__.emplace_back(beta[(sym1__ - 1)]);}
       } 
@@ -2628,7 +2863,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       } 
       lcm_sym56__ = logical_gte(nind, 1);
       if (lcm_sym56__) {
-        lcm_sym83__ = first[(1 - 1)];
+        lcm_sym83__ = rvalue(first,
+                        cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym65__ = (lcm_sym83__ - 1);
         if (logical_gte(lcm_sym65__, 1)) {
           current_statement__ = 6;
@@ -2659,8 +2895,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           assign(phi,
             cons_list(index_uni(1),
               cons_list(index_uni(lcm_sym83__), nil_index_list())),
-            beta[(x[(1 - 1)][(lcm_sym83__ - 1)] - 1)],
-            "assigning variable phi");
+            rvalue(beta,
+              cons_list(
+                index_uni(rvalue(x,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(lcm_sym83__),
+                                nil_index_list())), "x")), nil_index_list()),
+              "beta"), "assigning variable phi");
           lcm_sym71__ = (lcm_sym83__ + 1);
           assign(p,
             cons_list(index_uni(1),
@@ -2671,7 +2912,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             assign(phi,
               cons_list(index_uni(1),
                 cons_list(index_uni(t), nil_index_list())),
-              beta[(x[(1 - 1)][(t - 1)] - 1)], "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(1),
+                                cons_list(index_uni(t), nil_index_list())),
+                              "x")), nil_index_list()), "beta"),
+              "assigning variable phi");
             current_statement__ = 10;
             assign(p,
               cons_list(index_uni(1),
@@ -2679,7 +2926,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym82__ = first[(i - 1)];
+          lcm_sym82__ = rvalue(first,
+                          cons_list(index_uni(i), nil_index_list()), "first");
           lcm_sym64__ = (lcm_sym82__ - 1);
           if (logical_gte(lcm_sym64__, 1)) {
             current_statement__ = 6;
@@ -2710,8 +2958,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             assign(phi,
               cons_list(index_uni(i),
                 cons_list(index_uni(lcm_sym82__), nil_index_list())),
-              beta[(x[(i - 1)][(lcm_sym82__ - 1)] - 1)],
-              "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(i),
+                                cons_list(index_uni(lcm_sym82__),
+                                  nil_index_list())), "x")),
+                  nil_index_list()), "beta"), "assigning variable phi");
             lcm_sym70__ = (lcm_sym82__ + 1);
             assign(p,
               cons_list(index_uni(i),
@@ -2722,7 +2975,13 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               assign(phi,
                 cons_list(index_uni(i),
                   cons_list(index_uni(t), nil_index_list())),
-                beta[(x[(i - 1)][(t - 1)] - 1)], "assigning variable phi");
+                rvalue(beta,
+                  cons_list(
+                    index_uni(rvalue(x,
+                                cons_list(index_uni(i),
+                                  cons_list(index_uni(t), nil_index_list())),
+                                "x")), nil_index_list()), "beta"),
+                "assigning variable phi");
               current_statement__ = 10;
               assign(p,
                 cons_list(index_uni(i),
@@ -3221,7 +3480,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         if (lcm_sym46__) {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            beta_flat__[(1 - 1)], "assigning variable beta");
+            rvalue(beta_flat__, cons_list(index_uni(1), nil_index_list()),
+              "beta_flat__"), "assigning variable beta");
           current_statement__ = 2;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
@@ -3240,8 +3500,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       if (lcm_sym46__) {
         current_statement__ = 2;
         assign(beta_free__, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lub_free(beta[(1 - 1)], 0, 1),
-          "assigning variable beta_free__");
+          stan::math::lub_free(
+            rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+            0, 1), "assigning variable beta_free__");
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
           assign(beta_free__, cons_list(index_uni(sym1__), nil_index_list()),
@@ -3250,7 +3511,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       } 
       vars__.emplace_back(mean_p_free__);
       if (lcm_sym46__) {
-        vars__.emplace_back(beta_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta_free__, cons_list(index_uni(1), nil_index_list()),
+            "beta_free__"));
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           vars__.emplace_back(beta_free__[(sym1__ - 1)]);}
       } 
@@ -3706,8 +3969,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 45;
         current_statement__ = 45;
-        check_greater_or_equal(function__, "female[sym1__]", female[(1 - 1)],
-                               0);
+        check_greater_or_equal(function__, "female[sym1__]",
+                               rvalue(female,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "female"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 45;
           current_statement__ = 45;
@@ -3718,7 +3983,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 45;
         current_statement__ = 45;
-        check_less_or_equal(function__, "female[sym1__]", female[(1 - 1)], 1);
+        check_less_or_equal(function__, "female[sym1__]",
+                            rvalue(female,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "female"), 1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 45;
           current_statement__ = 45;
@@ -3739,7 +4007,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 47;
         current_statement__ = 47;
-        check_greater_or_equal(function__, "black[sym1__]", black[(1 - 1)], 0);
+        check_greater_or_equal(function__, "black[sym1__]",
+                               rvalue(black,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "black"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 47;
           current_statement__ = 47;
@@ -3750,7 +4021,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 47;
         current_statement__ = 47;
-        check_less_or_equal(function__, "black[sym1__]", black[(1 - 1)], 1);
+        check_less_or_equal(function__, "black[sym1__]",
+                            rvalue(black,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "black"), 1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 47;
           current_statement__ = 47;
@@ -3771,7 +4045,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 49;
         current_statement__ = 49;
-        check_greater_or_equal(function__, "age[sym1__]", age[(1 - 1)], 0);
+        check_greater_or_equal(function__, "age[sym1__]",
+                               rvalue(age,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "age"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 49;
           current_statement__ = 49;
@@ -3782,7 +4059,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 49;
         current_statement__ = 49;
-        check_less_or_equal(function__, "age[sym1__]", age[(1 - 1)], n_age);
+        check_less_or_equal(function__, "age[sym1__]",
+                            rvalue(age,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "age"), n_age);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 49;
           current_statement__ = 49;
@@ -3803,7 +4083,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 51;
         current_statement__ = 51;
-        check_greater_or_equal(function__, "edu[sym1__]", edu[(1 - 1)], 0);
+        check_greater_or_equal(function__, "edu[sym1__]",
+                               rvalue(edu,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "edu"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 51;
           current_statement__ = 51;
@@ -3814,7 +4097,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 51;
         current_statement__ = 51;
-        check_less_or_equal(function__, "edu[sym1__]", edu[(1 - 1)], n_edu);
+        check_less_or_equal(function__, "edu[sym1__]",
+                            rvalue(edu,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "edu"), n_edu);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 51;
           current_statement__ = 51;
@@ -3835,8 +4121,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym69__) {
         current_statement__ = 53;
         current_statement__ = 53;
-        check_greater_or_equal(function__, "region[sym1__]", region[(1 - 1)],
-                               0);
+        check_greater_or_equal(function__, "region[sym1__]",
+                               rvalue(region,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "region"), 0);
         for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
           current_statement__ = 53;
           current_statement__ = 53;
@@ -3847,8 +4135,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym69__) {
         current_statement__ = 53;
         current_statement__ = 53;
-        check_less_or_equal(function__, "region[sym1__]", region[(1 - 1)],
-                            n_state);
+        check_less_or_equal(function__, "region[sym1__]",
+                            rvalue(region,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "region"), n_state);
         for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
           current_statement__ = 53;
           current_statement__ = 53;
@@ -3869,7 +4159,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 55;
         current_statement__ = 55;
-        check_greater_or_equal(function__, "state[sym1__]", state[(1 - 1)], 0);
+        check_greater_or_equal(function__, "state[sym1__]",
+                               rvalue(state,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "state"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 55;
           current_statement__ = 55;
@@ -3880,8 +4173,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 55;
         current_statement__ = 55;
-        check_less_or_equal(function__, "state[sym1__]", state[(1 - 1)],
-                            n_state);
+        check_less_or_equal(function__, "state[sym1__]",
+                            rvalue(state,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "state"), n_state);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 55;
           current_statement__ = 55;
@@ -3902,7 +4197,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 57;
         current_statement__ = 57;
-        check_greater_or_equal(function__, "y[sym1__]", y[(1 - 1)], 0);
+        check_greater_or_equal(function__, "y[sym1__]",
+                               rvalue(y,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "y"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 57;
           current_statement__ = 57;
@@ -3913,7 +4211,10 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       if (lcm_sym68__) {
         current_statement__ = 57;
         current_statement__ = 57;
-        check_less_or_equal(function__, "y[sym1__]", y[(1 - 1)], 1);
+        check_less_or_equal(function__, "y[sym1__]",
+                            rvalue(y,
+                              cons_list(index_uni(1), nil_index_list()), "y"),
+                            1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 57;
           current_statement__ = 57;
@@ -3938,7 +4239,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         if (lcm_sym69__) {
           current_statement__ = 59;
           assign(v_prev, cons_list(index_uni(1), nil_index_list()),
-            v_prev_flat__[(1 - 1)], "assigning variable v_prev");
+            rvalue(v_prev_flat__, cons_list(index_uni(1), nil_index_list()),
+              "v_prev_flat__"), "assigning variable v_prev");
           current_statement__ = 59;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
@@ -4237,14 +4539,26 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         if (logical_gte(n_state, 1)) {
           current_statement__ = 33;
           assign(b_state_hat, cons_list(index_uni(1), nil_index_list()),
-            stan::math::fma(b_v_prev, v_prev[(1 - 1)],
-              b_region[(region[(1 - 1)] - 1)]),
+            stan::math::fma(b_v_prev,
+              rvalue(v_prev, cons_list(index_uni(1), nil_index_list()),
+                "v_prev"),
+              rvalue(b_region,
+                cons_list(
+                  index_uni(rvalue(region,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "region")), nil_index_list()), "b_region")),
             "assigning variable b_state_hat");
           for (int j = 2; j <= n_state; ++j) {
             current_statement__ = 33;
             assign(b_state_hat, cons_list(index_uni(j), nil_index_list()),
-              stan::math::fma(b_v_prev, v_prev[(j - 1)],
-                b_region[(region[(j - 1)] - 1)]),
+              stan::math::fma(b_v_prev,
+                rvalue(v_prev, cons_list(index_uni(j), nil_index_list()),
+                  "v_prev"),
+                rvalue(b_region,
+                  cons_list(
+                    index_uni(rvalue(region,
+                                cons_list(index_uni(j), nil_index_list()),
+                                "region")), nil_index_list()), "b_region")),
               "assigning variable b_state_hat");}
         } 
         current_statement__ = 35;
@@ -4256,16 +4570,48 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             stan::math::fmax(0,
               stan::math::fmin(1,
                 inv_logit(
-                  ((((stan::math::fma((b_female_black * female[(1 - 1)]),
-                        black[(1 - 1)],
-                        stan::math::fma(b_black, black[(1 - 1)],
-                          stan::math::fma(b_female, female[(1 - 1)], b_0))) +
-                       b_age[(age[(1 - 1)] - 1)]) +
-                      b_edu[(edu[(1 - 1)] - 1)]) +
+                  ((((stan::math::fma(
+                        (b_female_black *
+                          rvalue(female,
+                            cons_list(index_uni(1), nil_index_list()),
+                            "female")),
+                        rvalue(black,
+                          cons_list(index_uni(1), nil_index_list()), "black"),
+                        stan::math::fma(b_black,
+                          rvalue(black,
+                            cons_list(index_uni(1), nil_index_list()),
+                            "black"),
+                          stan::math::fma(b_female,
+                            rvalue(female,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "female"), b_0))) +
+                       rvalue(b_age,
+                         cons_list(
+                           index_uni(rvalue(age,
+                                       cons_list(index_uni(1),
+                                         nil_index_list()), "age")),
+                           nil_index_list()), "b_age")) +
+                      rvalue(b_edu,
+                        cons_list(
+                          index_uni(rvalue(edu,
+                                      cons_list(index_uni(1),
+                                        nil_index_list()), "edu")),
+                          nil_index_list()), "b_edu")) +
                      rvalue(b_age_edu,
-                       cons_list(index_uni(age[(1 - 1)]),
-                         cons_list(index_uni(edu[(1 - 1)]), nil_index_list())),
-                       "b_age_edu")) + b_hat[(state[(1 - 1)] - 1)])))),
+                       cons_list(
+                         index_uni(rvalue(age,
+                                     cons_list(index_uni(1),
+                                       nil_index_list()), "age")),
+                         cons_list(
+                           index_uni(rvalue(edu,
+                                       cons_list(index_uni(1),
+                                         nil_index_list()), "edu")),
+                           nil_index_list())), "b_age_edu")) +
+                    rvalue(b_hat,
+                      cons_list(
+                        index_uni(rvalue(state,
+                                    cons_list(index_uni(1), nil_index_list()),
+                                    "state")), nil_index_list()), "b_hat"))))),
             "assigning variable p");
           for (int i = 2; i <= N; ++i) {
             current_statement__ = 36;
@@ -4273,18 +4619,51 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
               stan::math::fmax(0,
                 stan::math::fmin(1,
                   inv_logit(
-                    ((((stan::math::fma((b_female_black * female[(i - 1)]),
-                          black[(i - 1)],
-                          stan::math::fma(b_black, black[(i - 1)],
-                            stan::math::fma(b_female, female[(i - 1)], b_0)))
-                         + b_age[(age[(i - 1)] - 1)]) +
-                        b_edu[(edu[(i - 1)] - 1)]) +
+                    ((((stan::math::fma(
+                          (b_female_black *
+                            rvalue(female,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "female")),
+                          rvalue(black,
+                            cons_list(index_uni(i), nil_index_list()),
+                            "black"),
+                          stan::math::fma(b_black,
+                            rvalue(black,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "black"),
+                            stan::math::fma(b_female,
+                              rvalue(female,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "female"), b_0))) +
+                         rvalue(b_age,
+                           cons_list(
+                             index_uni(rvalue(age,
+                                         cons_list(index_uni(i),
+                                           nil_index_list()), "age")),
+                             nil_index_list()), "b_age")) +
+                        rvalue(b_edu,
+                          cons_list(
+                            index_uni(rvalue(edu,
+                                        cons_list(index_uni(i),
+                                          nil_index_list()), "edu")),
+                            nil_index_list()), "b_edu")) +
                        rvalue(b_age_edu,
-                         cons_list(index_uni(age[(i - 1)]),
-                           cons_list(index_uni(edu[(i - 1)]),
+                         cons_list(
+                           index_uni(rvalue(age,
+                                       cons_list(index_uni(i),
+                                         nil_index_list()), "age")),
+                           cons_list(
+                             index_uni(rvalue(edu,
+                                         cons_list(index_uni(i),
+                                           nil_index_list()), "edu")),
                              nil_index_list())), "b_age_edu")) +
-                      b_hat[(state[(i - 1)] - 1)])))), "assigning variable p");
-          }
+                      rvalue(b_hat,
+                        cons_list(
+                          index_uni(rvalue(state,
+                                      cons_list(index_uni(i),
+                                        nil_index_list()), "state")),
+                          nil_index_list()), "b_hat"))))),
+              "assigning variable p");}
         } 
         current_statement__ = 38;
         lp_accum__.add(bernoulli_lpmf<propto__>(y, p));
@@ -4448,18 +4827,22 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       vars__.emplace_back(b_v_prev);
       lcm_sym28__ = logical_gte(n_age, 1);
       if (lcm_sym28__) {
-        vars__.emplace_back(b_age[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_age, cons_list(index_uni(1), nil_index_list()), "b_age"));
         for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
           vars__.emplace_back(b_age[(sym1__ - 1)]);}
       } 
       lcm_sym29__ = logical_gte(n_edu, 1);
       if (lcm_sym29__) {
-        vars__.emplace_back(b_edu[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_edu, cons_list(index_uni(1), nil_index_list()), "b_edu"));
         for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
           vars__.emplace_back(b_edu[(sym1__ - 1)]);}
       } 
       if (logical_gte(n_region, 1)) {
-        vars__.emplace_back(b_region[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_region, cons_list(index_uni(1), nil_index_list()),
+            "b_region"));
         for (int sym1__ = 2; sym1__ <= n_region; ++sym1__) {
           vars__.emplace_back(b_region[(sym1__ - 1)]);}
       } 
@@ -4491,7 +4874,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           } }
       } 
       if (logical_gte(n_state, 1)) {
-        vars__.emplace_back(b_hat[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_hat, cons_list(index_uni(1), nil_index_list()), "b_hat"));
         for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
           vars__.emplace_back(b_hat[(sym1__ - 1)]);}
       } 
@@ -4652,7 +5036,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         if (lcm_sym1__) {
           current_statement__ = 12;
           assign(b_age, cons_list(index_uni(1), nil_index_list()),
-            b_age_flat__[(1 - 1)], "assigning variable b_age");
+            rvalue(b_age_flat__, cons_list(index_uni(1), nil_index_list()),
+              "b_age_flat__"), "assigning variable b_age");
           current_statement__ = 12;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
@@ -4678,7 +5063,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         if (lcm_sym2__) {
           current_statement__ = 13;
           assign(b_edu, cons_list(index_uni(1), nil_index_list()),
-            b_edu_flat__[(1 - 1)], "assigning variable b_edu");
+            rvalue(b_edu_flat__, cons_list(index_uni(1), nil_index_list()),
+              "b_edu_flat__"), "assigning variable b_edu");
           current_statement__ = 13;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
@@ -4704,7 +5090,9 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         if (lcm_sym3__) {
           current_statement__ = 14;
           assign(b_region, cons_list(index_uni(1), nil_index_list()),
-            b_region_flat__[(1 - 1)], "assigning variable b_region");
+            rvalue(b_region_flat__,
+              cons_list(index_uni(1), nil_index_list()), "b_region_flat__"),
+            "assigning variable b_region");
           current_statement__ = 14;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_region; ++sym1__) {
@@ -4735,7 +5123,9 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             assign(b_age_edu,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              b_age_edu_flat__[(1 - 1)], "assigning variable b_age_edu");
+              rvalue(b_age_edu_flat__,
+                cons_list(index_uni(1), nil_index_list()),
+                "b_age_edu_flat__"), "assigning variable b_age_edu");
             current_statement__ = 15;
             pos__ = 2;
             for (int sym2__ = 2; sym2__ <= n_age; ++sym2__) {
@@ -4784,7 +5174,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         if (lcm_sym4__) {
           current_statement__ = 16;
           assign(b_hat, cons_list(index_uni(1), nil_index_list()),
-            b_hat_flat__[(1 - 1)], "assigning variable b_hat");
+            rvalue(b_hat_flat__, cons_list(index_uni(1), nil_index_list()),
+              "b_hat_flat__"), "assigning variable b_hat");
           current_statement__ = 16;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
@@ -4807,17 +5198,21 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       vars__.emplace_back(b_female_black);
       vars__.emplace_back(b_v_prev);
       if (lcm_sym1__) {
-        vars__.emplace_back(b_age[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_age, cons_list(index_uni(1), nil_index_list()), "b_age"));
         for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
           vars__.emplace_back(b_age[(sym1__ - 1)]);}
       } 
       if (lcm_sym2__) {
-        vars__.emplace_back(b_edu[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_edu, cons_list(index_uni(1), nil_index_list()), "b_edu"));
         for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
           vars__.emplace_back(b_edu[(sym1__ - 1)]);}
       } 
       if (lcm_sym3__) {
-        vars__.emplace_back(b_region[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_region, cons_list(index_uni(1), nil_index_list()),
+            "b_region"));
         for (int sym1__ = 2; sym1__ <= n_region; ++sym1__) {
           vars__.emplace_back(b_region[(sym1__ - 1)]);}
       } 
@@ -4849,7 +5244,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           } }
       } 
       if (lcm_sym4__) {
-        vars__.emplace_back(b_hat[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b_hat, cons_list(index_uni(1), nil_index_list()), "b_hat"));
         for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
           vars__.emplace_back(b_hat[(sym1__ - 1)]);}
       } 
@@ -5914,7 +6310,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
         if (logical_gte(N, 1)) {
           current_statement__ = 11;
           assign(y, cons_list(index_uni(1), nil_index_list()),
-            y_flat__[(1 - 1)], "assigning variable y");
+            rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+              "y_flat__"), "assigning variable y");
           current_statement__ = 11;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -6002,26 +6399,30 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
         if (jacobian__) {
           current_statement__ = 2;
           assign(sigma, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lb_constrain(sigma[(1 - 1)], 0, lp__),
-            "assigning variable sigma");
+            stan::math::lb_constrain(
+              rvalue(sigma, cons_list(index_uni(1), nil_index_list()),
+                "sigma"), 0, lp__), "assigning variable sigma");
         } else {
           current_statement__ = 2;
           assign(sigma, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lb_constrain(sigma[(1 - 1)], 0),
-            "assigning variable sigma");
+            stan::math::lb_constrain(
+              rvalue(sigma, cons_list(index_uni(1), nil_index_list()),
+                "sigma"), 0), "assigning variable sigma");
         }
         {
           current_statement__ = 2;
           if (jacobian__) {
             current_statement__ = 2;
             assign(sigma, cons_list(index_uni(2), nil_index_list()),
-              stan::math::lb_constrain(sigma[(2 - 1)], 0, lp__),
-              "assigning variable sigma");
+              stan::math::lb_constrain(
+                rvalue(sigma, cons_list(index_uni(2), nil_index_list()),
+                  "sigma"), 0, lp__), "assigning variable sigma");
           } else {
             current_statement__ = 2;
             assign(sigma, cons_list(index_uni(2), nil_index_list()),
-              stan::math::lb_constrain(sigma[(2 - 1)], 0),
-              "assigning variable sigma");
+              stan::math::lb_constrain(
+                rvalue(sigma, cons_list(index_uni(2), nil_index_list()),
+                  "sigma"), 0), "assigning variable sigma");
           }
         }
       }
@@ -6047,18 +6448,32 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
         lp_accum__.add(beta_lpdf<propto__>(theta, 5, 5));
         current_statement__ = 8;
         if (logical_gte(N, 1)) {
-          lcm_sym27__ = sigma[(1 - 1)];
+          lcm_sym27__ = rvalue(sigma,
+                          cons_list(index_uni(1), nil_index_list()), "sigma");
           lp_accum__.add(
             log_mix(theta,
-              normal_lpdf<false>(y[(1 - 1)], mu[(1 - 1)], lcm_sym27__),
-              normal_lpdf<false>(y[(1 - 1)], mu[(2 - 1)], sigma[(2 - 1)])));
+              normal_lpdf<false>(
+                rvalue(y, cons_list(index_uni(1), nil_index_list()), "y"),
+                rvalue(mu, cons_list(index_uni(1), nil_index_list()), "mu"),
+                lcm_sym27__),
+              normal_lpdf<false>(
+                rvalue(y, cons_list(index_uni(1), nil_index_list()), "y"),
+                rvalue(mu, cons_list(index_uni(2), nil_index_list()), "mu"),
+                rvalue(sigma, cons_list(index_uni(2), nil_index_list()),
+                  "sigma"))));
           for (int n = 2; n <= N; ++n) {
             current_statement__ = 7;
             lp_accum__.add(
               log_mix(theta,
-                normal_lpdf<false>(y[(n - 1)], mu[(1 - 1)], lcm_sym27__),
-                normal_lpdf<false>(y[(n - 1)], mu[(2 - 1)], sigma[(2 - 1)])));
-          }
+                normal_lpdf<false>(
+                  rvalue(y, cons_list(index_uni(n), nil_index_list()), "y"),
+                  rvalue(mu, cons_list(index_uni(1), nil_index_list()), "mu"),
+                  lcm_sym27__),
+                normal_lpdf<false>(
+                  rvalue(y, cons_list(index_uni(n), nil_index_list()), "y"),
+                  rvalue(mu, cons_list(index_uni(2), nil_index_list()), "mu"),
+                  rvalue(sigma, cons_list(index_uni(2), nil_index_list()),
+                    "sigma"))));}
         } 
       }
     } catch (const std::exception& e) {
@@ -6123,13 +6538,15 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       {
         current_statement__ = 2;
         assign(sigma, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lb_constrain(sigma[(1 - 1)], 0),
-          "assigning variable sigma");
+          stan::math::lb_constrain(
+            rvalue(sigma, cons_list(index_uni(1), nil_index_list()), "sigma"),
+            0), "assigning variable sigma");
         {
           current_statement__ = 2;
           assign(sigma, cons_list(index_uni(2), nil_index_list()),
-            stan::math::lb_constrain(sigma[(2 - 1)], 0),
-            "assigning variable sigma");
+            stan::math::lb_constrain(
+              rvalue(sigma, cons_list(index_uni(2), nil_index_list()),
+                "sigma"), 0), "assigning variable sigma");
         }
       }
       double theta;
@@ -6140,15 +6557,19 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       current_statement__ = 3;
       theta = stan::math::lub_constrain(theta, 0, 1);
       {
-        vars__.emplace_back(mu[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(mu, cons_list(index_uni(1), nil_index_list()), "mu"));
         {
-          vars__.emplace_back(mu[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(mu, cons_list(index_uni(2), nil_index_list()), "mu"));
         }
       }
       {
-        vars__.emplace_back(sigma[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(sigma, cons_list(index_uni(1), nil_index_list()), "sigma"));
         {
-          vars__.emplace_back(sigma[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(sigma, cons_list(index_uni(2), nil_index_list()), "sigma"));
         }
       }
       vars__.emplace_back(theta);
@@ -6205,7 +6626,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
         {
           current_statement__ = 1;
           assign(mu, cons_list(index_uni(1), nil_index_list()),
-            mu_flat__[(1 - 1)], "assigning variable mu");
+            rvalue(mu_flat__, cons_list(index_uni(1), nil_index_list()),
+              "mu_flat__"), "assigning variable mu");
           current_statement__ = 1;
           pos__ = 2;
           {
@@ -6236,13 +6658,15 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       {
         current_statement__ = 2;
         assign(sigma_free__, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lb_free(sigma[(1 - 1)], 0),
-          "assigning variable sigma_free__");
+          stan::math::lb_free(
+            rvalue(sigma, cons_list(index_uni(1), nil_index_list()), "sigma"),
+            0), "assigning variable sigma_free__");
         {
           current_statement__ = 2;
           assign(sigma_free__, cons_list(index_uni(2), nil_index_list()),
-            stan::math::lb_free(sigma[(2 - 1)], 0),
-            "assigning variable sigma_free__");
+            stan::math::lb_free(
+              rvalue(sigma, cons_list(index_uni(2), nil_index_list()),
+                "sigma"), 0), "assigning variable sigma_free__");
         }
       }
       double theta;
@@ -6256,15 +6680,23 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       current_statement__ = 3;
       theta_free__ = stan::math::lub_free(theta, 0, 1);
       {
-        vars__.emplace_back(mu_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(mu_free__, cons_list(index_uni(1), nil_index_list()),
+            "mu_free__"));
         {
-          vars__.emplace_back(mu_free__[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(mu_free__, cons_list(index_uni(2), nil_index_list()),
+              "mu_free__"));
         }
       }
       {
-        vars__.emplace_back(sigma_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(sigma_free__, cons_list(index_uni(1), nil_index_list()),
+            "sigma_free__"));
         {
-          vars__.emplace_back(sigma_free__[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(sigma_free__, cons_list(index_uni(2), nil_index_list()),
+              "sigma_free__"));
         }
       }
       vars__.emplace_back(theta_free__);
@@ -6551,7 +6983,10 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       if (logical_gte(J, 1)) {
         current_statement__ = 10;
         current_statement__ = 10;
-        check_greater_or_equal(function__, "sigma[sym1__]", sigma[(1 - 1)], 0);
+        check_greater_or_equal(function__, "sigma[sym1__]",
+                               rvalue(sigma,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "sigma"), 0);
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           current_statement__ = 10;
           current_statement__ = 10;
@@ -6698,7 +7133,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       tau = stan::math::lb_constrain(tau, 0);
       vars__.emplace_back(mu);
       if (lcm_sym4__) {
-        vars__.emplace_back(theta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(theta[(sym1__ - 1)]);}
       } 
@@ -6759,7 +7195,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       tau_free__ = stan::math::lb_free(tau, 0);
       vars__.emplace_back(mu);
       if (logical_gte(J, 1)) {
-        vars__.emplace_back(theta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(theta[(sym1__ - 1)]);}
       } 
@@ -7175,7 +7612,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 29;
         current_statement__ = 29;
-        check_greater_or_equal(function__, "age[sym1__]", age[(1 - 1)], 0);
+        check_greater_or_equal(function__, "age[sym1__]",
+                               rvalue(age,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "age"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 29;
           current_statement__ = 29;
@@ -7186,7 +7626,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 29;
         current_statement__ = 29;
-        check_less_or_equal(function__, "age[sym1__]", age[(1 - 1)], n_age);
+        check_less_or_equal(function__, "age[sym1__]",
+                            rvalue(age,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "age"), n_age);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 29;
           current_statement__ = 29;
@@ -7208,7 +7651,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         current_statement__ = 31;
         current_statement__ = 31;
         check_greater_or_equal(function__, "age_edu[sym1__]",
-                               age_edu[(1 - 1)], 0);
+                               rvalue(age_edu,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "age_edu"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 31;
           current_statement__ = 31;
@@ -7219,8 +7664,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 31;
         current_statement__ = 31;
-        check_less_or_equal(function__, "age_edu[sym1__]", age_edu[(1 - 1)],
-                            n_age_edu);
+        check_less_or_equal(function__, "age_edu[sym1__]",
+                            rvalue(age_edu,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "age_edu"), n_age_edu);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 31;
           current_statement__ = 31;
@@ -7246,7 +7693,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym65__) {
           current_statement__ = 33;
           assign(black, cons_list(index_uni(1), nil_index_list()),
-            black_flat__[(1 - 1)], "assigning variable black");
+            rvalue(black_flat__, cons_list(index_uni(1), nil_index_list()),
+              "black_flat__"), "assigning variable black");
           current_statement__ = 33;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -7261,7 +7709,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 33;
         current_statement__ = 33;
-        check_greater_or_equal(function__, "black[sym1__]", black[(1 - 1)], 0);
+        check_greater_or_equal(function__, "black[sym1__]",
+                               rvalue(black,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "black"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 33;
           current_statement__ = 33;
@@ -7272,7 +7723,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 33;
         current_statement__ = 33;
-        check_less_or_equal(function__, "black[sym1__]", black[(1 - 1)], 1);
+        check_less_or_equal(function__, "black[sym1__]",
+                            rvalue(black,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "black"), 1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 33;
           current_statement__ = 33;
@@ -7293,7 +7747,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 35;
         current_statement__ = 35;
-        check_greater_or_equal(function__, "edu[sym1__]", edu[(1 - 1)], 0);
+        check_greater_or_equal(function__, "edu[sym1__]",
+                               rvalue(edu,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "edu"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 35;
           current_statement__ = 35;
@@ -7304,7 +7761,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 35;
         current_statement__ = 35;
-        check_less_or_equal(function__, "edu[sym1__]", edu[(1 - 1)], n_edu);
+        check_less_or_equal(function__, "edu[sym1__]",
+                            rvalue(edu,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "edu"), n_edu);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 35;
           current_statement__ = 35;
@@ -7330,7 +7790,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym65__) {
           current_statement__ = 37;
           assign(female, cons_list(index_uni(1), nil_index_list()),
-            female_flat__[(1 - 1)], "assigning variable female");
+            rvalue(female_flat__, cons_list(index_uni(1), nil_index_list()),
+              "female_flat__"), "assigning variable female");
           current_statement__ = 37;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -7345,8 +7806,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 37;
         current_statement__ = 37;
-        check_greater_or_equal(function__, "female[sym1__]", female[(1 - 1)],
-                               0);
+        check_greater_or_equal(function__, "female[sym1__]",
+                               rvalue(female,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "female"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 37;
           current_statement__ = 37;
@@ -7357,7 +7820,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 37;
         current_statement__ = 37;
-        check_less_or_equal(function__, "female[sym1__]", female[(1 - 1)], 1);
+        check_less_or_equal(function__, "female[sym1__]",
+                            rvalue(female,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "female"), 1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 37;
           current_statement__ = 37;
@@ -7379,7 +7845,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         current_statement__ = 39;
         current_statement__ = 39;
         check_greater_or_equal(function__, "region_full[sym1__]",
-                               region_full[(1 - 1)], 0);
+                               rvalue(region_full,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "region_full"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 39;
           current_statement__ = 39;
@@ -7391,7 +7859,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         current_statement__ = 39;
         current_statement__ = 39;
         check_less_or_equal(function__, "region_full[sym1__]",
-                            region_full[(1 - 1)], n_region_full);
+                            rvalue(region_full,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "region_full"), n_region_full);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 39;
           current_statement__ = 39;
@@ -7412,7 +7882,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 41;
         current_statement__ = 41;
-        check_greater_or_equal(function__, "state[sym1__]", state[(1 - 1)], 0);
+        check_greater_or_equal(function__, "state[sym1__]",
+                               rvalue(state,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "state"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 41;
           current_statement__ = 41;
@@ -7423,8 +7896,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 41;
         current_statement__ = 41;
-        check_less_or_equal(function__, "state[sym1__]", state[(1 - 1)],
-                            n_state);
+        check_less_or_equal(function__, "state[sym1__]",
+                            rvalue(state,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "state"), n_state);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 41;
           current_statement__ = 41;
@@ -7451,7 +7926,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym65__) {
           current_statement__ = 43;
           assign(v_prev_full, cons_list(index_uni(1), nil_index_list()),
-            v_prev_full_flat__[(1 - 1)], "assigning variable v_prev_full");
+            rvalue(v_prev_full_flat__,
+              cons_list(index_uni(1), nil_index_list()),
+              "v_prev_full_flat__"), "assigning variable v_prev_full");
           current_statement__ = 43;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -7478,7 +7955,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 45;
         current_statement__ = 45;
-        check_greater_or_equal(function__, "y[sym1__]", y[(1 - 1)], 0);
+        check_greater_or_equal(function__, "y[sym1__]",
+                               rvalue(y,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "y"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 45;
           current_statement__ = 45;
@@ -7489,7 +7969,10 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym65__) {
         current_statement__ = 45;
         current_statement__ = 45;
-        check_less_or_equal(function__, "y[sym1__]", y[(1 - 1)], 1);
+        check_less_or_equal(function__, "y[sym1__]",
+                            rvalue(y,
+                              cons_list(index_uni(1), nil_index_list()), "y"),
+                            1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 45;
           current_statement__ = 45;
@@ -7669,26 +8152,112 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (logical_gte(N, 1)) {
         current_statement__ = 13;
         assign(y_hat, cons_list(index_uni(1), nil_index_list()),
-          (((((stan::math::fma(beta[(4 - 1)], v_prev_full[(1 - 1)],
-                 stan::math::fma((beta[(5 - 1)] * female[(1 - 1)]),
-                   black[(1 - 1)],
-                   stan::math::fma(beta[(3 - 1)], female[(1 - 1)],
-                     stan::math::fma(beta[(2 - 1)], black[(1 - 1)],
-                       beta[(1 - 1)])))) + a[(age[(1 - 1)] - 1)]) +
-               b[(edu[(1 - 1)] - 1)]) + c[(age_edu[(1 - 1)] - 1)]) +
-             d[(state[(1 - 1)] - 1)]) + e[(region_full[(1 - 1)] - 1)]),
+          (((((stan::math::fma(
+                 rvalue(beta, cons_list(index_uni(4), nil_index_list()),
+                   "beta"),
+                 rvalue(v_prev_full,
+                   cons_list(index_uni(1), nil_index_list()), "v_prev_full"),
+                 stan::math::fma(
+                   (rvalue(beta, cons_list(index_uni(5), nil_index_list()),
+                      "beta") *
+                     rvalue(female,
+                       cons_list(index_uni(1), nil_index_list()), "female")),
+                   rvalue(black, cons_list(index_uni(1), nil_index_list()),
+                     "black"),
+                   stan::math::fma(
+                     rvalue(beta, cons_list(index_uni(3), nil_index_list()),
+                       "beta"),
+                     rvalue(female,
+                       cons_list(index_uni(1), nil_index_list()), "female"),
+                     stan::math::fma(
+                       rvalue(beta,
+                         cons_list(index_uni(2), nil_index_list()), "beta"),
+                       rvalue(black,
+                         cons_list(index_uni(1), nil_index_list()), "black"),
+                       rvalue(beta,
+                         cons_list(index_uni(1), nil_index_list()), "beta")))))
+                +
+                rvalue(a,
+                  cons_list(
+                    index_uni(rvalue(age,
+                                cons_list(index_uni(1), nil_index_list()),
+                                "age")), nil_index_list()), "a")) +
+               rvalue(b,
+                 cons_list(
+                   index_uni(rvalue(edu,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "edu")), nil_index_list()), "b")) +
+              rvalue(c,
+                cons_list(
+                  index_uni(rvalue(age_edu,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "age_edu")), nil_index_list()), "c")) +
+             rvalue(d,
+               cons_list(
+                 index_uni(rvalue(state,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "state")), nil_index_list()), "d")) +
+            rvalue(e,
+              cons_list(
+                index_uni(rvalue(region_full,
+                            cons_list(index_uni(1), nil_index_list()),
+                            "region_full")), nil_index_list()), "e")),
           "assigning variable y_hat");
         for (int i = 2; i <= N; ++i) {
           current_statement__ = 13;
           assign(y_hat, cons_list(index_uni(i), nil_index_list()),
-            (((((stan::math::fma(beta[(4 - 1)], v_prev_full[(i - 1)],
-                   stan::math::fma((beta[(5 - 1)] * female[(i - 1)]),
-                     black[(i - 1)],
-                     stan::math::fma(beta[(3 - 1)], female[(i - 1)],
-                       stan::math::fma(beta[(2 - 1)], black[(i - 1)],
-                         beta[(1 - 1)])))) + a[(age[(i - 1)] - 1)]) +
-                 b[(edu[(i - 1)] - 1)]) + c[(age_edu[(i - 1)] - 1)]) +
-               d[(state[(i - 1)] - 1)]) + e[(region_full[(i - 1)] - 1)]),
+            (((((stan::math::fma(
+                   rvalue(beta, cons_list(index_uni(4), nil_index_list()),
+                     "beta"),
+                   rvalue(v_prev_full,
+                     cons_list(index_uni(i), nil_index_list()),
+                     "v_prev_full"),
+                   stan::math::fma(
+                     (rvalue(beta, cons_list(index_uni(5), nil_index_list()),
+                        "beta") *
+                       rvalue(female,
+                         cons_list(index_uni(i), nil_index_list()), "female")),
+                     rvalue(black, cons_list(index_uni(i), nil_index_list()),
+                       "black"),
+                     stan::math::fma(
+                       rvalue(beta,
+                         cons_list(index_uni(3), nil_index_list()), "beta"),
+                       rvalue(female,
+                         cons_list(index_uni(i), nil_index_list()), "female"),
+                       stan::math::fma(
+                         rvalue(beta,
+                           cons_list(index_uni(2), nil_index_list()), "beta"),
+                         rvalue(black,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "black"),
+                         rvalue(beta,
+                           cons_list(index_uni(1), nil_index_list()), "beta")))))
+                  +
+                  rvalue(a,
+                    cons_list(
+                      index_uni(rvalue(age,
+                                  cons_list(index_uni(i), nil_index_list()),
+                                  "age")), nil_index_list()), "a")) +
+                 rvalue(b,
+                   cons_list(
+                     index_uni(rvalue(edu,
+                                 cons_list(index_uni(i), nil_index_list()),
+                                 "edu")), nil_index_list()), "b")) +
+                rvalue(c,
+                  cons_list(
+                    index_uni(rvalue(age_edu,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "age_edu")), nil_index_list()), "c")) +
+               rvalue(d,
+                 cons_list(
+                   index_uni(rvalue(state,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "state")), nil_index_list()), "d")) +
+              rvalue(e,
+                cons_list(
+                  index_uni(rvalue(region_full,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "region_full")), nil_index_list()), "e")),
             "assigning variable y_hat");}
       } 
       {
@@ -7838,43 +8407,53 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       stan::math::fill(y_hat, DUMMY_VAR__);
       
       if (logical_gte(n_age, 1)) {
-        vars__.emplace_back(a[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(a, cons_list(index_uni(1), nil_index_list()), "a"));
         for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
           vars__.emplace_back(a[(sym1__ - 1)]);}
       } 
       if (logical_gte(n_edu, 1)) {
-        vars__.emplace_back(b[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b, cons_list(index_uni(1), nil_index_list()), "b"));
         for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
           vars__.emplace_back(b[(sym1__ - 1)]);}
       } 
       if (logical_gte(n_age_edu, 1)) {
-        vars__.emplace_back(c[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(c, cons_list(index_uni(1), nil_index_list()), "c"));
         for (int sym1__ = 2; sym1__ <= n_age_edu; ++sym1__) {
           vars__.emplace_back(c[(sym1__ - 1)]);}
       } 
       if (logical_gte(n_state, 1)) {
-        vars__.emplace_back(d[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(d, cons_list(index_uni(1), nil_index_list()), "d"));
         for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
           vars__.emplace_back(d[(sym1__ - 1)]);}
       } 
       if (logical_gte(n_region_full, 1)) {
-        vars__.emplace_back(e[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(e, cons_list(index_uni(1), nil_index_list()), "e"));
         for (int sym1__ = 2; sym1__ <= n_region_full; ++sym1__) {
           vars__.emplace_back(e[(sym1__ - 1)]);}
       } 
       {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"));
         {
-          vars__.emplace_back(beta[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"));
         }
         {
-          vars__.emplace_back(beta[(3 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(3), nil_index_list()), "beta"));
         }
         {
-          vars__.emplace_back(beta[(4 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(4), nil_index_list()), "beta"));
         }
         {
-          vars__.emplace_back(beta[(5 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(5), nil_index_list()), "beta"));
         }
       }
       vars__.emplace_back(sigma_a);
@@ -7890,31 +8469,118 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       if (lcm_sym31__) {
         current_statement__ = 13;
         assign(y_hat, cons_list(index_uni(1), nil_index_list()),
-          (((((stan::math::fma(beta[(4 - 1)], v_prev_full[(1 - 1)],
-                 stan::math::fma((beta[(5 - 1)] * female[(1 - 1)]),
-                   black[(1 - 1)],
-                   stan::math::fma(beta[(3 - 1)], female[(1 - 1)],
-                     stan::math::fma(beta[(2 - 1)], black[(1 - 1)],
-                       beta[(1 - 1)])))) + a[(age[(1 - 1)] - 1)]) +
-               b[(edu[(1 - 1)] - 1)]) + c[(age_edu[(1 - 1)] - 1)]) +
-             d[(state[(1 - 1)] - 1)]) + e[(region_full[(1 - 1)] - 1)]),
+          (((((stan::math::fma(
+                 rvalue(beta, cons_list(index_uni(4), nil_index_list()),
+                   "beta"),
+                 rvalue(v_prev_full,
+                   cons_list(index_uni(1), nil_index_list()), "v_prev_full"),
+                 stan::math::fma(
+                   (rvalue(beta, cons_list(index_uni(5), nil_index_list()),
+                      "beta") *
+                     rvalue(female,
+                       cons_list(index_uni(1), nil_index_list()), "female")),
+                   rvalue(black, cons_list(index_uni(1), nil_index_list()),
+                     "black"),
+                   stan::math::fma(
+                     rvalue(beta, cons_list(index_uni(3), nil_index_list()),
+                       "beta"),
+                     rvalue(female,
+                       cons_list(index_uni(1), nil_index_list()), "female"),
+                     stan::math::fma(
+                       rvalue(beta,
+                         cons_list(index_uni(2), nil_index_list()), "beta"),
+                       rvalue(black,
+                         cons_list(index_uni(1), nil_index_list()), "black"),
+                       rvalue(beta,
+                         cons_list(index_uni(1), nil_index_list()), "beta")))))
+                +
+                rvalue(a,
+                  cons_list(
+                    index_uni(rvalue(age,
+                                cons_list(index_uni(1), nil_index_list()),
+                                "age")), nil_index_list()), "a")) +
+               rvalue(b,
+                 cons_list(
+                   index_uni(rvalue(edu,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "edu")), nil_index_list()), "b")) +
+              rvalue(c,
+                cons_list(
+                  index_uni(rvalue(age_edu,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "age_edu")), nil_index_list()), "c")) +
+             rvalue(d,
+               cons_list(
+                 index_uni(rvalue(state,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "state")), nil_index_list()), "d")) +
+            rvalue(e,
+              cons_list(
+                index_uni(rvalue(region_full,
+                            cons_list(index_uni(1), nil_index_list()),
+                            "region_full")), nil_index_list()), "e")),
           "assigning variable y_hat");
         for (int i = 2; i <= N; ++i) {
           current_statement__ = 13;
           assign(y_hat, cons_list(index_uni(i), nil_index_list()),
-            (((((stan::math::fma(beta[(4 - 1)], v_prev_full[(i - 1)],
-                   stan::math::fma((beta[(5 - 1)] * female[(i - 1)]),
-                     black[(i - 1)],
-                     stan::math::fma(beta[(3 - 1)], female[(i - 1)],
-                       stan::math::fma(beta[(2 - 1)], black[(i - 1)],
-                         beta[(1 - 1)])))) + a[(age[(i - 1)] - 1)]) +
-                 b[(edu[(i - 1)] - 1)]) + c[(age_edu[(i - 1)] - 1)]) +
-               d[(state[(i - 1)] - 1)]) + e[(region_full[(i - 1)] - 1)]),
+            (((((stan::math::fma(
+                   rvalue(beta, cons_list(index_uni(4), nil_index_list()),
+                     "beta"),
+                   rvalue(v_prev_full,
+                     cons_list(index_uni(i), nil_index_list()),
+                     "v_prev_full"),
+                   stan::math::fma(
+                     (rvalue(beta, cons_list(index_uni(5), nil_index_list()),
+                        "beta") *
+                       rvalue(female,
+                         cons_list(index_uni(i), nil_index_list()), "female")),
+                     rvalue(black, cons_list(index_uni(i), nil_index_list()),
+                       "black"),
+                     stan::math::fma(
+                       rvalue(beta,
+                         cons_list(index_uni(3), nil_index_list()), "beta"),
+                       rvalue(female,
+                         cons_list(index_uni(i), nil_index_list()), "female"),
+                       stan::math::fma(
+                         rvalue(beta,
+                           cons_list(index_uni(2), nil_index_list()), "beta"),
+                         rvalue(black,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "black"),
+                         rvalue(beta,
+                           cons_list(index_uni(1), nil_index_list()), "beta")))))
+                  +
+                  rvalue(a,
+                    cons_list(
+                      index_uni(rvalue(age,
+                                  cons_list(index_uni(i), nil_index_list()),
+                                  "age")), nil_index_list()), "a")) +
+                 rvalue(b,
+                   cons_list(
+                     index_uni(rvalue(edu,
+                                 cons_list(index_uni(i), nil_index_list()),
+                                 "edu")), nil_index_list()), "b")) +
+                rvalue(c,
+                  cons_list(
+                    index_uni(rvalue(age_edu,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "age_edu")), nil_index_list()), "c")) +
+               rvalue(d,
+                 cons_list(
+                   index_uni(rvalue(state,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "state")), nil_index_list()), "d")) +
+              rvalue(e,
+                cons_list(
+                  index_uni(rvalue(region_full,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "region_full")), nil_index_list()), "e")),
             "assigning variable y_hat");}
       } 
       if (emit_transformed_parameters__) {
         if (lcm_sym31__) {
-          vars__.emplace_back(y_hat[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(y_hat, cons_list(index_uni(1), nil_index_list()), "y_hat"));
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
             vars__.emplace_back(y_hat[(sym1__ - 1)]);}
         } 
@@ -7990,7 +8656,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym1__) {
           current_statement__ = 1;
           assign(a, cons_list(index_uni(1), nil_index_list()),
-            a_flat__[(1 - 1)], "assigning variable a");
+            rvalue(a_flat__, cons_list(index_uni(1), nil_index_list()),
+              "a_flat__"), "assigning variable a");
           current_statement__ = 1;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
@@ -8016,7 +8683,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym3__) {
           current_statement__ = 2;
           assign(b, cons_list(index_uni(1), nil_index_list()),
-            b_flat__[(1 - 1)], "assigning variable b");
+            rvalue(b_flat__, cons_list(index_uni(1), nil_index_list()),
+              "b_flat__"), "assigning variable b");
           current_statement__ = 2;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
@@ -8042,7 +8710,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym2__) {
           current_statement__ = 3;
           assign(c, cons_list(index_uni(1), nil_index_list()),
-            c_flat__[(1 - 1)], "assigning variable c");
+            rvalue(c_flat__, cons_list(index_uni(1), nil_index_list()),
+              "c_flat__"), "assigning variable c");
           current_statement__ = 3;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_age_edu; ++sym1__) {
@@ -8068,7 +8737,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym5__) {
           current_statement__ = 4;
           assign(d, cons_list(index_uni(1), nil_index_list()),
-            d_flat__[(1 - 1)], "assigning variable d");
+            rvalue(d_flat__, cons_list(index_uni(1), nil_index_list()),
+              "d_flat__"), "assigning variable d");
           current_statement__ = 4;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
@@ -8094,7 +8764,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         if (lcm_sym4__) {
           current_statement__ = 5;
           assign(e, cons_list(index_uni(1), nil_index_list()),
-            e_flat__[(1 - 1)], "assigning variable e");
+            rvalue(e_flat__, cons_list(index_uni(1), nil_index_list()),
+              "e_flat__"), "assigning variable e");
           current_statement__ = 5;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_region_full; ++sym1__) {
@@ -8119,7 +8790,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         {
           current_statement__ = 6;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            beta_flat__[(1 - 1)], "assigning variable beta");
+            rvalue(beta_flat__, cons_list(index_uni(1), nil_index_list()),
+              "beta_flat__"), "assigning variable beta");
           current_statement__ = 6;
           pos__ = 2;
           {
@@ -8203,43 +8875,53 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       current_statement__ = 11;
       sigma_e_free__ = stan::math::lub_free(sigma_e, 0, 100);
       if (lcm_sym1__) {
-        vars__.emplace_back(a[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(a, cons_list(index_uni(1), nil_index_list()), "a"));
         for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
           vars__.emplace_back(a[(sym1__ - 1)]);}
       } 
       if (lcm_sym3__) {
-        vars__.emplace_back(b[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(b, cons_list(index_uni(1), nil_index_list()), "b"));
         for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
           vars__.emplace_back(b[(sym1__ - 1)]);}
       } 
       if (lcm_sym2__) {
-        vars__.emplace_back(c[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(c, cons_list(index_uni(1), nil_index_list()), "c"));
         for (int sym1__ = 2; sym1__ <= n_age_edu; ++sym1__) {
           vars__.emplace_back(c[(sym1__ - 1)]);}
       } 
       if (lcm_sym5__) {
-        vars__.emplace_back(d[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(d, cons_list(index_uni(1), nil_index_list()), "d"));
         for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
           vars__.emplace_back(d[(sym1__ - 1)]);}
       } 
       if (lcm_sym4__) {
-        vars__.emplace_back(e[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(e, cons_list(index_uni(1), nil_index_list()), "e"));
         for (int sym1__ = 2; sym1__ <= n_region_full; ++sym1__) {
           vars__.emplace_back(e[(sym1__ - 1)]);}
       } 
       {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"));
         {
-          vars__.emplace_back(beta[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"));
         }
         {
-          vars__.emplace_back(beta[(3 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(3), nil_index_list()), "beta"));
         }
         {
-          vars__.emplace_back(beta[(4 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(4), nil_index_list()), "beta"));
         }
         {
-          vars__.emplace_back(beta[(5 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(5), nil_index_list()), "beta"));
         }
       }
       vars__.emplace_back(sigma_a_free__);
@@ -8661,7 +9343,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       if (lcm_sym41__) {
         current_statement__ = 31;
         current_statement__ = 31;
-        check_greater_or_equal(function__, "node1[sym1__]", node1[(1 - 1)], 1);
+        check_greater_or_equal(function__, "node1[sym1__]",
+                               rvalue(node1,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "node1"), 1);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 31;
           current_statement__ = 31;
@@ -8672,7 +9357,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       if (lcm_sym41__) {
         current_statement__ = 31;
         current_statement__ = 31;
-        check_less_or_equal(function__, "node1[sym1__]", node1[(1 - 1)], N);
+        check_less_or_equal(function__, "node1[sym1__]",
+                            rvalue(node1,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "node1"), N);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 31;
           current_statement__ = 31;
@@ -8693,7 +9381,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       if (lcm_sym41__) {
         current_statement__ = 33;
         current_statement__ = 33;
-        check_greater_or_equal(function__, "node2[sym1__]", node2[(1 - 1)], 1);
+        check_greater_or_equal(function__, "node2[sym1__]",
+                               rvalue(node2,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "node2"), 1);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 33;
           current_statement__ = 33;
@@ -8704,7 +9395,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       if (lcm_sym41__) {
         current_statement__ = 33;
         current_statement__ = 33;
-        check_less_or_equal(function__, "node2[sym1__]", node2[(1 - 1)], N);
+        check_less_or_equal(function__, "node2[sym1__]",
+                            rvalue(node2,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "node2"), N);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 33;
           current_statement__ = 33;
@@ -8730,7 +9424,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         if (lcm_sym40__) {
           current_statement__ = 35;
           assign(E, cons_list(index_uni(1), nil_index_list()),
-            E_flat__[(1 - 1)], "assigning variable E");
+            rvalue(E_flat__, cons_list(index_uni(1), nil_index_list()),
+              "E_flat__"), "assigning variable E");
           current_statement__ = 35;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -8745,7 +9440,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       if (lcm_sym40__) {
         current_statement__ = 35;
         current_statement__ = 35;
-        check_greater_or_equal(function__, "E[sym1__]", E[(1 - 1)], 0);
+        check_greater_or_equal(function__, "E[sym1__]",
+                               rvalue(E,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "E"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 35;
           current_statement__ = 35;
@@ -8949,7 +9647,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       
       vars__.emplace_back(tau_phi);
       if (logical_gte(lcm_sym20__, 1)) {
-        vars__.emplace_back(phi_std_raw[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(phi_std_raw, cons_list(index_uni(1), nil_index_list()),
+            "phi_std_raw"));
         for (int sym1__ = 2; sym1__ <= lcm_sym20__; ++sym1__) {
           vars__.emplace_back(phi_std_raw[(sym1__ - 1)]);}
       } 
@@ -8977,7 +9677,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
           vars__.emplace_back(lcm_sym16__);
           lcm_sym8__ = logical_gte(N, 1);
           if (lcm_sym8__) {
-            vars__.emplace_back(phi[(1 - 1)]);
+            vars__.emplace_back(
+              rvalue(phi, cons_list(index_uni(1), nil_index_list()), "phi"));
             for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
               vars__.emplace_back(phi[(sym1__ - 1)]);}
           } 
@@ -9044,9 +9745,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         current_statement__ = 23;
         assign(y, cons_list(index_uni(1), nil_index_list()),
           poisson_log_rng(
-            ((stan::math::fma(beta1, x[(1 - 1)],
-                (stan::math::log(E)[(1 - 1)] + beta0)) + phi[(1 - 1)]) +
-              lcm_sym15__[(1 - 1)]), base_rng__), "assigning variable y");
+            ((stan::math::fma(beta1,
+                rvalue(x, cons_list(index_uni(1), nil_index_list()), "x"),
+                (rvalue(stan::math::log(E),
+                   cons_list(index_uni(1), nil_index_list()), "log(E)") +
+                  beta0)) +
+               rvalue(phi, cons_list(index_uni(1), nil_index_list()), "phi"))
+              +
+              rvalue(lcm_sym15__, cons_list(index_uni(1), nil_index_list()),
+                "lcm_sym15__")), base_rng__), "assigning variable y");
         for (int i = 2; i <= N; ++i) {
           current_statement__ = 22;
           assign(x, cons_list(index_uni(i), nil_index_list()),
@@ -9054,9 +9761,16 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
           current_statement__ = 23;
           assign(y, cons_list(index_uni(i), nil_index_list()),
             poisson_log_rng(
-              ((stan::math::fma(beta1, x[(i - 1)],
-                  (stan::math::log(E)[(i - 1)] + beta0)) + phi[(i - 1)]) +
-                lcm_sym15__[(i - 1)]), base_rng__), "assigning variable y");}
+              ((stan::math::fma(beta1,
+                  rvalue(x, cons_list(index_uni(i), nil_index_list()), "x"),
+                  (rvalue(stan::math::log(E),
+                     cons_list(index_uni(i), nil_index_list()), "log(E)") +
+                    beta0)) +
+                 rvalue(phi, cons_list(index_uni(i), nil_index_list()),
+                   "phi")) +
+                rvalue(lcm_sym15__,
+                  cons_list(index_uni(i), nil_index_list()), "lcm_sym15__")),
+              base_rng__), "assigning variable y");}
       } 
       current_statement__ = 10;
       current_statement__ = 10;
@@ -9069,22 +9783,28 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       vars__.emplace_back(tau_theta);
       vars__.emplace_back(lcm_sym17__);
       if (lcm_sym8__) {
-        vars__.emplace_back(lcm_sym15__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(lcm_sym15__, cons_list(index_uni(1), nil_index_list()),
+            "lcm_sym15__"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(lcm_sym15__[(sym1__ - 1)]);}
       } 
       if (lcm_sym8__) {
-        vars__.emplace_back(theta_std[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(theta_std, cons_list(index_uni(1), nil_index_list()),
+            "theta_std"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(theta_std[(sym1__ - 1)]);}
       } 
       if (lcm_sym8__) {
-        vars__.emplace_back(x[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(x, cons_list(index_uni(1), nil_index_list()), "x"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(x[(sym1__ - 1)]);}
       } 
       if (lcm_sym8__) {
-        vars__.emplace_back(y[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(y, cons_list(index_uni(1), nil_index_list()), "y"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(y[(sym1__ - 1)]);}
       } 
@@ -9145,7 +9865,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         if (lcm_sym1__) {
           current_statement__ = 2;
           assign(phi_std_raw, cons_list(index_uni(1), nil_index_list()),
-            phi_std_raw_flat__[(1 - 1)], "assigning variable phi_std_raw");
+            rvalue(phi_std_raw_flat__,
+              cons_list(index_uni(1), nil_index_list()),
+              "phi_std_raw_flat__"), "assigning variable phi_std_raw");
           current_statement__ = 2;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= lcm_sym2__; ++sym1__) {
@@ -9160,7 +9882,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       }
       vars__.emplace_back(tau_phi_free__);
       if (lcm_sym1__) {
-        vars__.emplace_back(phi_std_raw[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(phi_std_raw, cons_list(index_uni(1), nil_index_list()),
+            "phi_std_raw"));
         for (int sym1__ = 2; sym1__ <= lcm_sym2__; ++sym1__) {
           vars__.emplace_back(phi_std_raw[(sym1__ - 1)]);}
       } 
@@ -9515,13 +10239,13 @@ first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       lcm_sym27__ = size(y_i);
       if (logical_gte(lcm_sym27__, 1)) {
         current_statement__ = 48;
-        if (y_i[(1 - 1)]) {
+        if (rvalue(y_i, cons_list(index_uni(1), nil_index_list()), "y_i")) {
           current_statement__ = 47;
           return 1;
         } 
         for (int k = 2; k <= lcm_sym27__; ++k) {
           current_statement__ = 48;
-          if (y_i[(k - 1)]) {
+          if (rvalue(y_i, cons_list(index_uni(k), nil_index_list()), "y_i")) {
             current_statement__ = 47;
             return k;
           } }
@@ -9933,7 +10657,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 41;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= nind; ++sym2__) {
@@ -9976,12 +10701,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           current_statement__ = 41;
           current_statement__ = 41;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 0);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 41;
             current_statement__ = 41;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 41;
@@ -9989,7 +10720,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             current_statement__ = 41;
             current_statement__ = 41;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 0);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 41;
               current_statement__ = 41;
@@ -10004,12 +10738,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           current_statement__ = 41;
           current_statement__ = 41;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], 1);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), 1);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 41;
             current_statement__ = 41;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 41;
@@ -10017,7 +10757,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             current_statement__ = 41;
             current_statement__ = 41;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), 1);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 41;
               current_statement__ = 41;
@@ -10048,11 +10791,14 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym162__ = size(y[(1 - 1)]);
+          lcm_sym162__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym162__;
                ++inline_sym18__) {
             current_statement__ = 48;
-            if (y[(1 - 1)][(inline_sym18__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (inline_sym18__ - 1)]) {
               inline_sym19__ = 1;
               inline_sym17__ = inline_sym18__;
               break;
@@ -10072,11 +10818,15 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym161__ = size(y[(i - 1)]);
+            lcm_sym161__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym161__;
                  ++inline_sym18__) {
               current_statement__ = 48;
-              if (y[(i - 1)][(inline_sym18__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (inline_sym18__ - 1)]) {
                 inline_sym19__ = 1;
                 inline_sym17__ = inline_sym18__;
                 break;
@@ -10098,7 +10848,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym162__ = size(y[(1 - 1)]);
+          lcm_sym162__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           lcm_sym159__ = (lcm_sym162__ - 1);
           for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym159__;
                ++inline_sym23__) {
@@ -10108,7 +10860,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             lcm_sym158__ = (lcm_sym162__ - inline_sym23__);
             inline_sym22__ = lcm_sym158__;
             current_statement__ = 54;
-            if (y[(1 - 1)][(lcm_sym158__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (lcm_sym158__ - 1)]) {
               inline_sym24__ = 1;
               inline_sym21__ = lcm_sym158__;
               break;
@@ -10128,7 +10881,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym161__ = size(y[(i - 1)]);
+            lcm_sym161__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             lcm_sym157__ = (lcm_sym161__ - 1);
             for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym157__;
                  ++inline_sym23__) {
@@ -10138,7 +10894,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               lcm_sym156__ = (lcm_sym161__ - inline_sym23__);
               inline_sym22__ = lcm_sym156__;
               current_statement__ = 54;
-              if (y[(i - 1)][(lcm_sym156__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (lcm_sym156__ - 1)]) {
                 inline_sym24__ = 1;
                 inline_sym21__ = lcm_sym156__;
                 break;
@@ -10156,7 +10913,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       if (lcm_sym154__) {
         current_statement__ = 44;
         current_statement__ = 44;
-        check_greater_or_equal(function__, "first[sym1__]", first[(1 - 1)], 0);
+        check_greater_or_equal(function__, "first[sym1__]",
+                               rvalue(first,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "first"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 44;
           current_statement__ = 44;
@@ -10167,8 +10927,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       if (lcm_sym154__) {
         current_statement__ = 44;
         current_statement__ = 44;
-        check_less_or_equal(function__, "first[sym1__]", first[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "first[sym1__]",
+                            rvalue(first,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "first"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 44;
           current_statement__ = 44;
@@ -10179,7 +10941,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       if (lcm_sym154__) {
         current_statement__ = 46;
         current_statement__ = 46;
-        check_greater_or_equal(function__, "last[sym1__]", last[(1 - 1)], 0);
+        check_greater_or_equal(function__, "last[sym1__]",
+                               rvalue(last,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "last"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 46;
           current_statement__ = 46;
@@ -10190,8 +10955,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       if (lcm_sym154__) {
         current_statement__ = 46;
         current_statement__ = 46;
-        check_less_or_equal(function__, "last[sym1__]", last[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "last[sym1__]",
+                            rvalue(last,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "last"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 46;
           current_statement__ = 46;
@@ -10365,7 +11132,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       mu = lcm_sym135__;
       lcm_sym101__ = logical_gte(nind, 1);
       if (lcm_sym101__) {
-        lcm_sym138__ = first[(1 - 1)];
+        lcm_sym138__ = rvalue(first,
+                         cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym114__ = (lcm_sym138__ - 1);
         if (logical_gte(lcm_sym114__, 1)) {
           current_statement__ = 9;
@@ -10392,7 +11160,11 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         } 
         lcm_sym112__ = (n_occasions - 1);
         if (logical_gte(lcm_sym112__, lcm_sym138__)) {
-          lcm_sym134__ = inv_logit((lcm_sym135__ + epsilon[(1 - 1)]));
+          lcm_sym134__ = inv_logit(
+                           (lcm_sym135__ +
+                             rvalue(epsilon,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "epsilon")));
           assign(phi,
             cons_list(index_uni(1),
               cons_list(index_uni(lcm_sym138__), nil_index_list())),
@@ -10415,7 +11187,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym137__ = first[(i - 1)];
+          lcm_sym137__ = rvalue(first,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "first");
           lcm_sym113__ = (lcm_sym137__ - 1);
           if (logical_gte(lcm_sym113__, 1)) {
             current_statement__ = 9;
@@ -10442,7 +11216,11 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           } 
           current_statement__ = 15;
           if (logical_gte(lcm_sym112__, lcm_sym137__)) {
-            lcm_sym133__ = inv_logit((lcm_sym135__ + epsilon[(i - 1)]));
+            lcm_sym133__ = inv_logit(
+                             (lcm_sym135__ +
+                               rvalue(epsilon,
+                                 cons_list(index_uni(i), nil_index_list()),
+                                 "epsilon")));
             assign(phi,
               cons_list(index_uni(i),
                 cons_list(index_uni(lcm_sym137__), nil_index_list())),
@@ -10817,9 +11595,13 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         lp_accum__.add(normal_lpdf<propto__>(epsilon, 0, sigma));
         current_statement__ = 36;
         if (lcm_sym101__) {
-          lcm_sym138__ = first[(1 - 1)];
+          lcm_sym138__ = rvalue(first,
+                           cons_list(index_uni(1), nil_index_list()),
+                           "first");
           if (logical_gt(lcm_sym138__, 0)) {
-            lcm_sym144__ = last[(1 - 1)];
+            lcm_sym144__ = rvalue(last,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "last");
             lcm_sym120__ = (lcm_sym138__ + 1);
             if (logical_gte(lcm_sym144__, lcm_sym120__)) {
               current_statement__ = 30;
@@ -10831,7 +11613,11 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                         nil_index_list())), "phi")));
               lcm_sym118__ = (lcm_sym120__ + 1);
               lp_accum__.add(
-                bernoulli_lpmf<propto__>(y[(1 - 1)][(lcm_sym120__ - 1)],
+                bernoulli_lpmf<propto__>(
+                  rvalue(y,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(lcm_sym120__), nil_index_list())),
+                    "y"),
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym120__ - 1)),
@@ -10846,7 +11632,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                       "phi")));
                 current_statement__ = 31;
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(1 - 1)][(t - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni(t), nil_index_list())), "y"),
                     rvalue(p,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
@@ -10861,9 +11650,13 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                   "inline_sym9__")));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym137__ = first[(i - 1)];
+            lcm_sym137__ = rvalue(first,
+                             cons_list(index_uni(i), nil_index_list()),
+                             "first");
             if (logical_gt(lcm_sym137__, 0)) {
-              lcm_sym143__ = last[(i - 1)];
+              lcm_sym143__ = rvalue(last,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "last");
               lcm_sym119__ = (lcm_sym137__ + 1);
               if (logical_gte(lcm_sym143__, lcm_sym119__)) {
                 current_statement__ = 30;
@@ -10875,7 +11668,11 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                           nil_index_list())), "phi")));
                 lcm_sym117__ = (lcm_sym119__ + 1);
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(i - 1)][(lcm_sym119__ - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(lcm_sym119__), nil_index_list())),
+                      "y"),
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym119__ - 1)),
@@ -10890,7 +11687,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                         "phi")));
                   current_statement__ = 31;
                   lp_accum__.add(
-                    bernoulli_lpmf<propto__>(y[(i - 1)][(t - 1)],
+                    bernoulli_lpmf<propto__>(
+                      rvalue(y,
+                        cons_list(index_uni(i),
+                          cons_list(index_uni(t), nil_index_list())), "y"),
                       rvalue(p,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
@@ -11031,7 +11831,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       vars__.emplace_back(mean_p);
       lcm_sym53__ = logical_gte(nind, 1);
       if (lcm_sym53__) {
-        vars__.emplace_back(epsilon[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(epsilon, cons_list(index_uni(1), nil_index_list()),
+            "epsilon"));
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
@@ -11044,7 +11846,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       mu = lcm_sym73__;
       current_statement__ = 17;
       if (lcm_sym53__) {
-        lcm_sym78__ = first[(1 - 1)];
+        lcm_sym78__ = rvalue(first,
+                        cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym62__ = (lcm_sym78__ - 1);
         if (logical_gte(lcm_sym62__, 1)) {
           current_statement__ = 9;
@@ -11071,7 +11874,11 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         } 
         lcm_sym60__ = (n_occasions - 1);
         if (logical_gte(lcm_sym60__, lcm_sym78__)) {
-          lcm_sym72__ = inv_logit((lcm_sym73__ + epsilon[(1 - 1)]));
+          lcm_sym72__ = inv_logit(
+                          (lcm_sym73__ +
+                            rvalue(epsilon,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "epsilon")));
           assign(phi,
             cons_list(index_uni(1),
               cons_list(index_uni(lcm_sym78__), nil_index_list())),
@@ -11094,7 +11901,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym77__ = first[(i - 1)];
+          lcm_sym77__ = rvalue(first,
+                          cons_list(index_uni(i), nil_index_list()), "first");
           lcm_sym61__ = (lcm_sym77__ - 1);
           if (logical_gte(lcm_sym61__, 1)) {
             current_statement__ = 9;
@@ -11121,7 +11929,11 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           } 
           current_statement__ = 15;
           if (logical_gte(lcm_sym60__, lcm_sym77__)) {
-            lcm_sym71__ = inv_logit((lcm_sym73__ + epsilon[(i - 1)]));
+            lcm_sym71__ = inv_logit(
+                            (lcm_sym73__ +
+                              rvalue(epsilon,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "epsilon")));
             assign(phi,
               cons_list(index_uni(i),
                 cons_list(index_uni(lcm_sym77__), nil_index_list())),
@@ -11653,7 +12465,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         if (lcm_sym46__) {
           current_statement__ = 3;
           assign(epsilon, cons_list(index_uni(1), nil_index_list()),
-            epsilon_flat__[(1 - 1)], "assigning variable epsilon");
+            rvalue(epsilon_flat__, cons_list(index_uni(1), nil_index_list()),
+              "epsilon_flat__"), "assigning variable epsilon");
           current_statement__ = 3;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
@@ -11677,7 +12490,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       vars__.emplace_back(mean_phi_free__);
       vars__.emplace_back(mean_p_free__);
       if (lcm_sym46__) {
-        vars__.emplace_back(epsilon[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(epsilon, cons_list(index_uni(1), nil_index_list()),
+            "epsilon"));
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
@@ -12103,13 +12918,13 @@ first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       lcm_sym44__ = size(y_i);
       if (logical_gte(lcm_sym44__, 1)) {
         current_statement__ = 60;
-        if (y_i[(1 - 1)]) {
+        if (rvalue(y_i, cons_list(index_uni(1), nil_index_list()), "y_i")) {
           current_statement__ = 59;
           return 1;
         } 
         for (int k = 2; k <= lcm_sym44__; ++k) {
           current_statement__ = 60;
-          if (y_i[(k - 1)]) {
+          if (rvalue(y_i, cons_list(index_uni(k), nil_index_list()), "y_i")) {
             current_statement__ = 59;
             return k;
           } }
@@ -12477,11 +13292,13 @@ js_super_lp(const std::vector<std::vector<int>>& y,
       int n_ind;
       n_ind = std::numeric_limits<int>::min();
       
-      lcm_sym114__ = dims(y)[(1 - 1)];
+      lcm_sym114__ = rvalue(dims(y),
+                       cons_list(index_uni(1), nil_index_list()), "dims(y)");
       int n_occasions;
       n_occasions = std::numeric_limits<int>::min();
       
-      lcm_sym115__ = dims(y)[(2 - 1)];
+      lcm_sym115__ = rvalue(dims(y),
+                       cons_list(index_uni(2), nil_index_list()), "dims(y)");
       n_occasions = lcm_sym115__;
       current_statement__ = 80;
       validate_non_negative_index("qnu", "n_occasions", lcm_sym115__);
@@ -12504,7 +13321,8 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             transpose(
               rvalue(p, cons_list(index_uni(1), nil_index_list()), "p"))),
           "assigning variable lcm_sym75__");
-        lcm_sym111__ = first[(1 - 1)];
+        lcm_sym111__ = rvalue(first,
+                         cons_list(index_uni(1), nil_index_list()), "first");
         if (lcm_sym111__) {
           current_statement__ = 89;
           lp_accum__.add(bernoulli_lpmf<propto__>(1, psi));
@@ -12513,7 +13331,8 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             current_statement__ = 104;
             lp_accum__.add(
               bernoulli_lpmf<propto__>(1,
-                (nu[(1 - 1)] *
+                (rvalue(nu, cons_list(index_uni(1), nil_index_list()), "nu")
+                  *
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni(1), nil_index_list())), "p"))));
@@ -12526,7 +13345,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             
             lcm_sym77__ = (lcm_sym111__ - 1);
             assign(lp, cons_list(index_uni(1), nil_index_list()),
-              (((bernoulli_lpmf<false>(1, nu[(1 - 1)]) +
+              (((bernoulli_lpmf<false>(1,
+                   rvalue(nu, cons_list(index_uni(1), nil_index_list()),
+                     "nu")) +
                   bernoulli_lpmf<false>(1,
                     prod(
                       rvalue(lcm_sym75__,
@@ -12552,7 +13373,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                         rvalue(lcm_sym73__,
                           cons_list(index_min_max(1, 1), nil_index_list()),
                           "lcm_sym73__"))) +
-                     bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                     bernoulli_lpmf<false>(1,
+                       rvalue(nu, cons_list(index_uni(2), nil_index_list()),
+                         "nu"))) +
                     bernoulli_lpmf<false>(1,
                       prod(
                         rvalue(lcm_sym75__,
@@ -12577,7 +13400,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                           rvalue(lcm_sym73__,
                             cons_list(index_min_max(1, (t - 1)),
                               nil_index_list()), "lcm_sym73__"))) +
-                       bernoulli_lpmf<false>(1, nu[(t - 1)])) +
+                       bernoulli_lpmf<false>(1,
+                         rvalue(nu,
+                           cons_list(index_uni(t), nil_index_list()), "nu")))
+                      +
                       bernoulli_lpmf<false>(1,
                         prod(
                           rvalue(lcm_sym75__,
@@ -12612,7 +13438,8 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             current_statement__ = 94;
             lp_accum__.add(log_sum_exp(lp));
           }
-          lcm_sym113__ = last[(1 - 1)];
+          lcm_sym113__ = rvalue(last,
+                           cons_list(index_uni(1), nil_index_list()), "last");
           if (logical_gte(lcm_sym113__, (lcm_sym111__ + 1))) {
             current_statement__ = 98;
             lp_accum__.add(
@@ -12623,7 +13450,11 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                       nil_index_list())), "phi")));
             lcm_sym93__ = ((lcm_sym111__ + 1) + 1);
             lp_accum__.add(
-              bernoulli_lpmf<propto__>(y[(1 - 1)][((lcm_sym111__ + 1) - 1)],
+              bernoulli_lpmf<propto__>(
+                rvalue(y,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni((lcm_sym111__ + 1)),
+                      nil_index_list())), "y"),
                 rvalue(p,
                   cons_list(index_uni(1),
                     cons_list(index_uni((lcm_sym111__ + 1)),
@@ -12638,7 +13469,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                     "phi")));
               current_statement__ = 99;
               lp_accum__.add(
-                bernoulli_lpmf<propto__>(y[(1 - 1)][(t - 1)],
+                bernoulli_lpmf<propto__>(
+                  rvalue(y,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(t), nil_index_list())), "y"),
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni(t), nil_index_list())), "p")));}
@@ -12660,7 +13494,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
           current_statement__ = 103;
           assign(lp, cons_list(index_uni(1), nil_index_list()),
             (((bernoulli_lpmf<false>(1, psi) +
-                bernoulli_lpmf<false>(1, nu[(1 - 1)])) +
+                bernoulli_lpmf<false>(1,
+                  rvalue(nu, cons_list(index_uni(1), nil_index_list()), "nu")))
+               +
                bernoulli_lpmf<false>(0,
                  rvalue(p,
                    cons_list(index_uni(1),
@@ -12680,7 +13516,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                        rvalue(lcm_sym73__,
                          cons_list(index_min_max(1, 1), nil_index_list()),
                          "lcm_sym73__")))) +
-                  bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                  bernoulli_lpmf<false>(1,
+                    rvalue(nu, cons_list(index_uni(2), nil_index_list()),
+                      "nu"))) +
                  bernoulli_lpmf<false>(0,
                    rvalue(p,
                      cons_list(index_uni(1),
@@ -12699,7 +13537,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                          rvalue(lcm_sym73__,
                            cons_list(index_min_max(1, (t - 1)),
                              nil_index_list()), "lcm_sym73__")))) +
-                    bernoulli_lpmf<false>(1, nu[(t - 1)])) +
+                    bernoulli_lpmf<false>(1,
+                      rvalue(nu, cons_list(index_uni(t), nil_index_list()),
+                        "nu"))) +
                    bernoulli_lpmf<false>(0,
                      rvalue(p,
                        cons_list(index_uni(1),
@@ -12728,7 +13568,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
               transpose(
                 rvalue(p, cons_list(index_uni(i), nil_index_list()), "p"))),
             "assigning variable lcm_sym74__");
-          lcm_sym110__ = first[(i - 1)];
+          lcm_sym110__ = rvalue(first,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "first");
           if (lcm_sym110__) {
             current_statement__ = 89;
             lp_accum__.add(bernoulli_lpmf<propto__>(1, psi));
@@ -12737,7 +13579,8 @@ js_super_lp(const std::vector<std::vector<int>>& y,
               current_statement__ = 104;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
-                  (nu[(1 - 1)] *
+                  (rvalue(nu, cons_list(index_uni(1), nil_index_list()),
+                     "nu") *
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni(1), nil_index_list())), "p"))));
@@ -12750,7 +13593,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
               
               lcm_sym76__ = (lcm_sym110__ - 1);
               assign(lp, cons_list(index_uni(1), nil_index_list()),
-                (((bernoulli_lpmf<false>(1, nu[(1 - 1)]) +
+                (((bernoulli_lpmf<false>(1,
+                     rvalue(nu, cons_list(index_uni(1), nil_index_list()),
+                       "nu")) +
                     bernoulli_lpmf<false>(1,
                       prod(
                         rvalue(lcm_sym74__,
@@ -12776,7 +13621,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                           rvalue(lcm_sym73__,
                             cons_list(index_min_max(1, 1), nil_index_list()),
                             "lcm_sym73__"))) +
-                       bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                       bernoulli_lpmf<false>(1,
+                         rvalue(nu,
+                           cons_list(index_uni(2), nil_index_list()), "nu")))
+                      +
                       bernoulli_lpmf<false>(1,
                         prod(
                           rvalue(lcm_sym74__,
@@ -12802,7 +13650,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                             rvalue(lcm_sym73__,
                               cons_list(index_min_max(1, (t - 1)),
                                 nil_index_list()), "lcm_sym73__"))) +
-                         bernoulli_lpmf<false>(1, nu[(t - 1)])) +
+                         bernoulli_lpmf<false>(1,
+                           rvalue(nu,
+                             cons_list(index_uni(t), nil_index_list()), "nu")))
+                        +
                         bernoulli_lpmf<false>(1,
                           prod(
                             rvalue(lcm_sym74__,
@@ -12838,7 +13689,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
               current_statement__ = 94;
               lp_accum__.add(log_sum_exp(lp));
             }
-            lcm_sym112__ = last[(i - 1)];
+            lcm_sym112__ = rvalue(last,
+                             cons_list(index_uni(i), nil_index_list()),
+                             "last");
             if (logical_gte(lcm_sym112__, (lcm_sym110__ + 1))) {
               current_statement__ = 98;
               lp_accum__.add(
@@ -12850,7 +13703,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
               lcm_sym92__ = ((lcm_sym110__ + 1) + 1);
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(
-                  y[(i - 1)][((lcm_sym110__ + 1) - 1)],
+                  rvalue(y,
+                    cons_list(index_uni(i),
+                      cons_list(index_uni((lcm_sym110__ + 1)),
+                        nil_index_list())), "y"),
                   rvalue(p,
                     cons_list(index_uni(i),
                       cons_list(index_uni((lcm_sym110__ + 1)),
@@ -12865,7 +13721,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                       "phi")));
                 current_statement__ = 99;
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(i - 1)][(t - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(t), nil_index_list())), "y"),
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni(t), nil_index_list())), "p")));}
@@ -12887,7 +13746,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             current_statement__ = 103;
             assign(lp, cons_list(index_uni(1), nil_index_list()),
               (((bernoulli_lpmf<false>(1, psi) +
-                  bernoulli_lpmf<false>(1, nu[(1 - 1)])) +
+                  bernoulli_lpmf<false>(1,
+                    rvalue(nu, cons_list(index_uni(1), nil_index_list()),
+                      "nu"))) +
                  bernoulli_lpmf<false>(0,
                    rvalue(p,
                      cons_list(index_uni(i),
@@ -12907,7 +13768,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                          rvalue(lcm_sym73__,
                            cons_list(index_min_max(1, 1), nil_index_list()),
                            "lcm_sym73__")))) +
-                    bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                    bernoulli_lpmf<false>(1,
+                      rvalue(nu, cons_list(index_uni(2), nil_index_list()),
+                        "nu"))) +
                    bernoulli_lpmf<false>(0,
                      rvalue(p,
                        cons_list(index_uni(i),
@@ -12926,7 +13789,9 @@ js_super_lp(const std::vector<std::vector<int>>& y,
                            rvalue(lcm_sym73__,
                              cons_list(index_min_max(1, (t - 1)),
                                nil_index_list()), "lcm_sym73__")))) +
-                      bernoulli_lpmf<false>(1, nu[(t - 1)])) +
+                      bernoulli_lpmf<false>(1,
+                        rvalue(nu, cons_list(index_uni(t), nil_index_list()),
+                          "nu"))) +
                      bernoulli_lpmf<false>(0,
                        rvalue(p,
                          cons_list(index_uni(i),
@@ -13099,7 +13964,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 110;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
@@ -13142,12 +14008,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           current_statement__ = 110;
           current_statement__ = 110;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 0);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 110;
             current_statement__ = 110;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 110;
@@ -13155,7 +14027,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             current_statement__ = 110;
             current_statement__ = 110;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 0);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 110;
               current_statement__ = 110;
@@ -13170,12 +14045,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           current_statement__ = 110;
           current_statement__ = 110;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], 1);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), 1);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 110;
             current_statement__ = 110;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 110;
@@ -13183,7 +14064,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             current_statement__ = 110;
             current_statement__ = 110;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), 1);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 110;
               current_statement__ = 110;
@@ -13209,11 +14093,14 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         
         inline_sym36__ = 0;
         for (int inline_sym37__ = 1; inline_sym37__ <= 1; ++inline_sym37__) {
-          lcm_sym324__ = size(y[(1 - 1)]);
+          lcm_sym324__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           for (int inline_sym35__ = 1; inline_sym35__ <= lcm_sym324__;
                ++inline_sym35__) {
             current_statement__ = 60;
-            if (y[(1 - 1)][(inline_sym35__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (inline_sym35__ - 1)]) {
               inline_sym36__ = 1;
               inline_sym34__ = inline_sym35__;
               break;
@@ -13233,11 +14120,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           
           inline_sym36__ = 0;
           for (int inline_sym37__ = 1; inline_sym37__ <= 1; ++inline_sym37__) {
-            lcm_sym323__ = size(y[(i - 1)]);
+            lcm_sym323__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             for (int inline_sym35__ = 1; inline_sym35__ <= lcm_sym323__;
                  ++inline_sym35__) {
               current_statement__ = 60;
-              if (y[(i - 1)][(inline_sym35__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (inline_sym35__ - 1)]) {
                 inline_sym36__ = 1;
                 inline_sym34__ = inline_sym35__;
                 break;
@@ -13259,7 +14150,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         
         inline_sym41__ = 0;
         for (int inline_sym42__ = 1; inline_sym42__ <= 1; ++inline_sym42__) {
-          lcm_sym324__ = size(y[(1 - 1)]);
+          lcm_sym324__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           lcm_sym321__ = (lcm_sym324__ - 1);
           for (int inline_sym40__ = 0; inline_sym40__ <= lcm_sym321__;
                ++inline_sym40__) {
@@ -13269,7 +14162,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             lcm_sym320__ = (lcm_sym324__ - inline_sym40__);
             inline_sym39__ = lcm_sym320__;
             current_statement__ = 119;
-            if (y[(1 - 1)][(lcm_sym320__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (lcm_sym320__ - 1)]) {
               inline_sym41__ = 1;
               inline_sym38__ = lcm_sym320__;
               break;
@@ -13289,7 +14183,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           
           inline_sym41__ = 0;
           for (int inline_sym42__ = 1; inline_sym42__ <= 1; ++inline_sym42__) {
-            lcm_sym323__ = size(y[(i - 1)]);
+            lcm_sym323__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             lcm_sym319__ = (lcm_sym323__ - 1);
             for (int inline_sym40__ = 0; inline_sym40__ <= lcm_sym319__;
                  ++inline_sym40__) {
@@ -13299,7 +14196,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               lcm_sym318__ = (lcm_sym323__ - inline_sym40__);
               inline_sym39__ = lcm_sym318__;
               current_statement__ = 119;
-              if (y[(i - 1)][(lcm_sym318__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (lcm_sym318__ - 1)]) {
                 inline_sym41__ = 1;
                 inline_sym38__ = lcm_sym318__;
                 break;
@@ -13317,7 +14215,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym315__) {
         current_statement__ = 112;
         current_statement__ = 112;
-        check_greater_or_equal(function__, "first[sym1__]", first[(1 - 1)], 0);
+        check_greater_or_equal(function__, "first[sym1__]",
+                               rvalue(first,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "first"), 0);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 112;
           current_statement__ = 112;
@@ -13328,8 +14229,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym315__) {
         current_statement__ = 112;
         current_statement__ = 112;
-        check_less_or_equal(function__, "first[sym1__]", first[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "first[sym1__]",
+                            rvalue(first,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "first"), n_occasions);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 112;
           current_statement__ = 112;
@@ -13340,7 +14243,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym315__) {
         current_statement__ = 114;
         current_statement__ = 114;
-        check_greater_or_equal(function__, "last[sym1__]", last[(1 - 1)], 0);
+        check_greater_or_equal(function__, "last[sym1__]",
+                               rvalue(last,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "last"), 0);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 114;
           current_statement__ = 114;
@@ -13351,8 +14257,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym315__) {
         current_statement__ = 114;
         current_statement__ = 114;
-        check_less_or_equal(function__, "last[sym1__]", last[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "last[sym1__]",
+                            rvalue(last,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "last"), n_occasions);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 114;
           current_statement__ = 114;
@@ -13572,13 +14480,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         if (jacobian__) {
           current_statement__ = 4;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lb_constrain(beta[(1 - 1)], 0, lp__),
-            "assigning variable beta");
+            stan::math::lb_constrain(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              0, lp__), "assigning variable beta");
         } else {
           current_statement__ = 4;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lb_constrain(beta[(1 - 1)], 0),
-            "assigning variable beta");
+            stan::math::lb_constrain(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              0), "assigning variable beta");
         }
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 4;
@@ -13660,7 +14570,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         local_scalar_t__ cum_b;
         cum_b = DUMMY_VAR__;
         
-        lcm_sym308__ = lcm_sym222__[(1 - 1)];
+        lcm_sym308__ = rvalue(lcm_sym222__,
+                         cons_list(index_uni(1), nil_index_list()),
+                         "lcm_sym222__");
         current_statement__ = 15;
         assign(nu, cons_list(index_uni(1), nil_index_list()), lcm_sym308__,
           "assigning variable nu");
@@ -13668,17 +14580,25 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         if (logical_gte(lcm_sym238__, 2)) {
           current_statement__ = 16;
           assign(nu, cons_list(index_uni(2), nil_index_list()),
-            (lcm_sym222__[(2 - 1)] / (1.0 - lcm_sym308__)),
+            (rvalue(lcm_sym222__, cons_list(index_uni(2), nil_index_list()),
+               "lcm_sym222__") / (1.0 - lcm_sym308__)),
             "assigning variable nu");
           current_statement__ = 17;
-          cum_b = (lcm_sym308__ + lcm_sym222__[(2 - 1)]);
+          cum_b = (lcm_sym308__ +
+                    rvalue(lcm_sym222__,
+                      cons_list(index_uni(2), nil_index_list()),
+                      "lcm_sym222__"));
           for (int t = 3; t <= lcm_sym238__; ++t) {
             current_statement__ = 16;
             assign(nu, cons_list(index_uni(t), nil_index_list()),
-              (lcm_sym222__[(t - 1)] / (1.0 - cum_b)),
-              "assigning variable nu");
+              (rvalue(lcm_sym222__,
+                 cons_list(index_uni(t), nil_index_list()), "lcm_sym222__") /
+                (1.0 - cum_b)), "assigning variable nu");
             current_statement__ = 17;
-            cum_b = (cum_b + lcm_sym222__[(t - 1)]);}
+            cum_b = (cum_b +
+                      rvalue(lcm_sym222__,
+                        cons_list(index_uni(t), nil_index_list()),
+                        "lcm_sym222__"));}
         } 
         current_statement__ = 20;
         assign(nu, cons_list(index_uni(n_occasions), nil_index_list()), 1.0,
@@ -13963,7 +14883,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym228__) {
         current_statement__ = 10;
         current_statement__ = 10;
-        check_greater_or_equal(function__, "nu[sym1__]", nu[(1 - 1)], 0);
+        check_greater_or_equal(function__, "nu[sym1__]",
+                               rvalue(nu,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "nu"), 0);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 10;
           current_statement__ = 10;
@@ -13974,7 +14897,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym228__) {
         current_statement__ = 10;
         current_statement__ = 10;
-        check_less_or_equal(function__, "nu[sym1__]", nu[(1 - 1)], 1);
+        check_less_or_equal(function__, "nu[sym1__]",
+                            rvalue(nu,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "nu"), 1);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 10;
           current_statement__ = 10;
@@ -14079,11 +15005,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           int inline_sym25__;
           inline_sym25__ = std::numeric_limits<int>::min();
           
-          lcm_sym309__ = dims(y)[(1 - 1)];
+          lcm_sym309__ = rvalue(dims(y),
+                           cons_list(index_uni(1), nil_index_list()),
+                           "dims(y)");
           int inline_sym26__;
           inline_sym26__ = std::numeric_limits<int>::min();
           
-          lcm_sym310__ = dims(y)[(2 - 1)];
+          lcm_sym310__ = rvalue(dims(y),
+                           cons_list(index_uni(2), nil_index_list()),
+                           "dims(y)");
           current_statement__ = 80;
           validate_non_negative_index("qnu", "n_occasions", lcm_sym310__);
           Eigen::Matrix<double, -1, 1> inline_sym27__;
@@ -14105,13 +15035,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 transpose(
                   rvalue(p, cons_list(index_uni(1), nil_index_list()), "p"))),
               "assigning variable lcm_sym241__");
-            lcm_sym295__ = first[(1 - 1)];
+            lcm_sym295__ = rvalue(first,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "first");
             if (lcm_sym295__) {
               current_statement__ = 89;
               lp_accum__.add(bernoulli_lpmf<propto__>(1, psi));
               current_statement__ = 97;
               if (logical_eq(lcm_sym295__, 1)) {
-                lcm_sym303__ = nu[(1 - 1)];
+                lcm_sym303__ = rvalue(nu,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "nu");
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(1,
                     (lcm_sym303__ *
@@ -14125,7 +15059,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 inline_sym29__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym295__);
                 stan::math::fill(inline_sym29__, DUMMY_VAR__);
                 
-                lcm_sym303__ = nu[(1 - 1)];
+                lcm_sym303__ = rvalue(nu,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "nu");
                 lcm_sym245__ = (lcm_sym295__ - 1);
                 assign(inline_sym29__,
                   cons_list(index_uni(1), nil_index_list()),
@@ -14156,7 +15092,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                             rvalue(lcm_sym239__,
                               cons_list(index_min_max(1, 1),
                                 nil_index_list()), "lcm_sym239__"))) +
-                         bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                         bernoulli_lpmf<false>(1,
+                           rvalue(nu,
+                             cons_list(index_uni(2), nil_index_list()), "nu")))
+                        +
                         bernoulli_lpmf<false>(1,
                           prod(
                             rvalue(lcm_sym241__,
@@ -14225,7 +15164,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 current_statement__ = 94;
                 lp_accum__.add(log_sum_exp(inline_sym29__));
               }
-              lcm_sym301__ = last[(1 - 1)];
+              lcm_sym301__ = rvalue(last,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "last");
               if (logical_gte(lcm_sym301__, (lcm_sym295__ + 1))) {
                 current_statement__ = 98;
                 lp_accum__.add(
@@ -14237,7 +15178,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 lcm_sym264__ = ((lcm_sym295__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
-                    y[(1 - 1)][((lcm_sym295__ + 1) - 1)],
+                    rvalue(y,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni((lcm_sym295__ + 1)),
+                          nil_index_list())), "y"),
                     rvalue(p,
                       cons_list(index_uni(1),
                         cons_list(index_uni((lcm_sym295__ + 1)),
@@ -14254,7 +15198,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   current_statement__ = 99;
                   lp_accum__.add(
                     bernoulli_lpmf<propto__>(
-                      y[(1 - 1)][(inline_sym30__ - 1)],
+                      rvalue(y,
+                        cons_list(index_uni(1),
+                          cons_list(index_uni(inline_sym30__),
+                            nil_index_list())), "y"),
                       rvalue(p,
                         cons_list(index_uni(1),
                           cons_list(index_uni(inline_sym30__),
@@ -14275,7 +15222,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               inline_sym29__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym266__);
               stan::math::fill(inline_sym29__, DUMMY_VAR__);
               
-              lcm_sym303__ = nu[(1 - 1)];
+              lcm_sym303__ = rvalue(nu,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "nu");
               assign(inline_sym29__,
                 cons_list(index_uni(1), nil_index_list()),
                 (((bernoulli_lpmf<false>(1, psi) +
@@ -14300,7 +15249,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                            rvalue(lcm_sym239__,
                              cons_list(index_min_max(1, 1), nil_index_list()),
                              "lcm_sym239__")))) +
-                      bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                      bernoulli_lpmf<false>(1,
+                        rvalue(nu, cons_list(index_uni(2), nil_index_list()),
+                          "nu"))) +
                      bernoulli_lpmf<false>(0,
                        rvalue(p,
                          cons_list(index_uni(1),
@@ -14409,7 +15360,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                               rvalue(lcm_sym239__,
                                 cons_list(index_min_max(1, 1),
                                   nil_index_list()), "lcm_sym239__"))) +
-                           bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                           bernoulli_lpmf<false>(1,
+                             rvalue(nu,
+                               cons_list(index_uni(2), nil_index_list()),
+                               "nu"))) +
                           bernoulli_lpmf<false>(1,
                             prod(
                               rvalue(lcm_sym240__,
@@ -14491,7 +15445,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   lcm_sym263__ = ((lcm_sym294__ + 1) + 1);
                   lp_accum__.add(
                     bernoulli_lpmf<propto__>(
-                      y[(inline_sym31__ - 1)][((lcm_sym294__ + 1) - 1)],
+                      rvalue(y,
+                        cons_list(index_uni(inline_sym31__),
+                          cons_list(index_uni((lcm_sym294__ + 1)),
+                            nil_index_list())), "y"),
                       rvalue(p,
                         cons_list(index_uni(inline_sym31__),
                           cons_list(index_uni((lcm_sym294__ + 1)),
@@ -14555,7 +15512,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                              rvalue(lcm_sym239__,
                                cons_list(index_min_max(1, 1),
                                  nil_index_list()), "lcm_sym239__")))) +
-                        bernoulli_lpmf<false>(1, nu[(2 - 1)])) +
+                        bernoulli_lpmf<false>(1,
+                          rvalue(nu,
+                            cons_list(index_uni(2), nil_index_list()), "nu")))
+                       +
                        bernoulli_lpmf<false>(0,
                          rvalue(p,
                            cons_list(index_uni(inline_sym31__),
@@ -14756,8 +15716,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym133__) {
         current_statement__ = 4;
         assign(beta, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lb_constrain(beta[(1 - 1)], 0),
-          "assigning variable beta");
+          stan::math::lb_constrain(
+            rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+            0), "assigning variable beta");
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 4;
           assign(beta, cons_list(index_uni(sym1__), nil_index_list()),
@@ -14801,13 +15762,16 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       vars__.emplace_back(mean_p);
       vars__.emplace_back(psi);
       if (lcm_sym133__) {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(beta[(sym1__ - 1)]);}
       } 
       lcm_sym132__ = logical_gte(M, 1);
       if (lcm_sym132__) {
-        vars__.emplace_back(epsilon[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(epsilon, cons_list(index_uni(1), nil_index_list()),
+            "epsilon"));
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
@@ -14843,7 +15807,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         local_scalar_t__ cum_b;
         cum_b = DUMMY_VAR__;
         
-        lcm_sym212__ = lcm_sym129__[(1 - 1)];
+        lcm_sym212__ = rvalue(lcm_sym129__,
+                         cons_list(index_uni(1), nil_index_list()),
+                         "lcm_sym129__");
         current_statement__ = 15;
         assign(nu, cons_list(index_uni(1), nil_index_list()), lcm_sym212__,
           "assigning variable nu");
@@ -14851,17 +15817,25 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         if (logical_gte(lcm_sym141__, 2)) {
           current_statement__ = 16;
           assign(nu, cons_list(index_uni(2), nil_index_list()),
-            (lcm_sym129__[(2 - 1)] / (1.0 - lcm_sym212__)),
+            (rvalue(lcm_sym129__, cons_list(index_uni(2), nil_index_list()),
+               "lcm_sym129__") / (1.0 - lcm_sym212__)),
             "assigning variable nu");
           current_statement__ = 17;
-          cum_b = (lcm_sym212__ + lcm_sym129__[(2 - 1)]);
+          cum_b = (lcm_sym212__ +
+                    rvalue(lcm_sym129__,
+                      cons_list(index_uni(2), nil_index_list()),
+                      "lcm_sym129__"));
           for (int t = 3; t <= lcm_sym141__; ++t) {
             current_statement__ = 16;
             assign(nu, cons_list(index_uni(t), nil_index_list()),
-              (lcm_sym129__[(t - 1)] / (1.0 - cum_b)),
-              "assigning variable nu");
+              (rvalue(lcm_sym129__,
+                 cons_list(index_uni(t), nil_index_list()), "lcm_sym129__") /
+                (1.0 - cum_b)), "assigning variable nu");
             current_statement__ = 17;
-            cum_b = (cum_b + lcm_sym129__[(t - 1)]);}
+            cum_b = (cum_b +
+                      rvalue(lcm_sym129__,
+                        cons_list(index_uni(t), nil_index_list()),
+                        "lcm_sym129__"));}
         } 
         current_statement__ = 20;
         assign(nu, cons_list(index_uni(n_occasions), nil_index_list()), 1.0,
@@ -15146,7 +16120,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym133__) {
         current_statement__ = 10;
         current_statement__ = 10;
-        check_greater_or_equal(function__, "nu[sym1__]", nu[(1 - 1)], 0);
+        check_greater_or_equal(function__, "nu[sym1__]",
+                               rvalue(nu,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "nu"), 0);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 10;
           current_statement__ = 10;
@@ -15157,7 +16134,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym133__) {
         current_statement__ = 10;
         current_statement__ = 10;
-        check_less_or_equal(function__, "nu[sym1__]", nu[(1 - 1)], 1);
+        check_less_or_equal(function__, "nu[sym1__]",
+                            rvalue(nu,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "nu"), 1);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 10;
           current_statement__ = 10;
@@ -15306,12 +16286,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             } }
         } 
         if (lcm_sym133__) {
-          vars__.emplace_back(lcm_sym129__[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(lcm_sym129__, cons_list(index_uni(1), nil_index_list()),
+              "lcm_sym129__"));
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             vars__.emplace_back(lcm_sym129__[(sym1__ - 1)]);}
         } 
         if (lcm_sym133__) {
-          vars__.emplace_back(nu[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(nu, cons_list(index_uni(1), nil_index_list()), "nu"));
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             vars__.emplace_back(nu[(sym1__ - 1)]);}
         } 
@@ -15376,10 +16359,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           assign(z,
             cons_list(index_uni(1),
               cons_list(index_uni(1), nil_index_list())),
-            bernoulli_rng(nu[(1 - 1)], base_rng__), "assigning variable z");
+            bernoulli_rng(
+              rvalue(nu, cons_list(index_uni(1), nil_index_list()), "nu"),
+              base_rng__), "assigning variable z");
           current_statement__ = 46;
           if (logical_gte(n_occasions, 2)) {
-            lcm_sym209__ = z[(1 - 1)][(1 - 1)];
+            lcm_sym209__ = rvalue(z,
+                             cons_list(index_uni(1),
+                               cons_list(index_uni(1), nil_index_list())),
+                             "z");
             lcm_sym153__ = (1 * (1 - lcm_sym209__));
             q = lcm_sym153__;
             current_statement__ = 43;
@@ -15391,22 +16379,35 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   rvalue(lcm_sym165__,
                     cons_list(index_uni(1),
                       cons_list(index_uni(1), nil_index_list())),
-                    "lcm_sym165__"), (lcm_sym153__ * nu[(2 - 1)])),
-                base_rng__), "assigning variable z");
+                    "lcm_sym165__"),
+                  (lcm_sym153__ *
+                    rvalue(nu, cons_list(index_uni(2), nil_index_list()),
+                      "nu"))), base_rng__), "assigning variable z");
             for (int t = 3; t <= n_occasions; ++t) {
               current_statement__ = 44;
-              q = (q * (1 - z[(1 - 1)][((t - 1) - 1)]));
+              q = (q *
+                    (1 -
+                      rvalue(z,
+                        cons_list(index_uni(1),
+                          cons_list(index_uni((t - 1)), nil_index_list())),
+                        "z")));
               current_statement__ = 43;
               assign(z,
                 cons_list(index_uni(1),
                   cons_list(index_uni(t), nil_index_list())),
                 bernoulli_rng(
-                  stan::math::fma(z[(1 - 1)][((t - 1) - 1)],
+                  stan::math::fma(
+                    rvalue(z,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni((t - 1)), nil_index_list())),
+                      "z"),
                     rvalue(lcm_sym165__,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
-                      "lcm_sym165__"), (q * nu[(t - 1)])), base_rng__),
-                "assigning variable z");}
+                      "lcm_sym165__"),
+                    (q *
+                      rvalue(nu, cons_list(index_uni(t), nil_index_list()),
+                        "nu"))), base_rng__), "assigning variable z");}
           } 
         } else {
           current_statement__ = 40;
@@ -15425,36 +16426,59 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             assign(z,
               cons_list(index_uni(i),
                 cons_list(index_uni(1), nil_index_list())),
-              bernoulli_rng(nu[(1 - 1)], base_rng__), "assigning variable z");
+              bernoulli_rng(
+                rvalue(nu, cons_list(index_uni(1), nil_index_list()), "nu"),
+                base_rng__), "assigning variable z");
             current_statement__ = 46;
             if (logical_gte(n_occasions, 2)) {
-              lcm_sym152__ = (1 * (1 - z[(i - 1)][(1 - 1)]));
+              lcm_sym152__ = (1 *
+                               (1 -
+                                 rvalue(z,
+                                   cons_list(index_uni(i),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "z")));
               q = lcm_sym152__;
               current_statement__ = 43;
               assign(z,
                 cons_list(index_uni(i),
                   cons_list(index_uni(2), nil_index_list())),
                 bernoulli_rng(
-                  stan::math::fma(z[(i - 1)][(1 - 1)],
+                  stan::math::fma(
+                    rvalue(z,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(1), nil_index_list())), "z"),
                     rvalue(lcm_sym165__,
                       cons_list(index_uni(i),
                         cons_list(index_uni(1), nil_index_list())),
-                      "lcm_sym165__"), (lcm_sym152__ * nu[(2 - 1)])),
-                  base_rng__), "assigning variable z");
+                      "lcm_sym165__"),
+                    (lcm_sym152__ *
+                      rvalue(nu, cons_list(index_uni(2), nil_index_list()),
+                        "nu"))), base_rng__), "assigning variable z");
               for (int t = 3; t <= n_occasions; ++t) {
                 current_statement__ = 44;
-                q = (q * (1 - z[(i - 1)][((t - 1) - 1)]));
+                q = (q *
+                      (1 -
+                        rvalue(z,
+                          cons_list(index_uni(i),
+                            cons_list(index_uni((t - 1)), nil_index_list())),
+                          "z")));
                 current_statement__ = 43;
                 assign(z,
                   cons_list(index_uni(i),
                     cons_list(index_uni(t), nil_index_list())),
                   bernoulli_rng(
-                    stan::math::fma(z[(i - 1)][((t - 1) - 1)],
+                    stan::math::fma(
+                      rvalue(z,
+                        cons_list(index_uni(i),
+                          cons_list(index_uni((t - 1)), nil_index_list())),
+                        "z"),
                       rvalue(lcm_sym165__,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
-                        "lcm_sym165__"), (q * nu[(t - 1)])), base_rng__),
-                  "assigning variable z");}
+                        "lcm_sym165__"),
+                      (q *
+                        rvalue(nu, cons_list(index_uni(t), nil_index_list()),
+                          "nu"))), base_rng__), "assigning variable z");}
             } 
           } else {
             current_statement__ = 40;
@@ -15496,11 +16520,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           
           inline_sym13__ = 0;
           for (int inline_sym14__ = 1; inline_sym14__ <= 1; ++inline_sym14__) {
-            lcm_sym168__ = size(z[(1 - 1)]);
+            lcm_sym168__ = size(
+                             rvalue(z,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "z"));
             for (int inline_sym12__ = 1; inline_sym12__ <= lcm_sym168__;
                  ++inline_sym12__) {
               current_statement__ = 60;
-              if (z[(1 - 1)][(inline_sym12__ - 1)]) {
+              if (rvalue(z,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(inline_sym12__), nil_index_list())),
+                    "z")) {
                 inline_sym13__ = 1;
                 inline_sym11__ = inline_sym12__;
                 break;
@@ -15530,11 +16560,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             inline_sym13__ = 0;
             for (int inline_sym14__ = 1; inline_sym14__ <= 1;
                  ++inline_sym14__) {
-              lcm_sym167__ = size(z[(i - 1)]);
+              lcm_sym167__ = size(
+                               rvalue(z,
+                                 cons_list(index_uni(i), nil_index_list()),
+                                 "z"));
               for (int inline_sym12__ = 1; inline_sym12__ <= lcm_sym167__;
                    ++inline_sym12__) {
                 current_statement__ = 60;
-                if (z[(i - 1)][(inline_sym12__ - 1)]) {
+                if (rvalue(z,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(inline_sym12__),
+                          nil_index_list())), "z")) {
                   inline_sym13__ = 1;
                   inline_sym11__ = inline_sym12__;
                   break;
@@ -15590,17 +16626,23 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         if (lcm_sym132__) {
           current_statement__ = 70;
           assign(Nind, cons_list(index_uni(1), nil_index_list()),
-            sum(z[(1 - 1)]), "assigning variable Nind");
+            sum(rvalue(z, cons_list(index_uni(1), nil_index_list()), "z")),
+            "assigning variable Nind");
           current_statement__ = 71;
           assign(Nalive, cons_list(index_uni(1), nil_index_list()),
-            logical_gt(Nind[(1 - 1)], 0), "assigning variable Nalive");
+            logical_gt(
+              rvalue(Nind, cons_list(index_uni(1), nil_index_list()), "Nind"),
+              0), "assigning variable Nalive");
           for (int i = 2; i <= M; ++i) {
             current_statement__ = 70;
             assign(Nind, cons_list(index_uni(i), nil_index_list()),
-              sum(z[(i - 1)]), "assigning variable Nind");
+              sum(rvalue(z, cons_list(index_uni(i), nil_index_list()), "z")),
+              "assigning variable Nind");
             current_statement__ = 71;
             assign(Nalive, cons_list(index_uni(i), nil_index_list()),
-              logical_gt(Nind[(i - 1)], 0), "assigning variable Nalive");}
+              logical_gt(
+                rvalue(Nind, cons_list(index_uni(i), nil_index_list()),
+                  "Nind"), 0), "assigning variable Nalive");}
         } 
         current_statement__ = 74;
         Nsuper = sum(Nalive);
@@ -15615,7 +16657,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym133__) {
         current_statement__ = 36;
         current_statement__ = 36;
-        check_greater_or_equal(function__, "N[sym1__]", N[(1 - 1)], 0);
+        check_greater_or_equal(function__, "N[sym1__]",
+                               rvalue(N,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "N"), 0);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 36;
           current_statement__ = 36;
@@ -15626,7 +16671,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym133__) {
         current_statement__ = 37;
         current_statement__ = 37;
-        check_greater_or_equal(function__, "B[sym1__]", B[(1 - 1)], 0);
+        check_greater_or_equal(function__, "B[sym1__]",
+                               rvalue(B,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "B"), 0);
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 37;
           current_statement__ = 37;
@@ -15640,12 +16688,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           current_statement__ = 38;
           current_statement__ = 38;
           check_greater_or_equal(function__, "z[sym1__, sym2__]",
-                                 z[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(z,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "z"), 0);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 38;
             current_statement__ = 38;
             check_greater_or_equal(function__, "z[sym1__, sym2__]",
-                                   z[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(z,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "z"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 38;
@@ -15653,7 +16707,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             current_statement__ = 38;
             current_statement__ = 38;
             check_greater_or_equal(function__, "z[sym1__, sym2__]",
-                                   z[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(z,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "z"), 0);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 38;
               current_statement__ = 38;
@@ -15668,12 +16725,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           current_statement__ = 38;
           current_statement__ = 38;
           check_less_or_equal(function__, "z[sym1__, sym2__]",
-                              z[(1 - 1)][(1 - 1)], 1);
+                              rvalue(z,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "z"), 1);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 38;
             current_statement__ = 38;
             check_less_or_equal(function__, "z[sym1__, sym2__]",
-                                z[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(z,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "z"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 38;
@@ -15681,7 +16744,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             current_statement__ = 38;
             current_statement__ = 38;
             check_less_or_equal(function__, "z[sym1__, sym2__]",
-                                z[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(z,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "z"), 1);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 38;
               current_statement__ = 38;
@@ -15692,24 +16758,35 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       vars__.emplace_back(lcm_sym169__);
       vars__.emplace_back(Nsuper);
       if (lcm_sym133__) {
-        vars__.emplace_back(N[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(N, cons_list(index_uni(1), nil_index_list()), "N"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(N[(sym1__ - 1)]);}
       } 
       if (lcm_sym133__) {
-        vars__.emplace_back(B[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(B, cons_list(index_uni(1), nil_index_list()), "B"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(B[(sym1__ - 1)]);}
       } 
       if (lcm_sym133__) {
         if (lcm_sym132__) {
-          vars__.emplace_back(z[(1 - 1)][(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(z,
+              cons_list(index_uni(1),
+                cons_list(index_uni(1), nil_index_list())), "z"));
           for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
-            vars__.emplace_back(z[(sym2__ - 1)][(1 - 1)]);}
+            vars__.emplace_back(
+              rvalue(z,
+                cons_list(index_uni(sym2__),
+                  cons_list(index_uni(1), nil_index_list())), "z"));}
         } 
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           if (lcm_sym132__) {
-            vars__.emplace_back(z[(1 - 1)][(sym1__ - 1)]);
+            vars__.emplace_back(
+              rvalue(z,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(sym1__), nil_index_list())), "z"));
             for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
               vars__.emplace_back(z[(sym2__ - 1)][(sym1__ - 1)]);}
           } }
@@ -15795,7 +16872,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         if (lcm_sym117__) {
           current_statement__ = 4;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            beta_flat__[(1 - 1)], "assigning variable beta");
+            rvalue(beta_flat__, cons_list(index_uni(1), nil_index_list()),
+              "beta_flat__"), "assigning variable beta");
           current_statement__ = 4;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
@@ -15814,8 +16892,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       if (lcm_sym117__) {
         current_statement__ = 4;
         assign(beta_free__, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lb_free(beta[(1 - 1)], 0),
-          "assigning variable beta_free__");
+          stan::math::lb_free(
+            rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+            0), "assigning variable beta_free__");
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 4;
           assign(beta_free__, cons_list(index_uni(sym1__), nil_index_list()),
@@ -15837,7 +16916,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         if (lcm_sym116__) {
           current_statement__ = 5;
           assign(epsilon, cons_list(index_uni(1), nil_index_list()),
-            epsilon_flat__[(1 - 1)], "assigning variable epsilon");
+            rvalue(epsilon_flat__, cons_list(index_uni(1), nil_index_list()),
+              "epsilon_flat__"), "assigning variable epsilon");
           current_statement__ = 5;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
@@ -15862,12 +16942,16 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       vars__.emplace_back(mean_p_free__);
       vars__.emplace_back(psi_free__);
       if (lcm_sym117__) {
-        vars__.emplace_back(beta_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta_free__, cons_list(index_uni(1), nil_index_list()),
+            "beta_free__"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(beta_free__[(sym1__ - 1)]);}
       } 
       if (lcm_sym116__) {
-        vars__.emplace_back(epsilon[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(epsilon, cons_list(index_uni(1), nil_index_list()),
+            "epsilon"));
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
@@ -16376,7 +17460,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 26;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
@@ -16419,12 +17504,18 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           current_statement__ = 26;
           current_statement__ = 26;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 1);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 1);
           for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
             current_statement__ = 26;
             current_statement__ = 26;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 1);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
           current_statement__ = 26;
@@ -16432,7 +17523,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             current_statement__ = 26;
             current_statement__ = 26;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 1);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 1);
             for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
               current_statement__ = 26;
               current_statement__ = 26;
@@ -16447,12 +17541,18 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           current_statement__ = 26;
           current_statement__ = 26;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], K);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), K);
           for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
             current_statement__ = 26;
             current_statement__ = 26;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], K);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), K);}
         } 
         for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
           current_statement__ = 26;
@@ -16460,7 +17560,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             current_statement__ = 26;
             current_statement__ = 26;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], K);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), K);
             for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
               current_statement__ = 26;
               current_statement__ = 26;
@@ -16487,7 +17590,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         if (lcm_sym79__) {
           current_statement__ = 28;
           assign(alpha, cons_list(index_uni(1), nil_index_list()),
-            alpha_flat__[(1 - 1)], "assigning variable alpha");
+            rvalue(alpha_flat__, cons_list(index_uni(1), nil_index_list()),
+              "alpha_flat__"), "assigning variable alpha");
           current_statement__ = 28;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
@@ -16502,7 +17606,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       if (lcm_sym79__) {
         current_statement__ = 28;
         current_statement__ = 28;
-        check_greater_or_equal(function__, "alpha[sym1__]", alpha[(1 - 1)], 0);
+        check_greater_or_equal(function__, "alpha[sym1__]",
+                               rvalue(alpha,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "alpha"), 0);
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
           current_statement__ = 28;
           current_statement__ = 28;
@@ -16534,7 +17641,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             assign(beta,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              beta_flat__[(1 - 1)], "assigning variable beta");
+              rvalue(beta_flat__, cons_list(index_uni(1), nil_index_list()),
+                "beta_flat__"), "assigning variable beta");
             current_statement__ = 31;
             pos__ = 2;
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
@@ -16574,12 +17682,18 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           current_statement__ = 31;
           current_statement__ = 31;
           check_greater_or_equal(function__, "beta[sym1__, sym2__]",
-                                 beta[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(beta,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "beta"), 0);
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
             current_statement__ = 31;
             current_statement__ = 31;
             check_greater_or_equal(function__, "beta[sym1__, sym2__]",
-                                   beta[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(beta,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "beta"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
           current_statement__ = 31;
@@ -16587,7 +17701,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             current_statement__ = 31;
             current_statement__ = 31;
             check_greater_or_equal(function__, "beta[sym1__, sym2__]",
-                                   beta[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(beta,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "beta"), 0);
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               current_statement__ = 31;
               current_statement__ = 31;
@@ -16731,14 +17848,20 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             assign(theta,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              stan::math::simplex_constrain(theta_in__[(1 - 1)][(1 - 1)],
+              stan::math::simplex_constrain(
+                rvalue(theta_in__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(1), nil_index_list())), "theta_in__"),
                 lp__), "assigning variable theta");
           } else {
             current_statement__ = 2;
             assign(theta,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              stan::math::simplex_constrain(theta_in__[(1 - 1)][(1 - 1)]),
+              stan::math::simplex_constrain(
+                rvalue(theta_in__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(1), nil_index_list())), "theta_in__")),
               "assigning variable theta");
           }
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
@@ -16749,16 +17872,20 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                 cons_list(index_uni(1),
                   cons_list(index_uni(sym2__), nil_index_list())),
                 stan::math::simplex_constrain(
-                  theta_in__[(1 - 1)][(sym2__ - 1)], lp__),
-                "assigning variable theta");
+                  rvalue(theta_in__,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(sym2__), nil_index_list())),
+                    "theta_in__"), lp__), "assigning variable theta");
             } else {
               current_statement__ = 2;
               assign(theta,
                 cons_list(index_uni(1),
                   cons_list(index_uni(sym2__), nil_index_list())),
                 stan::math::simplex_constrain(
-                  theta_in__[(1 - 1)][(sym2__ - 1)]),
-                "assigning variable theta");
+                  rvalue(theta_in__,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(sym2__), nil_index_list())),
+                    "theta_in__")), "assigning variable theta");
             }}
         } 
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
@@ -16771,16 +17898,20 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(1), nil_index_list())),
                 stan::math::simplex_constrain(
-                  theta_in__[(sym1__ - 1)][(1 - 1)], lp__),
-                "assigning variable theta");
+                  rvalue(theta_in__,
+                    cons_list(index_uni(sym1__),
+                      cons_list(index_uni(1), nil_index_list())),
+                    "theta_in__"), lp__), "assigning variable theta");
             } else {
               current_statement__ = 2;
               assign(theta,
                 cons_list(index_uni(sym1__),
                   cons_list(index_uni(1), nil_index_list())),
                 stan::math::simplex_constrain(
-                  theta_in__[(sym1__ - 1)][(1 - 1)]),
-                "assigning variable theta");
+                  rvalue(theta_in__,
+                    cons_list(index_uni(sym1__),
+                      cons_list(index_uni(1), nil_index_list())),
+                    "theta_in__")), "assigning variable theta");
             }
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               current_statement__ = 2;
@@ -16812,26 +17943,42 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           if (lcm_sym56__) {
             current_statement__ = 11;
             lp_accum__.add(
-              dirichlet_lpdf<propto__>(theta[(1 - 1)][(1 - 1)],
-                beta[(1 - 1)]));
+              dirichlet_lpdf<propto__>(
+                rvalue(theta,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(1), nil_index_list())), "theta"),
+                rvalue(beta, cons_list(index_uni(1), nil_index_list()),
+                  "beta")));
             for (int k = 2; k <= K; ++k) {
               current_statement__ = 11;
               lp_accum__.add(
-                dirichlet_lpdf<propto__>(theta[(1 - 1)][(k - 1)],
-                  beta[(k - 1)]));}
+                dirichlet_lpdf<propto__>(
+                  rvalue(theta,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(k), nil_index_list())), "theta"),
+                  rvalue(beta, cons_list(index_uni(k), nil_index_list()),
+                    "beta")));}
           } 
           for (int j = 2; j <= J; ++j) {
             current_statement__ = 12;
             if (lcm_sym56__) {
               current_statement__ = 11;
               lp_accum__.add(
-                dirichlet_lpdf<propto__>(theta[(j - 1)][(1 - 1)],
-                  beta[(1 - 1)]));
+                dirichlet_lpdf<propto__>(
+                  rvalue(theta,
+                    cons_list(index_uni(j),
+                      cons_list(index_uni(1), nil_index_list())), "theta"),
+                  rvalue(beta, cons_list(index_uni(1), nil_index_list()),
+                    "beta")));
               for (int k = 2; k <= K; ++k) {
                 current_statement__ = 11;
                 lp_accum__.add(
-                  dirichlet_lpdf<propto__>(theta[(j - 1)][(k - 1)],
-                    beta[(k - 1)]));}
+                  dirichlet_lpdf<propto__>(
+                    rvalue(theta,
+                      cons_list(index_uni(j),
+                        cons_list(index_uni(k), nil_index_list())), "theta"),
+                    rvalue(beta, cons_list(index_uni(k), nil_index_list()),
+                      "beta")));}
             } }
         } 
         current_statement__ = 20;
@@ -16856,7 +18003,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                     rvalue(theta,
                       cons_list(index_uni(1),
                         cons_list(index_omni(),
-                          cons_list(index_uni(y[(1 - 1)][(1 - 1)]),
+                          cons_list(
+                            index_uni(rvalue(y,
+                                        cons_list(index_uni(1),
+                                          cons_list(index_uni(1),
+                                            nil_index_list())), "y")),
                             nil_index_list()))), "theta")))),
               "assigning variable log_q");
             for (int j = 2; j <= J; ++j) {
@@ -16868,7 +18019,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                       rvalue(theta,
                         cons_list(index_uni(j),
                           cons_list(index_omni(),
-                            cons_list(index_uni(y[(1 - 1)][(j - 1)]),
+                            cons_list(
+                              index_uni(rvalue(y,
+                                          cons_list(index_uni(1),
+                                            cons_list(index_uni(j),
+                                              nil_index_list())), "y")),
                               nil_index_list()))), "theta")))),
                 "assigning variable log_q");}
           } 
@@ -16894,7 +18049,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                       rvalue(theta,
                         cons_list(index_uni(1),
                           cons_list(index_omni(),
-                            cons_list(index_uni(y[(i - 1)][(1 - 1)]),
+                            cons_list(
+                              index_uni(rvalue(y,
+                                          cons_list(index_uni(i),
+                                            cons_list(index_uni(1),
+                                              nil_index_list())), "y")),
                               nil_index_list()))), "theta")))),
                 "assigning variable log_q");
               for (int j = 2; j <= J; ++j) {
@@ -16906,7 +18065,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                         rvalue(theta,
                           cons_list(index_uni(j),
                             cons_list(index_omni(),
-                              cons_list(index_uni(y[(i - 1)][(j - 1)]),
+                              cons_list(
+                                index_uni(rvalue(y,
+                                            cons_list(index_uni(i),
+                                              cons_list(index_uni(j),
+                                                nil_index_list())), "y")),
                                 nil_index_list()))), "theta")))),
                   "assigning variable log_q");}
             } 
@@ -17041,15 +18204,21 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           assign(theta,
             cons_list(index_uni(1),
               cons_list(index_uni(1), nil_index_list())),
-            stan::math::simplex_constrain(theta_in__[(1 - 1)][(1 - 1)]),
+            stan::math::simplex_constrain(
+              rvalue(theta_in__,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(1), nil_index_list())), "theta_in__")),
             "assigning variable theta");
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
             current_statement__ = 2;
             assign(theta,
               cons_list(index_uni(1),
                 cons_list(index_uni(sym2__), nil_index_list())),
-              stan::math::simplex_constrain(theta_in__[(1 - 1)][(sym2__ - 1)]),
-              "assigning variable theta");}
+              stan::math::simplex_constrain(
+                rvalue(theta_in__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(sym2__), nil_index_list())),
+                  "theta_in__")), "assigning variable theta");}
         } 
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           current_statement__ = 2;
@@ -17058,7 +18227,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             assign(theta,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(1), nil_index_list())),
-              stan::math::simplex_constrain(theta_in__[(sym1__ - 1)][(1 - 1)]),
+              stan::math::simplex_constrain(
+                rvalue(theta_in__,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(1), nil_index_list())), "theta_in__")),
               "assigning variable theta");
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               current_statement__ = 2;
@@ -17071,37 +18243,68 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           } }
       } 
       if (lcm_sym26__) {
-        vars__.emplace_back(pi[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(pi, cons_list(index_uni(1), nil_index_list()), "pi"));
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
           vars__.emplace_back(pi[(sym1__ - 1)]);}
       } 
       if (lcm_sym26__) {
         if (lcm_sym26__) {
           if (lcm_sym25__) {
-            vars__.emplace_back(theta[(1 - 1)][(1 - 1)][(1 - 1)]);
+            vars__.emplace_back(
+              rvalue(theta,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(1), nil_index_list()))), "theta"));
             for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
-              vars__.emplace_back(theta[(sym3__ - 1)][(1 - 1)][(1 - 1)]);}
+              vars__.emplace_back(
+                rvalue(theta,
+                  cons_list(index_uni(sym3__),
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(1), nil_index_list()))), "theta"));
+            }
           } 
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
             if (lcm_sym25__) {
-              vars__.emplace_back(theta[(1 - 1)][(sym2__ - 1)][(1 - 1)]);
+              vars__.emplace_back(
+                rvalue(theta,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(sym2__),
+                      cons_list(index_uni(1), nil_index_list()))), "theta"));
               for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
                 vars__.emplace_back(
-                  theta[(sym3__ - 1)][(sym2__ - 1)][(1 - 1)]);}
+                  rvalue(theta,
+                    cons_list(index_uni(sym3__),
+                      cons_list(index_uni(sym2__),
+                        cons_list(index_uni(1), nil_index_list()))), "theta"));
+              }
             } }
         } 
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
           if (lcm_sym26__) {
             if (lcm_sym25__) {
-              vars__.emplace_back(theta[(1 - 1)][(1 - 1)][(sym1__ - 1)]);
+              vars__.emplace_back(
+                rvalue(theta,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(sym1__), nil_index_list()))),
+                  "theta"));
               for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
                 vars__.emplace_back(
-                  theta[(sym3__ - 1)][(1 - 1)][(sym1__ - 1)]);}
+                  rvalue(theta,
+                    cons_list(index_uni(sym3__),
+                      cons_list(index_uni(1),
+                        cons_list(index_uni(sym1__), nil_index_list()))),
+                    "theta"));}
             } 
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               if (lcm_sym25__) {
                 vars__.emplace_back(
-                  theta[(1 - 1)][(sym2__ - 1)][(sym1__ - 1)]);
+                  rvalue(theta,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(sym2__),
+                        cons_list(index_uni(sym1__), nil_index_list()))),
+                    "theta"));
                 for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
                   vars__.emplace_back(
                     theta[(sym3__ - 1)][(sym2__ - 1)][(sym1__ - 1)]);}
@@ -17141,7 +18344,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                   rvalue(theta,
                     cons_list(index_uni(1),
                       cons_list(index_omni(),
-                        cons_list(index_uni(y[(1 - 1)][(1 - 1)]),
+                        cons_list(
+                          index_uni(rvalue(y,
+                                      cons_list(index_uni(1),
+                                        cons_list(index_uni(1),
+                                          nil_index_list())), "y")),
                           nil_index_list()))), "theta")))),
             "assigning variable log_q");
           for (int j = 2; j <= J; ++j) {
@@ -17153,7 +18360,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                     rvalue(theta,
                       cons_list(index_uni(j),
                         cons_list(index_omni(),
-                          cons_list(index_uni(y[(1 - 1)][(j - 1)]),
+                          cons_list(
+                            index_uni(rvalue(y,
+                                        cons_list(index_uni(1),
+                                          cons_list(index_uni(j),
+                                            nil_index_list())), "y")),
                             nil_index_list()))), "theta")))),
               "assigning variable log_q");}
         } 
@@ -17180,7 +18391,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                     rvalue(theta,
                       cons_list(index_uni(1),
                         cons_list(index_omni(),
-                          cons_list(index_uni(y[(i - 1)][(1 - 1)]),
+                          cons_list(
+                            index_uni(rvalue(y,
+                                        cons_list(index_uni(i),
+                                          cons_list(index_uni(1),
+                                            nil_index_list())), "y")),
                             nil_index_list()))), "theta")))),
               "assigning variable log_q");
             for (int j = 2; j <= J; ++j) {
@@ -17192,7 +18407,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                       rvalue(theta,
                         cons_list(index_uni(j),
                           cons_list(index_omni(),
-                            cons_list(index_uni(y[(i - 1)][(j - 1)]),
+                            cons_list(
+                              index_uni(rvalue(y,
+                                          cons_list(index_uni(i),
+                                            cons_list(index_uni(j),
+                                              nil_index_list())), "y")),
                               nil_index_list()))), "theta")))),
                 "assigning variable log_q");}
           } 
@@ -17203,13 +18422,23 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       } 
       if (lcm_sym26__) {
         if (lcm_sym24__) {
-          vars__.emplace_back(log_Pr_z[(1 - 1)][(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(log_Pr_z,
+              cons_list(index_uni(1),
+                cons_list(index_uni(1), nil_index_list())), "log_Pr_z"));
           for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-            vars__.emplace_back(log_Pr_z[(sym2__ - 1)][(1 - 1)]);}
+            vars__.emplace_back(
+              rvalue(log_Pr_z,
+                cons_list(index_uni(sym2__),
+                  cons_list(index_uni(1), nil_index_list())), "log_Pr_z"));}
         } 
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
           if (lcm_sym24__) {
-            vars__.emplace_back(log_Pr_z[(1 - 1)][(sym1__ - 1)]);
+            vars__.emplace_back(
+              rvalue(log_Pr_z,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(sym1__), nil_index_list())),
+                "log_Pr_z"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
               vars__.emplace_back(log_Pr_z[(sym2__ - 1)][(sym1__ - 1)]);}
           } }
@@ -17275,7 +18504,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         if (lcm_sym2__) {
           current_statement__ = 1;
           assign(pi, cons_list(index_uni(1), nil_index_list()),
-            pi_flat__[(1 - 1)], "assigning variable pi");
+            rvalue(pi_flat__, cons_list(index_uni(1), nil_index_list()),
+              "pi_flat__"), "assigning variable pi");
           current_statement__ = 1;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
@@ -17317,7 +18547,9 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                     cons_list(index_uni(1),
                       cons_list(index_uni(1),
                         cons_list(index_uni(1), nil_index_list()))),
-                    theta_flat__[(1 - 1)], "assigning variable theta");
+                    rvalue(theta_flat__,
+                      cons_list(index_uni(1), nil_index_list()),
+                      "theta_flat__"), "assigning variable theta");
                   current_statement__ = 2;
                   pos__ = 2;
                   for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
@@ -17418,14 +18650,20 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           assign(theta_free__,
             cons_list(index_uni(1),
               cons_list(index_uni(1), nil_index_list())),
-            stan::math::simplex_free(theta[(1 - 1)][(1 - 1)]),
+            stan::math::simplex_free(
+              rvalue(theta,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(1), nil_index_list())), "theta")),
             "assigning variable theta_free__");
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
             current_statement__ = 2;
             assign(theta_free__,
               cons_list(index_uni(1),
                 cons_list(index_uni(sym2__), nil_index_list())),
-              stan::math::simplex_free(theta[(1 - 1)][(sym2__ - 1)]),
+              stan::math::simplex_free(
+                rvalue(theta,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(sym2__), nil_index_list())), "theta")),
               "assigning variable theta_free__");}
         } 
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
@@ -17435,7 +18673,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             assign(theta_free__,
               cons_list(index_uni(sym1__),
                 cons_list(index_uni(1), nil_index_list())),
-              stan::math::simplex_free(theta[(sym1__ - 1)][(1 - 1)]),
+              stan::math::simplex_free(
+                rvalue(theta,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(1), nil_index_list())), "theta")),
               "assigning variable theta_free__");
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               current_statement__ = 2;
@@ -17449,40 +18690,71 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       lcm_sym4__ = (K - 1);
       lcm_sym3__ = logical_gte(lcm_sym4__, 1);
       if (lcm_sym3__) {
-        vars__.emplace_back(pi_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(pi_free__, cons_list(index_uni(1), nil_index_list()),
+            "pi_free__"));
         for (int sym1__ = 2; sym1__ <= lcm_sym4__; ++sym1__) {
           vars__.emplace_back(pi_free__[(sym1__ - 1)]);}
       } 
       if (lcm_sym1__) {
         if (lcm_sym2__) {
           if (lcm_sym3__) {
-            vars__.emplace_back(theta_free__[(1 - 1)][(1 - 1)][(1 - 1)]);
+            vars__.emplace_back(
+              rvalue(theta_free__,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(1), nil_index_list()))),
+                "theta_free__"));
             for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
               vars__.emplace_back(
-                theta_free__[(1 - 1)][(1 - 1)][(sym3__ - 1)]);}
+                rvalue(theta_free__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(sym3__), nil_index_list()))),
+                  "theta_free__"));}
           } 
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
             if (lcm_sym3__) {
               vars__.emplace_back(
-                theta_free__[(1 - 1)][(sym2__ - 1)][(1 - 1)]);
+                rvalue(theta_free__,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni(sym2__),
+                      cons_list(index_uni(1), nil_index_list()))),
+                  "theta_free__"));
               for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
                 vars__.emplace_back(
-                  theta_free__[(1 - 1)][(sym2__ - 1)][(sym3__ - 1)]);}
+                  rvalue(theta_free__,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(sym2__),
+                        cons_list(index_uni(sym3__), nil_index_list()))),
+                    "theta_free__"));}
             } }
         } 
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           if (lcm_sym2__) {
             if (lcm_sym3__) {
               vars__.emplace_back(
-                theta_free__[(sym1__ - 1)][(1 - 1)][(1 - 1)]);
+                rvalue(theta_free__,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(1), nil_index_list()))),
+                  "theta_free__"));
               for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
                 vars__.emplace_back(
-                  theta_free__[(sym1__ - 1)][(1 - 1)][(sym3__ - 1)]);}
+                  rvalue(theta_free__,
+                    cons_list(index_uni(sym1__),
+                      cons_list(index_uni(1),
+                        cons_list(index_uni(sym3__), nil_index_list()))),
+                    "theta_free__"));}
             } 
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
               if (lcm_sym3__) {
                 vars__.emplace_back(
-                  theta_free__[(sym1__ - 1)][(sym2__ - 1)][(1 - 1)]);
+                  rvalue(theta_free__,
+                    cons_list(index_uni(sym1__),
+                      cons_list(index_uni(sym2__),
+                        cons_list(index_uni(1), nil_index_list()))),
+                    "theta_free__"));
                 for (int sym3__ = 2; sym3__ <= lcm_sym4__; ++sym3__) {
                   vars__.emplace_back(
                     theta_free__[(sym1__ - 1)][(sym2__ - 1)][(sym3__ - 1)]);}
@@ -17829,7 +19101,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       if (lcm_sym26__) {
         current_statement__ = 15;
         current_statement__ = 15;
-        check_greater_or_equal(function__, "node1[sym1__]", node1[(1 - 1)], 1);
+        check_greater_or_equal(function__, "node1[sym1__]",
+                               rvalue(node1,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "node1"), 1);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 15;
           current_statement__ = 15;
@@ -17840,7 +19115,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       if (lcm_sym26__) {
         current_statement__ = 15;
         current_statement__ = 15;
-        check_less_or_equal(function__, "node1[sym1__]", node1[(1 - 1)], N);
+        check_less_or_equal(function__, "node1[sym1__]",
+                            rvalue(node1,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "node1"), N);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 15;
           current_statement__ = 15;
@@ -17861,7 +19139,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       if (lcm_sym26__) {
         current_statement__ = 17;
         current_statement__ = 17;
-        check_greater_or_equal(function__, "node2[sym1__]", node2[(1 - 1)], 1);
+        check_greater_or_equal(function__, "node2[sym1__]",
+                               rvalue(node2,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "node2"), 1);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 17;
           current_statement__ = 17;
@@ -17872,7 +19153,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       if (lcm_sym26__) {
         current_statement__ = 17;
         current_statement__ = 17;
-        check_less_or_equal(function__, "node2[sym1__]", node2[(1 - 1)], N);
+        check_less_or_equal(function__, "node2[sym1__]",
+                            rvalue(node2,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "node2"), N);
         for (int sym1__ = 2; sym1__ <= N_edges; ++sym1__) {
           current_statement__ = 17;
           current_statement__ = 17;
@@ -17893,7 +19177,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       if (lcm_sym25__) {
         current_statement__ = 19;
         current_statement__ = 19;
-        check_greater_or_equal(function__, "y[sym1__]", y[(1 - 1)], 0);
+        check_greater_or_equal(function__, "y[sym1__]",
+                               rvalue(y,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "y"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 19;
           current_statement__ = 19;
@@ -17919,7 +19206,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         if (lcm_sym25__) {
           current_statement__ = 21;
           assign(x, cons_list(index_uni(1), nil_index_list()),
-            x_flat__[(1 - 1)], "assigning variable x");
+            rvalue(x_flat__, cons_list(index_uni(1), nil_index_list()),
+              "x_flat__"), "assigning variable x");
           current_statement__ = 21;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -18142,12 +19430,16 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       vars__.emplace_back(tau_phi);
       lcm_sym11__ = logical_gte(N, 1);
       if (lcm_sym11__) {
-        vars__.emplace_back(theta_std[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(theta_std, cons_list(index_uni(1), nil_index_list()),
+            "theta_std"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(theta_std[(sym1__ - 1)]);}
       } 
       if (lcm_sym11__) {
-        vars__.emplace_back(phi_std_raw[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(phi_std_raw, cons_list(index_uni(1), nil_index_list()),
+            "phi_std_raw"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(phi_std_raw[(sym1__ - 1)]);}
       } 
@@ -18170,7 +19462,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       if (emit_transformed_parameters__) {
         vars__.emplace_back(lcm_sym15__);
         if (lcm_sym11__) {
-          vars__.emplace_back(phi[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(phi, cons_list(index_uni(1), nil_index_list()), "phi"));
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
             vars__.emplace_back(phi[(sym1__ - 1)]);}
         } 
@@ -18257,7 +19550,9 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         if (lcm_sym1__) {
           current_statement__ = 5;
           assign(theta_std, cons_list(index_uni(1), nil_index_list()),
-            theta_std_flat__[(1 - 1)], "assigning variable theta_std");
+            rvalue(theta_std_flat__,
+              cons_list(index_uni(1), nil_index_list()), "theta_std_flat__"),
+            "assigning variable theta_std");
           current_statement__ = 5;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -18284,7 +19579,9 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         if (lcm_sym1__) {
           current_statement__ = 6;
           assign(phi_std_raw, cons_list(index_uni(1), nil_index_list()),
-            phi_std_raw_flat__[(1 - 1)], "assigning variable phi_std_raw");
+            rvalue(phi_std_raw_flat__,
+              cons_list(index_uni(1), nil_index_list()),
+              "phi_std_raw_flat__"), "assigning variable phi_std_raw");
           current_statement__ = 6;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -18302,12 +19599,16 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       vars__.emplace_back(tau_theta_free__);
       vars__.emplace_back(tau_phi_free__);
       if (lcm_sym1__) {
-        vars__.emplace_back(theta_std[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(theta_std, cons_list(index_uni(1), nil_index_list()),
+            "theta_std"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(theta_std[(sym1__ - 1)]);}
       } 
       if (lcm_sym1__) {
-        vars__.emplace_back(phi_std_raw[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(phi_std_raw, cons_list(index_uni(1), nil_index_list()),
+            "phi_std_raw"));
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           vars__.emplace_back(phi_std_raw[(sym1__ - 1)]);}
       } 
@@ -18621,13 +19922,13 @@ first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       lcm_sym27__ = size(y_i);
       if (logical_gte(lcm_sym27__, 1)) {
         current_statement__ = 45;
-        if (y_i[(1 - 1)]) {
+        if (rvalue(y_i, cons_list(index_uni(1), nil_index_list()), "y_i")) {
           current_statement__ = 44;
           return 1;
         } 
         for (int k = 2; k <= lcm_sym27__; ++k) {
           current_statement__ = 45;
-          if (y_i[(k - 1)]) {
+          if (rvalue(y_i, cons_list(index_uni(k), nil_index_list()), "y_i")) {
             current_statement__ = 44;
             return k;
           } }
@@ -19055,7 +20356,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 35;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= nind; ++sym2__) {
@@ -19098,12 +20400,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 0);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 35;
@@ -19111,7 +20419,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 0);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -19126,12 +20437,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], 1);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), 1);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 35;
@@ -19139,7 +20456,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), 1);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -19181,7 +20501,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             assign(x,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              x_flat__[(1 - 1)], "assigning variable x");
+              rvalue(x_flat__, cons_list(index_uni(1), nil_index_list()),
+                "x_flat__"), "assigning variable x");
             current_statement__ = 38;
             pos__ = 2;
             for (int sym2__ = 2; sym2__ <= nind; ++sym2__) {
@@ -19221,12 +20542,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           current_statement__ = 38;
           current_statement__ = 38;
           check_greater_or_equal(function__, "x[sym1__, sym2__]",
-                                 x[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(x,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "x"), 0);
           for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
             current_statement__ = 38;
             current_statement__ = 38;
             check_greater_or_equal(function__, "x[sym1__, sym2__]",
-                                   x[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(x,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "x"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 38;
@@ -19234,7 +20561,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             current_statement__ = 38;
             current_statement__ = 38;
             check_greater_or_equal(function__, "x[sym1__, sym2__]",
-                                   x[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(x,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "x"), 0);
             for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
               current_statement__ = 38;
               current_statement__ = 38;
@@ -19249,12 +20579,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           current_statement__ = 38;
           current_statement__ = 38;
           check_less_or_equal(function__, "x[sym1__, sym2__]",
-                              x[(1 - 1)][(1 - 1)], max_age);
+                              rvalue(x,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "x"), max_age);
           for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
             current_statement__ = 38;
             current_statement__ = 38;
             check_less_or_equal(function__, "x[sym1__, sym2__]",
-                                x[(1 - 1)][(sym2__ - 1)], max_age);}
+                                rvalue(x,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "x"), max_age);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 38;
@@ -19262,7 +20598,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             current_statement__ = 38;
             current_statement__ = 38;
             check_less_or_equal(function__, "x[sym1__, sym2__]",
-                                x[(sym1__ - 1)][(1 - 1)], max_age);
+                                rvalue(x,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "x"), max_age);
             for (int sym2__ = 2; sym2__ <= lcm_sym166__; ++sym2__) {
               current_statement__ = 38;
               current_statement__ = 38;
@@ -19293,11 +20632,14 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym173__ = size(y[(1 - 1)]);
+          lcm_sym173__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym173__;
                ++inline_sym18__) {
             current_statement__ = 45;
-            if (y[(1 - 1)][(inline_sym18__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (inline_sym18__ - 1)]) {
               inline_sym19__ = 1;
               inline_sym17__ = inline_sym18__;
               break;
@@ -19317,11 +20659,15 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym172__ = size(y[(i - 1)]);
+            lcm_sym172__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym172__;
                  ++inline_sym18__) {
               current_statement__ = 45;
-              if (y[(i - 1)][(inline_sym18__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (inline_sym18__ - 1)]) {
                 inline_sym19__ = 1;
                 inline_sym17__ = inline_sym18__;
                 break;
@@ -19343,7 +20689,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym173__ = size(y[(1 - 1)]);
+          lcm_sym173__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           lcm_sym170__ = (lcm_sym173__ - 1);
           for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym170__;
                ++inline_sym23__) {
@@ -19353,7 +20701,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             lcm_sym169__ = (lcm_sym173__ - inline_sym23__);
             inline_sym22__ = lcm_sym169__;
             current_statement__ = 51;
-            if (y[(1 - 1)][(lcm_sym169__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (lcm_sym169__ - 1)]) {
               inline_sym24__ = 1;
               inline_sym21__ = lcm_sym169__;
               break;
@@ -19373,7 +20722,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym172__ = size(y[(i - 1)]);
+            lcm_sym172__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             lcm_sym168__ = (lcm_sym172__ - 1);
             for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym168__;
                  ++inline_sym23__) {
@@ -19383,7 +20735,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               lcm_sym167__ = (lcm_sym172__ - inline_sym23__);
               inline_sym22__ = lcm_sym167__;
               current_statement__ = 51;
-              if (y[(i - 1)][(lcm_sym167__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (lcm_sym167__ - 1)]) {
                 inline_sym24__ = 1;
                 inline_sym21__ = lcm_sym167__;
                 break;
@@ -19401,7 +20754,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       if (lcm_sym164__) {
         current_statement__ = 41;
         current_statement__ = 41;
-        check_greater_or_equal(function__, "first[sym1__]", first[(1 - 1)], 0);
+        check_greater_or_equal(function__, "first[sym1__]",
+                               rvalue(first,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "first"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 41;
           current_statement__ = 41;
@@ -19412,8 +20768,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       if (lcm_sym164__) {
         current_statement__ = 41;
         current_statement__ = 41;
-        check_less_or_equal(function__, "first[sym1__]", first[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "first[sym1__]",
+                            rvalue(first,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "first"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 41;
           current_statement__ = 41;
@@ -19424,7 +20782,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       if (lcm_sym164__) {
         current_statement__ = 43;
         current_statement__ = 43;
-        check_greater_or_equal(function__, "last[sym1__]", last[(1 - 1)], 0);
+        check_greater_or_equal(function__, "last[sym1__]",
+                               rvalue(last,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "last"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 43;
           current_statement__ = 43;
@@ -19435,8 +20796,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       if (lcm_sym164__) {
         current_statement__ = 43;
         current_statement__ = 43;
-        check_less_or_equal(function__, "last[sym1__]", last[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "last[sym1__]",
+                            rvalue(last,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "last"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 43;
           current_statement__ = 43;
@@ -19572,13 +20935,15 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         if (jacobian__) {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lub_constrain(beta[(1 - 1)], 0, 1, lp__),
-            "assigning variable beta");
+            stan::math::lub_constrain(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              0, 1, lp__), "assigning variable beta");
         } else {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lub_constrain(beta[(1 - 1)], 0, 1),
-            "assigning variable beta");
+            stan::math::lub_constrain(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              0, 1), "assigning variable beta");
         }
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
@@ -19608,7 +20973,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       
       lcm_sym107__ = logical_gte(nind, 1);
       if (lcm_sym107__) {
-        lcm_sym148__ = first[(1 - 1)];
+        lcm_sym148__ = rvalue(first,
+                         cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym120__ = (lcm_sym148__ - 1);
         if (logical_gte(lcm_sym120__, 1)) {
           current_statement__ = 6;
@@ -19639,8 +21005,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           assign(phi,
             cons_list(index_uni(1),
               cons_list(index_uni(lcm_sym148__), nil_index_list())),
-            beta[(x[(1 - 1)][(lcm_sym148__ - 1)] - 1)],
-            "assigning variable phi");
+            rvalue(beta,
+              cons_list(
+                index_uni(rvalue(x,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(lcm_sym148__),
+                                nil_index_list())), "x")), nil_index_list()),
+              "beta"), "assigning variable phi");
           lcm_sym126__ = (lcm_sym148__ + 1);
           assign(p,
             cons_list(index_uni(1),
@@ -19651,7 +21022,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             assign(phi,
               cons_list(index_uni(1),
                 cons_list(index_uni(t), nil_index_list())),
-              beta[(x[(1 - 1)][(t - 1)] - 1)], "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(1),
+                                cons_list(index_uni(t), nil_index_list())),
+                              "x")), nil_index_list()), "beta"),
+              "assigning variable phi");
             current_statement__ = 10;
             assign(p,
               cons_list(index_uni(1),
@@ -19659,7 +21036,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym147__ = first[(i - 1)];
+          lcm_sym147__ = rvalue(first,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "first");
           lcm_sym119__ = (lcm_sym147__ - 1);
           if (logical_gte(lcm_sym119__, 1)) {
             current_statement__ = 6;
@@ -19690,8 +21069,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             assign(phi,
               cons_list(index_uni(i),
                 cons_list(index_uni(lcm_sym147__), nil_index_list())),
-              beta[(x[(i - 1)][(lcm_sym147__ - 1)] - 1)],
-              "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(i),
+                                cons_list(index_uni(lcm_sym147__),
+                                  nil_index_list())), "x")),
+                  nil_index_list()), "beta"), "assigning variable phi");
             lcm_sym125__ = (lcm_sym147__ + 1);
             assign(p,
               cons_list(index_uni(i),
@@ -19702,7 +21086,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               assign(phi,
                 cons_list(index_uni(i),
                   cons_list(index_uni(t), nil_index_list())),
-                beta[(x[(i - 1)][(t - 1)] - 1)], "assigning variable phi");
+                rvalue(beta,
+                  cons_list(
+                    index_uni(rvalue(x,
+                                cons_list(index_uni(i),
+                                  cons_list(index_uni(t), nil_index_list())),
+                                "x")), nil_index_list()), "beta"),
+                "assigning variable phi");
               current_statement__ = 10;
               assign(p,
                 cons_list(index_uni(i),
@@ -20060,9 +21450,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       {
         current_statement__ = 30;
         if (lcm_sym107__) {
-          lcm_sym148__ = first[(1 - 1)];
+          lcm_sym148__ = rvalue(first,
+                           cons_list(index_uni(1), nil_index_list()),
+                           "first");
           if (logical_gt(lcm_sym148__, 0)) {
-            lcm_sym154__ = last[(1 - 1)];
+            lcm_sym154__ = rvalue(last,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "last");
             lcm_sym126__ = (lcm_sym148__ + 1);
             if (logical_gte(lcm_sym154__, lcm_sym126__)) {
               current_statement__ = 24;
@@ -20074,7 +21468,11 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                         nil_index_list())), "phi")));
               lcm_sym124__ = (lcm_sym126__ + 1);
               lp_accum__.add(
-                bernoulli_lpmf<propto__>(y[(1 - 1)][(lcm_sym126__ - 1)],
+                bernoulli_lpmf<propto__>(
+                  rvalue(y,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(lcm_sym126__), nil_index_list())),
+                    "y"),
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym126__ - 1)),
@@ -20089,7 +21487,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                       "phi")));
                 current_statement__ = 25;
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(1 - 1)][(t - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni(t), nil_index_list())), "y"),
                     rvalue(p,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
@@ -20104,9 +21505,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                   "inline_sym9__")));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym147__ = first[(i - 1)];
+            lcm_sym147__ = rvalue(first,
+                             cons_list(index_uni(i), nil_index_list()),
+                             "first");
             if (logical_gt(lcm_sym147__, 0)) {
-              lcm_sym153__ = last[(i - 1)];
+              lcm_sym153__ = rvalue(last,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "last");
               lcm_sym125__ = (lcm_sym147__ + 1);
               if (logical_gte(lcm_sym153__, lcm_sym125__)) {
                 current_statement__ = 24;
@@ -20118,7 +21523,11 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                           nil_index_list())), "phi")));
                 lcm_sym123__ = (lcm_sym125__ + 1);
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(i - 1)][(lcm_sym125__ - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(lcm_sym125__), nil_index_list())),
+                      "y"),
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym125__ - 1)),
@@ -20133,7 +21542,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                         "phi")));
                   current_statement__ = 25;
                   lp_accum__.add(
-                    bernoulli_lpmf<propto__>(y[(i - 1)][(t - 1)],
+                    bernoulli_lpmf<propto__>(
+                      rvalue(y,
+                        cons_list(index_uni(i),
+                          cons_list(index_uni(t), nil_index_list())), "y"),
                       rvalue(p,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
@@ -20246,8 +21658,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       if (lcm_sym54__) {
         current_statement__ = 2;
         assign(beta, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lub_constrain(beta[(1 - 1)], 0, 1),
-          "assigning variable beta");
+          stan::math::lub_constrain(
+            rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+            0, 1), "assigning variable beta");
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(sym1__), nil_index_list()),
@@ -20268,7 +21681,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       
       vars__.emplace_back(mean_p);
       if (lcm_sym54__) {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"));
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           vars__.emplace_back(beta[(sym1__ - 1)]);}
       } 
@@ -20278,7 +21692,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       } 
       lcm_sym56__ = logical_gte(nind, 1);
       if (lcm_sym56__) {
-        lcm_sym83__ = first[(1 - 1)];
+        lcm_sym83__ = rvalue(first,
+                        cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym65__ = (lcm_sym83__ - 1);
         if (logical_gte(lcm_sym65__, 1)) {
           current_statement__ = 6;
@@ -20309,8 +21724,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           assign(phi,
             cons_list(index_uni(1),
               cons_list(index_uni(lcm_sym83__), nil_index_list())),
-            beta[(x[(1 - 1)][(lcm_sym83__ - 1)] - 1)],
-            "assigning variable phi");
+            rvalue(beta,
+              cons_list(
+                index_uni(rvalue(x,
+                            cons_list(index_uni(1),
+                              cons_list(index_uni(lcm_sym83__),
+                                nil_index_list())), "x")), nil_index_list()),
+              "beta"), "assigning variable phi");
           lcm_sym71__ = (lcm_sym83__ + 1);
           assign(p,
             cons_list(index_uni(1),
@@ -20321,7 +21741,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             assign(phi,
               cons_list(index_uni(1),
                 cons_list(index_uni(t), nil_index_list())),
-              beta[(x[(1 - 1)][(t - 1)] - 1)], "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(1),
+                                cons_list(index_uni(t), nil_index_list())),
+                              "x")), nil_index_list()), "beta"),
+              "assigning variable phi");
             current_statement__ = 10;
             assign(p,
               cons_list(index_uni(1),
@@ -20329,7 +21755,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym82__ = first[(i - 1)];
+          lcm_sym82__ = rvalue(first,
+                          cons_list(index_uni(i), nil_index_list()), "first");
           lcm_sym64__ = (lcm_sym82__ - 1);
           if (logical_gte(lcm_sym64__, 1)) {
             current_statement__ = 6;
@@ -20360,8 +21787,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             assign(phi,
               cons_list(index_uni(i),
                 cons_list(index_uni(lcm_sym82__), nil_index_list())),
-              beta[(x[(i - 1)][(lcm_sym82__ - 1)] - 1)],
-              "assigning variable phi");
+              rvalue(beta,
+                cons_list(
+                  index_uni(rvalue(x,
+                              cons_list(index_uni(i),
+                                cons_list(index_uni(lcm_sym82__),
+                                  nil_index_list())), "x")),
+                  nil_index_list()), "beta"), "assigning variable phi");
             lcm_sym70__ = (lcm_sym82__ + 1);
             assign(p,
               cons_list(index_uni(i),
@@ -20372,7 +21804,13 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               assign(phi,
                 cons_list(index_uni(i),
                   cons_list(index_uni(t), nil_index_list())),
-                beta[(x[(i - 1)][(t - 1)] - 1)], "assigning variable phi");
+                rvalue(beta,
+                  cons_list(
+                    index_uni(rvalue(x,
+                                cons_list(index_uni(i),
+                                  cons_list(index_uni(t), nil_index_list())),
+                                "x")), nil_index_list()), "beta"),
+                "assigning variable phi");
               current_statement__ = 10;
               assign(p,
                 cons_list(index_uni(i),
@@ -20871,7 +22309,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         if (lcm_sym46__) {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            beta_flat__[(1 - 1)], "assigning variable beta");
+            rvalue(beta_flat__, cons_list(index_uni(1), nil_index_list()),
+              "beta_flat__"), "assigning variable beta");
           current_statement__ = 2;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
@@ -20890,8 +22329,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       if (lcm_sym46__) {
         current_statement__ = 2;
         assign(beta_free__, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lub_free(beta[(1 - 1)], 0, 1),
-          "assigning variable beta_free__");
+          stan::math::lub_free(
+            rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+            0, 1), "assigning variable beta_free__");
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           current_statement__ = 2;
           assign(beta_free__, cons_list(index_uni(sym1__), nil_index_list()),
@@ -20900,7 +22340,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       } 
       vars__.emplace_back(mean_p_free__);
       if (lcm_sym46__) {
-        vars__.emplace_back(beta_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta_free__, cons_list(index_uni(1), nil_index_list()),
+            "beta_free__"));
         for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
           vars__.emplace_back(beta_free__[(sym1__ - 1)]);}
       } 
@@ -21305,13 +22747,13 @@ first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       lcm_sym51__ = size(y_i);
       if (logical_gte(lcm_sym51__, 1)) {
         current_statement__ = 59;
-        if (y_i[(1 - 1)]) {
+        if (rvalue(y_i, cons_list(index_uni(1), nil_index_list()), "y_i")) {
           current_statement__ = 58;
           return 1;
         } 
         for (int k = 2; k <= lcm_sym51__; ++k) {
           current_statement__ = 59;
-          if (y_i[(k - 1)]) {
+          if (rvalue(y_i, cons_list(index_uni(k), nil_index_list()), "y_i")) {
             current_statement__ = 58;
             return k;
           } }
@@ -21677,11 +23119,13 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
       int n_ind;
       n_ind = std::numeric_limits<int>::min();
       
-      lcm_sym120__ = dims(y)[(1 - 1)];
+      lcm_sym120__ = rvalue(dims(y),
+                       cons_list(index_uni(1), nil_index_list()), "dims(y)");
       int n_occasions;
       n_occasions = std::numeric_limits<int>::min();
       
-      lcm_sym121__ = dims(y)[(2 - 1)];
+      lcm_sym121__ = rvalue(dims(y),
+                       cons_list(index_uni(2), nil_index_list()), "dims(y)");
       n_occasions = lcm_sym121__;
       current_statement__ = 78;
       validate_non_negative_index("qgamma", "n_occasions", lcm_sym121__);
@@ -21704,14 +23148,16 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             transpose(
               rvalue(p, cons_list(index_uni(1), nil_index_list()), "p"))),
           "assigning variable lcm_sym82__");
-        lcm_sym117__ = first[(1 - 1)];
+        lcm_sym117__ = rvalue(first,
+                         cons_list(index_uni(1), nil_index_list()), "first");
         if (lcm_sym117__) {
           current_statement__ = 94;
           if (logical_eq(lcm_sym117__, 1)) {
             current_statement__ = 101;
             lp_accum__.add(
               bernoulli_lpmf<propto__>(1,
-                (gamma[(1 - 1)] *
+                (rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                   "gamma") *
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni(1), nil_index_list())), "p"))));
@@ -21724,7 +23170,9 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             
             lcm_sym84__ = (lcm_sym117__ - 1);
             assign(lp, cons_list(index_uni(1), nil_index_list()),
-              (((bernoulli_lpmf<false>(1, gamma[(1 - 1)]) +
+              (((bernoulli_lpmf<false>(1,
+                   rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                     "gamma")) +
                   bernoulli_lpmf<false>(1,
                     prod(
                       rvalue(lcm_sym82__,
@@ -21750,7 +23198,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                         rvalue(lcm_sym80__,
                           cons_list(index_min_max(1, 1), nil_index_list()),
                           "lcm_sym80__"))) +
-                     bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                     bernoulli_lpmf<false>(1,
+                       rvalue(gamma,
+                         cons_list(index_uni(2), nil_index_list()), "gamma")))
+                    +
                     bernoulli_lpmf<false>(1,
                       prod(
                         rvalue(lcm_sym82__,
@@ -21775,7 +23226,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                           rvalue(lcm_sym80__,
                             cons_list(index_min_max(1, (t - 1)),
                               nil_index_list()), "lcm_sym80__"))) +
-                       bernoulli_lpmf<false>(1, gamma[(t - 1)])) +
+                       bernoulli_lpmf<false>(1,
+                         rvalue(gamma,
+                           cons_list(index_uni(t), nil_index_list()),
+                           "gamma"))) +
                       bernoulli_lpmf<false>(1,
                         prod(
                           rvalue(lcm_sym82__,
@@ -21810,7 +23264,8 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             current_statement__ = 91;
             lp_accum__.add(log_sum_exp(lp));
           }
-          lcm_sym119__ = last[(1 - 1)];
+          lcm_sym119__ = rvalue(last,
+                           cons_list(index_uni(1), nil_index_list()), "last");
           if (logical_gte(lcm_sym119__, (lcm_sym117__ + 1))) {
             current_statement__ = 95;
             lp_accum__.add(
@@ -21821,7 +23276,11 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                       nil_index_list())), "phi")));
             lcm_sym100__ = ((lcm_sym117__ + 1) + 1);
             lp_accum__.add(
-              bernoulli_lpmf<propto__>(y[(1 - 1)][((lcm_sym117__ + 1) - 1)],
+              bernoulli_lpmf<propto__>(
+                rvalue(y,
+                  cons_list(index_uni(1),
+                    cons_list(index_uni((lcm_sym117__ + 1)),
+                      nil_index_list())), "y"),
                 rvalue(p,
                   cons_list(index_uni(1),
                     cons_list(index_uni((lcm_sym117__ + 1)),
@@ -21836,7 +23295,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                     "phi")));
               current_statement__ = 96;
               lp_accum__.add(
-                bernoulli_lpmf<propto__>(y[(1 - 1)][(t - 1)],
+                bernoulli_lpmf<propto__>(
+                  rvalue(y,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(t), nil_index_list())), "y"),
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni(t), nil_index_list())), "p")));}
@@ -21857,7 +23319,9 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
           
           current_statement__ = 100;
           assign(lp, cons_list(index_uni(1), nil_index_list()),
-            ((bernoulli_lpmf<false>(1, gamma[(1 - 1)]) +
+            ((bernoulli_lpmf<false>(1,
+                rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                  "gamma")) +
                bernoulli_lpmf<false>(0,
                  rvalue(p,
                    cons_list(index_uni(1),
@@ -21876,7 +23340,9 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                      rvalue(lcm_sym80__,
                        cons_list(index_min_max(1, 1), nil_index_list()),
                        "lcm_sym80__"))) +
-                  bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                  bernoulli_lpmf<false>(1,
+                    rvalue(gamma, cons_list(index_uni(2), nil_index_list()),
+                      "gamma"))) +
                  bernoulli_lpmf<false>(0,
                    rvalue(p,
                      cons_list(index_uni(1),
@@ -21894,7 +23360,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                        rvalue(lcm_sym80__,
                          cons_list(index_min_max(1, (t - 1)),
                            nil_index_list()), "lcm_sym80__"))) +
-                    bernoulli_lpmf<false>(1, gamma[(t - 1)])) +
+                    bernoulli_lpmf<false>(1,
+                      rvalue(gamma,
+                        cons_list(index_uni(t), nil_index_list()), "gamma")))
+                   +
                    bernoulli_lpmf<false>(0,
                      rvalue(p,
                        cons_list(index_uni(1),
@@ -21924,14 +23393,17 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
               transpose(
                 rvalue(p, cons_list(index_uni(i), nil_index_list()), "p"))),
             "assigning variable lcm_sym81__");
-          lcm_sym116__ = first[(i - 1)];
+          lcm_sym116__ = rvalue(first,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "first");
           if (lcm_sym116__) {
             current_statement__ = 94;
             if (logical_eq(lcm_sym116__, 1)) {
               current_statement__ = 101;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
-                  (gamma[(1 - 1)] *
+                  (rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                     "gamma") *
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni(1), nil_index_list())), "p"))));
@@ -21944,7 +23416,9 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
               
               lcm_sym83__ = (lcm_sym116__ - 1);
               assign(lp, cons_list(index_uni(1), nil_index_list()),
-                (((bernoulli_lpmf<false>(1, gamma[(1 - 1)]) +
+                (((bernoulli_lpmf<false>(1,
+                     rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                       "gamma")) +
                     bernoulli_lpmf<false>(1,
                       prod(
                         rvalue(lcm_sym81__,
@@ -21970,7 +23444,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                           rvalue(lcm_sym80__,
                             cons_list(index_min_max(1, 1), nil_index_list()),
                             "lcm_sym80__"))) +
-                       bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                       bernoulli_lpmf<false>(1,
+                         rvalue(gamma,
+                           cons_list(index_uni(2), nil_index_list()),
+                           "gamma"))) +
                       bernoulli_lpmf<false>(1,
                         prod(
                           rvalue(lcm_sym81__,
@@ -21996,7 +23473,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                             rvalue(lcm_sym80__,
                               cons_list(index_min_max(1, (t - 1)),
                                 nil_index_list()), "lcm_sym80__"))) +
-                         bernoulli_lpmf<false>(1, gamma[(t - 1)])) +
+                         bernoulli_lpmf<false>(1,
+                           rvalue(gamma,
+                             cons_list(index_uni(t), nil_index_list()),
+                             "gamma"))) +
                         bernoulli_lpmf<false>(1,
                           prod(
                             rvalue(lcm_sym81__,
@@ -22032,7 +23512,9 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
               current_statement__ = 91;
               lp_accum__.add(log_sum_exp(lp));
             }
-            lcm_sym118__ = last[(i - 1)];
+            lcm_sym118__ = rvalue(last,
+                             cons_list(index_uni(i), nil_index_list()),
+                             "last");
             if (logical_gte(lcm_sym118__, (lcm_sym116__ + 1))) {
               current_statement__ = 95;
               lp_accum__.add(
@@ -22044,7 +23526,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
               lcm_sym99__ = ((lcm_sym116__ + 1) + 1);
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(
-                  y[(i - 1)][((lcm_sym116__ + 1) - 1)],
+                  rvalue(y,
+                    cons_list(index_uni(i),
+                      cons_list(index_uni((lcm_sym116__ + 1)),
+                        nil_index_list())), "y"),
                   rvalue(p,
                     cons_list(index_uni(i),
                       cons_list(index_uni((lcm_sym116__ + 1)),
@@ -22059,7 +23544,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                       "phi")));
                 current_statement__ = 96;
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(i - 1)][(t - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(t), nil_index_list())), "y"),
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni(t), nil_index_list())), "p")));}
@@ -22080,7 +23568,9 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             
             current_statement__ = 100;
             assign(lp, cons_list(index_uni(1), nil_index_list()),
-              ((bernoulli_lpmf<false>(1, gamma[(1 - 1)]) +
+              ((bernoulli_lpmf<false>(1,
+                  rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                    "gamma")) +
                  bernoulli_lpmf<false>(0,
                    rvalue(p,
                      cons_list(index_uni(i),
@@ -22099,7 +23589,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                        rvalue(lcm_sym80__,
                          cons_list(index_min_max(1, 1), nil_index_list()),
                          "lcm_sym80__"))) +
-                    bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                    bernoulli_lpmf<false>(1,
+                      rvalue(gamma,
+                        cons_list(index_uni(2), nil_index_list()), "gamma")))
+                   +
                    bernoulli_lpmf<false>(0,
                      rvalue(p,
                        cons_list(index_uni(i),
@@ -22117,7 +23610,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
                          rvalue(lcm_sym80__,
                            cons_list(index_min_max(1, (t - 1)),
                              nil_index_list()), "lcm_sym80__"))) +
-                      bernoulli_lpmf<false>(1, gamma[(t - 1)])) +
+                      bernoulli_lpmf<false>(1,
+                        rvalue(gamma,
+                          cons_list(index_uni(t), nil_index_list()), "gamma")))
+                     +
                      bernoulli_lpmf<false>(0,
                        rvalue(p,
                          cons_list(index_uni(i),
@@ -22198,17 +23694,28 @@ seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
       if (logical_gte(lcm_sym128__, 1)) {
         current_statement__ = 46;
         assign(log_cprob, cons_list(index_uni(1), nil_index_list()),
-          (stan::math::log(gamma[(1 - 1)]) + 0),
-          "assigning variable log_cprob");
+          (stan::math::log(
+             rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+               "gamma")) + 0), "assigning variable log_cprob");
         current_statement__ = 47;
-        log_residual_prob = (0 + log1m(gamma[(1 - 1)]));
+        log_residual_prob = (0 +
+                              log1m(
+                                rvalue(gamma,
+                                  cons_list(index_uni(1), nil_index_list()),
+                                  "gamma")));
         for (int n = 2; n <= lcm_sym128__; ++n) {
           current_statement__ = 46;
           assign(log_cprob, cons_list(index_uni(n), nil_index_list()),
-            (stan::math::log(gamma[(n - 1)]) + log_residual_prob),
+            (stan::math::log(
+               rvalue(gamma, cons_list(index_uni(n), nil_index_list()),
+                 "gamma")) + log_residual_prob),
             "assigning variable log_cprob");
           current_statement__ = 47;
-          log_residual_prob = (log_residual_prob + log1m(gamma[(n - 1)]));}
+          log_residual_prob = (log_residual_prob +
+                                log1m(
+                                  rvalue(gamma,
+                                    cons_list(index_uni(n), nil_index_list()),
+                                    "gamma")));}
       } 
       current_statement__ = 144;
       return stan::math::exp(log_cprob);
@@ -22361,7 +23868,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 107;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
@@ -22404,12 +23912,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           current_statement__ = 107;
           current_statement__ = 107;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 0);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 107;
             current_statement__ = 107;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 107;
@@ -22417,7 +23931,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             current_statement__ = 107;
             current_statement__ = 107;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 0);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 107;
               current_statement__ = 107;
@@ -22432,12 +23949,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           current_statement__ = 107;
           current_statement__ = 107;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], 1);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), 1);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 107;
             current_statement__ = 107;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 107;
@@ -22445,7 +23968,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             current_statement__ = 107;
             current_statement__ = 107;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), 1);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 107;
               current_statement__ = 107;
@@ -22471,11 +23997,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         
         inline_sym43__ = 0;
         for (int inline_sym44__ = 1; inline_sym44__ <= 1; ++inline_sym44__) {
-          lcm_sym331__ = size(y[(1 - 1)]);
+          lcm_sym331__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           for (int inline_sym42__ = 1; inline_sym42__ <= lcm_sym331__;
                ++inline_sym42__) {
             current_statement__ = 59;
-            if (y[(1 - 1)][(inline_sym42__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (inline_sym42__ - 1)]) {
               inline_sym43__ = 1;
               inline_sym41__ = inline_sym42__;
               break;
@@ -22495,11 +24024,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           
           inline_sym43__ = 0;
           for (int inline_sym44__ = 1; inline_sym44__ <= 1; ++inline_sym44__) {
-            lcm_sym330__ = size(y[(i - 1)]);
+            lcm_sym330__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             for (int inline_sym42__ = 1; inline_sym42__ <= lcm_sym330__;
                  ++inline_sym42__) {
               current_statement__ = 59;
-              if (y[(i - 1)][(inline_sym42__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (inline_sym42__ - 1)]) {
                 inline_sym43__ = 1;
                 inline_sym41__ = inline_sym42__;
                 break;
@@ -22521,7 +24054,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         
         inline_sym48__ = 0;
         for (int inline_sym49__ = 1; inline_sym49__ <= 1; ++inline_sym49__) {
-          lcm_sym331__ = size(y[(1 - 1)]);
+          lcm_sym331__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           lcm_sym328__ = (lcm_sym331__ - 1);
           for (int inline_sym47__ = 0; inline_sym47__ <= lcm_sym328__;
                ++inline_sym47__) {
@@ -22531,7 +24066,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             lcm_sym327__ = (lcm_sym331__ - inline_sym47__);
             inline_sym46__ = lcm_sym327__;
             current_statement__ = 116;
-            if (y[(1 - 1)][(lcm_sym327__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (lcm_sym327__ - 1)]) {
               inline_sym48__ = 1;
               inline_sym45__ = lcm_sym327__;
               break;
@@ -22551,7 +24087,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           
           inline_sym48__ = 0;
           for (int inline_sym49__ = 1; inline_sym49__ <= 1; ++inline_sym49__) {
-            lcm_sym330__ = size(y[(i - 1)]);
+            lcm_sym330__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             lcm_sym326__ = (lcm_sym330__ - 1);
             for (int inline_sym47__ = 0; inline_sym47__ <= lcm_sym326__;
                  ++inline_sym47__) {
@@ -22561,7 +24100,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               lcm_sym325__ = (lcm_sym330__ - inline_sym47__);
               inline_sym46__ = lcm_sym325__;
               current_statement__ = 116;
-              if (y[(i - 1)][(lcm_sym325__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (lcm_sym325__ - 1)]) {
                 inline_sym48__ = 1;
                 inline_sym45__ = lcm_sym325__;
                 break;
@@ -22579,7 +24119,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       if (lcm_sym322__) {
         current_statement__ = 109;
         current_statement__ = 109;
-        check_greater_or_equal(function__, "first[sym1__]", first[(1 - 1)], 0);
+        check_greater_or_equal(function__, "first[sym1__]",
+                               rvalue(first,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "first"), 0);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 109;
           current_statement__ = 109;
@@ -22590,8 +24133,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       if (lcm_sym322__) {
         current_statement__ = 109;
         current_statement__ = 109;
-        check_less_or_equal(function__, "first[sym1__]", first[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "first[sym1__]",
+                            rvalue(first,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "first"), n_occasions);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 109;
           current_statement__ = 109;
@@ -22602,7 +24147,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       if (lcm_sym322__) {
         current_statement__ = 111;
         current_statement__ = 111;
-        check_greater_or_equal(function__, "last[sym1__]", last[(1 - 1)], 0);
+        check_greater_or_equal(function__, "last[sym1__]",
+                               rvalue(last,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "last"), 0);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 111;
           current_statement__ = 111;
@@ -22613,8 +24161,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       if (lcm_sym322__) {
         current_statement__ = 111;
         current_statement__ = 111;
-        check_less_or_equal(function__, "last[sym1__]", last[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "last[sym1__]",
+                            rvalue(last,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "last"), n_occasions);
         for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
           current_statement__ = 111;
           current_statement__ = 111;
@@ -22813,13 +24363,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         if (jacobian__) {
           current_statement__ = 3;
           assign(gamma, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lub_constrain(gamma[(1 - 1)], 0, 1, lp__),
-            "assigning variable gamma");
+            stan::math::lub_constrain(
+              rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                "gamma"), 0, 1, lp__), "assigning variable gamma");
         } else {
           current_statement__ = 3;
           assign(gamma, cons_list(index_uni(1), nil_index_list()),
-            stan::math::lub_constrain(gamma[(1 - 1)], 0, 1),
-            "assigning variable gamma");
+            stan::math::lub_constrain(
+              rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                "gamma"), 0, 1), "assigning variable gamma");
         }
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 3;
@@ -22871,7 +24423,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         {
           lcm_sym240__ = logical_gte(M, 1);
           if (lcm_sym240__) {
-            lcm_sym294__ = inv_logit((logit(mean_phi) + epsilon[(1 - 1)]));
+            lcm_sym294__ = inv_logit(
+                             (logit(mean_phi) +
+                               rvalue(epsilon,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "epsilon")));
             assign(phi,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())), lcm_sym294__,
@@ -22886,7 +24442,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           for (int t = 2; t <= lcm_sym303__; ++t) {
             current_statement__ = 10;
             if (lcm_sym240__) {
-              lcm_sym293__ = inv_logit((logit(mean_phi) + epsilon[(t - 1)]));
+              lcm_sym293__ = inv_logit(
+                               (logit(mean_phi) +
+                                 rvalue(epsilon,
+                                   cons_list(index_uni(t), nil_index_list()),
+                                   "epsilon")));
               assign(phi,
                 cons_list(index_uni(1),
                   cons_list(index_uni(t), nil_index_list())), lcm_sym293__,
@@ -23272,11 +24832,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           int inline_sym32__;
           inline_sym32__ = std::numeric_limits<int>::min();
           
-          lcm_sym316__ = dims(y)[(1 - 1)];
+          lcm_sym316__ = rvalue(dims(y),
+                           cons_list(index_uni(1), nil_index_list()),
+                           "dims(y)");
           int inline_sym33__;
           inline_sym33__ = std::numeric_limits<int>::min();
           
-          lcm_sym317__ = dims(y)[(2 - 1)];
+          lcm_sym317__ = rvalue(dims(y),
+                           cons_list(index_uni(2), nil_index_list()),
+                           "dims(y)");
           current_statement__ = 78;
           validate_non_negative_index("qgamma", "n_occasions", lcm_sym317__);
           Eigen::Matrix<double, -1, 1> inline_sym34__;
@@ -23299,11 +24863,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   rvalue(lcm_sym297__,
                     cons_list(index_uni(1), nil_index_list()),
                     "lcm_sym297__"))), "assigning variable lcm_sym253__");
-            lcm_sym305__ = first[(1 - 1)];
+            lcm_sym305__ = rvalue(first,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "first");
             if (lcm_sym305__) {
               current_statement__ = 94;
               if (logical_eq(lcm_sym305__, 1)) {
-                lcm_sym302__ = gamma[(1 - 1)];
+                lcm_sym302__ = rvalue(gamma,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "gamma");
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(1,
                     (lcm_sym302__ *
@@ -23318,7 +24886,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 inline_sym36__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym305__);
                 stan::math::fill(inline_sym36__, DUMMY_VAR__);
                 
-                lcm_sym302__ = gamma[(1 - 1)];
+                lcm_sym302__ = rvalue(gamma,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "gamma");
                 lcm_sym257__ = (lcm_sym305__ - 1);
                 assign(inline_sym36__,
                   cons_list(index_uni(1), nil_index_list()),
@@ -23349,7 +24919,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                             rvalue(lcm_sym251__,
                               cons_list(index_min_max(1, 1),
                                 nil_index_list()), "lcm_sym251__"))) +
-                         bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                         bernoulli_lpmf<false>(1,
+                           rvalue(gamma,
+                             cons_list(index_uni(2), nil_index_list()),
+                             "gamma"))) +
                         bernoulli_lpmf<false>(1,
                           prod(
                             rvalue(lcm_sym253__,
@@ -23418,7 +24991,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 current_statement__ = 91;
                 lp_accum__.add(log_sum_exp(inline_sym36__));
               }
-              lcm_sym311__ = last[(1 - 1)];
+              lcm_sym311__ = rvalue(last,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "last");
               if (logical_gte(lcm_sym311__, (lcm_sym305__ + 1))) {
                 current_statement__ = 95;
                 lp_accum__.add(
@@ -23430,7 +25005,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 lcm_sym275__ = ((lcm_sym305__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
-                    y[(1 - 1)][((lcm_sym305__ + 1) - 1)],
+                    rvalue(y,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni((lcm_sym305__ + 1)),
+                          nil_index_list())), "y"),
                     rvalue(lcm_sym297__,
                       cons_list(index_uni(1),
                         cons_list(index_uni((lcm_sym305__ + 1)),
@@ -23447,7 +25025,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   current_statement__ = 96;
                   lp_accum__.add(
                     bernoulli_lpmf<propto__>(
-                      y[(1 - 1)][(inline_sym37__ - 1)],
+                      rvalue(y,
+                        cons_list(index_uni(1),
+                          cons_list(index_uni(inline_sym37__),
+                            nil_index_list())), "y"),
                       rvalue(lcm_sym297__,
                         cons_list(index_uni(1),
                           cons_list(index_uni(inline_sym37__),
@@ -23468,7 +25049,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               inline_sym36__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym276__);
               stan::math::fill(inline_sym36__, DUMMY_VAR__);
               
-              lcm_sym302__ = gamma[(1 - 1)];
+              lcm_sym302__ = rvalue(gamma,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "gamma");
               assign(inline_sym36__,
                 cons_list(index_uni(1), nil_index_list()),
                 ((bernoulli_lpmf<false>(1, lcm_sym302__) +
@@ -23492,7 +25075,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                          rvalue(lcm_sym251__,
                            cons_list(index_min_max(1, 1), nil_index_list()),
                            "lcm_sym251__"))) +
-                      bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                      bernoulli_lpmf<false>(1,
+                        rvalue(gamma,
+                          cons_list(index_uni(2), nil_index_list()), "gamma")))
+                     +
                      bernoulli_lpmf<false>(0,
                        rvalue(lcm_sym297__,
                          cons_list(index_uni(1),
@@ -23600,7 +25186,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                               rvalue(lcm_sym251__,
                                 cons_list(index_min_max(1, 1),
                                   nil_index_list()), "lcm_sym251__"))) +
-                           bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                           bernoulli_lpmf<false>(1,
+                             rvalue(gamma,
+                               cons_list(index_uni(2), nil_index_list()),
+                               "gamma"))) +
                           bernoulli_lpmf<false>(1,
                             prod(
                               rvalue(lcm_sym252__,
@@ -23682,7 +25271,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   lcm_sym274__ = ((lcm_sym304__ + 1) + 1);
                   lp_accum__.add(
                     bernoulli_lpmf<propto__>(
-                      y[(inline_sym38__ - 1)][((lcm_sym304__ + 1) - 1)],
+                      rvalue(y,
+                        cons_list(index_uni(inline_sym38__),
+                          cons_list(index_uni((lcm_sym304__ + 1)),
+                            nil_index_list())), "y"),
                       rvalue(lcm_sym297__,
                         cons_list(index_uni(inline_sym38__),
                           cons_list(index_uni((lcm_sym304__ + 1)),
@@ -23744,7 +25336,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                            rvalue(lcm_sym251__,
                              cons_list(index_min_max(1, 1), nil_index_list()),
                              "lcm_sym251__"))) +
-                        bernoulli_lpmf<false>(1, gamma[(2 - 1)])) +
+                        bernoulli_lpmf<false>(1,
+                          rvalue(gamma,
+                            cons_list(index_uni(2), nil_index_list()),
+                            "gamma"))) +
                        bernoulli_lpmf<false>(0,
                          rvalue(lcm_sym297__,
                            cons_list(index_uni(inline_sym38__),
@@ -23934,8 +25529,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       if (lcm_sym145__) {
         current_statement__ = 3;
         assign(gamma, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lub_constrain(gamma[(1 - 1)], 0, 1),
-          "assigning variable gamma");
+          stan::math::lub_constrain(
+            rvalue(gamma, cons_list(index_uni(1), nil_index_list()), "gamma"),
+            0, 1), "assigning variable gamma");
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 3;
           assign(gamma, cons_list(index_uni(sym1__), nil_index_list()),
@@ -23970,13 +25566,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       vars__.emplace_back(mean_phi);
       vars__.emplace_back(mean_p);
       if (lcm_sym145__) {
-        vars__.emplace_back(gamma[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(gamma, cons_list(index_uni(1), nil_index_list()), "gamma"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(gamma[(sym1__ - 1)]);}
       } 
       lcm_sym147__ = logical_gte(lcm_sym200__, 1);
       if (lcm_sym147__) {
-        vars__.emplace_back(epsilon[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(epsilon, cons_list(index_uni(1), nil_index_list()),
+            "epsilon"));
         for (int sym1__ = 2; sym1__ <= lcm_sym200__; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
@@ -23990,7 +25589,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         {
           lcm_sym144__ = logical_gte(M, 1);
           if (lcm_sym144__) {
-            lcm_sym182__ = inv_logit((logit(mean_phi) + epsilon[(1 - 1)]));
+            lcm_sym182__ = inv_logit(
+                             (logit(mean_phi) +
+                               rvalue(epsilon,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "epsilon")));
             assign(phi,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())), lcm_sym182__,
@@ -24005,7 +25608,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           for (int t = 2; t <= lcm_sym200__; ++t) {
             current_statement__ = 10;
             if (lcm_sym144__) {
-              lcm_sym181__ = inv_logit((logit(mean_phi) + epsilon[(t - 1)]));
+              lcm_sym181__ = inv_logit(
+                               (logit(mean_phi) +
+                                 rvalue(epsilon,
+                                   cons_list(index_uni(t), nil_index_list()),
+                                   "epsilon")));
               assign(phi,
                 cons_list(index_uni(1),
                   cons_list(index_uni(t), nil_index_list())), lcm_sym181__,
@@ -24499,13 +26106,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         double mu2;
         mu2 = std::numeric_limits<double>::quiet_NaN();
         
-        lcm_sym208__ = gamma[(1 - 1)];
+        lcm_sym208__ = rvalue(gamma,
+                         cons_list(index_uni(1), nil_index_list()), "gamma");
         assign(z,
           cons_list(index_uni(1), cons_list(index_uni(1), nil_index_list())),
           bernoulli_rng(lcm_sym208__, base_rng__), "assigning variable z");
         lcm_sym146__ = logical_gte(n_occasions, 2);
         if (lcm_sym146__) {
-          lcm_sym226__ = z[(1 - 1)][(1 - 1)];
+          lcm_sym226__ = rvalue(z,
+                           cons_list(index_uni(1),
+                             cons_list(index_uni(1), nil_index_list())), "z");
           lcm_sym167__ = (1 * (1 - lcm_sym226__));
           q = lcm_sym167__;
           lcm_sym222__ = rvalue(phi,
@@ -24513,7 +26123,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                              cons_list(index_uni(1), nil_index_list())),
                            "phi");
           lcm_sym179__ = stan::math::fma(lcm_sym222__, lcm_sym226__,
-                           (gamma[(2 - 1)] * lcm_sym167__));
+                           (rvalue(gamma,
+                              cons_list(index_uni(2), nil_index_list()),
+                              "gamma") * lcm_sym167__));
           current_statement__ = 33;
           assign(z,
             cons_list(index_uni(1),
@@ -24521,13 +26133,24 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             bernoulli_rng(lcm_sym179__, base_rng__), "assigning variable z");
           for (int t = 3; t <= n_occasions; ++t) {
             current_statement__ = 34;
-            q = (q * (1 - z[(1 - 1)][((t - 1) - 1)]));
+            q = (q *
+                  (1 -
+                    rvalue(z,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni((t - 1)), nil_index_list())),
+                      "z")));
             lcm_sym180__ = stan::math::fma(
                              rvalue(phi,
                                cons_list(index_uni(1),
                                  cons_list(index_uni((t - 1)),
                                    nil_index_list())), "phi"),
-                             z[(1 - 1)][((t - 1) - 1)], (gamma[(t - 1)] * q));
+                             rvalue(z,
+                               cons_list(index_uni(1),
+                                 cons_list(index_uni((t - 1)),
+                                   nil_index_list())), "z"),
+                             (rvalue(gamma,
+                                cons_list(index_uni(t), nil_index_list()),
+                                "gamma") * q));
             current_statement__ = 33;
             assign(z,
               cons_list(index_uni(1),
@@ -24549,14 +26172,25 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             bernoulli_rng(lcm_sym208__, base_rng__), "assigning variable z");
           current_statement__ = 37;
           if (lcm_sym146__) {
-            lcm_sym166__ = (1 * (1 - z[(i - 1)][(1 - 1)]));
+            lcm_sym166__ = (1 *
+                             (1 -
+                               rvalue(z,
+                                 cons_list(index_uni(i),
+                                   cons_list(index_uni(1), nil_index_list())),
+                                 "z")));
             q = lcm_sym166__;
             lcm_sym177__ = stan::math::fma(
                              rvalue(phi,
                                cons_list(index_uni(i),
                                  cons_list(index_uni(1), nil_index_list())),
-                               "phi"), z[(i - 1)][(1 - 1)],
-                             (gamma[(2 - 1)] * lcm_sym166__));
+                               "phi"),
+                             rvalue(z,
+                               cons_list(index_uni(i),
+                                 cons_list(index_uni(1), nil_index_list())),
+                               "z"),
+                             (rvalue(gamma,
+                                cons_list(index_uni(2), nil_index_list()),
+                                "gamma") * lcm_sym166__));
             current_statement__ = 33;
             assign(z,
               cons_list(index_uni(i),
@@ -24564,14 +26198,24 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               bernoulli_rng(lcm_sym177__, base_rng__), "assigning variable z");
             for (int t = 3; t <= n_occasions; ++t) {
               current_statement__ = 34;
-              q = (q * (1 - z[(i - 1)][((t - 1) - 1)]));
+              q = (q *
+                    (1 -
+                      rvalue(z,
+                        cons_list(index_uni(i),
+                          cons_list(index_uni((t - 1)), nil_index_list())),
+                        "z")));
               lcm_sym178__ = stan::math::fma(
                                rvalue(phi,
                                  cons_list(index_uni(i),
                                    cons_list(index_uni((t - 1)),
                                      nil_index_list())), "phi"),
-                               z[(i - 1)][((t - 1) - 1)],
-                               (gamma[(t - 1)] * q));
+                               rvalue(z,
+                                 cons_list(index_uni(i),
+                                   cons_list(index_uni((t - 1)),
+                                     nil_index_list())), "z"),
+                               (rvalue(gamma,
+                                  cons_list(index_uni(t), nil_index_list()),
+                                  "gamma") * q));
               current_statement__ = 33;
               assign(z,
                 cons_list(index_uni(i),
@@ -24609,10 +26253,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           if (logical_gte(lcm_sym185__, 1)) {
             current_statement__ = 46;
             assign(inline_sym13__, cons_list(index_uni(1), nil_index_list()),
-              (stan::math::log(gamma[(1 - 1)]) + 0),
-              "assigning variable inline_sym13__");
+              (stan::math::log(
+                 rvalue(gamma, cons_list(index_uni(1), nil_index_list()),
+                   "gamma")) + 0), "assigning variable inline_sym13__");
             current_statement__ = 47;
-            inline_sym14__ = (0 + log1m(gamma[(1 - 1)]));
+            inline_sym14__ = (0 +
+                               log1m(
+                                 rvalue(gamma,
+                                   cons_list(index_uni(1), nil_index_list()),
+                                   "gamma")));
             for (int inline_sym15__ = 2; inline_sym15__ <= lcm_sym185__;
                  ++inline_sym15__) {
               current_statement__ = 46;
@@ -24671,11 +26320,17 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           
           inline_sym20__ = 0;
           for (int inline_sym21__ = 1; inline_sym21__ <= 1; ++inline_sym21__) {
-            lcm_sym188__ = size(z[(1 - 1)]);
+            lcm_sym188__ = size(
+                             rvalue(z,
+                               cons_list(index_uni(1), nil_index_list()),
+                               "z"));
             for (int inline_sym19__ = 1; inline_sym19__ <= lcm_sym188__;
                  ++inline_sym19__) {
               current_statement__ = 59;
-              if (z[(1 - 1)][(inline_sym19__ - 1)]) {
+              if (rvalue(z,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(inline_sym19__), nil_index_list())),
+                    "z")) {
                 inline_sym20__ = 1;
                 inline_sym18__ = inline_sym19__;
                 break;
@@ -24705,11 +26360,17 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             inline_sym20__ = 0;
             for (int inline_sym21__ = 1; inline_sym21__ <= 1;
                  ++inline_sym21__) {
-              lcm_sym187__ = size(z[(i - 1)]);
+              lcm_sym187__ = size(
+                               rvalue(z,
+                                 cons_list(index_uni(i), nil_index_list()),
+                                 "z"));
               for (int inline_sym19__ = 1; inline_sym19__ <= lcm_sym187__;
                    ++inline_sym19__) {
                 current_statement__ = 59;
-                if (z[(i - 1)][(inline_sym19__ - 1)]) {
+                if (rvalue(z,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(inline_sym19__),
+                          nil_index_list())), "z")) {
                   inline_sym20__ = 1;
                   inline_sym18__ = inline_sym19__;
                   break;
@@ -24765,19 +26426,25 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         if (lcm_sym144__) {
           current_statement__ = 69;
           assign(Nind, cons_list(index_uni(1), nil_index_list()),
-            sum(z[(1 - 1)]), "assigning variable Nind");
+            sum(rvalue(z, cons_list(index_uni(1), nil_index_list()), "z")),
+            "assigning variable Nind");
           current_statement__ = 70;
           assign(Nalive, cons_list(index_uni(1), nil_index_list()),
-            (1 - logical_negation(Nind[(1 - 1)])),
-            "assigning variable Nalive");
+            (1 -
+              logical_negation(
+                rvalue(Nind, cons_list(index_uni(1), nil_index_list()),
+                  "Nind"))), "assigning variable Nalive");
           for (int i = 2; i <= M; ++i) {
             current_statement__ = 69;
             assign(Nind, cons_list(index_uni(i), nil_index_list()),
-              sum(z[(i - 1)]), "assigning variable Nind");
+              sum(rvalue(z, cons_list(index_uni(i), nil_index_list()), "z")),
+              "assigning variable Nind");
             current_statement__ = 70;
             assign(Nalive, cons_list(index_uni(i), nil_index_list()),
-              (1 - logical_negation(Nind[(i - 1)])),
-              "assigning variable Nalive");}
+              (1 -
+                logical_negation(
+                  rvalue(Nind, cons_list(index_uni(i), nil_index_list()),
+                    "Nind"))), "assigning variable Nalive");}
         } 
         current_statement__ = 73;
         Nsuper = sum(Nalive);
@@ -24785,30 +26452,43 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       vars__.emplace_back(lcm_sym189__);
       vars__.emplace_back(lcm_sym191__);
       if (lcm_sym145__) {
-        vars__.emplace_back(lcm_sym143__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(lcm_sym143__, cons_list(index_uni(1), nil_index_list()),
+            "lcm_sym143__"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(lcm_sym143__[(sym1__ - 1)]);}
       } 
       vars__.emplace_back(Nsuper);
       if (lcm_sym145__) {
-        vars__.emplace_back(N[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(N, cons_list(index_uni(1), nil_index_list()), "N"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(N[(sym1__ - 1)]);}
       } 
       if (lcm_sym145__) {
-        vars__.emplace_back(B[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(B, cons_list(index_uni(1), nil_index_list()), "B"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(B[(sym1__ - 1)]);}
       } 
       if (lcm_sym145__) {
         if (lcm_sym144__) {
-          vars__.emplace_back(z[(1 - 1)][(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(z,
+              cons_list(index_uni(1),
+                cons_list(index_uni(1), nil_index_list())), "z"));
           for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
-            vars__.emplace_back(z[(sym2__ - 1)][(1 - 1)]);}
+            vars__.emplace_back(
+              rvalue(z,
+                cons_list(index_uni(sym2__),
+                  cons_list(index_uni(1), nil_index_list())), "z"));}
         } 
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           if (lcm_sym144__) {
-            vars__.emplace_back(z[(1 - 1)][(sym1__ - 1)]);
+            vars__.emplace_back(
+              rvalue(z,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(sym1__), nil_index_list())), "z"));
             for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
               vars__.emplace_back(z[(sym2__ - 1)][(sym1__ - 1)]);}
           } }
@@ -24885,7 +26565,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         if (lcm_sym129__) {
           current_statement__ = 3;
           assign(gamma, cons_list(index_uni(1), nil_index_list()),
-            gamma_flat__[(1 - 1)], "assigning variable gamma");
+            rvalue(gamma_flat__, cons_list(index_uni(1), nil_index_list()),
+              "gamma_flat__"), "assigning variable gamma");
           current_statement__ = 3;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
@@ -24904,8 +26585,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       if (lcm_sym129__) {
         current_statement__ = 3;
         assign(gamma_free__, cons_list(index_uni(1), nil_index_list()),
-          stan::math::lub_free(gamma[(1 - 1)], 0, 1),
-          "assigning variable gamma_free__");
+          stan::math::lub_free(
+            rvalue(gamma, cons_list(index_uni(1), nil_index_list()), "gamma"),
+            0, 1), "assigning variable gamma_free__");
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           current_statement__ = 3;
           assign(gamma_free__,
@@ -24929,7 +26611,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         if (lcm_sym130__) {
           current_statement__ = 4;
           assign(epsilon, cons_list(index_uni(1), nil_index_list()),
-            epsilon_flat__[(1 - 1)], "assigning variable epsilon");
+            rvalue(epsilon_flat__, cons_list(index_uni(1), nil_index_list()),
+              "epsilon_flat__"), "assigning variable epsilon");
           current_statement__ = 4;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= lcm_sym131__; ++sym1__) {
@@ -24953,12 +26636,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       vars__.emplace_back(mean_phi_free__);
       vars__.emplace_back(mean_p_free__);
       if (lcm_sym129__) {
-        vars__.emplace_back(gamma_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(gamma_free__, cons_list(index_uni(1), nil_index_list()),
+            "gamma_free__"));
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
           vars__.emplace_back(gamma_free__[(sym1__ - 1)]);}
       } 
       if (lcm_sym130__) {
-        vars__.emplace_back(epsilon[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(epsilon, cons_list(index_uni(1), nil_index_list()),
+            "epsilon"));
         for (int sym1__ = 2; sym1__ <= lcm_sym131__; ++sym1__) {
           vars__.emplace_back(epsilon[(sym1__ - 1)]);}
       } 
@@ -26140,7 +27827,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
             in__.scalar(), "assigning variable theta");}
       } 
       if (lcm_sym4__) {
-        vars__.emplace_back(theta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(theta[(sym1__ - 1)]);}
       } 
@@ -26184,7 +27872,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       assign(theta, nil_index_list(), context__.vals_r("theta"),
         "assigning variable theta");
       if (logical_gte(J, 1)) {
-        vars__.emplace_back(theta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(theta, cons_list(index_uni(1), nil_index_list()), "theta"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(theta[(sym1__ - 1)]);}
       } 
@@ -26449,13 +28138,13 @@ first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       lcm_sym27__ = size(y_i);
       if (logical_gte(lcm_sym27__, 1)) {
         current_statement__ = 42;
-        if (y_i[(1 - 1)]) {
+        if (rvalue(y_i, cons_list(index_uni(1), nil_index_list()), "y_i")) {
           current_statement__ = 41;
           return 1;
         } 
         for (int k = 2; k <= lcm_sym27__; ++k) {
           current_statement__ = 42;
-          if (y_i[(k - 1)]) {
+          if (rvalue(y_i, cons_list(index_uni(k), nil_index_list()), "y_i")) {
             current_statement__ = 41;
             return k;
           } }
@@ -26867,7 +28556,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 35;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= nind; ++sym2__) {
@@ -26910,12 +28600,18 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 0);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 35;
@@ -26923,7 +28619,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 0);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -26938,12 +28637,18 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], 1);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), 1);
           for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 35;
@@ -26951,7 +28656,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), 1);
             for (int sym2__ = 2; sym2__ <= n_occasions; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -26982,11 +28690,14 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
         
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym146__ = size(y[(1 - 1)]);
+          lcm_sym146__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym146__;
                ++inline_sym18__) {
             current_statement__ = 42;
-            if (y[(1 - 1)][(inline_sym18__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (inline_sym18__ - 1)]) {
               inline_sym19__ = 1;
               inline_sym17__ = inline_sym18__;
               break;
@@ -27006,11 +28717,15 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
           
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym145__ = size(y[(i - 1)]);
+            lcm_sym145__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym145__;
                  ++inline_sym18__) {
               current_statement__ = 42;
-              if (y[(i - 1)][(inline_sym18__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (inline_sym18__ - 1)]) {
                 inline_sym19__ = 1;
                 inline_sym17__ = inline_sym18__;
                 break;
@@ -27032,7 +28747,9 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
         
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym146__ = size(y[(1 - 1)]);
+          lcm_sym146__ = size(
+                           rvalue(y,
+                             cons_list(index_uni(1), nil_index_list()), "y"));
           lcm_sym143__ = (lcm_sym146__ - 1);
           for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym143__;
                ++inline_sym23__) {
@@ -27042,7 +28759,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             lcm_sym142__ = (lcm_sym146__ - inline_sym23__);
             inline_sym22__ = lcm_sym142__;
             current_statement__ = 48;
-            if (y[(1 - 1)][(lcm_sym142__ - 1)]) {
+            if (rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")[
+                (lcm_sym142__ - 1)]) {
               inline_sym24__ = 1;
               inline_sym21__ = lcm_sym142__;
               break;
@@ -27062,7 +28780,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
           
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym145__ = size(y[(i - 1)]);
+            lcm_sym145__ = size(
+                             rvalue(y,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "y"));
             lcm_sym141__ = (lcm_sym145__ - 1);
             for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym141__;
                  ++inline_sym23__) {
@@ -27072,7 +28793,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
               lcm_sym140__ = (lcm_sym145__ - inline_sym23__);
               inline_sym22__ = lcm_sym140__;
               current_statement__ = 48;
-              if (y[(i - 1)][(lcm_sym140__ - 1)]) {
+              if (rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")[
+                  (lcm_sym140__ - 1)]) {
                 inline_sym24__ = 1;
                 inline_sym21__ = lcm_sym140__;
                 break;
@@ -27090,7 +28812,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       if (lcm_sym138__) {
         current_statement__ = 38;
         current_statement__ = 38;
-        check_greater_or_equal(function__, "first[sym1__]", first[(1 - 1)], 0);
+        check_greater_or_equal(function__, "first[sym1__]",
+                               rvalue(first,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "first"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 38;
           current_statement__ = 38;
@@ -27101,8 +28826,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       if (lcm_sym138__) {
         current_statement__ = 38;
         current_statement__ = 38;
-        check_less_or_equal(function__, "first[sym1__]", first[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "first[sym1__]",
+                            rvalue(first,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "first"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 38;
           current_statement__ = 38;
@@ -27113,7 +28840,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       if (lcm_sym138__) {
         current_statement__ = 40;
         current_statement__ = 40;
-        check_greater_or_equal(function__, "last[sym1__]", last[(1 - 1)], 0);
+        check_greater_or_equal(function__, "last[sym1__]",
+                               rvalue(last,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "last"), 0);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 40;
           current_statement__ = 40;
@@ -27124,8 +28854,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       if (lcm_sym138__) {
         current_statement__ = 40;
         current_statement__ = 40;
-        check_less_or_equal(function__, "last[sym1__]", last[(1 - 1)],
-                            n_occasions);
+        check_less_or_equal(function__, "last[sym1__]",
+                            rvalue(last,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "last"), n_occasions);
         for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
           current_statement__ = 40;
           current_statement__ = 40;
@@ -27267,7 +28999,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       
       lcm_sym89__ = logical_gte(nind, 1);
       if (lcm_sym89__) {
-        lcm_sym122__ = first[(1 - 1)];
+        lcm_sym122__ = rvalue(first,
+                         cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym102__ = (lcm_sym122__ - 1);
         if (logical_gte(lcm_sym102__, 1)) {
           current_statement__ = 6;
@@ -27317,7 +29050,9 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym121__ = first[(i - 1)];
+          lcm_sym121__ = rvalue(first,
+                           cons_list(index_uni(i), nil_index_list()),
+                           "first");
           lcm_sym101__ = (lcm_sym121__ - 1);
           if (logical_gte(lcm_sym101__, 1)) {
             current_statement__ = 6;
@@ -27717,9 +29452,13 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       {
         current_statement__ = 30;
         if (lcm_sym89__) {
-          lcm_sym122__ = first[(1 - 1)];
+          lcm_sym122__ = rvalue(first,
+                           cons_list(index_uni(1), nil_index_list()),
+                           "first");
           if (logical_gt(lcm_sym122__, 0)) {
-            lcm_sym128__ = last[(1 - 1)];
+            lcm_sym128__ = rvalue(last,
+                             cons_list(index_uni(1), nil_index_list()),
+                             "last");
             lcm_sym108__ = (lcm_sym122__ + 1);
             if (logical_gte(lcm_sym128__, lcm_sym108__)) {
               current_statement__ = 24;
@@ -27731,7 +29470,11 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                         nil_index_list())), "phi")));
               lcm_sym106__ = (lcm_sym108__ + 1);
               lp_accum__.add(
-                bernoulli_lpmf<propto__>(y[(1 - 1)][(lcm_sym108__ - 1)],
+                bernoulli_lpmf<propto__>(
+                  rvalue(y,
+                    cons_list(index_uni(1),
+                      cons_list(index_uni(lcm_sym108__), nil_index_list())),
+                    "y"),
                   rvalue(p,
                     cons_list(index_uni(1),
                       cons_list(index_uni((lcm_sym108__ - 1)),
@@ -27746,7 +29489,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                       "phi")));
                 current_statement__ = 25;
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(1 - 1)][(t - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(1),
+                        cons_list(index_uni(t), nil_index_list())), "y"),
                     rvalue(p,
                       cons_list(index_uni(1),
                         cons_list(index_uni((t - 1)), nil_index_list())),
@@ -27761,9 +29507,13 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                   "inline_sym9__")));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym121__ = first[(i - 1)];
+            lcm_sym121__ = rvalue(first,
+                             cons_list(index_uni(i), nil_index_list()),
+                             "first");
             if (logical_gt(lcm_sym121__, 0)) {
-              lcm_sym127__ = last[(i - 1)];
+              lcm_sym127__ = rvalue(last,
+                               cons_list(index_uni(i), nil_index_list()),
+                               "last");
               lcm_sym107__ = (lcm_sym121__ + 1);
               if (logical_gte(lcm_sym127__, lcm_sym107__)) {
                 current_statement__ = 24;
@@ -27775,7 +29525,11 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                           nil_index_list())), "phi")));
                 lcm_sym105__ = (lcm_sym107__ + 1);
                 lp_accum__.add(
-                  bernoulli_lpmf<propto__>(y[(i - 1)][(lcm_sym107__ - 1)],
+                  bernoulli_lpmf<propto__>(
+                    rvalue(y,
+                      cons_list(index_uni(i),
+                        cons_list(index_uni(lcm_sym107__), nil_index_list())),
+                      "y"),
                     rvalue(p,
                       cons_list(index_uni(i),
                         cons_list(index_uni((lcm_sym107__ - 1)),
@@ -27790,7 +29544,10 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                         "phi")));
                   current_statement__ = 25;
                   lp_accum__.add(
-                    bernoulli_lpmf<propto__>(y[(i - 1)][(t - 1)],
+                    bernoulli_lpmf<propto__>(
+                      rvalue(y,
+                        cons_list(index_uni(i),
+                          cons_list(index_uni(t), nil_index_list())), "y"),
                       rvalue(p,
                         cons_list(index_uni(i),
                           cons_list(index_uni((t - 1)), nil_index_list())),
@@ -27913,7 +29670,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       } 
       lcm_sym47__ = logical_gte(nind, 1);
       if (lcm_sym47__) {
-        lcm_sym66__ = first[(1 - 1)];
+        lcm_sym66__ = rvalue(first,
+                        cons_list(index_uni(1), nil_index_list()), "first");
         lcm_sym56__ = (lcm_sym66__ - 1);
         if (logical_gte(lcm_sym56__, 1)) {
           current_statement__ = 6;
@@ -27963,7 +29721,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
               "assigning variable p");}
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym65__ = first[(i - 1)];
+          lcm_sym65__ = rvalue(first,
+                          cons_list(index_uni(i), nil_index_list()), "first");
           lcm_sym55__ = (lcm_sym65__ - 1);
           if (logical_gte(lcm_sym55__, 1)) {
             current_statement__ = 6;
@@ -29434,7 +31193,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
               assign(y,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                y_flat__[(1 - 1)], "assigning variable y");
+                rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "y_flat__"), "assigning variable y");
               current_statement__ = 35;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= R; ++sym2__) {
@@ -29477,12 +31237,18 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                 y[(1 - 1)][(1 - 1)], 0);
+                                 rvalue(y,
+                                   cons_list(index_uni(1),
+                                     cons_list(index_uni(1),
+                                       nil_index_list())), "y"), 0);
           for (int sym2__ = 2; sym2__ <= T; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(1 - 1)][(sym2__ - 1)], 0);}
+                                   rvalue(y,
+                                     cons_list(index_uni(1),
+                                       cons_list(index_uni(sym2__),
+                                         nil_index_list())), "y"), 0);}
         } 
         for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
           current_statement__ = 35;
@@ -29490,7 +31256,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_greater_or_equal(function__, "y[sym1__, sym2__]",
-                                   y[(sym1__ - 1)][(1 - 1)], 0);
+                                   rvalue(y,
+                                     cons_list(index_uni(sym1__),
+                                       cons_list(index_uni(1),
+                                         nil_index_list())), "y"), 0);
             for (int sym2__ = 2; sym2__ <= T; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -29505,12 +31274,18 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
           current_statement__ = 35;
           current_statement__ = 35;
           check_less_or_equal(function__, "y[sym1__, sym2__]",
-                              y[(1 - 1)][(1 - 1)], 1);
+                              rvalue(y,
+                                cons_list(index_uni(1),
+                                  cons_list(index_uni(1), nil_index_list())),
+                                "y"), 1);
           for (int sym2__ = 2; sym2__ <= T; ++sym2__) {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(1 - 1)][(sym2__ - 1)], 1);}
+                                rvalue(y,
+                                  cons_list(index_uni(1),
+                                    cons_list(index_uni(sym2__),
+                                      nil_index_list())), "y"), 1);}
         } 
         for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
           current_statement__ = 35;
@@ -29518,7 +31293,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             current_statement__ = 35;
             current_statement__ = 35;
             check_less_or_equal(function__, "y[sym1__, sym2__]",
-                                y[(sym1__ - 1)][(1 - 1)], 1);
+                                rvalue(y,
+                                  cons_list(index_uni(sym1__),
+                                    cons_list(index_uni(1), nil_index_list())),
+                                  "y"), 1);
             for (int sym2__ = 2; sym2__ <= T; ++sym2__) {
               current_statement__ = 35;
               current_statement__ = 35;
@@ -29545,7 +31323,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
         if (lcm_sym41__) {
           current_statement__ = 37;
           assign(X, cons_list(index_uni(1), nil_index_list()),
-            X_flat__[(1 - 1)], "assigning variable X");
+            rvalue(X_flat__, cons_list(index_uni(1), nil_index_list()),
+              "X_flat__"), "assigning variable X");
           current_statement__ = 37;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
@@ -29570,18 +31349,21 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       if (lcm_sym41__) {
         current_statement__ = 42;
         assign(sum_y, cons_list(index_uni(1), nil_index_list()),
-          sum(y[(1 - 1)]), "assigning variable sum_y");
+          sum(rvalue(y, cons_list(index_uni(1), nil_index_list()), "y")),
+          "assigning variable sum_y");
         current_statement__ = 44;
-        if (sum_y[(1 - 1)]) {
+        if (rvalue(sum_y, cons_list(index_uni(1), nil_index_list()), "sum_y")) {
           current_statement__ = 43;
           occ_obs = 1;
         } 
         for (int i = 2; i <= R; ++i) {
           current_statement__ = 42;
           assign(sum_y, cons_list(index_uni(i), nil_index_list()),
-            sum(y[(i - 1)]), "assigning variable sum_y");
+            sum(rvalue(y, cons_list(index_uni(i), nil_index_list()), "y")),
+            "assigning variable sum_y");
           current_statement__ = 44;
-          if (sum_y[(i - 1)]) {
+          if (rvalue(sum_y, cons_list(index_uni(i), nil_index_list()),
+                "sum_y")) {
             current_statement__ = 43;
             occ_obs = (occ_obs + 1);
           } }
@@ -29590,7 +31372,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       if (lcm_sym41__) {
         current_statement__ = 39;
         current_statement__ = 39;
-        check_greater_or_equal(function__, "sum_y[sym1__]", sum_y[(1 - 1)], 0);
+        check_greater_or_equal(function__, "sum_y[sym1__]",
+                               rvalue(sum_y,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "sum_y"), 0);
         for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
           current_statement__ = 39;
           current_statement__ = 39;
@@ -29601,7 +31386,10 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       if (lcm_sym41__) {
         current_statement__ = 39;
         current_statement__ = 39;
-        check_less_or_equal(function__, "sum_y[sym1__]", sum_y[(1 - 1)], T);
+        check_less_or_equal(function__, "sum_y[sym1__]",
+                            rvalue(sum_y,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "sum_y"), T);
         for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
           current_statement__ = 39;
           current_statement__ = 39;
@@ -29713,47 +31501,66 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
         current_statement__ = 30;
         if (logical_gte(R, 1)) {
           current_statement__ = 28;
-          if (sum_y[(1 - 1)]) {
+          if (rvalue(sum_y, cons_list(index_uni(1), nil_index_list()),
+                "sum_y")) {
             current_statement__ = 25;
             lp_accum__.add(
-              bernoulli_logit_lpmf<propto__>(1, lcm_sym31__[(1 - 1)]));
+              bernoulli_logit_lpmf<propto__>(1,
+                rvalue(lcm_sym31__,
+                  cons_list(index_uni(1), nil_index_list()), "lcm_sym31__")));
             current_statement__ = 26;
             lp_accum__.add(
-              bernoulli_logit_lpmf<propto__>(y[(1 - 1)],
+              bernoulli_logit_lpmf<propto__>(
+                rvalue(y, cons_list(index_uni(1), nil_index_list()), "y"),
                 rvalue(lcm_sym38__,
                   cons_list(index_uni(1), nil_index_list()), "lcm_sym38__")));
           } else {
             current_statement__ = 23;
             lp_accum__.add(
               log_sum_exp(
-                (bernoulli_logit_lpmf<false>(1, lcm_sym31__[(1 - 1)]) +
+                (bernoulli_logit_lpmf<false>(1,
+                   rvalue(lcm_sym31__,
+                     cons_list(index_uni(1), nil_index_list()),
+                     "lcm_sym31__")) +
                   bernoulli_logit_lpmf<false>(0,
                     rvalue(lcm_sym38__,
                       cons_list(index_uni(1), nil_index_list()),
                       "lcm_sym38__"))),
-                bernoulli_logit_lpmf<false>(0, lcm_sym31__[(1 - 1)])));
+                bernoulli_logit_lpmf<false>(0,
+                  rvalue(lcm_sym31__,
+                    cons_list(index_uni(1), nil_index_list()), "lcm_sym31__"))));
           }
           for (int i = 2; i <= R; ++i) {
             current_statement__ = 28;
-            if (sum_y[(i - 1)]) {
+            if (rvalue(sum_y, cons_list(index_uni(i), nil_index_list()),
+                  "sum_y")) {
               current_statement__ = 25;
               lp_accum__.add(
-                bernoulli_logit_lpmf<propto__>(1, lcm_sym31__[(i - 1)]));
+                bernoulli_logit_lpmf<propto__>(1,
+                  rvalue(lcm_sym31__,
+                    cons_list(index_uni(i), nil_index_list()), "lcm_sym31__")));
               current_statement__ = 26;
               lp_accum__.add(
-                bernoulli_logit_lpmf<propto__>(y[(i - 1)],
+                bernoulli_logit_lpmf<propto__>(
+                  rvalue(y, cons_list(index_uni(i), nil_index_list()), "y"),
                   rvalue(lcm_sym38__,
                     cons_list(index_uni(i), nil_index_list()), "lcm_sym38__")));
             } else {
               current_statement__ = 23;
               lp_accum__.add(
                 log_sum_exp(
-                  (bernoulli_logit_lpmf<false>(1, lcm_sym31__[(i - 1)]) +
+                  (bernoulli_logit_lpmf<false>(1,
+                     rvalue(lcm_sym31__,
+                       cons_list(index_uni(i), nil_index_list()),
+                       "lcm_sym31__")) +
                     bernoulli_logit_lpmf<false>(0,
                       rvalue(lcm_sym38__,
                         cons_list(index_uni(i), nil_index_list()),
                         "lcm_sym38__"))),
-                  bernoulli_logit_lpmf<false>(0, lcm_sym31__[(i - 1)])));
+                  bernoulli_logit_lpmf<false>(0,
+                    rvalue(lcm_sym31__,
+                      cons_list(index_uni(i), nil_index_list()),
+                      "lcm_sym31__"))));
             }}
         } 
       }
@@ -29866,7 +31673,9 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
         {
           lcm_sym5__ = logical_gte(R, 1);
           if (lcm_sym5__) {
-            vars__.emplace_back(lcm_sym9__[(1 - 1)]);
+            vars__.emplace_back(
+              rvalue(lcm_sym9__, cons_list(index_uni(1), nil_index_list()),
+                "lcm_sym9__"));
             for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
               vars__.emplace_back(lcm_sym9__[(sym1__ - 1)]);}
           } 
@@ -29918,11 +31727,15 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       current_statement__ = 22;
       if (lcm_sym5__) {
         current_statement__ = 20;
-        if (logical_eq(sum_y[(1 - 1)], 0)) {
+        if (logical_eq(
+              rvalue(sum_y, cons_list(index_uni(1), nil_index_list()),
+                "sum_y"), 0)) {
           double psi;
           psi = std::numeric_limits<double>::quiet_NaN();
           
-          lcm_sym25__ = lcm_sym9__[(1 - 1)];
+          lcm_sym25__ = rvalue(lcm_sym9__,
+                          cons_list(index_uni(1), nil_index_list()),
+                          "lcm_sym9__");
           lcm_sym15__ = inv_logit(lcm_sym25__);
           current_statement__ = 14;
           validate_non_negative_index("q", "T", T);
@@ -29948,8 +31761,9 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             "assigning variable psi_con");
           current_statement__ = 18;
           assign(z, cons_list(index_uni(1), nil_index_list()),
-            bernoulli_rng(psi_con[(1 - 1)], base_rng__),
-            "assigning variable z");
+            bernoulli_rng(
+              rvalue(psi_con, cons_list(index_uni(1), nil_index_list()),
+                "psi_con"), base_rng__), "assigning variable z");
         } else {
           current_statement__ = 10;
           assign(psi_con, cons_list(index_uni(1), nil_index_list()), 1,
@@ -29960,11 +31774,16 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
         }
         for (int i = 2; i <= R; ++i) {
           current_statement__ = 20;
-          if (logical_eq(sum_y[(i - 1)], 0)) {
+          if (logical_eq(
+                rvalue(sum_y, cons_list(index_uni(i), nil_index_list()),
+                  "sum_y"), 0)) {
             double psi;
             psi = std::numeric_limits<double>::quiet_NaN();
             
-            lcm_sym14__ = inv_logit(lcm_sym9__[(i - 1)]);
+            lcm_sym14__ = inv_logit(
+                            rvalue(lcm_sym9__,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "lcm_sym9__"));
             current_statement__ = 14;
             validate_non_negative_index("q", "T", T);
             Eigen::Matrix<double, -1, 1> q;
@@ -29989,8 +31808,9 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
               "assigning variable psi_con");
             current_statement__ = 18;
             assign(z, cons_list(index_uni(i), nil_index_list()),
-              bernoulli_rng(psi_con[(i - 1)], base_rng__),
-              "assigning variable z");
+              bernoulli_rng(
+                rvalue(psi_con, cons_list(index_uni(i), nil_index_list()),
+                  "psi_con"), base_rng__), "assigning variable z");
           } else {
             current_statement__ = 10;
             assign(psi_con, cons_list(index_uni(i), nil_index_list()), 1,
@@ -30004,12 +31824,15 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       occ_fs = lcm_sym19__;
       vars__.emplace_back(lcm_sym19__);
       if (lcm_sym5__) {
-        vars__.emplace_back(psi_con[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(psi_con, cons_list(index_uni(1), nil_index_list()),
+            "psi_con"));
         for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
           vars__.emplace_back(psi_con[(sym1__ - 1)]);}
       } 
       if (lcm_sym5__) {
-        vars__.emplace_back(z[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(z, cons_list(index_uni(1), nil_index_list()), "z"));
         for (int sym1__ = 2; sym1__ <= R; ++sym1__) {
           vars__.emplace_back(z[(sym1__ - 1)]);}
       } 
@@ -30428,8 +32251,10 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       if (lcm_sym40__) {
         current_statement__ = 23;
         current_statement__ = 23;
-        check_greater_or_equal(function__, "person[sym1__]", person[(1 - 1)],
-                               1);
+        check_greater_or_equal(function__, "person[sym1__]",
+                               rvalue(person,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "person"), 1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 23;
           current_statement__ = 23;
@@ -30440,7 +32265,10 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       if (lcm_sym40__) {
         current_statement__ = 23;
         current_statement__ = 23;
-        check_less_or_equal(function__, "person[sym1__]", person[(1 - 1)], J);
+        check_less_or_equal(function__, "person[sym1__]",
+                            rvalue(person,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "person"), J);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 23;
           current_statement__ = 23;
@@ -30466,7 +32294,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         if (lcm_sym40__) {
           current_statement__ = 25;
           assign(time, cons_list(index_uni(1), nil_index_list()),
-            time_flat__[(1 - 1)], "assigning variable time");
+            rvalue(time_flat__, cons_list(index_uni(1), nil_index_list()),
+              "time_flat__"), "assigning variable time");
           current_statement__ = 25;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -30497,7 +32326,9 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         if (lcm_sym40__) {
           current_statement__ = 27;
           assign(treatment, cons_list(index_uni(1), nil_index_list()),
-            treatment_flat__[(1 - 1)], "assigning variable treatment");
+            rvalue(treatment_flat__,
+              cons_list(index_uni(1), nil_index_list()), "treatment_flat__"),
+            "assigning variable treatment");
           current_statement__ = 27;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -30527,7 +32358,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         if (lcm_sym40__) {
           current_statement__ = 29;
           assign(y, cons_list(index_uni(1), nil_index_list()),
-            y_flat__[(1 - 1)], "assigning variable y");
+            rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+              "y_flat__"), "assigning variable y");
           current_statement__ = 29;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -30689,17 +32521,46 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       if (logical_gte(N, 1)) {
         current_statement__ = 12;
         assign(y_hat, cons_list(index_uni(1), nil_index_list()),
-          stan::math::fma(lcm_sym31__[(person[(1 - 1)] - 1)], time[(1 - 1)],
-            stan::math::fma((beta * time[(1 - 1)]), treatment[(1 - 1)],
-              lcm_sym30__[(person[(1 - 1)] - 1)])),
+          stan::math::fma(
+            rvalue(lcm_sym31__,
+              cons_list(
+                index_uni(rvalue(person,
+                            cons_list(index_uni(1), nil_index_list()),
+                            "person")), nil_index_list()), "lcm_sym31__"),
+            rvalue(time, cons_list(index_uni(1), nil_index_list()), "time"),
+            stan::math::fma(
+              (beta *
+                rvalue(time, cons_list(index_uni(1), nil_index_list()),
+                  "time")),
+              rvalue(treatment, cons_list(index_uni(1), nil_index_list()),
+                "treatment"),
+              rvalue(lcm_sym30__,
+                cons_list(
+                  index_uni(rvalue(person,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "person")), nil_index_list()), "lcm_sym30__"))),
           "assigning variable y_hat");
         for (int i = 2; i <= N; ++i) {
           current_statement__ = 12;
           assign(y_hat, cons_list(index_uni(i), nil_index_list()),
-            stan::math::fma(lcm_sym31__[(person[(i - 1)] - 1)],
-              time[(i - 1)],
-              stan::math::fma((beta * time[(i - 1)]), treatment[(i - 1)],
-                lcm_sym30__[(person[(i - 1)] - 1)])),
+            stan::math::fma(
+              rvalue(lcm_sym31__,
+                cons_list(
+                  index_uni(rvalue(person,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "person")), nil_index_list()), "lcm_sym31__"),
+              rvalue(time, cons_list(index_uni(i), nil_index_list()), "time"),
+              stan::math::fma(
+                (beta *
+                  rvalue(time, cons_list(index_uni(i), nil_index_list()),
+                    "time")),
+                rvalue(treatment, cons_list(index_uni(i), nil_index_list()),
+                  "treatment"),
+                rvalue(lcm_sym30__,
+                  cons_list(
+                    index_uni(rvalue(person,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "person")), nil_index_list()), "lcm_sym30__"))),
             "assigning variable y_hat");}
       } 
       {
@@ -30828,12 +32689,14 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       vars__.emplace_back(beta);
       lcm_sym11__ = logical_gte(J, 1);
       if (lcm_sym11__) {
-        vars__.emplace_back(eta1[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(eta1, cons_list(index_uni(1), nil_index_list()), "eta1"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(eta1[(sym1__ - 1)]);}
       } 
       if (lcm_sym11__) {
-        vars__.emplace_back(eta2[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(eta2, cons_list(index_uni(1), nil_index_list()), "eta2"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(eta2[(sym1__ - 1)]);}
       } 
@@ -30858,32 +32721,66 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       if (lcm_sym12__) {
         current_statement__ = 12;
         assign(y_hat, cons_list(index_uni(1), nil_index_list()),
-          stan::math::fma(lcm_sym16__[(person[(1 - 1)] - 1)], time[(1 - 1)],
-            stan::math::fma((beta * time[(1 - 1)]), treatment[(1 - 1)],
-              lcm_sym15__[(person[(1 - 1)] - 1)])),
+          stan::math::fma(
+            rvalue(lcm_sym16__,
+              cons_list(
+                index_uni(rvalue(person,
+                            cons_list(index_uni(1), nil_index_list()),
+                            "person")), nil_index_list()), "lcm_sym16__"),
+            rvalue(time, cons_list(index_uni(1), nil_index_list()), "time"),
+            stan::math::fma(
+              (beta *
+                rvalue(time, cons_list(index_uni(1), nil_index_list()),
+                  "time")),
+              rvalue(treatment, cons_list(index_uni(1), nil_index_list()),
+                "treatment"),
+              rvalue(lcm_sym15__,
+                cons_list(
+                  index_uni(rvalue(person,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "person")), nil_index_list()), "lcm_sym15__"))),
           "assigning variable y_hat");
         for (int i = 2; i <= N; ++i) {
           current_statement__ = 12;
           assign(y_hat, cons_list(index_uni(i), nil_index_list()),
-            stan::math::fma(lcm_sym16__[(person[(i - 1)] - 1)],
-              time[(i - 1)],
-              stan::math::fma((beta * time[(i - 1)]), treatment[(i - 1)],
-                lcm_sym15__[(person[(i - 1)] - 1)])),
+            stan::math::fma(
+              rvalue(lcm_sym16__,
+                cons_list(
+                  index_uni(rvalue(person,
+                              cons_list(index_uni(i), nil_index_list()),
+                              "person")), nil_index_list()), "lcm_sym16__"),
+              rvalue(time, cons_list(index_uni(i), nil_index_list()), "time"),
+              stan::math::fma(
+                (beta *
+                  rvalue(time, cons_list(index_uni(i), nil_index_list()),
+                    "time")),
+                rvalue(treatment, cons_list(index_uni(i), nil_index_list()),
+                  "treatment"),
+                rvalue(lcm_sym15__,
+                  cons_list(
+                    index_uni(rvalue(person,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "person")), nil_index_list()), "lcm_sym15__"))),
             "assigning variable y_hat");}
       } 
       if (emit_transformed_parameters__) {
         if (lcm_sym11__) {
-          vars__.emplace_back(lcm_sym15__[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(lcm_sym15__, cons_list(index_uni(1), nil_index_list()),
+              "lcm_sym15__"));
           for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
             vars__.emplace_back(lcm_sym15__[(sym1__ - 1)]);}
         } 
         if (lcm_sym11__) {
-          vars__.emplace_back(lcm_sym16__[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(lcm_sym16__, cons_list(index_uni(1), nil_index_list()),
+              "lcm_sym16__"));
           for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
             vars__.emplace_back(lcm_sym16__[(sym1__ - 1)]);}
         } 
         if (lcm_sym12__) {
-          vars__.emplace_back(y_hat[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(y_hat, cons_list(index_uni(1), nil_index_list()), "y_hat"));
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
             vars__.emplace_back(y_hat[(sym1__ - 1)]);}
         } 
@@ -30944,7 +32841,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         if (lcm_sym1__) {
           current_statement__ = 2;
           assign(eta1, cons_list(index_uni(1), nil_index_list()),
-            eta1_flat__[(1 - 1)], "assigning variable eta1");
+            rvalue(eta1_flat__, cons_list(index_uni(1), nil_index_list()),
+              "eta1_flat__"), "assigning variable eta1");
           current_statement__ = 2;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
@@ -30970,7 +32868,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         if (lcm_sym1__) {
           current_statement__ = 3;
           assign(eta2, cons_list(index_uni(1), nil_index_list()),
-            eta2_flat__[(1 - 1)], "assigning variable eta2");
+            rvalue(eta2_flat__, cons_list(index_uni(1), nil_index_list()),
+              "eta2_flat__"), "assigning variable eta2");
           current_statement__ = 3;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
@@ -31023,12 +32922,14 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       sigma_y_free__ = stan::math::lub_free(sigma_y, 0, 100);
       vars__.emplace_back(beta);
       if (lcm_sym1__) {
-        vars__.emplace_back(eta1[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(eta1, cons_list(index_uni(1), nil_index_list()), "eta1"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(eta1[(sym1__ - 1)]);}
       } 
       if (lcm_sym1__) {
-        vars__.emplace_back(eta2[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(eta2, cons_list(index_uni(1), nil_index_list()), "eta2"));
         for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
           vars__.emplace_back(eta2[(sym1__ - 1)]);}
       } 
@@ -32233,9 +34134,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
       }
       {
-        vars__.emplace_back(x_vector[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(x_vector, cons_list(index_uni(1), nil_index_list()),
+            "x_vector"));
         {
-          vars__.emplace_back(x_vector[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(x_vector, cons_list(index_uni(2), nil_index_list()),
+              "x_vector"));
         }
       }
       {
@@ -32338,7 +34243,9 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             assign(x_matrix,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              x_matrix_flat__[(1 - 1)], "assigning variable x_matrix");
+              rvalue(x_matrix_flat__,
+                cons_list(index_uni(1), nil_index_list()), "x_matrix_flat__"),
+              "assigning variable x_matrix");
             current_statement__ = 3;
             pos__ = 2;
             {
@@ -32405,7 +34312,9 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         {
           current_statement__ = 4;
           assign(x_vector, cons_list(index_uni(1), nil_index_list()),
-            x_vector_flat__[(1 - 1)], "assigning variable x_vector");
+            rvalue(x_vector_flat__,
+              cons_list(index_uni(1), nil_index_list()), "x_vector_flat__"),
+            "assigning variable x_vector");
           current_statement__ = 4;
           pos__ = 2;
           {
@@ -32434,7 +34343,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             assign(x_cov,
               cons_list(index_uni(1),
                 cons_list(index_uni(1), nil_index_list())),
-              x_cov_flat__[(1 - 1)], "assigning variable x_cov");
+              rvalue(x_cov_flat__, cons_list(index_uni(1), nil_index_list()),
+                "x_cov_flat__"), "assigning variable x_cov");
             current_statement__ = 5;
             pos__ = 2;
             {
@@ -32519,18 +34429,28 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
       }
       {
-        vars__.emplace_back(x_vector[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(x_vector, cons_list(index_uni(1), nil_index_list()),
+            "x_vector"));
         {
-          vars__.emplace_back(x_vector[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(x_vector, cons_list(index_uni(2), nil_index_list()),
+              "x_vector"));
         }
       }
       {
-        vars__.emplace_back(x_cov_free__[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(x_cov_free__, cons_list(index_uni(1), nil_index_list()),
+            "x_cov_free__"));
         {
-          vars__.emplace_back(x_cov_free__[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(x_cov_free__, cons_list(index_uni(2), nil_index_list()),
+              "x_cov_free__"));
         }
         {
-          vars__.emplace_back(x_cov_free__[(3 - 1)]);
+          vars__.emplace_back(
+            rvalue(x_cov_free__, cons_list(index_uni(3), nil_index_list()),
+              "x_cov_free__"));
         }
       }
     } catch (const std::exception& e) {
@@ -32877,7 +34797,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       if (lcm_sym30__) {
         current_statement__ = 16;
         current_statement__ = 16;
-        check_greater_or_equal(function__, "pair[sym1__]", pair[(1 - 1)], 1);
+        check_greater_or_equal(function__, "pair[sym1__]",
+                               rvalue(pair,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "pair"), 1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 16;
           current_statement__ = 16;
@@ -32888,7 +34811,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       if (lcm_sym30__) {
         current_statement__ = 16;
         current_statement__ = 16;
-        check_less_or_equal(function__, "pair[sym1__]", pair[(1 - 1)], n_pair);
+        check_less_or_equal(function__, "pair[sym1__]",
+                            rvalue(pair,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "pair"), n_pair);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 16;
           current_statement__ = 16;
@@ -32914,7 +34840,9 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         if (lcm_sym30__) {
           current_statement__ = 18;
           assign(pre_test, cons_list(index_uni(1), nil_index_list()),
-            pre_test_flat__[(1 - 1)], "assigning variable pre_test");
+            rvalue(pre_test_flat__,
+              cons_list(index_uni(1), nil_index_list()), "pre_test_flat__"),
+            "assigning variable pre_test");
           current_statement__ = 18;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -32945,7 +34873,9 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         if (lcm_sym30__) {
           current_statement__ = 20;
           assign(treatment, cons_list(index_uni(1), nil_index_list()),
-            treatment_flat__[(1 - 1)], "assigning variable treatment");
+            rvalue(treatment_flat__,
+              cons_list(index_uni(1), nil_index_list()), "treatment_flat__"),
+            "assigning variable treatment");
           current_statement__ = 20;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -32961,7 +34891,9 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 20;
         current_statement__ = 20;
         check_greater_or_equal(function__, "treatment[sym1__]",
-                               treatment[(1 - 1)], 0);
+                               rvalue(treatment,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "treatment"), 0);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 20;
           current_statement__ = 20;
@@ -32973,7 +34905,9 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 20;
         current_statement__ = 20;
         check_less_or_equal(function__, "treatment[sym1__]",
-                            treatment[(1 - 1)], 1);
+                            rvalue(treatment,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "treatment"), 1);
         for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
           current_statement__ = 20;
           current_statement__ = 20;
@@ -32999,7 +34933,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         if (lcm_sym30__) {
           current_statement__ = 22;
           assign(y, cons_list(index_uni(1), nil_index_list()),
-            y_flat__[(1 - 1)], "assigning variable y");
+            rvalue(y_flat__, cons_list(index_uni(1), nil_index_list()),
+              "y_flat__"), "assigning variable y");
           current_statement__ = 22;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
@@ -33109,15 +35044,38 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       if (logical_gte(N, 1)) {
         current_statement__ = 7;
         assign(y_hat, cons_list(index_uni(1), nil_index_list()),
-          stan::math::fma(beta[(2 - 1)], pre_test[(1 - 1)],
-            stan::math::fma(beta[(1 - 1)], treatment[(1 - 1)],
-              a[(pair[(1 - 1)] - 1)])), "assigning variable y_hat");
+          stan::math::fma(
+            rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"),
+            rvalue(pre_test, cons_list(index_uni(1), nil_index_list()),
+              "pre_test"),
+            stan::math::fma(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              rvalue(treatment, cons_list(index_uni(1), nil_index_list()),
+                "treatment"),
+              rvalue(a,
+                cons_list(
+                  index_uni(rvalue(pair,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "pair")), nil_index_list()), "a"))),
+          "assigning variable y_hat");
         for (int i = 2; i <= N; ++i) {
           current_statement__ = 7;
           assign(y_hat, cons_list(index_uni(i), nil_index_list()),
-            stan::math::fma(beta[(2 - 1)], pre_test[(i - 1)],
-              stan::math::fma(beta[(1 - 1)], treatment[(i - 1)],
-                a[(pair[(i - 1)] - 1)])), "assigning variable y_hat");}
+            stan::math::fma(
+              rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"),
+              rvalue(pre_test, cons_list(index_uni(i), nil_index_list()),
+                "pre_test"),
+              stan::math::fma(
+                rvalue(beta, cons_list(index_uni(1), nil_index_list()),
+                  "beta"),
+                rvalue(treatment, cons_list(index_uni(i), nil_index_list()),
+                  "treatment"),
+                rvalue(a,
+                  cons_list(
+                    index_uni(rvalue(pair,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "pair")), nil_index_list()), "a"))),
+            "assigning variable y_hat");}
       } 
       {
         current_statement__ = 9;
@@ -33208,14 +35166,17 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       stan::math::fill(y_hat, DUMMY_VAR__);
       
       if (logical_gte(n_pair, 1)) {
-        vars__.emplace_back(a[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(a, cons_list(index_uni(1), nil_index_list()), "a"));
         for (int sym1__ = 2; sym1__ <= n_pair; ++sym1__) {
           vars__.emplace_back(a[(sym1__ - 1)]);}
       } 
       {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"));
         {
-          vars__.emplace_back(beta[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"));
         }
       }
       vars__.emplace_back(mu_a);
@@ -33229,19 +35190,43 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       if (lcm_sym11__) {
         current_statement__ = 7;
         assign(y_hat, cons_list(index_uni(1), nil_index_list()),
-          stan::math::fma(beta[(2 - 1)], pre_test[(1 - 1)],
-            stan::math::fma(beta[(1 - 1)], treatment[(1 - 1)],
-              a[(pair[(1 - 1)] - 1)])), "assigning variable y_hat");
+          stan::math::fma(
+            rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"),
+            rvalue(pre_test, cons_list(index_uni(1), nil_index_list()),
+              "pre_test"),
+            stan::math::fma(
+              rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"),
+              rvalue(treatment, cons_list(index_uni(1), nil_index_list()),
+                "treatment"),
+              rvalue(a,
+                cons_list(
+                  index_uni(rvalue(pair,
+                              cons_list(index_uni(1), nil_index_list()),
+                              "pair")), nil_index_list()), "a"))),
+          "assigning variable y_hat");
         for (int i = 2; i <= N; ++i) {
           current_statement__ = 7;
           assign(y_hat, cons_list(index_uni(i), nil_index_list()),
-            stan::math::fma(beta[(2 - 1)], pre_test[(i - 1)],
-              stan::math::fma(beta[(1 - 1)], treatment[(i - 1)],
-                a[(pair[(i - 1)] - 1)])), "assigning variable y_hat");}
+            stan::math::fma(
+              rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"),
+              rvalue(pre_test, cons_list(index_uni(i), nil_index_list()),
+                "pre_test"),
+              stan::math::fma(
+                rvalue(beta, cons_list(index_uni(1), nil_index_list()),
+                  "beta"),
+                rvalue(treatment, cons_list(index_uni(i), nil_index_list()),
+                  "treatment"),
+                rvalue(a,
+                  cons_list(
+                    index_uni(rvalue(pair,
+                                cons_list(index_uni(i), nil_index_list()),
+                                "pair")), nil_index_list()), "a"))),
+            "assigning variable y_hat");}
       } 
       if (emit_transformed_parameters__) {
         if (lcm_sym11__) {
-          vars__.emplace_back(y_hat[(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(y_hat, cons_list(index_uni(1), nil_index_list()), "y_hat"));
           for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
             vars__.emplace_back(y_hat[(sym1__ - 1)]);}
         } 
@@ -33297,7 +35282,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         if (lcm_sym1__) {
           current_statement__ = 1;
           assign(a, cons_list(index_uni(1), nil_index_list()),
-            a_flat__[(1 - 1)], "assigning variable a");
+            rvalue(a_flat__, cons_list(index_uni(1), nil_index_list()),
+              "a_flat__"), "assigning variable a");
           current_statement__ = 1;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= n_pair; ++sym1__) {
@@ -33322,7 +35308,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         {
           current_statement__ = 2;
           assign(beta, cons_list(index_uni(1), nil_index_list()),
-            beta_flat__[(1 - 1)], "assigning variable beta");
+            rvalue(beta_flat__, cons_list(index_uni(1), nil_index_list()),
+              "beta_flat__"), "assigning variable beta");
           current_statement__ = 2;
           pos__ = 2;
           {
@@ -33360,14 +35347,17 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       current_statement__ = 5;
       sigma_y_free__ = stan::math::lub_free(sigma_y, 0, 100);
       if (lcm_sym1__) {
-        vars__.emplace_back(a[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(a, cons_list(index_uni(1), nil_index_list()), "a"));
         for (int sym1__ = 2; sym1__ <= n_pair; ++sym1__) {
           vars__.emplace_back(a[(sym1__ - 1)]);}
       } 
       {
-        vars__.emplace_back(beta[(1 - 1)]);
+        vars__.emplace_back(
+          rvalue(beta, cons_list(index_uni(1), nil_index_list()), "beta"));
         {
-          vars__.emplace_back(beta[(2 - 1)]);
+          vars__.emplace_back(
+            rvalue(beta, cons_list(index_uni(2), nil_index_list()), "beta"));
         }
       }
       vars__.emplace_back(mu_a);
@@ -33706,7 +35696,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       if (lcm_sym29__) {
         current_statement__ = 19;
         current_statement__ = 19;
-        check_greater_or_equal(function__, "n[sym1__]", n[(1 - 1)], 0);
+        check_greater_or_equal(function__, "n[sym1__]",
+                               rvalue(n,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "n"), 0);
         for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
           current_statement__ = 19;
           current_statement__ = 19;
@@ -33727,7 +35720,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       if (lcm_sym29__) {
         current_statement__ = 21;
         current_statement__ = 21;
-        check_greater_or_equal(function__, "N[sym1__]", N[(1 - 1)], 0);
+        check_greater_or_equal(function__, "N[sym1__]",
+                               rvalue(N,
+                                 cons_list(index_uni(1), nil_index_list()),
+                                 "N"), 0);
         for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
           current_statement__ = 21;
           current_statement__ = 21;
@@ -33753,7 +35749,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         if (lcm_sym29__) {
           current_statement__ = 23;
           assign(x1, cons_list(index_uni(1), nil_index_list()),
-            x1_flat__[(1 - 1)], "assigning variable x1");
+            rvalue(x1_flat__, cons_list(index_uni(1), nil_index_list()),
+              "x1_flat__"), "assigning variable x1");
           current_statement__ = 23;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
@@ -33783,7 +35780,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         if (lcm_sym29__) {
           current_statement__ = 25;
           assign(x2, cons_list(index_uni(1), nil_index_list()),
-            x2_flat__[(1 - 1)], "assigning variable x2");
+            rvalue(x2_flat__, cons_list(index_uni(1), nil_index_list()),
+              "x2_flat__"), "assigning variable x2");
           current_statement__ = 25;
           pos__ = 2;
           for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
@@ -33927,27 +35925,50 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         current_statement__ = 16;
         if (lcm_sym18__) {
           current_statement__ = 13;
-          lp_accum__.add(normal_lpdf<propto__>(b[(1 - 1)], 0.0, lcm_sym17__));
+          lp_accum__.add(
+            normal_lpdf<propto__>(
+              rvalue(b, cons_list(index_uni(1), nil_index_list()), "b"), 0.0,
+              lcm_sym17__));
           current_statement__ = 14;
           lp_accum__.add(
-            binomial_logit_lpmf<propto__>(n[(1 - 1)], N[(1 - 1)],
+            binomial_logit_lpmf<propto__>(
+              rvalue(n, cons_list(index_uni(1), nil_index_list()), "n"),
+              rvalue(N, cons_list(index_uni(1), nil_index_list()), "N"),
               add(
-                stan::math::fma(alpha12, elt_multiply(x1, x2)[(1 - 1)],
-                  stan::math::fma(alpha2, x2[(1 - 1)],
-                    stan::math::fma(alpha1, x1[(1 - 1)], alpha0))),
-                b[(1 - 1)])));
+                stan::math::fma(alpha12,
+                  rvalue(elt_multiply(x1, x2),
+                    cons_list(index_uni(1), nil_index_list()), "(x1 .* x2)"),
+                  stan::math::fma(alpha2,
+                    rvalue(x2, cons_list(index_uni(1), nil_index_list()),
+                      "x2"),
+                    stan::math::fma(alpha1,
+                      rvalue(x1, cons_list(index_uni(1), nil_index_list()),
+                        "x1"), alpha0))),
+                rvalue(b, cons_list(index_uni(1), nil_index_list()), "b"))));
           for (int i = 2; i <= I; ++i) {
             current_statement__ = 13;
             lp_accum__.add(
-              normal_lpdf<propto__>(b[(i - 1)], 0.0, lcm_sym17__));
+              normal_lpdf<propto__>(
+                rvalue(b, cons_list(index_uni(i), nil_index_list()), "b"),
+                0.0, lcm_sym17__));
             current_statement__ = 14;
             lp_accum__.add(
-              binomial_logit_lpmf<propto__>(n[(i - 1)], N[(i - 1)],
+              binomial_logit_lpmf<propto__>(
+                rvalue(n, cons_list(index_uni(i), nil_index_list()), "n"),
+                rvalue(N, cons_list(index_uni(i), nil_index_list()), "N"),
                 add(
-                  stan::math::fma(alpha12, elt_multiply(x1, x2)[(i - 1)],
-                    stan::math::fma(alpha2, x2[(i - 1)],
-                      stan::math::fma(alpha1, x1[(i - 1)], alpha0))),
-                  b[(i - 1)])));}
+                  stan::math::fma(alpha12,
+                    rvalue(elt_multiply(x1, x2),
+                      cons_list(index_uni(i), nil_index_list()),
+                      "(x1 .* x2)"),
+                    stan::math::fma(alpha2,
+                      rvalue(x2, cons_list(index_uni(i), nil_index_list()),
+                        "x2"),
+                      stan::math::fma(alpha1,
+                        rvalue(x1, cons_list(index_uni(i), nil_index_list()),
+                          "x1"), alpha0))),
+                  rvalue(b, cons_list(index_uni(i), nil_index_list()), "b"))));
+          }
         } 
       }
     } catch (const std::exception& e) {
@@ -34040,57 +36061,105 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       vars__.emplace_back(tau);
       {
         if (lcm_sym10__) {
-          vars__.emplace_back(b[(1 - 1)][(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(b,
+              cons_list(index_uni(1),
+                cons_list(index_uni(1), nil_index_list())), "b"));
           for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-            vars__.emplace_back(b[(sym2__ - 1)][(1 - 1)]);}
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(sym2__),
+                  cons_list(index_uni(1), nil_index_list())), "b"));}
         } 
         {
           if (lcm_sym10__) {
-            vars__.emplace_back(b[(1 - 1)][(2 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(2), nil_index_list())), "b"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              vars__.emplace_back(b[(sym2__ - 1)][(2 - 1)]);}
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(2), nil_index_list())), "b"));}
           } 
         }
         {
           if (lcm_sym10__) {
-            vars__.emplace_back(b[(1 - 1)][(3 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(3), nil_index_list())), "b"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              vars__.emplace_back(b[(sym2__ - 1)][(3 - 1)]);}
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(3), nil_index_list())), "b"));}
           } 
         }
         {
           if (lcm_sym10__) {
-            vars__.emplace_back(b[(1 - 1)][(4 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(4), nil_index_list())), "b"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              vars__.emplace_back(b[(sym2__ - 1)][(4 - 1)]);}
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(4), nil_index_list())), "b"));}
           } 
         }
         {
           if (lcm_sym10__) {
-            vars__.emplace_back(b[(1 - 1)][(5 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(5), nil_index_list())), "b"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              vars__.emplace_back(b[(sym2__ - 1)][(5 - 1)]);}
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(5), nil_index_list())), "b"));}
           } 
         }
         {
           if (lcm_sym10__) {
-            vars__.emplace_back(b[(1 - 1)][(6 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(6), nil_index_list())), "b"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              vars__.emplace_back(b[(sym2__ - 1)][(6 - 1)]);}
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(6), nil_index_list())), "b"));}
           } 
         }
         {
           if (lcm_sym10__) {
-            vars__.emplace_back(b[(1 - 1)][(7 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(7), nil_index_list())), "b"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              vars__.emplace_back(b[(sym2__ - 1)][(7 - 1)]);}
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(7), nil_index_list())), "b"));}
           } 
         }
         {
           if (lcm_sym10__) {
-            vars__.emplace_back(b[(1 - 1)][(8 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(8), nil_index_list())), "b"));
             for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              vars__.emplace_back(b[(sym2__ - 1)][(8 - 1)]);}
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym2__),
+                    cons_list(index_uni(8), nil_index_list())), "b"));}
           } 
         }
       }
@@ -34186,7 +36255,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
               assign(b,
                 cons_list(index_uni(1),
                   cons_list(index_uni(1), nil_index_list())),
-                b_flat__[(1 - 1)], "assigning variable b");
+                rvalue(b_flat__, cons_list(index_uni(1), nil_index_list()),
+                  "b_flat__"), "assigning variable b");
               current_statement__ = 6;
               pos__ = 2;
               for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
@@ -34348,52 +36418,100 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       vars__.emplace_back(tau_free__);
       if (lcm_sym1__) {
         {
-          vars__.emplace_back(b[(1 - 1)][(1 - 1)]);
+          vars__.emplace_back(
+            rvalue(b,
+              cons_list(index_uni(1),
+                cons_list(index_uni(1), nil_index_list())), "b"));
           {
-            vars__.emplace_back(b[(1 - 1)][(2 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(2), nil_index_list())), "b"));
           }
           {
-            vars__.emplace_back(b[(1 - 1)][(3 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(3), nil_index_list())), "b"));
           }
           {
-            vars__.emplace_back(b[(1 - 1)][(4 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(4), nil_index_list())), "b"));
           }
           {
-            vars__.emplace_back(b[(1 - 1)][(5 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(5), nil_index_list())), "b"));
           }
           {
-            vars__.emplace_back(b[(1 - 1)][(6 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(6), nil_index_list())), "b"));
           }
           {
-            vars__.emplace_back(b[(1 - 1)][(7 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(7), nil_index_list())), "b"));
           }
           {
-            vars__.emplace_back(b[(1 - 1)][(8 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(1),
+                  cons_list(index_uni(8), nil_index_list())), "b"));
           }
         }
         for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
           {
-            vars__.emplace_back(b[(sym1__ - 1)][(1 - 1)]);
+            vars__.emplace_back(
+              rvalue(b,
+                cons_list(index_uni(sym1__),
+                  cons_list(index_uni(1), nil_index_list())), "b"));
             {
-              vars__.emplace_back(b[(sym1__ - 1)][(2 - 1)]);
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(2), nil_index_list())), "b"));
             }
             {
-              vars__.emplace_back(b[(sym1__ - 1)][(3 - 1)]);
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(3), nil_index_list())), "b"));
             }
             {
-              vars__.emplace_back(b[(sym1__ - 1)][(4 - 1)]);
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(4), nil_index_list())), "b"));
             }
             {
-              vars__.emplace_back(b[(sym1__ - 1)][(5 - 1)]);
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(5), nil_index_list())), "b"));
             }
             {
-              vars__.emplace_back(b[(sym1__ - 1)][(6 - 1)]);
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(6), nil_index_list())), "b"));
             }
             {
-              vars__.emplace_back(b[(sym1__ - 1)][(7 - 1)]);
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(7), nil_index_list())), "b"));
             }
             {
-              vars__.emplace_back(b[(sym1__ - 1)][(8 - 1)]);
+              vars__.emplace_back(
+                rvalue(b,
+                  cons_list(index_uni(sym1__),
+                    cons_list(index_uni(8), nil_index_list())), "b"));
             }
           }}
       } 


### PR DESCRIPTION
## Release notes

This is a revert of #656 to put the fix in #521 back in to fix #489, #776, #847.

The revert in #656 was cause there was a substantial performance hit (like 30%) of including this fix and we were in code freeze and the simplest thing was revert.

I think it would be good to put this fix back in even without an immediate fix to the performance thing. We can re-evaluate the performance thing (lots of stuff has changed between error checks and indexing) and fix that later, but at least then the segfaults are out of the way.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
