### PR TITLE
Fix build directions with `make`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ To be able to build the project, make sure you have `GNU make`.
 To install OCaml and the dependencies we need to build and do development run the following from the stanc3 directory:
 
 ```
-cd scripts
-bash -x setup_dev_env.sh
+bash -x scripts/setup_dev_env.sh
 ```
 Note that `curl` and `m4` are prerequisites to run the install script.
 


### PR DESCRIPTION
When following the current directions to build `stanc3` with `make`, I get the error:


```+ install_missing='t know how to build scripts/src/stanc/stanc.exe'
+ echo 'Trying to install missing deps for stanc with t know how to build scripts/src/stanc/stanc.exe'
Trying to install missing deps for stanc with t know how to build scripts/src/stanc/stanc.exe
+ t know how to build scripts/src/stanc/stanc.exe
setup_dev_env.sh: line 15: t: command not found
```

This looks like `bash` attempting to parse the output of `dune external-lib-deps --missing src/stanc/stanc.exe`, which gives:

```Entering directory '/Users/chrislambda/stanc3'
Error: Don't know how to build scripts/src/stanc/stanc.exe
```

The error seems to be due to the fact that `scripts/src/stanc` doesn't exist; if the setup script is run from the toplevel, everything builds fine with no error:

```bash -x scripts/setup_dev_env.sh```