### PR TITLE
tries to make more meaningful names for the general types

### DIFF
--- a/src/frontend/Symbol_table.ml
+++ b/src/frontend/Symbol_table.ml
@@ -4,8 +4,8 @@ open Core_kernel
 
 (* TODO: I'm sure this implementation could be made more efficient if that's necessary. There's no need for all the string comparison.
 We could just keep track of the count of the entry into the hash table and use that for comparison. *)
-type 'a state =
-  { table: (string, 'a) Hashtbl.t
+type 'value state =
+  { table: (string, 'value) Hashtbl.t
   ; stack: string Stack.t
   ; scopedepth: int ref
   ; readonly: (string, unit) Hashtbl.t

--- a/src/frontend/Symbol_table.mli
+++ b/src/frontend/Symbol_table.mli
@@ -1,43 +1,43 @@
 (** Symbol table interface to implement var map *)
 
-type 'a state
+type 'value state
 
-val initialize : unit -> 'a state
+val initialize : unit -> 'value state
 (** Creates a new symbol table *)
 
-val enter : 'a state -> string -> 'a -> unit
+val enter : 'value state -> string -> 'value -> unit
 (** Enters a specified identifier with its specified type (or other) information
     into a symbol table  *)
 
-val look : 'a state -> string -> 'a option
+val look : 'value state -> string -> 'value option
 (** Looks for an identifier in a symbol table and returns its information if found and None otherwise  *)
 
-val begin_scope : 'a state -> unit
+val begin_scope : 'value state -> unit
 (** Used to start a new local scope which symbols added from now will end up in *)
 
-val end_scope : 'a state -> unit
+val end_scope : 'value state -> unit
 (** Used to end a local scope, purging the symbol table of all symbols added in that scope *)
 
-val set_read_only : 'a state -> string -> unit
+val set_read_only : 'value state -> string -> unit
 (** Used to add a read only label to an identifier *)
 
-val get_read_only : 'a state -> string -> bool
+val get_read_only : 'value state -> string -> bool
 (** Used to check for a read only label for an identifier *)
 
-val set_is_assigned : 'a state -> string -> unit
+val set_is_assigned : 'value state -> string -> unit
 (** Label an identifier as having been assigned to *)
 
-val set_is_unassigned : 'a state -> string -> unit
+val set_is_unassigned : 'value state -> string -> unit
 (** Label an identifier as not having been assigned to *)
 
-val check_is_unassigned : 'a state -> string -> bool
+val check_is_unassigned : 'value state -> string -> bool
 (** Check whether an identifier is labelled as unassigned *)
 
-val check_some_id_is_unassigned : 'a state -> bool
+val check_some_id_is_unassigned : 'value state -> bool
 (** Used to check whether some identifier is labelled as unassigned *)
 
-val is_global : 'a state -> string -> bool
+val is_global : 'value state -> string -> bool
 (** Used to check whether an identifier was declared in global scope *)
 
-val unsafe_clear_symbol_table : 'a state -> unit
+val unsafe_clear_symbol_table : 'value state -> unit
 (** Used to clear the whole symbol table *)

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -7,14 +7,14 @@ module Fixed = struct
   module Pattern = struct
     type litType = Int | Real | Str [@@deriving sexp, hash, compare]
 
-    type 'a t =
+    type 'exprs t =
       | Var of string
       | Lit of litType * string
-      | FunApp of Fun_kind.t * 'a list
-      | TernaryIf of 'a * 'a * 'a
-      | EAnd of 'a * 'a
-      | EOr of 'a * 'a
-      | Indexed of 'a * 'a Index.t list
+      | FunApp of Fun_kind.t * 'exprs list
+      | TernaryIf of 'exprs * 'exprs * 'exprs
+      | EAnd of 'exprs * 'exprs
+      | EOr of 'exprs * 'exprs
+      | Indexed of 'exprs * 'exprs Index.t list
     [@@deriving sexp, hash, map, compare, fold]
 
     let pp pp_e ppf = function
@@ -41,9 +41,10 @@ module Fixed = struct
       | EAnd (l, r) -> Fmt.pf ppf "%a && %a" pp_e l pp_e r
       | EOr (l, r) -> Fmt.pf ppf "%a || %a" pp_e l pp_e r
 
-    include Foldable.Make (struct type nonrec 'a t = 'a t
+    include Foldable.Make (struct
+      type nonrec 'exprs t = 'exprs t
 
-                                  let fold = fold
+      let fold = fold
     end)
   end
 

--- a/src/middle/Expr.mli
+++ b/src/middle/Expr.mli
@@ -5,17 +5,17 @@ module Fixed : sig
   module Pattern : sig
     type litType = Int | Real | Str [@@deriving sexp, hash, compare]
 
-    type 'a t =
+    type 'exprs t =
       | Var of string
       | Lit of litType * string
-      | FunApp of Fun_kind.t * 'a list
-      | TernaryIf of 'a * 'a * 'a
-      | EAnd of 'a * 'a
-      | EOr of 'a * 'a
-      | Indexed of 'a * 'a Index.t list
+      | FunApp of Fun_kind.t * 'exprs list
+      | TernaryIf of 'exprs * 'exprs * 'exprs
+      | EAnd of 'exprs * 'exprs
+      | EOr of 'exprs * 'exprs
+      | Indexed of 'exprs * 'exprs Index.t list
     [@@deriving sexp, hash, compare]
 
-    include Pattern.S with type 'a t := 'a t
+    include Pattern.S with type 'exprs t := 'exprs t
   end
 
   include Fixed.S with module Pattern := Pattern
@@ -30,7 +30,7 @@ module NoMeta : sig
 
   include Specialized.S with module Meta := Meta and type t = Meta.t Fixed.t
 
-  val remove_meta : 'a Fixed.t -> t
+  val remove_meta : 'exprs Fixed.t -> t
 end
 
 module Typed : sig
@@ -84,12 +84,16 @@ module Helpers : sig
   val one : Typed.t
   val binop : Typed.t -> Operator.t -> Typed.t -> Typed.t
   val loop_bottom : Typed.t
-  val internal_funapp : Internal_fun.t -> 'a Fixed.t list -> 'a -> 'a Fixed.t
+
+  val internal_funapp :
+    Internal_fun.t -> 'exprs Fixed.t list -> 'exprs -> 'exprs Fixed.t
 
   val contains_fn_kind :
-    (Fun_kind.t -> bool) -> ?init:bool -> 'a Fixed.t -> bool
+    (Fun_kind.t -> bool) -> ?init:bool -> 'exprs Fixed.t -> bool
 
-  val infer_type_of_indexed : UnsizedType.t -> 'a Index.t list -> UnsizedType.t
+  val infer_type_of_indexed :
+    UnsizedType.t -> 'exprs Index.t list -> UnsizedType.t
+
   val add_int_index : Typed.t -> Typed.t Index.t -> Typed.t
-  val collect_indices : 'a Fixed.t -> 'a Fixed.t Index.t list
+  val collect_indices : 'exprs Fixed.t -> 'exprs Fixed.t Index.t list
 end

--- a/src/middle/Index.ml
+++ b/src/middle/Index.ml
@@ -1,11 +1,11 @@
 open Core_kernel
 
-type 'a t =
+type 'expr t =
   | All
-  | Single of 'a
-  | Upfrom of 'a
-  | Between of 'a * 'a
-  | MultiIndex of 'a
+  | Single of 'expr
+  | Upfrom of 'expr
+  | Between of 'expr * 'expr
+  | MultiIndex of 'expr
 [@@deriving sexp, hash, map, compare, fold]
 
 let pp pp_e ppf = function

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -5,13 +5,13 @@ open Helpers
 type fun_arg_decl = (UnsizedType.autodifftype * string * UnsizedType.t) list
 [@@deriving sexp, hash, map]
 
-type 'a fun_def =
+type 'stmts fun_def =
   { fdrt: UnsizedType.t option
   ; fdname: string
   ; fdargs:
       (UnsizedType.autodifftype * string * UnsizedType.t) list
       (* If fdbody is None, this is a function declaration without body. *)
-  ; fdbody: 'a option
+  ; fdbody: 'stmts option
   ; fdloc: Location_span.t sexp_opaque [@compare.ignore] }
 [@@deriving compare, hash, map, sexp, map, fold]
 
@@ -19,14 +19,14 @@ type io_block = Parameters | TransformedParameters | GeneratedQuantities
 [@@deriving sexp, hash]
 
 (** Transformations (constraints) for global variable declarations *)
-type 'e transformation =
+type 'expr transformation =
   | Identity
-  | Lower of 'e
-  | Upper of 'e
-  | LowerUpper of 'e * 'e
-  | Offset of 'e
-  | Multiplier of 'e
-  | OffsetMultiplier of 'e * 'e
+  | Lower of 'expr
+  | Upper of 'expr
+  | LowerUpper of 'expr * 'expr
+  | Offset of 'expr
+  | Multiplier of 'expr
+  | OffsetMultiplier of 'expr * 'expr
   | Ordered
   | PositiveOrdered
   | Simplex
@@ -37,21 +37,25 @@ type 'e transformation =
   | Covariance
 [@@deriving sexp, compare, map, hash, fold]
 
-type 'e outvar =
-  { out_unconstrained_st: 'e SizedType.t
-  ; out_constrained_st: 'e SizedType.t
+type 'expr outvar =
+  { out_unconstrained_st: 'expr SizedType.t
+  ; out_constrained_st: 'expr SizedType.t
   ; out_block: io_block
-  ; out_trans: 'e transformation }
+  ; out_trans: 'expr transformation }
 [@@deriving sexp, map, hash, fold]
 
-type ('a, 'b) t =
-  { functions_block: 'b fun_def list
-  ; input_vars: (string * 'a SizedType.t) list
-  ; prepare_data: 'b list (* data & transformed data decls and statements *)
-  ; log_prob: 'b list (*assumes data & params are in scope and ready*)
-  ; generate_quantities: 'b list (* assumes data & params ready & in scope*)
-  ; transform_inits: 'b list
-  ; output_vars: (string * 'a outvar) list
+type ('stmt, 'stmts) t =
+  { functions_block: 'stmts fun_def list
+  ; input_vars: (string * 'stmt SizedType.t) list
+  ; prepare_data:
+      'stmts list
+      (* data & transformed data decls and statements *)
+  ; log_prob: 'stmts list (*assumes data & params are in scope and ready*)
+  ; generate_quantities:
+      'stmts list
+      (* assumes data & params ready & in scope*)
+  ; transform_inits: 'stmts list
+  ; output_vars: (string * 'stmt outvar) list
   ; prog_name: string
   ; prog_path: string }
 [@@deriving sexp, map, fold]

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -1,13 +1,13 @@
 open Core_kernel
 open Common
 
-type 'a t =
+type 'dim_expr t =
   | SInt
   | SReal
-  | SVector of 'a
-  | SRowVector of 'a
-  | SMatrix of 'a * 'a
-  | SArray of 'a t * 'a
+  | SVector of 'dim_expr
+  | SRowVector of 'dim_expr
+  | SMatrix of 'dim_expr * 'dim_expr
+  | SArray of 'dim_expr t * 'dim_expr
 [@@deriving sexp, compare, map, hash, fold]
 
 let rec pp pp_e ppf = function

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -7,27 +7,27 @@ module Fixed = struct
   module First = Expr.Fixed
 
   module Pattern = struct
-    type ('a, 'b) t =
-      | Assignment of 'a lvalue * 'a
-      | TargetPE of 'a
-      | NRFunApp of Fun_kind.t * 'a list
+    type ('expr, 'exprs) t =
+      | Assignment of 'expr lvalue * 'expr
+      | TargetPE of 'expr
+      | NRFunApp of Fun_kind.t * 'expr list
       | Break
       | Continue
-      | Return of 'a option
+      | Return of 'expr option
       | Skip
-      | IfElse of 'a * 'b * 'b option
-      | While of 'a * 'b
-      | For of {loopvar: string; lower: 'a; upper: 'a; body: 'b}
-      | Profile of string * 'b list
-      | Block of 'b list
-      | SList of 'b list
+      | IfElse of 'expr * 'exprs * 'exprs option
+      | While of 'expr * 'exprs
+      | For of {loopvar: string; lower: 'expr; upper: 'expr; body: 'exprs}
+      | Profile of string * 'exprs list
+      | Block of 'exprs list
+      | SList of 'exprs list
       | Decl of
           { decl_adtype: UnsizedType.autodifftype
           ; decl_id: string
-          ; decl_type: 'a Type.t }
+          ; decl_type: 'expr Type.t }
     [@@deriving sexp, hash, map, fold, compare]
 
-    and 'a lvalue = string * UnsizedType.t * 'a Index.t list
+    and 'expr lvalue = string * UnsizedType.t * 'expr Index.t list
     [@@deriving sexp, hash, map, compare, fold]
 
     let pp pp_e pp_s ppf = function
@@ -71,7 +71,7 @@ module Fixed = struct
             (Type.pp pp_e) decl_type decl_id
 
     include Foldable.Make2 (struct
-      type nonrec ('a, 'b) t = ('a, 'b) t
+      type nonrec ('expr, 'exprs) t = ('expr, 'exprs) t
 
       let fold = fold
     end)

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -7,7 +7,7 @@ module Fixed = struct
   module First = Expr.Fixed
 
   module Pattern = struct
-    type ('expr, 'exprs) t =
+    type ('expr, 'stmts) t =
       | Assignment of 'expr lvalue * 'expr
       | TargetPE of 'expr
       | NRFunApp of Fun_kind.t * 'expr list
@@ -15,12 +15,12 @@ module Fixed = struct
       | Continue
       | Return of 'expr option
       | Skip
-      | IfElse of 'expr * 'exprs * 'exprs option
-      | While of 'expr * 'exprs
-      | For of {loopvar: string; lower: 'expr; upper: 'expr; body: 'exprs}
-      | Profile of string * 'exprs list
-      | Block of 'exprs list
-      | SList of 'exprs list
+      | IfElse of 'expr * 'stmts * 'stmts option
+      | While of 'expr * 'stmts
+      | For of {loopvar: string; lower: 'expr; upper: 'expr; body: 'stmts}
+      | Profile of string * 'stmts list
+      | Block of 'stmts list
+      | SList of 'stmts list
       | Decl of
           { decl_adtype: UnsizedType.autodifftype
           ; decl_id: string
@@ -71,7 +71,7 @@ module Fixed = struct
             (Type.pp pp_e) decl_type decl_id
 
     include Foldable.Make2 (struct
-      type nonrec ('expr, 'exprs) t = ('expr, 'exprs) t
+      type nonrec ('expr, 'stmts) t = ('expr, 'stmts) t
 
       let fold = fold
     end)

--- a/src/middle/Stmt.mli
+++ b/src/middle/Stmt.mli
@@ -4,30 +4,30 @@ open Label
 
 module Fixed : sig
   module Pattern : sig
-    type ('a, 'b) t =
-      | Assignment of 'a lvalue * 'a
-      | TargetPE of 'a
-      | NRFunApp of Fun_kind.t * 'a list
+    type ('expr, 'exprs) t =
+      | Assignment of 'expr lvalue * 'expr
+      | TargetPE of 'expr
+      | NRFunApp of Fun_kind.t * 'expr list
       | Break
       | Continue
-      | Return of 'a option
+      | Return of 'expr option
       | Skip
-      | IfElse of 'a * 'b * 'b option
-      | While of 'a * 'b
-      | For of {loopvar: string; lower: 'a; upper: 'a; body: 'b}
-      | Profile of string * 'b list
-      | Block of 'b list
-      | SList of 'b list
+      | IfElse of 'expr * 'exprs * 'exprs option
+      | While of 'expr * 'exprs
+      | For of {loopvar: string; lower: 'expr; upper: 'expr; body: 'exprs}
+      | Profile of string * 'exprs list
+      | Block of 'exprs list
+      | SList of 'exprs list
       | Decl of
           { decl_adtype: UnsizedType.autodifftype
           ; decl_id: string
-          ; decl_type: 'a Type.t }
+          ; decl_type: 'expr Type.t }
     [@@deriving sexp, hash, compare]
 
-    and 'a lvalue = string * UnsizedType.t * 'a Index.t list
+    and 'expr lvalue = string * UnsizedType.t * 'expr Index.t list
     [@@deriving sexp, hash, map, compare, fold]
 
-    include Pattern.S2 with type ('a, 'b) t := ('a, 'b) t
+    include Pattern.S2 with type ('expr, 'exprs) t := ('expr, 'exprs) t
   end
 
   include Fixed.S2 with module First = Expr.Fixed and module Pattern := Pattern
@@ -45,7 +45,7 @@ module NoMeta : sig
     with module Meta := Meta
      and type t = (Expr.NoMeta.Meta.t, Meta.t) Fixed.t
 
-  val remove_meta : ('a, 'b) Fixed.t -> t
+  val remove_meta : ('expr, 'exprs) Fixed.t -> t
 end
 
 module Located : sig
@@ -117,13 +117,16 @@ end
 
 module Helpers : sig
   val ensure_var :
-    (Expr.Typed.t -> 'a -> Located.t) -> Expr.Typed.t -> 'a -> Located.t
+    (Expr.Typed.t -> 'expr -> Located.t) -> Expr.Typed.t -> 'expr -> Located.t
 
   val internal_nrfunapp :
-    Internal_fun.t -> 'a Fixed.First.t list -> 'b -> ('a, 'b) Fixed.t
+       Internal_fun.t
+    -> 'expr Fixed.First.t list
+    -> 'exprs
+    -> ('expr, 'exprs) Fixed.t
 
   val contains_fn_kind :
-    (Fun_kind.t -> bool) -> ?init:bool -> ('a, 'b) Fixed.t -> bool
+    (Fun_kind.t -> bool) -> ?init:bool -> ('expr, 'exprs) Fixed.t -> bool
 
   val mkfor :
        Expr.Typed.t
@@ -159,8 +162,8 @@ module Helpers : sig
   val assign_indexed :
        UnsizedType.t
     -> string
-    -> 'a
-    -> ('b Expr.Fixed.t -> 'b Expr.Fixed.t)
-    -> 'b Expr.Fixed.t
-    -> ('b, 'a) Fixed.t
+    -> 'expr
+    -> ('exprs Expr.Fixed.t -> 'exprs Expr.Fixed.t)
+    -> 'exprs Expr.Fixed.t
+    -> ('exprs, 'expr) Fixed.t
 end

--- a/src/middle/Type.ml
+++ b/src/middle/Type.ml
@@ -1,6 +1,6 @@
 open Common
 
-type 'a t = Sized of 'a SizedType.t | Unsized of UnsizedType.t
+type 'dim_expr t = Sized of 'dim_expr SizedType.t | Unsized of UnsizedType.t
 [@@deriving sexp, compare, map, hash, fold]
 
 let pp pp_e ppf = function

--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -107,7 +107,6 @@ let pp_bool_expr ppf expr =
   | _ -> pp_expr ppf expr
 
 let rec pp_statement (ppf : Format.formatter) Stmt.Fixed.({pattern; meta}) =
-  (* ({stmt; smeta} : (mtype_loc_ad, 'a) stmt_with) = *)
   let pp_stmt_list = list ~sep:cut pp_statement in
   ( match pattern with
   | Block _ | SList _ | Decl _ | Skip | Break | Continue -> ()
@@ -132,7 +131,7 @@ let rec pp_statement (ppf : Format.formatter) Stmt.Fixed.({pattern; meta}) =
        inside some function call - the function should get its own copy
        (in all cases???) *)
       let rec maybe_deep_copy e =
-        let recurse (e : 'a Expr.Fixed.t) =
+        let recurse (e : 'exprs Expr.Fixed.t) =
           { e with
             Expr.Fixed.pattern=
               Expr.Fixed.Pattern.map maybe_deep_copy e.pattern }

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -512,7 +512,7 @@ let%expect_test "insert before" =
   [%sexp (l : int list)] |> print_s ;
   [%expect {| (1 2 3 4 5 999 6) |}]
 
-let map_prog_stmt_lists f (p : ('a, 'b) Program.t) =
+let map_prog_stmt_lists f (p : ('stmt, 'stmts) Program.t) =
   { p with
     Program.prepare_data= f p.prepare_data
   ; log_prob= f p.log_prob

--- a/src/tfp_backend/Transform_mir.ml
+++ b/src/tfp_backend/Transform_mir.ml
@@ -143,7 +143,7 @@ let trans_prog (p : Program.Typed.t) =
   in
   let rename_kwrds (s, e) = (add_suffix_to_kwrds s, e) in
   let rename_fdarg (e1, s, e2) = (e1, add_suffix_to_kwrds s, e2) in
-  let rename_func (s : 'a Program.fun_def) =
+  let rename_func (s : 'stmts Program.fun_def) =
     { s with
       fdname= add_suffix_to_kwrds s.fdname
     ; fdargs= List.map ~f:rename_fdarg s.fdargs }


### PR DESCRIPTION
## Summary

When I'm working over the ocaml it's pretty often I'll run into some type like `('a, 'b) Stmt.Fixed...` and I always found it kind of harder to parse out what 'a or 'b is. This PR tries to give "nicer" names for those general types.

I get that yes `'a` is just a general type, but in the types they are used, for example in `Stmt.Fixed.Pattern` the general types (`'a ,'b)` on the pattern `t` is not going to be like a string, websocket, or a random number generator. The general type there is going to be some type that is derived or has inside of it expressions. So why don't we just use a nicer name like 

```ocaml
  module Pattern = struct
    type ('expr, 'stmts) t =
      | Assignment of 'expr lvalue * 'expr
      | TargetPE of 'expr
      | NRFunApp of Fun_kind.t * 'expr list
      | Break
      | Continue
      | Return of 'expr option
      | Skip
      | IfElse of 'expr * 'stmts * 'stmts option
      | While of 'expr * 'stmts
      | For of {loopvar: string; lower: 'expr; upper: 'expr; body: 'stmts}
      | Profile of string * 'stmts list
      | Block of 'stmts list
      | SList of 'stmts list
      | Decl of
          { decl_adtype: UnsizedType.autodifftype
          ; decl_id: string
          ; decl_type: 'expr Type.t }
    [@@deriving sexp, hash, map, fold, compare]
```

What I'd like is for the names of the types to be the least upper bound of the types that we expect to go into the type. Here I just looked around and sorted out that the `'a` is going to be a thing that holds an expression, where `'b` is generally a thing that holds a list of statements. imo I think this is a lot easier to read when I'm looking at types elsewhere in the program.

Though I think there is some places I have bad names rn. Like in `expr_with` idt `'fun_kind` is the right name for the least upper bound of types that can go in there since an `untyped_expression` is an `expr_with` that takes in a `unit`. 

```ocaml
type ('meta_loc, 'fun_kind) expr_with =
  { expr: (('meta_loc, 'fun_kind) expr_with, 'fun_kind) expression
  ; emeta: 'meta_loc }
[@@deriving sexp, compare, map, hash, fold]

(*later...*)
type untyped_expression = (located_meta, unit) expr_with
[@@deriving sexp, compare, map, hash, fold]
```

Maybe just `'any` is more appropriate when the type can be a unit?

Expressive names that are wrong are certainly worse than meaningless names, but I think if someone can look over the names I have here and help me sort out the weird ones then this should be a bit nicer to work over

## Release notes

Cleanup names of generic types inside of type declarations

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
