### PR TITLE
Fix testing error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,7 @@ pipeline {
                                     text:"O=0\nCXX=${CXX}")
                             sh """
                                 cd performance-tests-cmdstan
-                                cd cmdstan; make -j${env.PARALLEL} build; cd ..
+                                cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ..
                                 cp ../bin/stanc cmdstan/bin/stanc
                                 ./runPerformanceTests.py -j7 --runs=0 ../test/integration/good
                                 ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 example-models
@@ -188,7 +188,7 @@ pipeline {
                             cat shotgun_perf_all.tests >> all.tests
                             cat all.tests
                             echo "CXXFLAGS+=-march=core2" > cmdstan/make/local
-                            cd cmdstan; git show HEAD --stat; make -j4 build; cd ..
+                            cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build; cd ..
                             CXX="${CXX}" ./compare-compilers.sh "--tests-file all.tests --num-samples=10" "\$(readlink -f ../bin/stanc)"
                         """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,7 @@ pipeline {
                                 cd performance-tests-cmdstan
                                 cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ..
                                 cp ../bin/stanc cmdstan/bin/stanc
-                                ./runPerformanceTests.py -j7 --runs=0 ../test/integration/good
+                                ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ../test/integration/good
                                 ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 example-models
                                 """
                         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,24 @@
 STANC3 RELEASE NOTES
 ======================================================================
 
+v2.27.0 (2 June 2021)
+======================================================================
+
+ - Added the `--info` argument to output a list of functions and distributions used.(#813)
+ - Added `ode_ckrk` and `ode_ckrk_tol` to the Stan language.(#828)
+ - Cleaned up indexing by using variadic rvalue and assign functions.(#829)
+ - Fixed incorrect codegen for mixed-type array expressions.(#830)
+ - Added building ARM to our infrastructure.(#832, #833)
+ - Made locations_array constexpr and moved curr_statement__ to function scope.(#842, #845)
+ - Added range checks.(#849, #521)
+ - Consolidated the use of | in cdf functions to match lpdf/lpmf and lccdf functions. Comma version of cdf function is deprecated.(#863)
+ - Adds signatures for data-only quantile functions.(#870)
+ - Cleanup readability of the C++.(#871)
+ - Adds vectorized versions of `fma()`.(#888)
+ - Fixed optimizer crash on divide-by-zero expressions.(#891)
+ - Added clearing of read/write events for global matrix_cls.(#897)
+ - Added  `ode_adjoint_tol_ctl` and improved type printing with variadic ODEs.(#900)
+
 v2.26.1 (15 February 2021)
 ======================================================================
 


### PR DESCRIPTION
This PR just merges the release branch (contains release notes) and attempts to fix the issues we were having in testing where end-to-end tests occasionally threw

```
fatal error: file '/usr/include/errno.h' has been modified since the precompiled header 'stan/src/stan/model/model_header.hpp.gch' was built

note: please rebuild precompiled header 'stan/src/stan/model/model_header.hpp.gch'
```
which means that somewhere a `make clean-all` was not happening properly.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
