### PR TITLE
Adds type annotation to functions in semantic_check.ml

### DIFF
--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -62,6 +62,9 @@ type typed_expr_meta =
 type typed_expression = (typed_expr_meta, fun_kind) expr_with
 [@@deriving sexp, compare, map, hash, fold]
 
+type 'a abstract_typed_expression = (typed_expr_meta, 'a) expr_with
+[@@deriving sexp, compare, map, hash, fold]
+
 let mk_untyped_expression ~expr ~loc = {expr; emeta= {loc}}
 
 let mk_typed_expression ~expr ~loc ~type_ ~ad_level =


### PR DESCRIPTION
## Release notes

Adds type annotation in `Semantic_check.ml`

This PR shouldn't change any functionality. I often found that when looking at the code in `vscode` the gui would dump out some ginormous type whenever we actually had a specialized type or it would put `'a` in for a type that was actually the same from all the function call sites. This PR adds type annotations to the functions in semantic checking that I thought could reasonably use it. A good example is the `cf` argument which was some `'a` but actually is just a `context_flag_record` This also helps clarify some cases where we use the same argument name in multiple functions but they have different types in each of those functions. `name` is a common example where sometimes it is an `Ast.identifier` and other times it's a `string`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause) Steve Bronder
