### PR TITLE
Set -j PARALLEL in compile tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,8 +158,8 @@ pipeline {
                                 cd performance-tests-cmdstan
                                 cd cmdstan; make -j${env.PARALLEL} build; cd ..
                                 cp ../bin/stanc cmdstan/bin/stanc
-                                ./runPerformanceTests.py --runs=0 ../test/integration/good
-                                ./runPerformanceTests.py --runs=0 example-models
+                                ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ../test/integration/good
+                                ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 example-models
                                 """
                         }
 


### PR DESCRIPTION
The compile tests in #856 seem to be taking way longer than before. Last master run they took a little under 24 minutes, on PR they take 2-3hours.