### PR TITLE
Add `to_matrix(array[] row_vector)`

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1803,6 +1803,7 @@ let () =
   add_unqualified ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt]) ;
   add_unqualified ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt; UInt]) ;
   add_unqualified ("to_matrix", ReturnType UMatrix, [URowVector]) ;
+  add_unqualified ("to_matrix", ReturnType UMatrix, [UArray URowVector]) ;
   add_unqualified ("to_matrix", ReturnType UMatrix, [URowVector; UInt; UInt]) ;
   add_unqualified
     ("to_matrix", ReturnType UMatrix, [URowVector; UInt; UInt; UInt]) ;

--- a/test/integration/good/function-signatures/math/matrix/pretty.expected
+++ b/test/integration/good/function-signatures/math/matrix/pretty.expected
@@ -19456,6 +19456,7 @@ data {
   matrix[d_int, d_int] d_matrix;
   vector[d_int] d_vector;
   row_vector[d_int] d_row_vector;
+  array[d_int] row_vector[d_int] array_d_row_vector;
   array[6] real d_array;
   array[6, 2] real d_array2;
   array[6] int d_iarray;
@@ -19466,6 +19467,7 @@ transformed data {
   transformed_data_matrix = to_matrix(d_matrix);
   transformed_data_matrix = to_matrix(d_vector);
   transformed_data_matrix = to_matrix(d_row_vector);
+  transformed_data_matrix = to_matrix(array_d_row_vector);
   transformed_data_matrix = to_matrix(d_matrix, 4, 2);
   transformed_data_matrix = to_matrix(d_vector, 4, 3);
   transformed_data_matrix = to_matrix(d_row_vector, 5, 2);
@@ -19484,6 +19486,7 @@ parameters {
   matrix[d_int, d_int] p_matrix;
   vector[d_int] p_vector;
   row_vector[d_int] p_row_vector;
+  array[d_int] row_vector[d_int] array_p_row_vector;
   array[6] real p_array;
   array[6, 7] real p_array2;
 }
@@ -19492,6 +19495,7 @@ transformed parameters {
   transformed_param_matrix = to_matrix(d_matrix);
   transformed_param_matrix = to_matrix(d_vector);
   transformed_param_matrix = to_matrix(d_row_vector);
+  transformed_param_matrix = to_matrix(array_p_row_vector);
   transformed_param_matrix = to_matrix(d_matrix, 4, 2);
   transformed_param_matrix = to_matrix(d_vector, 3, 5);
   transformed_param_matrix = to_matrix(d_row_vector, 2, 4);

--- a/test/integration/good/function-signatures/math/matrix/to_matrix.stan
+++ b/test/integration/good/function-signatures/math/matrix/to_matrix.stan
@@ -3,6 +3,7 @@ data {
   matrix[d_int,d_int] d_matrix;
   vector[d_int] d_vector;
   row_vector[d_int] d_row_vector;
+  array[d_int] row_vector[d_int] array_d_row_vector;
   real d_array[6];
   real d_array2[6, 2];
   int d_iarray[6];
@@ -15,6 +16,7 @@ transformed data {
   transformed_data_matrix = to_matrix(d_matrix);
   transformed_data_matrix = to_matrix(d_vector);
   transformed_data_matrix = to_matrix(d_row_vector);
+  transformed_data_matrix = to_matrix(array_d_row_vector);
 
   transformed_data_matrix = to_matrix(d_matrix, 4, 2);
   transformed_data_matrix = to_matrix(d_vector, 4, 3);
@@ -37,6 +39,7 @@ parameters {
   matrix[d_int,d_int] p_matrix;
   vector[d_int] p_vector;
   row_vector[d_int] p_row_vector;
+  array[d_int] row_vector[d_int] array_p_row_vector;
   real p_array[6];
   real p_array2[6, 7];
 }
@@ -46,6 +49,7 @@ transformed parameters {
   transformed_param_matrix = to_matrix(d_matrix);
   transformed_param_matrix = to_matrix(d_vector);
   transformed_param_matrix = to_matrix(d_row_vector);
+  transformed_param_matrix = to_matrix(array_p_row_vector);
 
   transformed_param_matrix = to_matrix(d_matrix, 4, 2);
   transformed_param_matrix = to_matrix(d_vector, 3, 5);

--- a/test/integration/signatures/stan_math_sigs.expected
+++ b/test/integration/signatures/stan_math_sigs.expected
@@ -23641,6 +23641,7 @@ to_matrix(array[] int, int, int) => matrix
 to_matrix(array[] int, int, int, int) => matrix
 to_matrix(array[] real, int, int) => matrix
 to_matrix(array[] real, int, int, int) => matrix
+to_matrix(array[] row_vector) => matrix
 to_matrix(array[,] int) => matrix
 to_matrix(array[,] real) => matrix
 to_row_vector(vector) => row_vector


### PR DESCRIPTION
Fixes #928 

## Release notes

Added `to_matrix(array[] row_vector) => matrix`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
