### PR TITLE
Clear read/write event for global matrix_cls

### DIFF
--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -21,6 +21,7 @@ type t =
   | FnResizeToMatch
   | FnNaN
   | FnDeepCopy
+  | FnReadWriteEventsOpenCL of string
 [@@deriving sexp, hash, compare]
 
 let to_string x = Sexp.to_string (sexp_of_t x) ^ "__"

--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -224,6 +224,7 @@ let math_fn_translations = function
   | FnValidateSize -> Some ("validate_non_negative_index", [])
   | FnValidateSizeSimplex -> Some ("validate_positive_index", [])
   | FnValidateSizeUnitVector -> Some ("validate_unit_vector_index", [])
+  | FnReadWriteEventsOpenCL x -> Some (x ^ ".wait_for_read_write_events", [])
   | _ -> None
 
 let trans_math_fn fname =

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -627,6 +627,14 @@ let trans_prog (p : Program.Typed.t) =
          [log_prob; generate_quantities])
     |> String.Set.to_list
   in
+  let maybe_add_opencl_events_clear =
+    let event_clear_stmt x =
+      Stmt.Fixed.
+        { pattern= NRFunApp (CompilerInternal (FnReadWriteEventsOpenCL x), [])
+        ; meta= Location_span.empty }
+    in
+    List.map ~f:event_clear_stmt opencl_vars
+  in
   let to_matrix_cl_stmts =
     List.concat_map opencl_vars ~f:(fun vident ->
         let vident_sans_opencl =
@@ -656,7 +664,7 @@ let trans_prog (p : Program.Typed.t) =
   in
   let p =
     { p with
-      log_prob
+      log_prob= log_prob @ maybe_add_opencl_events_clear
     ; prog_name= escape_name p.prog_name
     ; prepare_data=
         init_pos

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1253,6 +1253,12 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
             to_matrix_cl(rvalue(X_d_a, "X_d_a", index_uni(1))), alpha,
             to_matrix_cl(beta), sigma));
       }
+      X_d_opencl__.wait_for_read_write_events();
+      X_d_td_opencl__.wait_for_read_write_events();
+      y_v_d_opencl__.wait_for_read_write_events();
+      y_v_d_td_opencl__.wait_for_read_write_events();
+      y_vi_d_opencl__.wait_for_read_write_events();
+      y_vi_d_td_opencl__.wait_for_read_write_events();
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -3474,6 +3474,10 @@ class distributions_model final : public model_base_crtp<distributions_model> {
         current_statement__ = 755;
         lp_accum__.add(normal_lpdf<propto__>(y_p, 0, 1));
       }
+      d_int_array_opencl__.wait_for_read_write_events();
+      d_real_array_opencl__.wait_for_read_write_events();
+      d_row_vector_opencl__.wait_for_read_write_events();
+      d_vector_opencl__.wait_for_read_write_events();
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return
@@ -6676,6 +6680,7 @@ class restricted_model final : public model_base_crtp<restricted_model> {
         current_statement__ = 24;
         lp_accum__.add(normal_lpdf<propto__>(y_p, 0, 1));
       }
+      d_vector_opencl__.wait_for_read_write_events();
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
       // Next line prevents compiler griping about no return


### PR DESCRIPTION
Fixes #857 

## Release notes

Added clearing of read/write events for global matrix_cls.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
