### PR TITLE
Add newline after warnings are printed

### DIFF
--- a/src/middle/Warnings.ml
+++ b/src/middle/Warnings.ml
@@ -25,5 +25,6 @@ let pp ?printed_filename ppf (span, message) =
   in
   Fmt.pf ppf "@[<hov>Warning%s: %s@]" loc_str message
 
-let pp_warnings ?printed_filename ppf =
-  Fmt.(pf ppf "@[<v>%a@]" (list ~sep:cut (pp ?printed_filename)))
+let pp_warnings ?printed_filename ppf warnings =
+  Fmt.(
+    pf ppf "@[<v>%a@]%a" (list ~sep:cut (pp ?printed_filename)) warnings cut ())


### PR DESCRIPTION
We don't emit a newline after printing warnings:
```
stanc3$ ./run pedantic-mode-example.stan --warn-pedantic
Warning: The parameter c has no priors.
Warning: The parameter b has no priors.
Warning: The parameter a has no priors.stanc3$
```
I'm guessing that's causing this issue: https://discourse.mc-stan.org/t/bugs-in-pedantic-mode/22961/3
But even if it's not, that's some weird formatting. The new behavior is:
```
stanc3$ ./run pedantic-mode-example.stan --warn-pedantic
Warning: The parameter c has no priors.
Warning: The parameter b has no priors.
Warning: The parameter a has no priors.
stanc3$
```