### PR TITLE
Move input warnings to separate module

### DIFF
--- a/src/frontend/Input_warnings.ml
+++ b/src/frontend/Input_warnings.ml
@@ -1,0 +1,23 @@
+open! Core_kernel
+
+let warnings = ref []
+let init () = warnings := []
+let collect () = List.rev !warnings
+let add_warning span message = warnings := (span, message) :: !warnings
+
+let empty file =
+  add_warning Middle.Location_span.empty
+    ( "Empty file '" ^ file
+    ^ "' detected; this is a valid stan model but likely unintended!" )
+
+let deprecated token (pos, message) =
+  (* TODO(seantalts): should we only print deprecation warnings once per token? *)
+  let begin_pos =
+    {pos with Lexing.pos_cnum= pos.Lexing.pos_cnum - String.length token}
+  in
+  let end_pos = {begin_pos with Lexing.pos_cnum= pos.pos_cnum - 1} in
+  let span =
+    Middle.Location_span.of_positions_opt begin_pos end_pos
+    |> Option.value ~default:Middle.Location_span.empty
+  in
+  add_warning span message

--- a/src/frontend/Input_warnings.mli
+++ b/src/frontend/Input_warnings.mli
@@ -1,0 +1,15 @@
+val init : unit -> unit
+(** As something of a hack, Input_warnings keeps track of which warnings the lexer has
+    emitted as a form of hidden state, which must be initialized and [collect]ed.*)
+
+val collect : unit -> Middle.Warnings.t list
+(** Returns all of the warnings issued since [init] was called. *)
+
+val add_warning : Middle.Location_span.t -> string -> unit
+(** Add a generic warning string to the current list *)
+
+val deprecated : string -> Lexing.position * string -> unit
+(** Register that a deprecated language construct has been found. *)
+
+val empty : string -> unit
+(** Register that an empty file is being lexxed *)

--- a/src/frontend/Parse.ml
+++ b/src/frontend/Parse.ml
@@ -5,7 +5,7 @@ open Core_kernel
 open Middle
 
 let parse parse_fun lexbuf =
-  Warnings.init () ;
+  Input_warnings.init () ;
   (* see the Menhir manual for the description of
      error messages support *)
   let module Interp = Parser.MenhirInterpreter in
@@ -57,7 +57,7 @@ let parse parse_fun lexbuf =
       |> Result.map_error ~f:(fun e -> Errors.Syntax_error e)
     with Errors.SyntaxError err -> Result.Error (Errors.Syntax_error err)
   in
-  (result, Warnings.collect ())
+  (result, Input_warnings.collect ())
 
 let parse_string parse_fun str =
   let lexbuf =

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -2,7 +2,6 @@
 
 {
   module Stack = Core_kernel.Stack
-  module Warnings = Middle.Warnings
   module Errors = Middle.Errors
   open Lexing
   open Debugging
@@ -51,7 +50,7 @@ rule token = parse
                                   try_get_new_lexbuf fname lexbuf.lex_curr_p in
                                 token new_lexbuf }
   | "#"                       { lexer_logger "#comment" ;
-                                Warnings.deprecated "#"
+                                Input_warnings.deprecated "#"
                                   (lexbuf.lex_curr_p, "Comments beginning with \
                                                        # are deprecated. \
                                                        Please use // in place \
@@ -155,14 +154,14 @@ rule token = parse
   | ".*="                     { lexer_logger ".*=" ; Parser.ELTTIMESASSIGN }
   | "./="                     { lexer_logger "./=" ; Parser.ELTDIVIDEASSIGN }
   | "<-"                      { lexer_logger "<-" ;
-                                Warnings.deprecated "<-"
+                                Input_warnings.deprecated "<-"
                                   (lexbuf.lex_curr_p, "assignment operator <- \
                                                        is deprecated in the \
                                                        Stan language; use = \
                                                        instead.") ;
                                 Parser.ARROWASSIGN } (* deprecated *)
   | "increment_log_prob"      { lexer_logger "increment_log_prob" ;
-                                Warnings.deprecated "increment_log_prob"
+                                Input_warnings.deprecated "increment_log_prob"
                                   (lexbuf.lex_curr_p, "increment_log_prob(...)\
                                                        ; is deprecated and \
                                                        will be removed in the \
@@ -180,7 +179,7 @@ rule token = parse
                                 Parser.REALNUMERAL (lexeme lexbuf) }
   | "target"                  { lexer_logger "target" ; Parser.TARGET } (* NB: the stanc2 parser allows variables to be named target. I think it's a bad idea and have disallowed it. *)
   | "get_lp"                  { lexer_logger "get_lp" ;
-                                Warnings.deprecated "get_lp"
+                                Input_warnings.deprecated "get_lp"
                                   (lexbuf.lex_curr_p, "get_lp() function is \
                                                        deprecated. It will be \
                                                        removed in a future \

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -93,7 +93,7 @@ program:
       let () =
         match (ofb, odb, otdb, opb, otpb, omb, ogb) with
         | None, None, None, None, None, None, None ->
-            Warnings.empty (fst $loc).pos_fname
+            Input_warnings.empty (fst $loc).pos_fname
         | _ -> ()
       in
       { functionblock= ofb

--- a/src/middle/Warnings.ml
+++ b/src/middle/Warnings.ml
@@ -1,32 +1,4 @@
-open! Core_kernel
-
 type t = Location_span.t * string
-
-let warnings = ref []
-let init () = warnings := []
-let collect () = List.rev !warnings
-
-let add_warning (span : Location_span.t) (message : string) =
-  warnings := (span, message) :: !warnings
-
-let empty file =
-  warnings :=
-    ( Location_span.empty
-    , "Empty file '" ^ file
-      ^ "' detected; this is a valid stan model but likely unintended!" )
-    :: !warnings
-
-let deprecated token (pos, message) =
-  (* TODO(seantalts): should we only print deprecation warnings once per token? *)
-  let begin_pos =
-    {pos with Lexing.pos_cnum= pos.Lexing.pos_cnum - String.length token}
-  in
-  let end_pos = {begin_pos with Lexing.pos_cnum= pos.pos_cnum - 1} in
-  let span =
-    Location_span.of_positions_opt begin_pos end_pos
-    |> Option.value ~default:Location_span.empty
-  in
-  add_warning span message
 
 let pp ?printed_filename ppf (span, message) =
   let loc_str =

--- a/src/middle/Warnings.mli
+++ b/src/middle/Warnings.mli
@@ -1,19 +1,4 @@
 type t = Location_span.t * string
 
-val init : unit -> unit
-(** As something of a hack, Warnings keeps track of which warnings the lexer has
-    emitted as a form of hidden state, which must be initialized and [collect]ed.*)
-
-val collect : unit -> t list
-(** Returns all of the warnings issued since [init] was called. *)
-
 val pp : ?printed_filename:string -> t Fmt.t
 val pp_warnings : ?printed_filename:string -> t list Fmt.t
-
-val deprecated : string -> Lexing.position * string -> unit
-(** Register that a deprecated language construct has been found. *)
-
-val add_warning : Location_span.t -> string -> unit
-
-val empty : string -> unit
-(** Register that an empty file is being lexxed *)


### PR DESCRIPTION
This completes some internal reorganization mentioned in #869. It moves the warnings "Hack" used by the parser/lexer out of the Warnings module and into its own module in the frontend. This should prevent confusion caused by trying to use the stateful part of the warnings in parts of the code after the parser.

## Release notes

Reorganized warning system internally.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
