### PR TITLE
Build non-x86 and arm binaries on pushes to master only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,6 +329,7 @@ pipeline {
                 }
 
                 stage("Build & test a static Linux mips64el binary") {
+                    when { anyOf { buildingTag(); branch 'master' } }
                     agent {
                         dockerfile {
                             filename 'docker/static/Dockerfile'
@@ -357,6 +358,7 @@ pipeline {
                 }
 
                 stage("Build & test a static Linux ppc64el binary") {
+                    when { anyOf { buildingTag(); branch 'master' } }
                     agent {
                         dockerfile {
                             filename 'docker/static/Dockerfile'
@@ -385,6 +387,7 @@ pipeline {
                 }
 
                 stage("Build & test a static Linux s390x binary") {
+                    when { anyOf { buildingTag(); branch 'master' } }
                     agent {
                         dockerfile {
                             filename 'docker/static/Dockerfile'
@@ -441,6 +444,7 @@ pipeline {
                 }
 
                 stage("Build & test a static Linux armhf binary") {
+                    when { anyOf { buildingTag(); branch 'master' } }
                     agent {
                         dockerfile {
                             filename 'docker/static/Dockerfile'
@@ -469,6 +473,7 @@ pipeline {
                 }
 
                 stage("Build & test a static Linux armel binary") {
+                    when { anyOf { buildingTag(); branch 'master' } }
                     agent {
                         dockerfile {
                             filename 'docker/static/Dockerfile'


### PR DESCRIPTION
I think there is no real need to build all the various Linux binaries for different archs on PRs given that they are not published on PRs. I left the arm architecture, so that we try to build with one of them, just to make sure there are no suprises. I missed this when reviewing the original PR.

@andrjohns are you cool with this?
 
## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
