### PR TITLE
Add PR checklist to template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+#### Submission Checklist
+
+- [ ] Run unit tests
+- Documentation
+    - [ ] If an user-facing facing change was made, the documentation PR is here: <LINK>
+    - [ ] OR, no user-facing changes were made
 
 ## Release notes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 - [ ] Run unit tests
 - Documentation
-    - [ ] If an user-facing facing change was made, the documentation PR is here: <LINK>
+    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
     - [ ] OR, no user-facing changes were made
 
 ## Release notes


### PR DESCRIPTION
This change is motivated in part by the discussion in https://github.com/stan-dev/docs/issues/372 and again by https://github.com/stan-dev/docs/issues/379. We should have a submission checklist that requests either a link to the documentation PR, or a acknowledgement that the PR needs no further documentation.

The template I propose looks like this:

----

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

[Internal] Updated contribution template in attempt to keep docs in sync

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)

