### PR TITLE
handle divide-by-zero in partial evaluator

### DIFF
--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -310,7 +310,7 @@ let constant_propagation_transfer
             (* TODO: we are currently only propagating constants for scalars.
              We could do the same for matrix and array expressions if we wanted. *)
             | Assignment ((s, t, []), e) -> (
-              match Partial_evaluator.eval_expr (subst_expr m e) with
+              match Partial_evaluator.try_eval_expr (subst_expr m e) with
               | {pattern= Lit (_, _); _} as e'
                 when not (preserve_stability && UnsizedType.is_autodiffable t)
                 ->

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -537,8 +537,8 @@ let unroll_static_loops_statement _ =
   let f stmt =
     match stmt with
     | Stmt.Fixed.Pattern.For {loopvar; lower; upper; body} -> (
-        let lower = Partial_evaluator.eval_expr lower in
-        let upper = Partial_evaluator.eval_expr upper in
+        let lower = Partial_evaluator.try_eval_expr lower in
+        let upper = Partial_evaluator.try_eval_expr upper in
         match
           (contains_top_break_or_continue body, lower.pattern, upper.pattern)
         with

--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -776,4 +776,4 @@ let eval_stmt s =
         NRFunApp (CompilerInternal FnReject, [Expr.Helpers.str m])
     ; meta= loc }
 
-let eval_prog = Program.map eval_expr eval_stmt
+let eval_prog = Program.map try_eval_expr eval_stmt

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -1976,6 +1976,28 @@ let%expect_test "partial evaluation" =
         if(PNot__(emit_generated_quantities__)) return;
       } |}]
 
+let%expect_test "partial evaluate reject" =
+  let mir =
+    reset_and_mir_of_string
+      {|
+      model {
+        int x = 5 %/% 0;
+      }
+      |}
+  in
+  let mir = partial_evaluation mir in
+  Fmt.strf "@[<v>%a@]" Program.Typed.pp mir |> print_endline ;
+  [%expect
+    {|
+      log_prob {
+        FnReject__("Integer division by zero");
+      }
+
+      generate_quantities {
+        if(PNot__(emit_transformed_parameters__ || emit_generated_quantities__)) return;
+        if(PNot__(emit_generated_quantities__)) return;
+      } |}]
+
 let%expect_test "try partially evaluate" =
   let mir =
     reset_and_mir_of_string

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -1990,7 +1990,10 @@ let%expect_test "partial evaluate reject" =
   [%expect
     {|
       log_prob {
-        FnReject__("Integer division by zero");
+        {
+          int x;
+          FnReject__("Integer division by zero");
+        }
       }
 
       generate_quantities {


### PR DESCRIPTION
Fix #890 . C++ considers divide-by-zero undefined behavior but I think throwing an exception is the best option.

## Release notes

Fix optimizer crash on divide-by-zero expressions.

## Copyright and Licensing
Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
