### PR TITLE
Produce a warning for empty files

### DIFF
--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -89,6 +89,13 @@ program:
     EOF
     {
       grammar_logger "program" ;
+      (* check for empty programs*)
+      let () =
+        match (ofb, odb, otdb, opb, otpb, omb, ogb) with
+        | None, None, None, None, None, None, None ->
+            Warnings.empty (fst $loc).pos_fname
+        | _ -> ()
+      in
       { functionblock= ofb
       ; datablock= odb
       ; transformeddatablock= otdb

--- a/src/middle/Warnings.ml
+++ b/src/middle/Warnings.ml
@@ -6,6 +6,13 @@ let warnings = ref []
 let init () = warnings := []
 let collect () = List.rev !warnings
 
+let empty file =
+  warnings :=
+    ( Location_span.empty
+    , "Empty file '" ^ file
+      ^ "' detected; this is a valid stan model but likely unintended!" )
+    :: !warnings
+
 let deprecated token (pos, message) =
   (* TODO(seantalts): should we only print deprecation warnings once per token? *)
   let begin_pos =

--- a/src/middle/Warnings.mli
+++ b/src/middle/Warnings.mli
@@ -12,3 +12,6 @@ val pp_warnings : ?printed_filename:string -> t list Fmt.t
 
 val deprecated : string -> Lexing.position * string -> unit
 (** Register that a deprecated language construct has been found. *)
+
+val empty : string -> unit
+(** Register that an empty file is being lexxed *)

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -514,6 +514,8 @@ Semantic error in 'declare-define-var-vec-1.stan', line 6, column 2 to column 23
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator =: lhs has type vector and rhs has type row_vector
+  $ ../../../../install/default/bin/stanc empty.stan
+Warning: Empty file 'empty.stan' detected; this is a valid stan model but likely unintended!
   $ ../../../../install/default/bin/stanc err-bare-type-close-square.stan
 Syntax error in 'err-bare-type-close-square.stan', line 2, column 8 to column 11, parsing error:
    -------------------------------------------------

--- a/test/integration/rstanarm/pre/pretty.expected
+++ b/test/integration/rstanarm/pre/pretty.expected
@@ -1,6 +1,9 @@
   $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format Brilleman_copyright.stan
 
+Warning: Empty file 'Brilleman_copyright.stan' detected; this is a valid stan model but likely unintended!
   $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format Columbia_copyright.stan
 
+Warning: Empty file 'Columbia_copyright.stan' detected; this is a valid stan model but likely unintended!
   $ ../../../../../install/default/bin/stanc --include-paths="../" --auto-format license.stan
 
+Warning: Empty file 'license.stan' detected; this is a valid stan model but likely unintended!


### PR DESCRIPTION
This is addressing #905. 
The new output is:

```
$ touch empty.stan
$ ./_build/default/src/stanc/stanc.exe empty.stan 
Warning: Empty file 'empty.stan' detected; this is a valid stan model but likely unintended!
```

The change is done in the parser rather than the lexxer so that a file of only comments still produces the warning. This may (or may not) want to be changed based on #93, but it is a simple enough fix for now. One test was added, integration/bad/empty.stan, and a few existing test outputs were updated to include this warning.

## Release notes

A warning is now produced if an empty file is compiled.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
