### PR TITLE
Add --info and --debug-generate-data flags to stancjs

### DIFF
--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -47,11 +47,18 @@ let stan2cpp model_name model_string is_flag_set =
         in
         typed_ast
         >>| fun typed_ast ->
+        if is_flag_set "info" then
+          r.return (Result.Ok (Info.info typed_ast), warnings, []) ;
         if is_flag_set "print-canonical" then
           r.return
             ( Result.Ok
                 (Pretty_printing.pretty_print_typed_program
                    (Canonicalize.canonicalize_program typed_ast))
+            , warnings
+            , [] ) ;
+        if is_flag_set "debug-generate-data" then
+          r.return
+            ( Result.Ok (Debug_data_generation.print_data_prog typed_ast)
             , warnings
             , [] ) ;
         let mir = Ast_to_Mir.trans_prog model_name typed_ast in

--- a/test/stancjs/data-generation.js
+++ b/test/stancjs/data-generation.js
@@ -1,0 +1,15 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+let datagen_model = `
+data {
+    int x[3, 4];
+    int y[5, 2, 4];
+    matrix[3, 4] z;
+    vector[3] w;
+    vector[3] p[4];
+}
+`
+
+let datagen = stanc.stanc("basic_model", datagen_model, ["debug-generate-data"]);
+utils.print_result(datagen)

--- a/test/stancjs/info.js
+++ b/test/stancjs/info.js
@@ -1,0 +1,34 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+let info_model = `
+data {
+    int a;
+    real b;
+    vector[2] c;
+    row_vector[3] d;
+    matrix[2,2] e;
+    int f[5];
+    real g[6];
+    vector[1] h[7];
+    matrix[2,2] i[2];
+    int j[3,1,3];
+}
+transformed data {
+    int k = a + 1;
+}
+parameters {
+    simplex[10] l;
+    unit_vector[11] m;
+    ordered[12] n;
+    positive_ordered[13] o;
+    cov_matrix[14] p;
+    corr_matrix[15] q;
+    cholesky_factor_cov[16] r;
+    cholesky_factor_corr[17] s;
+    real y;
+}
+`
+
+let info = stanc.stanc("basic_model", info_model, ["info"]);
+utils.print_result(info)

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -23,11 +23,57 @@ model {
   y ~ normal(0, 1);
 }
 
+$ node data-generation.js
+{
+"x": [[6, 2, 4, 2], [3, 2, 6, 2], [6, 3, 4, 2]],
+"y":
+  [[[6, 5, 5, 5], [6, 3, 2, 5]], [[6, 2, 6, 6], [2, 5, 5, 2]],
+    [[4, 4, 4, 3], [2, 4, 6, 2]], [[2, 5, 3, 6], [5, 5, 6, 5]],
+    [[6, 6, 5, 3], [3, 4, 2, 5]]],
+"z":
+  [[5.8530474347281336, 6.3955297933730639, 6.4404632518168468,
+     5.8926590620580992],
+    [5.8815901469879766, 3.9191590616049568, 3.7206314135215708,
+      2.171635388977561],
+    [4.925001387848174, 6.97212837743693, 2.8719106043920211,
+      5.3835056697400123]],
+"w": [2.9621789585306804, 5.5083017771155482, 5.505904011446936],
+"p":
+  [[5.2217505923869556, 2.0493220812048105, 3.1335081619228875],
+    [2.3086085754863221, 5.0735880143406691, 4.9955866267343172],
+    [6.7239589323018487, 6.0503609645580525, 6.1832136714928119],
+    [2.9385807829191903, 5.5620586856883119, 6.2768699310734206]]
+}
 $ node filename.js
 Semantic error in 'good_filename', line 6, column 4 to column 5: 
 Identifier 'z' not in scope.
 Semantic error in 'string', line 6, column 4 to column 5: 
 Identifier 'z' not in scope.
+$ node info.js
+{ "inputs": { "a": { "type": "int", "dimensions": 0},
+              "b": { "type": "real", "dimensions": 0},
+              "c": { "type": "real", "dimensions": 1},
+              "d": { "type": "real", "dimensions": 1},
+              "e": { "type": "real", "dimensions": 2},
+              "f": { "type": "int", "dimensions": 1},
+              "g": { "type": "real", "dimensions": 1},
+              "h": { "type": "real", "dimensions": 2},
+              "i": { "type": "real", "dimensions": 3},
+              "j": { "type": "int", "dimensions": 3} },
+  "parameters": { "l": { "type": "real", "dimensions": 1},
+                  "m": { "type": "real", "dimensions": 1},
+                  "n": { "type": "real", "dimensions": 1},
+                  "o": { "type": "real", "dimensions": 1},
+                  "p": { "type": "real", "dimensions": 2},
+                  "q": { "type": "real", "dimensions": 2},
+                  "r": { "type": "real", "dimensions": 2},
+                  "s": { "type": "real", "dimensions": 2},
+                  "y": { "type": "real", "dimensions": 0} },
+  "transformed parameters": {  },
+  "generated quantities": {  },
+  "functions": [  ],
+  "distributions": [  ] }
+
 $ node optimization.js
 Semantic error in 'string', line 3, column 4 to column 20: 
 Some function is declared without specifying a definition.


### PR DESCRIPTION
Stancjs was missing some of Stanc3's command line options. I've added `--info` and `--debug-generate-data` which seem like the most useful ones. The other missing options are all for parser debugging or printing various stages of the MIR.

## Release notes

Stancjs now has `--info` and `--debug-generate-data` options.

## Copyright and Licensing

Copyright holder: Niko Huurre
By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
