### PR TITLE
Adds mem_pattern needed for SoA and AoS types

### DIFF
--- a/src/analysis_and_optimization/Factor_graph.ml
+++ b/src/analysis_and_optimization/Factor_graph.ml
@@ -23,7 +23,7 @@ let extract_factors_statement stmt =
   | Stmt.Fixed.Pattern.TargetPE e ->
       List.map (summation_terms e) ~f:(fun x -> TargetTerm x)
   | NRFunApp (CompilerInternal FnReject, _) -> [Reject]
-  | NRFunApp ((UserDefined (s, FnTarget) | StanLib (s, FnTarget)), args) ->
+  | NRFunApp ((UserDefined (s, FnTarget) | StanLib (s, FnTarget, _)), args) ->
       [LPFunction (s, args)]
   | Assignment (_, _)
    |NRFunApp (_, _)

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -30,7 +30,8 @@ let rec num_expr_value (v : Expr.Typed.t) : (float * string) option =
   | {pattern= Fixed.Pattern.Lit (Real, str); _}
    |{pattern= Fixed.Pattern.Lit (Int, str); _} ->
       Some (float_of_string str, str)
-  | {pattern= Fixed.Pattern.FunApp (StanLib ("PMinus__", FnPlain), [v]); _} -> (
+  | {pattern= Fixed.Pattern.FunApp (StanLib ("PMinus__", FnPlain, _), [v]); _}
+  -> (
     match num_expr_value v with
     | Some (v, s) -> Some (-.v, "-" ^ s)
     | None -> None )
@@ -295,7 +296,7 @@ let expr_assigned_var Expr.Fixed.({pattern; _}) =
 (** See interface file *)
 let rec summation_terms (Expr.Fixed.({pattern; _}) as rhs) =
   match pattern with
-  | FunApp (StanLib ("Plus__", FnPlain), [e1; e2]) ->
+  | FunApp (StanLib ("Plus__", FnPlain, _), [e1; e2]) ->
       List.append (summation_terms e1) (summation_terms e2)
   | _ -> [rhs]
 

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -442,7 +442,7 @@ let assigned_vars_stmt (s : (Expr.Typed.t, 'a) Stmt.Fixed.Pattern.t) =
   match s with
   | Assignment ((x, _, _), _) -> Set.Poly.singleton x
   | TargetPE _ -> Set.Poly.singleton "target"
-  | NRFunApp ((UserDefined (_, FnTarget) | StanLib (_, FnTarget)), _) ->
+  | NRFunApp ((UserDefined (_, FnTarget) | StanLib (_, FnTarget, _)), _) ->
       Set.Poly.singleton "target"
   | For {loopvar= x; _} -> Set.Poly.singleton x
   | Decl {decl_id= _; _}
@@ -485,7 +485,8 @@ let reaching_definitions_transfer
          |For {loopvar= x; _} ->
             Set.filter p ~f:(fun (y, _) -> y = x)
         | TargetPE _ -> Set.filter p ~f:(fun (y, _) -> y = "target")
-        | NRFunApp ((UserDefined (_, FnTarget) | StanLib (_, FnTarget)), _) ->
+        | NRFunApp ((UserDefined (_, FnTarget) | StanLib (_, FnTarget, _)), _)
+          ->
             Set.filter p ~f:(fun (y, _) -> y = "target")
         | NRFunApp (_, _)
          |Break | Continue | Return _ | Skip

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -238,7 +238,7 @@ let rec inline_function_expression propto adt fim
       match kind with
       | CompilerInternal _ ->
           (d_list, s_list, {e with pattern= FunApp (kind, es)})
-      | UserDefined (fname, suffix) | StanLib (fname, suffix) -> (
+      | UserDefined (fname, suffix) | StanLib (fname, suffix, _) -> (
           let suffix, fname' =
             match suffix with
             | FnLpdf propto' when propto' && propto ->
@@ -252,7 +252,7 @@ let rec inline_function_expression propto adt fim
               let fun_kind =
                 match kind with
                 | Fun_kind.UserDefined _ -> Fun_kind.UserDefined (fname, suffix)
-                | _ -> StanLib (fname, suffix)
+                | _ -> StanLib (fname, suffix, AoS)
               in
               (d_list, s_list, {e with pattern= FunApp (fun_kind, es)})
           | Some (rt, args, b) ->
@@ -388,7 +388,7 @@ let rec inline_function_statement propto adt fim Stmt.Fixed.({pattern; meta}) =
             slist_concat_no_loc (d_list @ s_list)
               ( match kind with
               | CompilerInternal _ -> NRFunApp (kind, es)
-              | UserDefined (s, _) | StanLib (s, _) -> (
+              | UserDefined (s, _) | StanLib (s, _, _) -> (
                 match Map.find fim s with
                 | None -> NRFunApp (kind, es)
                 | Some (_, args, b) ->
@@ -593,8 +593,8 @@ let unroll_loop_one_step_statement _ =
           IfElse
             ( Expr.Fixed.
                 { lower with
-                  pattern= FunApp (StanLib ("Geq__", FnPlain), [upper; lower])
-                }
+                  pattern=
+                    FunApp (StanLib ("Geq__", FnPlain, SoA), [upper; lower]) }
             , { pattern=
                   (let body_unrolled =
                      subst_args_stmt [loopvar] [lower]
@@ -610,7 +610,7 @@ let unroll_loop_one_step_statement _ =
                                { lower with
                                  pattern=
                                    FunApp
-                                     ( StanLib ("Plus__", FnPlain)
+                                     ( StanLib ("Plus__", FnPlain, SoA)
                                      , [lower; Expr.Helpers.loop_bottom] ) } }
                      ; meta= Location_span.empty }
                    in
@@ -694,7 +694,7 @@ and accum_any pred b e = b || expr_any pred e
 
 let can_side_effect_top_expr (e : Expr.Typed.t) =
   match e.pattern with
-  | FunApp ((UserDefined (_, FnTarget) | StanLib (_, FnTarget)), _) -> true
+  | FunApp ((UserDefined (_, FnTarget) | StanLib (_, FnTarget, _)), _) -> true
   | FunApp (CompilerInternal internal_fn, _) ->
       Internal_fun.can_side_effect internal_fn
   | _ -> false
@@ -703,7 +703,7 @@ let cannot_duplicate_expr (e : Expr.Typed.t) =
   let pred e =
     can_side_effect_top_expr e
     || ( match e.pattern with
-       | FunApp ((UserDefined (_, FnRng) | StanLib (_, FnRng)), _) -> true
+       | FunApp ((UserDefined (_, FnRng) | StanLib (_, FnRng, _)), _) -> true
        | _ -> false )
     || (preserve_stability && UnsizedType.is_autodiffable e.meta.type_)
   in

--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -263,7 +263,7 @@ let compiletime_value_of_expr
 let list_distributions (mir : Program.Typed.t) : dist_info Set.Poly.t =
   let take_dist (expr : Expr.Typed.t) =
     match expr.pattern with
-    | Expr.Fixed.Pattern.FunApp (StanLib (fname, FnLpdf true), arg_exprs) ->
+    | Expr.Fixed.Pattern.FunApp (StanLib (fname, FnLpdf true, _), arg_exprs) ->
         let fname = chop_dist_name fname |> Option.value_exn in
         let params = parameter_set mir in
         let data = data_set mir in

--- a/src/common/Helpers.ml
+++ b/src/common/Helpers.ml
@@ -1,5 +1,22 @@
 open Core_kernel
 
+(**
+  * This type represents whether or not an autodiff type can be represented 
+  * as an Array of Structs (AoS) or as a Struct of Arrays. This applies to 
+  * matrices, vectors, row vectors, and arrays of those types.
+  * In the C++ this allows us to swap out matrix types from an
+  * Eigen::Matrix<stan::math::var_value<double>, Rows, Cols> to an 
+  * stan::math::var_value<Eigen::Matrix<double, Rows, Cols>>.
+  * (fyi a var in the C++ code is an alias for var_value<double>)
+  *
+ **)
+type mem_pattern = AoS | SoA [@@deriving sexp, compare, map, hash, fold]
+
+let lub_mem_pat lst =
+  let find_soa mem_pat = mem_pat = SoA in
+  let any_soa = List.exists ~f:find_soa lst in
+  match any_soa with true -> SoA | false -> AoS
+
 let option_or_else ~if_none x = Option.first_some x if_none
 let on_snd f (x, y) = (x, f y)
 let on_fst f (x, y) = (f x, y)

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -12,7 +12,7 @@ let unwrap_return_exn = function
 let trans_fn_kind kind name =
   let fname = Utils.stdlib_distribution_name name in
   match kind with
-  | Ast.StanLib suffix -> Fun_kind.StanLib (fname, suffix)
+  | Ast.StanLib suffix -> Fun_kind.StanLib (fname, suffix, AoS)
   | UserDefined suffix -> UserDefined (fname, suffix)
 
 let without_underscores = String.filter ~f:(( <> ) '_')
@@ -47,7 +47,7 @@ let rec op_to_funapp op args =
   and adlevel = Ast.expr_ad_lub args in
   Expr.
     { Fixed.pattern=
-        FunApp (StanLib (Operator.to_string op, FnPlain), trans_exprs args)
+        FunApp (StanLib (Operator.to_string op, FnPlain, AoS), trans_exprs args)
     ; meta= Expr.Typed.Meta.create ~type_ ~adlevel ~loc () }
 
 and trans_expr {Ast.expr; Ast.emeta} =
@@ -75,7 +75,8 @@ and trans_expr {Ast.expr; Ast.emeta} =
   | FunApp (fn_kind, {name; _}, args) | CondDistApp (fn_kind, {name; _}, args)
     ->
       FunApp (trans_fn_kind fn_kind name, trans_exprs args) |> ewrap
-  | GetLP | GetTarget -> FunApp (StanLib ("target", FnTarget), []) |> ewrap
+  | GetLP | GetTarget ->
+      FunApp (StanLib ("target", FnTarget, AoS), []) |> ewrap
   | ArrayExpr eles ->
       FunApp (CompilerInternal FnMakeArray, trans_exprs eles) |> ewrap
   | RowVectorExpr eles ->
@@ -209,7 +210,7 @@ let same_shape decl_id decl_var id var meta =
     [ Stmt.
         { Fixed.pattern=
             NRFunApp
-              ( StanLib ("check_matching_dims", FnPlain)
+              ( StanLib ("check_matching_dims", FnPlain, AoS)
               , Expr.Helpers.
                   [str "constraint"; str decl_id; decl_var; str id; var] )
         ; meta } ]
@@ -258,7 +259,8 @@ let param_size transform sizedtype =
   let rec shrink_eigen f st =
     match st with
     | SizedType.SArray (t, d) -> SizedType.SArray (shrink_eigen f t, d)
-    | SVector d | SMatrix (d, _) -> SVector (f d)
+    | SVector (mem_pattern, d) | SMatrix (mem_pattern, d, _) ->
+        SVector (mem_pattern, f d)
     | SInt | SReal | SRowVector _ ->
         raise_s
           [%message
@@ -267,7 +269,7 @@ let param_size transform sizedtype =
   let rec shrink_eigen_mat f st =
     match st with
     | SizedType.SArray (t, d) -> SizedType.SArray (shrink_eigen_mat f t, d)
-    | SMatrix (d1, d2) -> SVector (f d1 d2)
+    | SMatrix (mem_pattern, d1, d2) -> SVector (mem_pattern, f d1 d2)
     | SInt | SReal | SRowVector _ | SVector _ ->
         raise_s
           [%message "Expecting SMatrix, got " (st : Expr.Typed.t SizedType.t)]
@@ -336,16 +338,16 @@ let check_sizedtype name =
   in
   let rec sizedtype = function
     | SizedType.(SInt | SReal) as t -> ([], t)
-    | SVector s ->
+    | SVector (mem_pattern, s) ->
         let e = trans_expr s in
-        (check s e, SizedType.SVector e)
-    | SRowVector s ->
+        (check s e, SizedType.SVector (mem_pattern, e))
+    | SRowVector (mem_pattern, s) ->
         let e = trans_expr s in
-        (check s e, SizedType.SRowVector e)
-    | SMatrix (r, c) ->
+        (check s e, SizedType.SRowVector (mem_pattern, e))
+    | SMatrix (mem_pattern, r, c) ->
         let er = trans_expr r in
         let ec = trans_expr c in
-        (check r er @ check c ec, SizedType.SMatrix (er, ec))
+        (check r er @ check c ec, SizedType.SMatrix (mem_pattern, er, ec))
     | SArray (t, s) ->
         let e = trans_expr s in
         let ll, t = sizedtype t in
@@ -477,7 +479,7 @@ let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
         in
         if List.exists ~f:(fun (n, _) -> Set.mem possible_names n) ud_dists
         then Fun_kind.UserDefined (name, FnLpdf true)
-        else StanLib (name, FnLpdf true)
+        else StanLib (name, FnLpdf true, AoS)
       in
       let add_dist =
         Stmt.Fixed.Pattern.TargetPE
@@ -633,7 +635,7 @@ let trans_sizedtype_decl declc tr name =
   in
   let rec go n = function
     | SizedType.(SInt | SReal) as t -> ([], t)
-    | SVector s ->
+    | SVector (mem_pattern, s) ->
         let fn =
           match (declc.transform_action, tr) with
           | Constrain, Transformation.Simplex ->
@@ -642,11 +644,11 @@ let trans_sizedtype_decl declc tr name =
           | _ -> FnValidateSize
         in
         let l, s = grab_size fn n s in
-        (l, SizedType.SVector s)
-    | SRowVector s ->
+        (l, SizedType.SVector (mem_pattern, s))
+    | SRowVector (mem_pattern, s) ->
         let l, s = grab_size FnValidateSize n s in
-        (l, SizedType.SRowVector s)
-    | SMatrix (r, c) ->
+        (l, SizedType.SRowVector (mem_pattern, s))
+    | SMatrix (mem_pattern, r, c) ->
         let l1, r = grab_size FnValidateSize n r in
         let l2, c = grab_size FnValidateSize (n + 1) c in
         let cf_cov =
@@ -654,7 +656,7 @@ let trans_sizedtype_decl declc tr name =
           | Constrain, CholeskyCov ->
               [ { Stmt.Fixed.pattern=
                     NRFunApp
-                      ( StanLib ("check_greater_or_equal", FnPlain)
+                      ( StanLib ("check_greater_or_equal", FnPlain, AoS)
                       , Expr.Helpers.
                           [ str ("cholesky_factor_cov " ^ name)
                           ; str
@@ -663,7 +665,7 @@ let trans_sizedtype_decl declc tr name =
                 ; meta= r.Expr.Fixed.meta.Expr.Typed.Meta.loc } ]
           | _ -> []
         in
-        (l1 @ l2 @ cf_cov, SizedType.SMatrix (r, c))
+        (l1 @ l2 @ cf_cov, SizedType.SMatrix (mem_pattern, r, c))
     | SArray (t, s) ->
         let l, s = grab_size FnValidateSize n s in
         let ll, t = go (n + 1) t in
@@ -843,7 +845,7 @@ let trans_prog filename (p : Ast.typed_program) : Program.Typed.t =
   in
   let iexpr pattern = Expr.{pattern; Fixed.meta= Typed.Meta.empty} in
   let fnot e =
-    FunApp (StanLib (Operator.to_string PNot, FnPlain), [e]) |> iexpr
+    FunApp (StanLib (Operator.to_string PNot, FnPlain, AoS), [e]) |> iexpr
   in
   let tparam_early_return =
     let to_var fv = iexpr (Var (Flag_vars.to_string fv)) in

--- a/src/frontend/Debug_data_generation.ml
+++ b/src/frontend/Debug_data_generation.ml
@@ -278,9 +278,9 @@ let rec generate_value m st t =
   match st with
   | SizedType.SInt -> gen_int m t
   | SReal -> gen_real m t
-  | SVector e -> gen_vector m (unwrap_int_exn m e) t
-  | SRowVector e -> gen_row_vector m (unwrap_int_exn m e) t
-  | SMatrix (e1, e2) ->
+  | SVector (_, e) -> gen_vector m (unwrap_int_exn m e) t
+  | SRowVector (_, e) -> gen_row_vector m (unwrap_int_exn m e) t
+  | SMatrix (_, e1, e2) ->
       gen_matrix m (unwrap_int_exn m e1) (unwrap_int_exn m e2) t
   | SArray (st, e) ->
       let element () = generate_value m st t in

--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -20,7 +20,7 @@ let deprecated_odes =
 let deprecated_distributions =
   String.Map.of_alist_exn
     (List.concat_map Middle.Stan_math_signatures.distributions
-       ~f:(fun (fnkinds, name, _) ->
+       ~f:(fun (fnkinds, name, _, _) ->
          List.filter_map fnkinds ~f:(function
            | Lpdf -> Some (name ^ "_log", name ^ "_lpdf")
            | Lpmf -> Some (name ^ "_log", name ^ "_lpmf")

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -165,9 +165,9 @@ and pp_list_of_printables ppf l =
 and pp_sizedtype ppf = function
   | Middle.SizedType.SInt -> Fmt.pf ppf "int"
   | SReal -> Fmt.pf ppf "real"
-  | SVector e -> Fmt.pf ppf "vector[%a]" pp_expression e
-  | SRowVector e -> Fmt.pf ppf "row_vector[%a]" pp_expression e
-  | SMatrix (e1, e2) ->
+  | SVector (_, e) -> Fmt.pf ppf "vector[%a]" pp_expression e
+  | SRowVector (_, e) -> Fmt.pf ppf "row_vector[%a]" pp_expression e
+  | SMatrix (_, e1, e2) ->
       Fmt.pf ppf "matrix[%a, %a]" pp_expression e1 pp_expression e2
   | SArray _ -> raise (Middle.Errors.FatalError "This should never happen.")
 
@@ -207,9 +207,9 @@ and pp_transformed_type ppf (pst, trans) =
   in
   let sizes_fmt =
     match pst with
-    | Sized (SVector e) | Sized (SRowVector e) ->
+    | Sized (SVector (_, e)) | Sized (SRowVector (_, e)) ->
         Fmt.const (fun ppf -> Fmt.pf ppf "[%a]" pp_expression) e
-    | Sized (SMatrix (e1, e2)) ->
+    | Sized (SMatrix (_, e1, e2)) ->
         Fmt.const
           (fun ppf -> Fmt.pf ppf "[%a, %a]" pp_expression e1 pp_expression)
           e2
@@ -219,7 +219,7 @@ and pp_transformed_type ppf (pst, trans) =
   in
   let cov_sizes_fmt =
     match pst with
-    | Sized (SMatrix (e1, e2)) ->
+    | Sized (SMatrix (_, e1, e2)) ->
         if e1 = e2 then
           Fmt.const (fun ppf -> Fmt.pf ppf "[%a]" pp_expression) e1
         else

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -383,11 +383,11 @@ sized_basic_type:
   | REAL
     { grammar_logger "REAL_var_type" ; (SizedType.SReal, Identity) }
   | VECTOR LBRACK e=expression RBRACK
-    { grammar_logger "VECTOR_var_type" ; (SizedType.SVector e, Identity) }
+    { grammar_logger "VECTOR_var_type" ; (SizedType.SVector (Common.Helpers.AoS, e), Identity) }
   | ROWVECTOR LBRACK e=expression RBRACK
-    { grammar_logger "ROWVECTOR_var_type" ; (SizedType.SRowVector e , Identity) }
+    { grammar_logger "ROWVECTOR_var_type" ; (SizedType.SRowVector (AoS, e) , Identity) }
   | MATRIX LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "MATRIX_var_type" ; (SizedType.SMatrix (e1, e2), Identity) }
+    { grammar_logger "MATRIX_var_type" ; (SizedType.SMatrix (AoS, e1, e2), Identity) }
 
 top_var_type:
   | INT r=range_constraint
@@ -395,38 +395,38 @@ top_var_type:
   | REAL c=type_constraint
     { grammar_logger "REAL_top_var_type" ; (SReal, c) }
   | VECTOR c=type_constraint LBRACK e=expression RBRACK
-    { grammar_logger "VECTOR_top_var_type" ; (SVector e, c) }
+    { grammar_logger "VECTOR_top_var_type" ; (SVector (AoS, e), c) }
   | ROWVECTOR c=type_constraint LBRACK e=expression RBRACK
-    { grammar_logger "ROWVECTOR_top_var_type" ; (SRowVector e, c) }
+    { grammar_logger "ROWVECTOR_top_var_type" ; (SRowVector (AoS, e), c) }
   | MATRIX c=type_constraint LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "MATRIX_top_var_type" ; (SMatrix (e1, e2), c) }
+    { grammar_logger "MATRIX_top_var_type" ; (SMatrix (AoS, e1, e2), c) }
   | ORDERED LBRACK e=expression RBRACK
-    { grammar_logger "ORDERED_top_var_type" ; (SVector e, Ordered) }
+    { grammar_logger "ORDERED_top_var_type" ; (SVector (AoS, e), Ordered) }
   | POSITIVEORDERED LBRACK e=expression RBRACK
     {
       grammar_logger "POSITIVEORDERED_top_var_type" ;
-      (SVector e, PositiveOrdered)
+      (SVector (AoS, e), PositiveOrdered)
     }
   | SIMPLEX LBRACK e=expression RBRACK
-    { grammar_logger "SIMPLEX_top_var_type" ; (SVector e, Simplex) }
+    { grammar_logger "SIMPLEX_top_var_type" ; (SVector (AoS, e), Simplex) }
   | UNITVECTOR LBRACK e=expression RBRACK
-    { grammar_logger "UNITVECTOR_top_var_type" ; (SVector e, UnitVector) }
+    { grammar_logger "UNITVECTOR_top_var_type" ; (SVector (AoS, e), UnitVector) }
   | CHOLESKYFACTORCORR LBRACK e=expression RBRACK
     {
       grammar_logger "CHOLESKYFACTORCORR_top_var_type" ;
-      (SMatrix (e, e), CholeskyCorr)
+      (SMatrix (AoS, e, e), CholeskyCorr)
     }
   | CHOLESKYFACTORCOV LBRACK e1=expression oe2=option(pair(COMMA, expression))
     RBRACK
     {
       grammar_logger "CHOLESKYFACTORCOV_top_var_type" ;
-      match oe2 with Some (_,e2) -> ( SMatrix (e1, e2), CholeskyCov)
-                   | _           ->  (SMatrix (e1, e1),  CholeskyCov)
+      match oe2 with Some (_,e2) -> ( SMatrix (AoS, e1, e2), CholeskyCov)
+                   | _           ->  (SMatrix (AoS, e1, e1),  CholeskyCov)
     }
   | CORRMATRIX LBRACK e=expression RBRACK
-    { grammar_logger "CORRMATRIX_top_var_type" ; (SMatrix (e, e), Correlation) }
+    { grammar_logger "CORRMATRIX_top_var_type" ; (SMatrix (AoS, e, e), Correlation) }
   | COVMATRIX LBRACK e=expression RBRACK
-    { grammar_logger "COVMATRIX_top_var_type" ; (SMatrix (e, e), Covariance) }
+    { grammar_logger "COVMATRIX_top_var_type" ; (SMatrix (AoS, e, e), Covariance) }
 
 type_constraint:
   | r=range_constraint

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -21,7 +21,7 @@ module Fixed = struct
       | Var varname -> Fmt.string ppf varname
       | Lit (Str, str) -> Fmt.pf ppf "%S" str
       | Lit (_, str) -> Fmt.string ppf str
-      | FunApp (StanLib (name, FnPlain), [lhs; rhs])
+      | FunApp (StanLib (name, FnPlain, _), [lhs; rhs])
         when Option.is_some (Operator.of_string_opt name) ->
           Fmt.pf ppf "(%a %a %a)" pp_e lhs Operator.pp
             (Option.value_exn (Operator.of_string_opt name))
@@ -165,7 +165,8 @@ module Helpers = struct
 
   let binop e1 op e2 =
     { Fixed.meta= Typed.Meta.empty
-    ; pattern= FunApp (StanLib (Operator.to_string op, FnPlain), [e1; e2]) }
+    ; pattern= FunApp (StanLib (Operator.to_string op, FnPlain, AoS), [e1; e2])
+    }
 
   let binop_list es op ~default =
     match es with

--- a/src/middle/Fun_kind.ml
+++ b/src/middle/Fun_kind.ml
@@ -6,7 +6,7 @@ type 'propto suffix = FnPlain | FnRng | FnLpdf of 'propto | FnTarget
 let without_propto = map_suffix (function true | false -> ())
 
 type 'e t =
-  | StanLib of string * bool suffix
+  | StanLib of string * bool suffix * Common.Helpers.mem_pattern
   | CompilerInternal of 'e Internal_fun.t
   | UserDefined of string * bool suffix
 [@@deriving compare, sexp, hash, map, fold]
@@ -27,10 +27,10 @@ let suffix_from_name fname =
   else FnPlain
 
 let pp pp_expr ppf = function
-  | StanLib (s, FnLpdf true) | UserDefined (s, FnLpdf true) ->
+  | StanLib (s, FnLpdf true, _) | UserDefined (s, FnLpdf true) ->
       Fmt.string ppf
         (Utils.with_unnormalized_suffix s |> Option.value ~default:s)
-  | StanLib (s, _) | UserDefined (s, _) -> Fmt.string ppf s
+  | StanLib (s, _, _) | UserDefined (s, _) -> Fmt.string ppf s
   | CompilerInternal internal -> Internal_fun.pp pp_expr ppf internal
 
 let collect_exprs fn = fold (fun accum e -> e :: accum) [] fn

--- a/src/middle/Index.ml
+++ b/src/middle/Index.ml
@@ -25,3 +25,19 @@ let bounds = function
   | All -> []
   | Single e | Upfrom e | MultiIndex e -> [e]
   | Between (e1, e2) -> [e1; e2]
+
+(**
+ * Apply an op over the `Index` types inner expressions.
+ * @param default Value to return for `All`
+ * @param merge Function taking in lhs and rhs of `Between` and
+ *  merging their result.
+ * @param op a functor to run with inputs of inner exprs
+ * @param ind the Index.t to
+ *)
+let apply ~default ~merge op ind =
+  match ind with
+  | All -> default
+  | Single ind_expr -> op ind_expr
+  | Upfrom ind_expr -> op ind_expr
+  | Between (expr_top, expr_bottom) -> merge (op expr_top) (op expr_bottom)
+  | MultiIndex exprs -> op exprs

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -9,7 +9,10 @@ type 'expr t =
   | FnReadData
   | FnReadDataSerializer
   (* XXX move these to a backend specific file?*)
-  | FnReadParam of {constrain: 'expr Transformation.t; dims: 'expr list}
+  | FnReadParam of
+      { constrain: 'expr Transformation.t
+      ; dims: 'expr list
+      ; mem_pattern: Common.Helpers.mem_pattern }
   | FnWriteParam of {unconstrain_opt: 'expr Transformation.t option; var: 'expr}
   | FnValidateSize
   | FnValidateSizeSimplex

--- a/src/middle/SignatureMismatch.ml
+++ b/src/middle/SignatureMismatch.ml
@@ -36,7 +36,7 @@ let pp_fundef ctx ppf =
     | AutoDiffable -> pp_unsized_type ctx ppf ty
   in
   function
-  | UnsizedType.UFun (args, rt, _) ->
+  | UnsizedType.UFun (args, rt, _, _) ->
       Fmt.pf ppf "@[<hov>(@[<hov>%a@]) => %a@]"
         Fmt.(list ~sep:comma pp_fun_arg)
         args pp_returntype rt
@@ -119,14 +119,14 @@ let rec check_same_type depth t1 t2 =
   match (t1, t2) with
   | t1, t2 when t1 = t2 -> None
   | UnsizedType.(UReal, UInt) when depth < 1 -> None
-  | UFun (_, _, s1), UFun (_, _, s2)
+  | UFun (_, _, s1, _), UFun (_, _, s2, _)
     when Fun_kind.without_propto s1 <> Fun_kind.without_propto s2 ->
       Some
         (SuffixMismatch (Fun_kind.without_propto s1, Fun_kind.without_propto s2))
       |> wrap_func
-  | UFun (_, rt1, _), UFun (_, rt2, _) when rt1 <> rt2 ->
+  | UFun (_, rt1, _, _), UFun (_, rt2, _, _) when rt1 <> rt2 ->
       Some (ReturnTypeMismatch (rt1, rt2)) |> wrap_func
-  | UFun (l1, _, _), UFun (l2, _, _) ->
+  | UFun (l1, _, _, _), UFun (l2, _, _, _) ->
       check_compatible_arguments (depth + 1) l2 l1
       |> Option.map ~f:(fun e -> InputMismatch e)
       |> wrap_func
@@ -152,11 +152,11 @@ let stan_math_returntype name args =
   (* NB: Variadic arguments are special-cased in Semantic_check and not handled here *)
   let name = Utils.stdlib_distribution_name name in
   Hashtbl.find_multi Stan_math_signatures.stan_math_signatures name
-  |> List.sort ~compare:(fun (x, _) (y, _) ->
+  |> List.sort ~compare:(fun (x, _, _) (y, _, _) ->
          UnsizedType.compare_returntype x y )
   (* Check the least return type first in case there are multiple options (due to implicit UInt-UReal conversion), where UInt<UReal *)
   |> List.fold_until ~init:[]
-       ~f:(fun errors (rt, tys) ->
+       ~f:(fun errors (rt, tys, _) ->
          match check_compatible_arguments 0 tys args with
          | None -> Stop (Ok rt)
          | Some e -> Continue (((rt, tys), e) :: errors) )
@@ -171,7 +171,8 @@ let stan_math_returntype name args =
 let check_variadic_args allow_lpdf mandatory_arg_tys mandatory_fun_arg_tys
     fun_return args =
   let minimal_func_type =
-    UnsizedType.UFun (mandatory_fun_arg_tys, ReturnType fun_return, FnPlain)
+    UnsizedType.UFun
+      (mandatory_fun_arg_tys, ReturnType fun_return, FnPlain, AoS)
   in
   let minimal_args =
     (UnsizedType.AutoDiffable, minimal_func_type) :: mandatory_arg_tys
@@ -179,8 +180,8 @@ let check_variadic_args allow_lpdf mandatory_arg_tys mandatory_fun_arg_tys
   let wrap_err x = Some (minimal_args, ArgError (1, x)) in
   match args with
   | ( _
-    , (UnsizedType.UFun (fun_args, ReturnType return_type, suffix) as func_type)
-    )
+    , ( UnsizedType.UFun (fun_args, ReturnType return_type, suffix, _) as
+      func_type ) )
     :: _ ->
       let mandatory, variadic_arg_tys =
         List.split_n fun_args (List.length mandatory_fun_arg_tys)
@@ -294,7 +295,7 @@ let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
         pf ppf "(@[<hov>%a@])" (list ~sep:comma (pp_unsized_type ctx)) )
   in
   let pp_signature ppf ((rt, args), err) =
-    let fun_ty = UnsizedType.UFun (args, rt, FnPlain) in
+    let fun_ty = UnsizedType.UFun (args, rt, FnPlain, AoS) in
     Fmt.pf ppf "%a@ @[<hov 2>  %a@]"
       (pp_with_where ctx (pp_fundef ctx))
       fun_ty pp_explain err

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -4,18 +4,19 @@ open Common
 type 'a t =
   | SInt
   | SReal
-  | SVector of 'a
-  | SRowVector of 'a
-  | SMatrix of 'a * 'a
+  | SVector of Common.Helpers.mem_pattern * 'a
+  | SRowVector of Common.Helpers.mem_pattern * 'a
+  | SMatrix of Common.Helpers.mem_pattern * 'a * 'a
   | SArray of 'a t * 'a
 [@@deriving sexp, compare, map, hash, fold]
 
 let rec pp pp_e ppf = function
   | SInt -> Fmt.string ppf "int"
   | SReal -> Fmt.string ppf "real"
-  | SVector expr -> Fmt.pf ppf {|vector%a|} (Fmt.brackets pp_e) expr
-  | SRowVector expr -> Fmt.pf ppf {|row_vector%a|} (Fmt.brackets pp_e) expr
-  | SMatrix (d1_expr, d2_expr) ->
+  | SVector (_, expr) -> Fmt.pf ppf {|vector%a|} (Fmt.brackets pp_e) expr
+  | SRowVector (_, expr) ->
+      Fmt.pf ppf {|row_vector%a|} (Fmt.brackets pp_e) expr
+  | SMatrix (_, d1_expr, d2_expr) ->
       Fmt.pf ppf {|matrix%a|}
         Fmt.(pair ~sep:comma pp_e pp_e |> brackets)
         (d1_expr, d2_expr)
@@ -27,8 +28,8 @@ let rec pp pp_e ppf = function
 let collect_exprs st =
   let rec aux accu = function
     | SInt | SReal -> List.rev accu
-    | SVector e | SRowVector e -> List.rev @@ (e :: accu)
-    | SMatrix (e1, e2) -> List.rev @@ (e1 :: e2 :: accu)
+    | SVector (_, e) | SRowVector (_, e) -> List.rev @@ (e :: accu)
+    | SMatrix (_, e1, e2) -> List.rev @@ (e1 :: e2 :: accu)
     | SArray (inner, e) -> aux (e :: accu) inner
   in
   aux [] st
@@ -43,8 +44,9 @@ let rec to_unsized = function
 
 let rec associate ?init:(assocs = Label.Int_label.Map.empty) = function
   | SInt | SReal -> assocs
-  | SVector e | SRowVector e -> Expr.Labelled.associate ~init:assocs e
-  | SMatrix (e1, e2) ->
+  | SVector (_, e) | SRowVector (_, e) ->
+      Expr.Labelled.associate ~init:assocs e
+  | SMatrix (_, e1, e2) ->
       Expr.Labelled.(associate ~init:(associate ~init:assocs e1) e2)
   | SArray (st, e) ->
       associate ~init:(Expr.Labelled.associate ~init:assocs e) st
@@ -55,23 +57,23 @@ let rec inner_type = function SArray (t, _) -> inner_type t | t -> t
 let rec dims_of st =
   match st with
   | SArray (t, _) -> dims_of t
-  | SMatrix (d1, d2) -> [d1; d2]
-  | SRowVector dim | SVector dim -> [dim]
+  | SMatrix (_, d1, d2) -> [d1; d2]
+  | SRowVector (_, dim) | SVector (_, dim) -> [dim]
   | SInt | SReal -> []
 
 let rec get_dims st =
   match st with
   | SInt | SReal -> []
-  | SVector d | SRowVector d -> [d]
-  | SMatrix (dim1, dim2) -> [dim1; dim2]
+  | SVector (_, d) | SRowVector (_, d) -> [d]
+  | SMatrix (_, dim1, dim2) -> [dim1; dim2]
   | SArray (t, dim) -> dim :: get_dims t
 
 (* Return a type's array dimensions and the type inside the (possibly nested) array *)
 let rec get_array_dims st =
   match st with
   | SInt | SReal -> (st, [])
-  | SVector d | SRowVector d -> (st, [d])
-  | SMatrix (d1, d2) -> (st, [d1; d2])
+  | SVector (_, d) | SRowVector (_, d) -> (st, [d])
+  | SMatrix (_, d1, d2) -> (st, [d1; d2])
   | SArray (st, dim) ->
       let st', dims = get_array_dims st in
       (st', dim :: dims)
@@ -83,6 +85,66 @@ let num_elems_expr st =
 let%expect_test "dims" =
   let open Fmt in
   strf "@[%a@]" (list ~sep:comma string)
-    (get_dims (SArray (SMatrix ("x", "y"), "z")))
+    (get_dims (SArray (SMatrix (Common.Helpers.AoS, "x", "y"), "z")))
   |> print_endline ;
   [%expect {| z, x, y |}]
+
+(**
+ * Return true if SizedType contains an Eigen type
+ *)
+let rec contains_eigen_type st =
+  match st with
+  | SInt -> false
+  | SReal -> false
+  | SVector _ | SRowVector _ | SMatrix _ -> true
+  | SArray (t, _) -> contains_eigen_type t
+
+(**
+ * Return true if SizedType contains a type tagged SoA
+ *)
+let rec contains_soa st =
+  match st with
+  | SInt -> false
+  | SReal -> false
+  | SVector (SoA, _) | SRowVector (SoA, _) | SMatrix (SoA, _, _) -> true
+  | SVector (AoS, _) | SRowVector (AoS, _) | SMatrix (AoS, _, _) -> false
+  | SArray (t, _) -> contains_soa t
+
+(**
+ * Return the mem_pattern of the SizedType
+ *)
+let rec get_mem_pattern st =
+  match st with
+  | SInt | SReal -> Common.Helpers.AoS
+  | SVector (SoA, _) | SRowVector (SoA, _) | SMatrix (SoA, _, _) -> SoA
+  | SVector (AoS, _) | SRowVector (AoS, _) | SMatrix (AoS, _, _) -> AoS
+  | SArray (t, _) -> get_mem_pattern t
+
+(*Given a sizedtype, demote it's mem pattern from SoA to AoS*)
+let rec demote_sizedtype_mem st =
+  match st with
+  | ( SInt | SReal
+    | SVector (AoS, _)
+    | SRowVector (AoS, _)
+    | SMatrix (AoS, _, _) ) as ret ->
+      ret
+  | SArray (inner_type, dim) -> SArray (demote_sizedtype_mem inner_type, dim)
+  | SVector (SoA, dim) -> SVector (AoS, dim)
+  | SRowVector (SoA, dim) -> SRowVector (AoS, dim)
+  | SMatrix (SoA, dim1, dim2) -> SMatrix (AoS, dim1, dim2)
+
+(*Given a sizedtype, promote it's mem pattern from AoS to SoA*)
+let rec promote_sizedtype_mem st =
+  match st with
+  | (SInt | SReal) as ret -> ret
+  | SVector (AoS, dim) -> SVector (SoA, dim)
+  | SRowVector (AoS, dim) -> SRowVector (SoA, dim)
+  | SMatrix (AoS, dim1, dim2) -> SMatrix (SoA, dim1, dim2)
+  | SArray (inner_type, dim) -> SArray (promote_sizedtype_mem inner_type, dim)
+  | _ -> st
+
+(*Given a mem_pattern and SizedType, modify the SizedType to AoS or SoA*)
+let modify_sizedtype_mem (mem_pattern : Common.Helpers.mem_pattern) st =
+  match mem_pattern with
+  | Common.Helpers.AoS -> demote_sizedtype_mem st
+  | Common.Helpers.SoA -> promote_sizedtype_mem st

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -43,6 +43,10 @@ let rec expand_arg = function
             map (range 0 8) ~f:(fun i -> bare_array_type (a, i)) ))
 
 type fkind = Lpmf | Lpdf | Rng | Cdf | Ccdf | UnaryVectorized
+type fun_arg = UnsizedType.autodifftype * UnsizedType.t
+
+type stan_math_table_values =
+  UnsizedType.returntype * fun_arg list * Common.Helpers.mem_pattern
 
 let is_primitive = function
   | UnsizedType.UReal -> true
@@ -50,11 +54,14 @@ let is_primitive = function
   | _ -> false
 
 (** The signatures hash table *)
-let stan_math_signatures = String.Table.create ()
+let (stan_math_signatures : (string, stan_math_table_values list) Hashtbl.t) =
+  String.Table.create ()
 
 (** All of the signatures that are added by hand, rather than the ones
     added "declaratively" *)
-let manual_stan_math_signatures = String.Table.create ()
+let (manual_stan_math_signatures :
+      (string, stan_math_table_values list) Hashtbl.t) =
+  String.Table.create ()
 
 (* XXX The correct word here isn't combination - what is it? *)
 let all_combinations xx =
@@ -73,11 +80,15 @@ let missing_math_functions = String.Set.of_list ["beta_proportion_cdf"]
 let rng_return_type t lt =
   if List.for_all ~f:is_primitive lt then t else UnsizedType.UArray t
 
-let add_unqualified (name, rt, uqargts) =
+let add_unqualified (name, rt, uqargts, mem_pattern) =
   Hashtbl.add_multi manual_stan_math_signatures ~key:name
-    ~data:(rt, List.map ~f:(fun x -> (UnsizedType.AutoDiffable, x)) uqargts)
+    ~data:
+      ( rt
+      , List.map ~f:(fun x -> (UnsizedType.AutoDiffable, x)) uqargts
+      , mem_pattern )
 
-let rec ints_to_real = function
+let rec ints_to_real unsized =
+  match unsized with
   | UnsizedType.UInt -> UnsizedType.UReal
   | UArray t -> UArray (ints_to_real t)
   | x -> x
@@ -127,7 +138,7 @@ let variadic_ode_mandatory_fun_args =
 let variadic_ode_fun_return_type = UnsizedType.UVector
 let variadic_ode_return_type = UnsizedType.UArray UnsizedType.UVector
 
-let mk_declarative_sig (fnkinds, name, args) =
+let mk_declarative_sig (fnkinds, name, args, mem_pattern) =
   let sfxes = function
     | Lpmf -> ["_lpmf"; "_log"]
     | Lpdf -> ["_lpdf"; "_log"]
@@ -151,7 +162,7 @@ let mk_declarative_sig (fnkinds, name, args) =
   let create_from_fk_args fk arglists =
     List.concat_map arglists ~f:(fun args ->
         List.map (sfxes fk) ~f:(fun sfx ->
-            (name ^ sfx, find_rt UReal args fk, args) ) )
+            (name ^ sfx, find_rt UReal args fk, args, mem_pattern) ) )
   in
   let add_fnkind = function
     | Rng ->
@@ -160,15 +171,18 @@ let mk_declarative_sig (fnkinds, name, args) =
         let rt = promoted_dim rt in
         let name = name ^ "_rng" in
         List.map (all_expanded args) ~f:(fun args ->
-            (name, find_rt rt args Rng, args) )
+            (name, find_rt rt args Rng, args, mem_pattern) )
     | UnaryVectorized ->
         create_from_fk_args UnaryVectorized (all_expanded args)
     | fk -> create_from_fk_args fk (all_expanded args)
   in
   List.concat_map fnkinds ~f:add_fnkind
-  |> List.filter ~f:(fun (n, _, _) -> not (Set.mem missing_math_functions n))
-  |> List.map ~f:(fun (n, rt, args) ->
-         (n, rt, List.map ~f:(fun x -> (UnsizedType.AutoDiffable, x)) args) )
+  |> List.filter ~f:(fun (n, _, _, _) -> not (Set.mem missing_math_functions n))
+  |> List.map ~f:(fun (n, rt, args, support_soa) ->
+         ( n
+         , rt
+         , List.map ~f:(fun x -> (UnsizedType.AutoDiffable, x)) args
+         , support_soa ) )
 
 let full_lpdf = [Lpdf; Rng; Ccdf; Cdf]
 let full_lpmf = [Lpmf; Rng; Ccdf; Cdf]
@@ -195,120 +209,127 @@ let is_variadic_ode_nonadjoint_tol_fn f =
   && String.is_suffix f ~suffix:ode_tolerances_suffix
 
 let distributions =
-  [ (full_lpmf, "beta_binomial", [DVInt; DVInt; DVReal; DVReal])
-  ; (full_lpdf, "beta", [DVReal; DVReal; DVReal])
-  ; ([Lpdf; Ccdf; Cdf], "beta_proportion", [DVReal; DVReal; DIntAndReals])
-  ; (full_lpmf, "bernoulli", [DVInt; DVReal])
-  ; ([Lpmf; Rng], "bernoulli_logit", [DVInt; DVReal])
-  ; (full_lpmf, "binomial", [DVInt; DVInt; DVReal])
-  ; ([Lpmf], "binomial_logit", [DVInt; DVInt; DVReal])
-  ; ([Lpmf], "categorical", [DVInt; DVector])
-  ; ([Lpmf], "categorical_logit", [DVInt; DVector])
-  ; (full_lpdf, "cauchy", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "chi_square", [DVReal; DVReal])
-  ; ([Lpdf], "dirichlet", [DVectors; DVectors])
-  ; (full_lpmf, "discrete_range", [DVInt; DVInt; DVInt])
-  ; (full_lpdf, "double_exponential", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "exp_mod_normal", [DVReal; DVReal; DVReal; DVReal])
-  ; (full_lpdf, "exponential", [DVReal; DVReal])
-  ; (full_lpdf, "frechet", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "gamma", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "gumbel", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "inv_chi_square", [DVReal; DVReal])
-  ; (full_lpdf, "inv_gamma", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "logistic", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "lognormal", [DVReal; DVReal; DVReal])
-  ; ([Lpdf], "multi_gp", [DMatrix; DMatrix; DVector])
-  ; ([Lpdf], "multi_gp_cholesky", [DMatrix; DMatrix; DVector])
-  ; ([Lpdf], "multi_normal", [DVectors; DVectors; DMatrix])
-  ; ([Lpdf], "multi_normal_cholesky", [DVectors; DVectors; DMatrix])
-  ; ([Lpdf], "multi_normal_prec", [DVectors; DVectors; DMatrix])
-  ; ([Lpdf], "multi_student_t", [DVectors; DReal; DVectors; DMatrix])
-  ; (full_lpmf, "neg_binomial", [DVInt; DVReal; DVReal])
-  ; (full_lpmf, "neg_binomial_2", [DVInt; DVReal; DVReal])
-  ; ([Lpmf; Rng], "neg_binomial_2_log", [DVInt; DVReal; DVReal])
-  ; (full_lpdf, "normal", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "pareto", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "pareto_type_2", [DVReal; DVReal; DVReal; DVReal])
-  ; (full_lpmf, "poisson", [DVInt; DVReal])
-  ; ([Lpmf; Rng], "poisson_log", [DVInt; DVReal])
-  ; (full_lpdf, "rayleigh", [DVReal; DVReal])
-  ; (full_lpdf, "scaled_inv_chi_square", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "skew_normal", [DVReal; DVReal; DVReal; DVReal])
-  ; (full_lpdf, "student_t", [DVReal; DVReal; DVReal; DVReal])
-  ; (full_lpdf, "std_normal", [DVReal])
-  ; (full_lpdf, "uniform", [DVReal; DVReal; DVReal])
-  ; ([Lpdf; Rng], "von_mises", [DVReal; DVReal; DVReal])
-  ; (full_lpdf, "weibull", [DVReal; DVReal; DVReal])
-  ; ([Lpdf], "wiener", [DVReal; DVReal; DVReal; DVReal; DVReal])
-  ; ([Lpdf], "wishart", [DMatrix; DReal; DMatrix]) ]
+  [ ( full_lpmf
+    , "beta_binomial"
+    , [DVInt; DVInt; DVReal; DVReal]
+    , Common.Helpers.AoS )
+  ; (full_lpdf, "beta", [DVReal; DVReal; DVReal], AoS)
+  ; ([Lpdf; Ccdf; Cdf], "beta_proportion", [DVReal; DVReal; DIntAndReals], AoS)
+  ; (full_lpmf, "bernoulli", [DVInt; DVReal], AoS)
+  ; ([Lpmf; Rng], "bernoulli_logit", [DVInt; DVReal], AoS)
+  ; (full_lpmf, "binomial", [DVInt; DVInt; DVReal], AoS)
+  ; ([Lpmf], "binomial_logit", [DVInt; DVInt; DVReal], AoS)
+  ; ([Lpmf], "categorical", [DVInt; DVector], AoS)
+  ; ([Lpmf], "categorical_logit", [DVInt; DVector], AoS)
+  ; (full_lpdf, "cauchy", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "chi_square", [DVReal; DVReal], AoS)
+  ; ([Lpdf], "dirichlet", [DVectors; DVectors], AoS)
+  ; (full_lpmf, "discrete_range", [DVInt; DVInt; DVInt], AoS)
+  ; (full_lpdf, "double_exponential", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "exp_mod_normal", [DVReal; DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "exponential", [DVReal; DVReal], AoS)
+  ; (full_lpdf, "frechet", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "gamma", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "gumbel", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "inv_chi_square", [DVReal; DVReal], AoS)
+  ; (full_lpdf, "inv_gamma", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "logistic", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "lognormal", [DVReal; DVReal; DVReal], AoS)
+  ; ([Lpdf], "multi_gp", [DMatrix; DMatrix; DVector], AoS)
+  ; ([Lpdf], "multi_gp_cholesky", [DMatrix; DMatrix; DVector], AoS)
+  ; ([Lpdf], "multi_normal", [DVectors; DVectors; DMatrix], AoS)
+  ; ([Lpdf], "multi_normal_cholesky", [DVectors; DVectors; DMatrix], AoS)
+  ; ([Lpdf], "multi_normal_prec", [DVectors; DVectors; DMatrix], AoS)
+  ; ([Lpdf], "multi_student_t", [DVectors; DReal; DVectors; DMatrix], AoS)
+  ; (full_lpmf, "neg_binomial", [DVInt; DVReal; DVReal], AoS)
+  ; (full_lpmf, "neg_binomial_2", [DVInt; DVReal; DVReal], AoS)
+  ; ([Lpmf; Rng], "neg_binomial_2_log", [DVInt; DVReal; DVReal], AoS)
+  ; (full_lpdf, "normal", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "pareto", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "pareto_type_2", [DVReal; DVReal; DVReal; DVReal], AoS)
+  ; (full_lpmf, "poisson", [DVInt; DVReal], AoS)
+  ; ([Lpmf; Rng], "poisson_log", [DVInt; DVReal], AoS)
+  ; (full_lpdf, "rayleigh", [DVReal; DVReal], AoS)
+  ; (full_lpdf, "scaled_inv_chi_square", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "skew_normal", [DVReal; DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "student_t", [DVReal; DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "std_normal", [DVReal], AoS)
+  ; (full_lpdf, "uniform", [DVReal; DVReal; DVReal], AoS)
+  ; ([Lpdf; Rng], "von_mises", [DVReal; DVReal; DVReal], AoS)
+  ; (full_lpdf, "weibull", [DVReal; DVReal; DVReal], AoS)
+  ; ([Lpdf], "wiener", [DVReal; DVReal; DVReal; DVReal; DVReal], AoS)
+  ; ([Lpdf], "wishart", [DMatrix; DReal; DMatrix], AoS) ]
 
 let math_sigs =
-  [ ([UnaryVectorized], "acos", [DDeepVectorized])
-  ; ([UnaryVectorized], "acosh", [DDeepVectorized])
-  ; ([UnaryVectorized], "asin", [DDeepVectorized])
-  ; ([UnaryVectorized], "asinh", [DDeepVectorized])
-  ; ([UnaryVectorized], "atan", [DDeepVectorized])
-  ; ([UnaryVectorized], "atanh", [DDeepVectorized])
-  ; ([UnaryVectorized], "cbrt", [DDeepVectorized])
-  ; ([UnaryVectorized], "ceil", [DDeepVectorized])
-  ; ([UnaryVectorized], "cos", [DDeepVectorized])
-  ; ([UnaryVectorized], "cosh", [DDeepVectorized])
-  ; ([UnaryVectorized], "digamma", [DDeepVectorized])
-  ; ([UnaryVectorized], "erf", [DDeepVectorized])
-  ; ([UnaryVectorized], "erfc", [DDeepVectorized])
-  ; ([UnaryVectorized], "exp", [DDeepVectorized])
-  ; ([UnaryVectorized], "exp2", [DDeepVectorized])
-  ; ([UnaryVectorized], "expm1", [DDeepVectorized])
-  ; ([UnaryVectorized], "fabs", [DDeepVectorized])
-  ; ([UnaryVectorized], "floor", [DDeepVectorized])
-  ; ([UnaryVectorized], "inv", [DDeepVectorized])
-  ; ([UnaryVectorized], "inv_cloglog", [DDeepVectorized])
-  ; ([UnaryVectorized], "inv_logit", [DDeepVectorized])
-  ; ([UnaryVectorized], "inv_Phi", [DDeepVectorized])
-  ; ([UnaryVectorized], "inv_sqrt", [DDeepVectorized])
-  ; ([UnaryVectorized], "inv_square", [DDeepVectorized])
-  ; ([UnaryVectorized], "lambert_w0", [DDeepVectorized])
-  ; ([UnaryVectorized], "lambert_wm1", [DDeepVectorized])
-  ; ([UnaryVectorized], "lgamma", [DDeepVectorized])
-  ; ([UnaryVectorized], "log", [DDeepVectorized])
-  ; ([UnaryVectorized], "log10", [DDeepVectorized])
-  ; ([UnaryVectorized], "log1m", [DDeepVectorized])
-  ; ([UnaryVectorized], "log1m_exp", [DDeepVectorized])
-  ; ([UnaryVectorized], "log1m_inv_logit", [DDeepVectorized])
-  ; ([UnaryVectorized], "log1p", [DDeepVectorized])
-  ; ([UnaryVectorized], "log1p_exp", [DDeepVectorized])
-  ; ([UnaryVectorized], "log2", [DDeepVectorized])
-  ; ([UnaryVectorized], "log_inv_logit", [DDeepVectorized])
-  ; ([UnaryVectorized], "logit", [DDeepVectorized])
-  ; ([UnaryVectorized], "Phi", [DDeepVectorized])
-  ; ([UnaryVectorized], "Phi_approx", [DDeepVectorized])
-  ; ([UnaryVectorized], "round", [DDeepVectorized])
-  ; ([UnaryVectorized], "sin", [DDeepVectorized])
-  ; ([UnaryVectorized], "sinh", [DDeepVectorized])
-  ; ([UnaryVectorized], "sqrt", [DDeepVectorized])
-  ; ([UnaryVectorized], "square", [DDeepVectorized])
-  ; ([UnaryVectorized], "step", [DReal])
-  ; ([UnaryVectorized], "tan", [DDeepVectorized])
-  ; ([UnaryVectorized], "tanh", [DDeepVectorized])
+  [ ([UnaryVectorized], "acos", [DDeepVectorized], Common.Helpers.AoS)
+  ; ([UnaryVectorized], "acosh", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "asin", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "asinh", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "atan", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "atanh", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "cbrt", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "ceil", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "cos", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "cosh", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "digamma", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "erf", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "erfc", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "exp", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "exp2", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "expm1", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "fabs", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "floor", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "inv", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "inv_cloglog", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "inv_logit", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "inv_Phi", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "inv_sqrt", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "inv_square", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "lambert_w0", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "lambert_wm1", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "lgamma", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log10", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log1m", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log1m_exp", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log1m_inv_logit", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log1p", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log1p_exp", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log2", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "log_inv_logit", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "logit", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "Phi", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "Phi_approx", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "round", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "sin", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "sinh", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "sqrt", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "square", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "step", [DReal], AoS)
+  ; ([UnaryVectorized], "tan", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "tanh", [DDeepVectorized], AoS)
     (* ; add_nullary ("target") *)
-  ; ([UnaryVectorized], "tgamma", [DDeepVectorized])
-  ; ([UnaryVectorized], "trunc", [DDeepVectorized])
-  ; ([UnaryVectorized], "trigamma", [DDeepVectorized]) ]
+  ; ([UnaryVectorized], "tgamma", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "trunc", [DDeepVectorized], AoS)
+  ; ([UnaryVectorized], "trigamma", [DDeepVectorized], AoS) ]
 
 let all_declarative_sigs = distributions @ math_sigs
 
 let declarative_fnsigs =
   List.concat_map ~f:mk_declarative_sig all_declarative_sigs
 
+let snd2 (_, b, _) = b
+let fst2 (a, _, _) = a
+let thrd (_, _, c) = c
+
 (* -- Querying stan_math_signatures -- *)
-let stan_math_returntype name args =
+let stan_math_returntype (name : string) (args : fun_arg list) =
   let name = Utils.stdlib_distribution_name name in
   let namematches = Hashtbl.find_multi stan_math_signatures name in
   let filteredmatches =
     List.filter
       ~f:(fun x ->
-        UnsizedType.check_compatible_arguments_mod_conv name (snd x) args )
+        UnsizedType.check_compatible_arguments_mod_conv name (snd2 x) args )
       namematches
   in
   match name with
@@ -322,11 +343,26 @@ let stan_math_returntype name args =
         Some
           (List.hd_exn
              (List.sort ~compare:UnsizedType.compare_returntype
-                (List.map ~f:fst filteredmatches)))
+                (List.map ~f:fst2 filteredmatches)))
 
 let is_stan_math_function_name name =
   let name = Utils.stdlib_distribution_name name in
   Hashtbl.mem stan_math_signatures name
+
+let is_soa_supported name args =
+  let name = Utils.stdlib_distribution_name name in
+  let value = Hashtbl.find stan_math_signatures name in
+  match value with
+  | Some (a : stan_math_table_values list) ->
+      let find_soa (_, table_args, mem_pat) =
+        let args_match = table_args = args in
+        match (args_match, mem_pat) with
+        | false, _ -> false
+        | true, Common.Helpers.AoS -> false
+        | true, SoA -> true
+      in
+      List.exists ~f:find_soa a
+  | None -> false
 
 let dist_name_suffix udf_names name =
   let is_udf_name s = List.exists ~f:(fun (n, _) -> n = s) udf_names in
@@ -340,7 +376,8 @@ let dist_name_suffix udf_names name =
   | Some hd -> hd
   | None -> raise_s [%message "Couldn't find distribution " name]
 
-let operator_to_stan_math_fns = function
+let operator_to_stan_math_fns op =
+  match op with
   | Operator.Plus -> ["add"]
   | PPlus -> ["plus"]
   | Minus -> ["subtract"]
@@ -366,7 +403,10 @@ let operator_to_stan_math_fns = function
   | Transpose -> ["transpose"]
 
 let int_divide_type =
-  UnsizedType.(ReturnType UInt, [(AutoDiffable, UInt); (AutoDiffable, UInt)])
+  UnsizedType.
+    ( ReturnType UInt
+    , [(AutoDiffable, UInt); (AutoDiffable, UInt)]
+    , Common.Helpers.AoS )
 
 let operator_stan_math_return_type op arg_tys =
   match (op, arg_tys) with
@@ -403,27 +443,88 @@ let make_assigmentoperator_stan_math_signatures assop =
   | assop -> operator_to_stan_math_fns assop )
   |> List.concat_map ~f:get_sigs
   |> List.concat_map ~f:(function
-       | ReturnType rtype, [(ad1, lhs); (ad2, rhs)]
+       | ReturnType rtype, [(ad1, lhs); (ad2, rhs)], _
          when rtype = lhs
               && not
                    ( (assop = Operator.EltTimes || assop = Operator.EltDivide)
                    && UnsizedType.is_scalar_type rtype ) ->
            if rhs = UReal then
-             [ (UnsizedType.Void, [(ad1, lhs); (ad2, UInt)])
-             ; (Void, [(ad1, lhs); (ad2, UReal)]) ]
-           else [(Void, [(ad1, lhs); (ad2, rhs)])]
+             [ (UnsizedType.Void, [(ad1, lhs); (ad2, UInt)], Common.Helpers.AoS)
+             ; (Void, [(ad1, lhs); (ad2, UReal)], AoS) ]
+           else [(Void, [(ad1, lhs); (ad2, rhs)], AoS)]
        | _ -> [] )
 
-let pp_math_sig ppf (rt, args) = UnsizedType.pp ppf (UFun (args, rt, FnPlain))
+let pp_math_sig ppf (rt, args, mem_pattern) =
+  UnsizedType.pp ppf (UFun (args, rt, FnPlain, mem_pattern))
 
 let pp_math_sigs ppf name =
   (Fmt.list ~sep:Fmt.cut pp_math_sig) ppf (get_sigs name)
 
 let pretty_print_math_sigs = Fmt.strf "@[<v>@,%a@]" pp_math_sigs
 
+let string_operator_to_stan_math_fns str =
+  match str with
+  | "Plus__" -> "add"
+  | "PPlus__" -> "plus"
+  | "Minus__" -> "subtract"
+  | "PMinus__" -> "minus"
+  | "Times__" -> "multiply"
+  | "Divide__" -> "divide"
+  | "Modulo__" -> "modulus"
+  | "IntDivide__" -> "divide"
+  | "LDivide__" -> "mdivide_left"
+  | "EltTimes__" -> "elt_multiply"
+  | "EltDivide__" -> "elt_divide"
+  | "Pow__" -> "pow"
+  | "EltPow__" -> "pow"
+  | "Or__" -> "logical_or"
+  | "And__" -> "logical_and"
+  | "Equals__" -> "logical_eq"
+  | "NEquals__" -> "logical_neq"
+  | "Less__" -> "logical_lt"
+  | "Leq__" -> "logical_lte"
+  | "Greater__" -> "logical_gt"
+  | "Geq__" -> "logical_gte"
+  | "PNot__" -> "logical_negation"
+  | "Transpose__" -> "transpose"
+  | _ -> str
+
+(* -- Querying stan_math_signatures -- *)
+let query_stan_math_mem_pattern_support (name : string) (args : fun_arg list) =
+  let name =
+    string_operator_to_stan_math_fns (Utils.stdlib_distribution_name name)
+  in
+  let namematches = Hashtbl.find_multi stan_math_signatures name in
+  let filteredmatches =
+    List.filter
+      ~f:(fun x ->
+        UnsizedType.check_compatible_arguments_mod_conv name (snd2 x) args )
+      namematches
+  in
+  match name with
+  | x when is_reduce_sum_fn x -> false
+  | x when is_variadic_ode_fn x -> false
+  | _ -> (
+    (*    let printer intro s = Set.Poly.iter ~f:(printf intro) s in*)
+    match List.length filteredmatches = 0 with
+    | true ->
+        false
+        (* Return the least return type in case there are multiple options (due to implicit UInt-UReal conversion), where UInt<UReal *)
+    | false -> (
+        let is_soa ((_ : UnsizedType.returntype), (_ : fun_arg list), mem) =
+          mem = Common.Helpers.SoA
+        in
+        let blah = List.exists ~f:is_soa filteredmatches in
+        match blah with
+        | true ->
+            (*printer "\n%s is supported\n" (Set.Poly.singleton name);*) true
+        | false ->
+            (*printer "\n%s is not supported\n" (Set.Poly.singleton name);*)
+            false ) )
+
 let pretty_print_all_math_sigs ppf () =
   let open Fmt in
-  let pp_sig ppf (name, (rt, args)) =
+  let pp_sig ppf (name, (rt, args, _)) =
     pf ppf "%s(@[<hov 2>%a@]) => %a" name
       (list ~sep:comma UnsizedType.pp)
       (List.map ~f:snd args) UnsizedType.pp_returntype rt
@@ -463,20 +564,24 @@ let all_vector_types =
 
 let all_vector_types_size = List.length all_vector_types
 
-let add_qualified (name, rt, argts) =
-  Hashtbl.add_multi stan_math_signatures ~key:name ~data:(rt, argts)
+let add_qualified (name, rt, argts, supports_soa) =
+  Hashtbl.add_multi stan_math_signatures ~key:name
+    ~data:(rt, argts, supports_soa)
 
-let add_nullary name = add_unqualified (name, UnsizedType.ReturnType UReal, [])
+let add_nullary name =
+  add_unqualified (name, UnsizedType.ReturnType UReal, [], AoS)
 
-let add_binary name =
-  add_unqualified (name, ReturnType UReal, [UnsizedType.UReal; UReal])
+let add_binary name supports_soa =
+  add_unqualified
+    (name, ReturnType UReal, [UnsizedType.UReal; UReal], supports_soa)
 
-let add_binary_vec name =
+let add_binary_vec name supports_soa =
   List.iter
     ~f:(fun i ->
       List.iter
         ~f:(fun j ->
-          add_unqualified (name, ReturnType (ints_to_real i), [i; j]) )
+          add_unqualified
+            (name, ReturnType (ints_to_real i), [i; j], supports_soa) )
         [UnsizedType.UInt; UReal] )
     [UnsizedType.UInt; UReal] ;
   List.iter
@@ -486,7 +591,8 @@ let add_binary_vec name =
           add_unqualified
             ( name
             , ReturnType (ints_to_real (bare_array_type (j, i)))
-            , [bare_array_type (j, i); bare_array_type (j, i)] ) )
+            , [bare_array_type (j, i); bare_array_type (j, i)]
+            , supports_soa ) )
         [UnsizedType.UArray UInt; UArray UReal; UVector; URowVector; UMatrix]
       )
     (List.range 0 8) ;
@@ -499,7 +605,8 @@ let add_binary_vec name =
               add_unqualified
                 ( name
                 , ReturnType (ints_to_real (bare_array_type (k, j)))
-                , [bare_array_type (k, j); i] ) )
+                , [bare_array_type (k, j); i]
+                , supports_soa ) )
             [ UnsizedType.UArray UInt; UArray UReal; UVector; URowVector
             ; UMatrix ] )
         (List.range 0 8) )
@@ -513,14 +620,15 @@ let add_binary_vec name =
               add_unqualified
                 ( name
                 , ReturnType (ints_to_real (bare_array_type (k, j)))
-                , [i; bare_array_type (k, j)] ) )
+                , [i; bare_array_type (k, j)]
+                , supports_soa ) )
             [ UnsizedType.UArray UInt; UArray UReal; UVector; URowVector
             ; UMatrix ] )
         (List.range 0 8) )
     [UnsizedType.UInt; UReal]
 
-let add_binary_vec_real_real name =
-  add_binary name ;
+let add_binary_vec_real_real name supports_soa =
+  add_binary name supports_soa ;
   List.iter
     ~f:(fun i ->
       List.iter
@@ -528,7 +636,8 @@ let add_binary_vec_real_real name =
           add_unqualified
             ( name
             , ReturnType (bare_array_type (j, i))
-            , [bare_array_type (j, i); bare_array_type (j, i)] ) )
+            , [bare_array_type (j, i); bare_array_type (j, i)]
+            , supports_soa ) )
         [UnsizedType.UArray UReal; UVector; URowVector; UMatrix] )
     (List.range 0 8) ;
   List.iter
@@ -540,7 +649,8 @@ let add_binary_vec_real_real name =
               add_unqualified
                 ( name
                 , ReturnType (bare_array_type (k, j))
-                , [bare_array_type (k, j); i] ) )
+                , [bare_array_type (k, j); i]
+                , supports_soa ) )
             [UnsizedType.UArray UReal; UVector; URowVector; UMatrix] )
         (List.range 0 8) )
     [UnsizedType.UReal] ;
@@ -553,12 +663,13 @@ let add_binary_vec_real_real name =
               add_unqualified
                 ( name
                 , ReturnType (bare_array_type (k, j))
-                , [i; bare_array_type (k, j)] ) )
+                , [i; bare_array_type (k, j)]
+                , supports_soa ) )
             [UnsizedType.UArray UReal; UVector; URowVector; UMatrix] )
         (List.range 0 8) )
     [UnsizedType.UReal]
 
-let add_binary_vec_int_real name =
+let add_binary_vec_int_real name supports_soa =
   List.iter
     ~f:(fun i ->
       List.iter
@@ -566,7 +677,8 @@ let add_binary_vec_int_real name =
           add_unqualified
             ( name
             , ReturnType (bare_array_type (i, j))
-            , [UInt; bare_array_type (i, j)] ) )
+            , [UInt; bare_array_type (i, j)]
+            , supports_soa ) )
         (List.range 0 8) )
     [UnsizedType.UArray UReal; UVector; URowVector; UMatrix] ;
   List.iter
@@ -576,7 +688,8 @@ let add_binary_vec_int_real name =
           add_unqualified
             ( name
             , ReturnType (bare_array_type (i, j))
-            , [bare_array_type (UInt, j + 1); bare_array_type (i, j)] ) )
+            , [bare_array_type (UInt, j + 1); bare_array_type (i, j)]
+            , supports_soa ) )
         (List.range 0 8) )
     [UnsizedType.UArray UReal; UVector; URowVector] ;
   List.iter
@@ -584,17 +697,19 @@ let add_binary_vec_int_real name =
       add_unqualified
         ( name
         , ReturnType (bare_array_type (UMatrix, i))
-        , [bare_array_type (UInt, i + 2); bare_array_type (UMatrix, i)] ) )
+        , [bare_array_type (UInt, i + 2); bare_array_type (UMatrix, i)]
+        , supports_soa ) )
     (List.range 0 8) ;
   List.iter
     ~f:(fun i ->
       add_unqualified
         ( name
         , ReturnType (bare_array_type (UReal, i))
-        , [bare_array_type (UInt, i); UReal] ) )
+        , [bare_array_type (UInt, i); UReal]
+        , supports_soa ) )
     (List.range 0 8)
 
-let add_binary_vec_real_int name =
+let add_binary_vec_real_int name supports_soa =
   List.iter
     ~f:(fun i ->
       List.iter
@@ -602,7 +717,8 @@ let add_binary_vec_real_int name =
           add_unqualified
             ( name
             , ReturnType (bare_array_type (i, j))
-            , [bare_array_type (i, j); UInt] ) )
+            , [bare_array_type (i, j); UInt]
+            , supports_soa ) )
         (List.range 0 8) )
     [UnsizedType.UArray UReal; UVector; URowVector; UMatrix] ;
   List.iter
@@ -612,7 +728,8 @@ let add_binary_vec_real_int name =
           add_unqualified
             ( name
             , ReturnType (bare_array_type (i, j))
-            , [bare_array_type (i, j); bare_array_type (UInt, j + 1)] ) )
+            , [bare_array_type (i, j); bare_array_type (UInt, j + 1)]
+            , supports_soa ) )
         (List.range 0 8) )
     [UnsizedType.UArray UReal; UVector; URowVector] ;
   List.iter
@@ -620,89 +737,118 @@ let add_binary_vec_real_int name =
       add_unqualified
         ( name
         , ReturnType (bare_array_type (UMatrix, i))
-        , [bare_array_type (UMatrix, i); bare_array_type (UInt, i + 2)] ) )
+        , [bare_array_type (UMatrix, i); bare_array_type (UInt, i + 2)]
+        , supports_soa ) )
     (List.range 0 8) ;
   List.iter
     ~f:(fun i ->
       add_unqualified
         ( name
         , ReturnType (bare_array_type (UReal, i))
-        , [UReal; bare_array_type (UInt, i)] ) )
+        , [UReal; bare_array_type (UInt, i)]
+        , supports_soa ) )
     (List.range 0 8)
 
-let add_binary_vec_int_int name =
+let add_binary_vec_int_int name supports_soa =
   List.iter
     ~f:(fun i ->
       add_unqualified
         ( name
         , ReturnType (bare_array_type (UInt, i))
-        , [bare_array_type (UInt, i); UInt] ) )
+        , [bare_array_type (UInt, i); UInt]
+        , supports_soa ) )
     (List.range 0 8) ;
   List.iter
     ~f:(fun i ->
       add_unqualified
         ( name
         , ReturnType (bare_array_type (UInt, i))
-        , [UInt; bare_array_type (UInt, i)] ) )
+        , [UInt; bare_array_type (UInt, i)]
+        , supports_soa ) )
     (List.range 1 8) ;
   List.iter
     ~f:(fun i ->
       add_unqualified
         ( name
         , ReturnType (bare_array_type (UInt, i))
-        , [bare_array_type (UInt, i); bare_array_type (UInt, i)] ) )
+        , [bare_array_type (UInt, i); bare_array_type (UInt, i)]
+        , supports_soa ) )
     (List.range 1 8)
 
-let add_ternary name =
-  add_unqualified (name, ReturnType UReal, [UReal; UReal; UReal])
+let add_ternary name supports_soa =
+  add_unqualified (name, ReturnType UReal, [UReal; UReal; UReal], supports_soa)
 
 (*Adds functions that operate on matrix, double array and real types*)
-let add_ternary_vec name =
-  add_unqualified (name, ReturnType UReal, [UReal; UReal; UReal]) ;
-  add_unqualified (name, ReturnType UVector, [UVector; UReal; UReal]) ;
-  add_unqualified (name, ReturnType UVector, [UVector; UVector; UReal]) ;
-  add_unqualified (name, ReturnType UVector, [UVector; UReal; UVector]) ;
-  add_unqualified (name, ReturnType UVector, [UVector; UVector; UVector]) ;
-  add_unqualified (name, ReturnType UVector, [UReal; UVector; UReal]) ;
-  add_unqualified (name, ReturnType UVector, [UReal; UVector; UVector]) ;
-  add_unqualified (name, ReturnType UVector, [UReal; UReal; UVector]) ;
-  add_unqualified (name, ReturnType URowVector, [URowVector; UReal; UReal]) ;
-  add_unqualified (name, ReturnType URowVector, [URowVector; URowVector; UReal]) ;
-  add_unqualified (name, ReturnType URowVector, [URowVector; UReal; URowVector]) ;
+let add_ternary_vec name supports_soa =
+  add_unqualified (name, ReturnType UReal, [UReal; UReal; UReal], supports_soa) ;
   add_unqualified
-    (name, ReturnType URowVector, [URowVector; URowVector; URowVector]) ;
-  add_unqualified (name, ReturnType URowVector, [UReal; URowVector; UReal]) ;
-  add_unqualified (name, ReturnType URowVector, [UReal; URowVector; URowVector]) ;
-  add_unqualified (name, ReturnType URowVector, [UReal; UReal; URowVector]) ;
-  add_unqualified (name, ReturnType UMatrix, [UMatrix; UReal; UReal]) ;
-  add_unqualified (name, ReturnType UMatrix, [UMatrix; UMatrix; UReal]) ;
-  add_unqualified (name, ReturnType UMatrix, [UMatrix; UReal; UMatrix]) ;
-  add_unqualified (name, ReturnType UMatrix, [UMatrix; UMatrix; UMatrix]) ;
-  add_unqualified (name, ReturnType UMatrix, [UReal; UMatrix; UReal]) ;
-  add_unqualified (name, ReturnType UMatrix, [UReal; UMatrix; UMatrix]) ;
-  add_unqualified (name, ReturnType UMatrix, [UReal; UReal; UMatrix])
+    (name, ReturnType UVector, [UVector; UReal; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UVector, [UVector; UVector; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UVector, [UVector; UReal; UVector], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UVector, [UVector; UVector; UVector], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UVector, [UReal; UVector; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UVector, [UReal; UVector; UVector], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UVector, [UReal; UReal; UVector], supports_soa) ;
+  add_unqualified
+    (name, ReturnType URowVector, [URowVector; UReal; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType URowVector, [URowVector; URowVector; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType URowVector, [URowVector; UReal; URowVector], supports_soa) ;
+  add_unqualified
+    ( name
+    , ReturnType URowVector
+    , [URowVector; URowVector; URowVector]
+    , supports_soa ) ;
+  add_unqualified
+    (name, ReturnType URowVector, [UReal; URowVector; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType URowVector, [UReal; URowVector; URowVector], supports_soa) ;
+  add_unqualified
+    (name, ReturnType URowVector, [UReal; UReal; URowVector], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UMatrix, [UMatrix; UReal; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UMatrix, [UMatrix; UMatrix; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UMatrix, [UMatrix; UReal; UMatrix], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UMatrix, [UMatrix; UMatrix; UMatrix], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UMatrix, [UReal; UMatrix; UReal], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UMatrix, [UReal; UMatrix; UMatrix], supports_soa) ;
+  add_unqualified
+    (name, ReturnType UMatrix, [UReal; UReal; UMatrix], supports_soa)
 
 let for_all_vector_types s = List.iter ~f:s all_vector_types
 let for_vector_types s = List.iter ~f:s vector_types
 
 (* -- Start populating stan_math_signaturess -- *)
 let () =
-  List.iter declarative_fnsigs ~f:(fun (key, rt, args) ->
-      Hashtbl.add_multi stan_math_signatures ~key ~data:(rt, args) ) ;
-  add_unqualified ("abs", ReturnType UInt, [UInt]) ;
-  add_unqualified ("abs", ReturnType UReal, [UReal]) ;
+  List.iter declarative_fnsigs ~f:(fun (key, rt, args, mem_pattern) ->
+      Hashtbl.add_multi stan_math_signatures ~key ~data:(rt, args, mem_pattern)
+  ) ;
+  add_unqualified ("abs", ReturnType UInt, [UInt], AoS) ;
+  add_unqualified ("abs", ReturnType UReal, [UReal], AoS) ;
   List.iter
-    ~f:(fun x -> add_unqualified ("add", ReturnType x, [x; x]))
+    ~f:(fun x -> add_unqualified ("add", ReturnType x, [x; x], AoS))
     bare_types ;
-  add_unqualified ("add", ReturnType UVector, [UVector; UReal]) ;
-  add_unqualified ("add", ReturnType URowVector, [URowVector; UReal]) ;
-  add_unqualified ("add", ReturnType UMatrix, [UMatrix; UReal]) ;
-  add_unqualified ("add", ReturnType UVector, [UReal; UVector]) ;
-  add_unqualified ("add", ReturnType URowVector, [UReal; URowVector]) ;
-  add_unqualified ("add", ReturnType UMatrix, [UReal; UMatrix]) ;
-  add_unqualified ("add_diag", ReturnType UMatrix, [UMatrix; UReal]) ;
-  add_unqualified ("add_diag", ReturnType UMatrix, [UMatrix; UVector]) ;
-  add_unqualified ("add_diag", ReturnType UMatrix, [UMatrix; URowVector]) ;
+  add_unqualified ("add", ReturnType UVector, [UVector; UReal], AoS) ;
+  add_unqualified ("add", ReturnType URowVector, [URowVector; UReal], AoS) ;
+  add_unqualified ("add", ReturnType UMatrix, [UMatrix; UReal], AoS) ;
+  add_unqualified ("add", ReturnType UVector, [UReal; UVector], AoS) ;
+  add_unqualified ("add", ReturnType URowVector, [UReal; URowVector], AoS) ;
+  add_unqualified ("add", ReturnType UMatrix, [UReal; UMatrix], AoS) ;
+  add_unqualified ("add_diag", ReturnType UMatrix, [UMatrix; UReal], AoS) ;
+  add_unqualified ("add_diag", ReturnType UMatrix, [UMatrix; UVector], AoS) ;
+  add_unqualified ("add_diag", ReturnType UMatrix, [UMatrix; URowVector], AoS) ;
   add_qualified
     ( "algebra_solver"
     , ReturnType UVector
@@ -711,9 +857,11 @@ let () =
             ( [ (AutoDiffable, UVector); (AutoDiffable, UVector)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType UVector
-            , FnPlain ) )
+            , FnPlain
+            , AoS ) )
       ; (AutoDiffable, UVector); (AutoDiffable, UVector)
-      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
+      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
+    , AoS ) ;
   add_qualified
     ( "algebra_solver"
     , ReturnType UVector
@@ -722,10 +870,12 @@ let () =
             ( [ (AutoDiffable, UVector); (AutoDiffable, UVector)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType UVector
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UVector); (AutoDiffable, UVector)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
-      ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;
+      ; (DataOnly, UReal); (DataOnly, UReal) ]
+    , AoS ) ;
   add_qualified
     ( "algebra_solver_newton"
     , ReturnType UVector
@@ -734,9 +884,11 @@ let () =
             ( [ (AutoDiffable, UVector); (AutoDiffable, UVector)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType UVector
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UVector); (AutoDiffable, UVector)
-      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
+      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
+    , AoS ) ;
   add_qualified
     ( "algebra_solver_newton"
     , ReturnType UVector
@@ -745,10 +897,12 @@ let () =
             ( [ (AutoDiffable, UVector); (AutoDiffable, UVector)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType UVector
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UVector); (AutoDiffable, UVector)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
-      ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;
+      ; (DataOnly, UReal); (DataOnly, UReal) ]
+    , AoS ) ;
   List.iter
     ~f:(fun i ->
       List.iter
@@ -756,322 +910,393 @@ let () =
           add_unqualified
             ( "append_array"
             , ReturnType (bare_array_type (t, i))
-            , [bare_array_type (t, i); bare_array_type (t, i)] ) )
+            , [bare_array_type (t, i); bare_array_type (t, i)]
+            , AoS ) )
         bare_types )
     (List.range 1 8) ;
-  add_binary "atan2" ;
+  add_binary "atan2" AoS ;
   add_unqualified
     ( "bernoulli_logit_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UMatrix; UReal; UVector] ) ;
+    , [UArray UInt; UMatrix; UReal; UVector]
+    , AoS ) ;
   add_unqualified
     ( "bernoulli_logit_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UMatrix; UVector; UVector] ) ;
+    , [UArray UInt; UMatrix; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "bernoulli_logit_glm_lpmf"
     , ReturnType UReal
-    , [UInt; UMatrix; UReal; UVector] ) ;
+    , [UInt; UMatrix; UReal; UVector]
+    , AoS ) ;
   add_unqualified
     ( "bernoulli_logit_glm_lpmf"
     , ReturnType UReal
-    , [UInt; UMatrix; UVector; UVector] ) ;
+    , [UInt; UMatrix; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "bernoulli_logit_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UReal; UVector] ) ;
+    , [UArray UInt; URowVector; UReal; UVector]
+    , AoS ) ;
   add_unqualified
     ( "bernoulli_logit_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UVector; UVector] ) ;
-  add_binary_vec_int_real "bessel_first_kind" ;
-  add_binary_vec_int_real "bessel_second_kind" ;
-  add_binary_vec "beta" ;
+    , [UArray UInt; URowVector; UVector; UVector]
+    , AoS ) ;
+  add_binary_vec_int_real "bessel_first_kind" AoS ;
+  add_binary_vec_int_real "bessel_second_kind" AoS ;
+  add_binary_vec "beta" AoS ;
   (* XXX For some reason beta_proportion_rng doesn't take ints as first arg *)
   for_vector_types (fun t ->
       for_all_vector_types (fun u ->
           add_unqualified
             ( "beta_proportion_rng"
             , ReturnType (rng_return_type UReal [t; u])
-            , [t; u] ) ) ) ;
-  add_binary_vec_int_real "binary_log_loss" ;
-  add_binary_vec "binomial_coefficient_log" ;
+            , [t; u]
+            , AoS ) ) ) ;
+  add_binary_vec_int_real "binary_log_loss" AoS ;
+  add_binary_vec "binomial_coefficient_log" AoS ;
   add_unqualified
-    ("block", ReturnType UMatrix, [UMatrix; UInt; UInt; UInt; UInt]) ;
-  add_unqualified ("categorical_rng", ReturnType UInt, [UVector]) ;
-  add_unqualified ("categorical_logit_rng", ReturnType UInt, [UVector]) ;
-  add_unqualified
-    ( "categorical_logit_glm_lpmf"
-    , ReturnType UReal
-    , [UArray UInt; UMatrix; UVector; UMatrix] ) ;
+    ("block", ReturnType UMatrix, [UMatrix; UInt; UInt; UInt; UInt], AoS) ;
+  add_unqualified ("categorical_rng", ReturnType UInt, [UVector], AoS) ;
+  add_unqualified ("categorical_logit_rng", ReturnType UInt, [UVector], AoS) ;
   add_unqualified
     ( "categorical_logit_glm_lpmf"
     , ReturnType UReal
-    , [UInt; UMatrix; UVector; UMatrix] ) ;
+    , [UArray UInt; UMatrix; UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
     ( "categorical_logit_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UVector; UMatrix] ) ;
+    , [UInt; UMatrix; UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
     ( "categorical_logit_glm_lpmf"
     , ReturnType UReal
-    , [UInt; URowVector; UVector; UMatrix] ) ;
-  add_unqualified ("append_col", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("append_col", ReturnType UMatrix, [UVector; UMatrix]) ;
-  add_unqualified ("append_col", ReturnType UMatrix, [UMatrix; UVector]) ;
-  add_unqualified ("append_col", ReturnType UMatrix, [UVector; UVector]) ;
+    , [UArray UInt; URowVector; UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("append_col", ReturnType URowVector, [URowVector; URowVector]) ;
-  add_unqualified ("append_col", ReturnType URowVector, [UReal; URowVector]) ;
-  add_unqualified ("append_col", ReturnType URowVector, [URowVector; UReal]) ;
-  add_unqualified ("chol2inv", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("cholesky_decompose", ReturnType UMatrix, [UMatrix]) ;
-  add_binary_vec_int_int "choose" ;
-  add_unqualified ("col", ReturnType UVector, [UMatrix; UInt]) ;
-  add_unqualified ("cols", ReturnType UInt, [UVector]) ;
-  add_unqualified ("cols", ReturnType UInt, [URowVector]) ;
-  add_unqualified ("cols", ReturnType UInt, [UMatrix]) ;
+    ( "categorical_logit_glm_lpmf"
+    , ReturnType UReal
+    , [UInt; URowVector; UVector; UMatrix]
+    , AoS ) ;
+  add_unqualified ("append_col", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("append_col", ReturnType UMatrix, [UVector; UMatrix], AoS) ;
+  add_unqualified ("append_col", ReturnType UMatrix, [UMatrix; UVector], AoS) ;
+  add_unqualified ("append_col", ReturnType UMatrix, [UVector; UVector], AoS) ;
   add_unqualified
-    ("columns_dot_product", ReturnType URowVector, [UVector; UVector]) ;
+    ("append_col", ReturnType URowVector, [URowVector; URowVector], AoS) ;
   add_unqualified
-    ("columns_dot_product", ReturnType URowVector, [URowVector; URowVector]) ;
+    ("append_col", ReturnType URowVector, [UReal; URowVector], AoS) ;
   add_unqualified
-    ("columns_dot_product", ReturnType URowVector, [UMatrix; UMatrix]) ;
-  add_unqualified ("columns_dot_self", ReturnType URowVector, [UVector]) ;
-  add_unqualified ("columns_dot_self", ReturnType URowVector, [URowVector]) ;
-  add_unqualified ("columns_dot_self", ReturnType URowVector, [UMatrix]) ;
+    ("append_col", ReturnType URowVector, [URowVector; UReal], AoS) ;
+  add_unqualified ("chol2inv", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("cholesky_decompose", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_binary_vec_int_int "choose" AoS ;
+  add_unqualified ("col", ReturnType UVector, [UMatrix; UInt], AoS) ;
+  add_unqualified ("cols", ReturnType UInt, [UVector], AoS) ;
+  add_unqualified ("cols", ReturnType UInt, [URowVector], AoS) ;
+  add_unqualified ("cols", ReturnType UInt, [UMatrix], AoS) ;
   add_unqualified
-    ("cov_exp_quad", ReturnType UMatrix, [UArray UReal; UReal; UReal]) ;
+    ("columns_dot_product", ReturnType URowVector, [UVector; UVector], AoS) ;
   add_unqualified
-    ("cov_exp_quad", ReturnType UMatrix, [UArray UVector; UReal; UReal]) ;
+    ( "columns_dot_product"
+    , ReturnType URowVector
+    , [URowVector; URowVector]
+    , AoS ) ;
   add_unqualified
-    ("cov_exp_quad", ReturnType UMatrix, [UArray URowVector; UReal; UReal]) ;
+    ("columns_dot_product", ReturnType URowVector, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("columns_dot_self", ReturnType URowVector, [UVector], AoS) ;
+  add_unqualified ("columns_dot_self", ReturnType URowVector, [URowVector], AoS) ;
+  add_unqualified ("columns_dot_self", ReturnType URowVector, [UMatrix], AoS) ;
+  add_unqualified
+    ("cov_exp_quad", ReturnType UMatrix, [UArray UReal; UReal; UReal], AoS) ;
+  add_unqualified
+    ("cov_exp_quad", ReturnType UMatrix, [UArray UVector; UReal; UReal], AoS) ;
+  add_unqualified
+    ("cov_exp_quad", ReturnType UMatrix, [UArray URowVector; UReal; UReal], AoS) ;
   add_unqualified
     ( "cov_exp_quad"
     , ReturnType UMatrix
-    , [UArray UReal; UArray UReal; UReal; UReal] ) ;
+    , [UArray UReal; UArray UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "cov_exp_quad"
     , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UReal] ) ;
+    , [UArray UVector; UArray UVector; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "cov_exp_quad"
     , ReturnType UMatrix
-    , [UArray URowVector; UArray URowVector; UReal; UReal] ) ;
-  add_unqualified ("crossprod", ReturnType UMatrix, [UMatrix]) ;
+    , [UArray URowVector; UArray URowVector; UReal; UReal]
+    , AoS ) ;
+  add_unqualified ("crossprod", ReturnType UMatrix, [UMatrix], AoS) ;
   add_unqualified
     ( "csr_matrix_times_vector"
     , ReturnType UVector
-    , [UInt; UInt; UVector; UArray UInt; UArray UInt; UVector] ) ;
+    , [UInt; UInt; UVector; UArray UInt; UArray UInt; UVector]
+    , AoS ) ;
   add_unqualified
     ( "csr_to_dense_matrix"
     , ReturnType UMatrix
-    , [UInt; UInt; UVector; UArray UInt; UArray UInt] ) ;
-  add_unqualified ("csr_extract_w", ReturnType UVector, [UMatrix]) ;
-  add_unqualified ("csr_extract_v", ReturnType (UArray UInt), [UMatrix]) ;
-  add_unqualified ("csr_extract_u", ReturnType (UArray UInt), [UMatrix]) ;
-  add_unqualified ("cumulative_sum", ReturnType (UArray UReal), [UArray UReal]) ;
-  add_unqualified ("cumulative_sum", ReturnType UVector, [UVector]) ;
-  add_unqualified ("cumulative_sum", ReturnType URowVector, [URowVector]) ;
-  add_unqualified ("determinant", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("diag_matrix", ReturnType UMatrix, [UVector]) ;
-  add_unqualified ("diag_post_multiply", ReturnType UMatrix, [UMatrix; UVector]) ;
+    , [UInt; UInt; UVector; UArray UInt; UArray UInt]
+    , AoS ) ;
+  add_unqualified ("csr_extract_w", ReturnType UVector, [UMatrix], AoS) ;
+  add_unqualified ("csr_extract_v", ReturnType (UArray UInt), [UMatrix], AoS) ;
+  add_unqualified ("csr_extract_u", ReturnType (UArray UInt), [UMatrix], AoS) ;
   add_unqualified
-    ("diag_post_multiply", ReturnType UMatrix, [UMatrix; URowVector]) ;
-  add_unqualified ("diag_pre_multiply", ReturnType UMatrix, [UVector; UMatrix]) ;
+    ("cumulative_sum", ReturnType (UArray UReal), [UArray UReal], AoS) ;
+  add_unqualified ("cumulative_sum", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("cumulative_sum", ReturnType URowVector, [URowVector], AoS) ;
+  add_unqualified ("determinant", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("diag_matrix", ReturnType UMatrix, [UVector], AoS) ;
   add_unqualified
-    ("diag_pre_multiply", ReturnType UMatrix, [URowVector; UMatrix]) ;
-  add_unqualified ("diagonal", ReturnType UVector, [UMatrix]) ;
-  add_unqualified ("dims", ReturnType (UArray UInt), [UInt]) ;
-  add_unqualified ("dims", ReturnType (UArray UInt), [UReal]) ;
-  add_unqualified ("dims", ReturnType (UArray UInt), [UVector]) ;
-  add_unqualified ("dims", ReturnType (UArray UInt), [URowVector]) ;
-  add_unqualified ("dims", ReturnType (UArray UInt), [UMatrix]) ;
+    ("diag_post_multiply", ReturnType UMatrix, [UMatrix; UVector], AoS) ;
+  add_unqualified
+    ("diag_post_multiply", ReturnType UMatrix, [UMatrix; URowVector], AoS) ;
+  add_unqualified
+    ("diag_pre_multiply", ReturnType UMatrix, [UVector; UMatrix], AoS) ;
+  add_unqualified
+    ("diag_pre_multiply", ReturnType UMatrix, [URowVector; UMatrix], AoS) ;
+  add_unqualified ("diagonal", ReturnType UVector, [UMatrix], AoS) ;
+  add_unqualified ("dims", ReturnType (UArray UInt), [UInt], AoS) ;
+  add_unqualified ("dims", ReturnType (UArray UInt), [UReal], AoS) ;
+  add_unqualified ("dims", ReturnType (UArray UInt), [UVector], AoS) ;
+  add_unqualified ("dims", ReturnType (UArray UInt), [URowVector], AoS) ;
+  add_unqualified ("dims", ReturnType (UArray UInt), [UMatrix], AoS) ;
   List.iter
     ~f:(fun i ->
       List.iter
         ~f:(fun t ->
           add_unqualified
-            ("dims", ReturnType (UArray UInt), [bare_array_type (t, i + 1)]) )
+            ( "dims"
+            , ReturnType (UArray UInt)
+            , [bare_array_type (t, i + 1)]
+            , AoS ) )
         bare_types )
     (List.range 0 8) ;
-  add_unqualified ("dirichlet_rng", ReturnType UVector, [UVector]) ;
-  add_unqualified ("distance", ReturnType UReal, [UVector; UVector]) ;
-  add_unqualified ("distance", ReturnType UReal, [URowVector; URowVector]) ;
-  add_unqualified ("distance", ReturnType UReal, [UVector; URowVector]) ;
-  add_unqualified ("distance", ReturnType UReal, [URowVector; UVector]) ;
-  add_unqualified ("divide", ReturnType UInt, [UInt; UInt]) ;
-  add_unqualified ("divide", ReturnType UReal, [UReal; UReal]) ;
-  add_unqualified ("divide", ReturnType UVector, [UVector; UReal]) ;
-  add_unqualified ("divide", ReturnType URowVector, [URowVector; UReal]) ;
-  add_unqualified ("divide", ReturnType UMatrix, [UMatrix; UReal]) ;
-  add_unqualified ("dot_product", ReturnType UReal, [UVector; UVector]) ;
-  add_unqualified ("dot_product", ReturnType UReal, [URowVector; URowVector]) ;
-  add_unqualified ("dot_product", ReturnType UReal, [UVector; URowVector]) ;
-  add_unqualified ("dot_product", ReturnType UReal, [URowVector; UVector]) ;
+  add_unqualified ("dirichlet_rng", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("distance", ReturnType UReal, [UVector; UVector], AoS) ;
+  add_unqualified ("distance", ReturnType UReal, [URowVector; URowVector], AoS) ;
+  add_unqualified ("distance", ReturnType UReal, [UVector; URowVector], AoS) ;
+  add_unqualified ("distance", ReturnType UReal, [URowVector; UVector], AoS) ;
+  add_unqualified ("divide", ReturnType UInt, [UInt; UInt], AoS) ;
+  add_unqualified ("divide", ReturnType UReal, [UReal; UReal], AoS) ;
+  add_unqualified ("divide", ReturnType UVector, [UVector; UReal], AoS) ;
+  add_unqualified ("divide", ReturnType URowVector, [URowVector; UReal], AoS) ;
+  add_unqualified ("divide", ReturnType UMatrix, [UMatrix; UReal], AoS) ;
+  add_unqualified ("dot_product", ReturnType UReal, [UVector; UVector], AoS) ;
   add_unqualified
-    ("dot_product", ReturnType UReal, [UArray UReal; UArray UReal]) ;
-  add_unqualified ("dot_self", ReturnType UReal, [UVector]) ;
-  add_unqualified ("dot_self", ReturnType UReal, [URowVector]) ;
+    ("dot_product", ReturnType UReal, [URowVector; URowVector], AoS) ;
+  add_unqualified ("dot_product", ReturnType UReal, [UVector; URowVector], AoS) ;
+  add_unqualified ("dot_product", ReturnType UReal, [URowVector; UVector], AoS) ;
+  add_unqualified
+    ("dot_product", ReturnType UReal, [UArray UReal; UArray UReal], AoS) ;
+  add_unqualified ("dot_self", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("dot_self", ReturnType UReal, [URowVector], AoS) ;
   add_nullary "e" ;
-  add_unqualified ("eigenvalues_sym", ReturnType UVector, [UMatrix]) ;
-  add_unqualified ("eigenvectors_sym", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("generalized_inverse", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("qr_Q", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("qr_R", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("qr_thin_Q", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("qr_thin_R", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("elt_divide", ReturnType UInt, [UInt; UInt]) ;
-  add_unqualified ("elt_divide", ReturnType UReal, [UReal; UReal]) ;
-  add_unqualified ("elt_divide", ReturnType UVector, [UVector; UVector]) ;
+  add_unqualified ("eigenvalues_sym", ReturnType UVector, [UMatrix], AoS) ;
+  add_unqualified ("eigenvectors_sym", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("generalized_inverse", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("qr_Q", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("qr_R", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("qr_thin_Q", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("qr_thin_R", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UInt, [UInt; UInt], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UReal, [UReal; UReal], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UVector, [UVector; UVector], AoS) ;
   add_unqualified
-    ("elt_divide", ReturnType URowVector, [URowVector; URowVector]) ;
-  add_unqualified ("elt_divide", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("elt_divide", ReturnType UVector, [UVector; UReal]) ;
-  add_unqualified ("elt_divide", ReturnType URowVector, [URowVector; UReal]) ;
-  add_unqualified ("elt_divide", ReturnType UMatrix, [UMatrix; UReal]) ;
-  add_unqualified ("elt_divide", ReturnType UVector, [UReal; UVector]) ;
-  add_unqualified ("elt_divide", ReturnType URowVector, [UReal; URowVector]) ;
-  add_unqualified ("elt_divide", ReturnType UMatrix, [UReal; UMatrix]) ;
-  add_unqualified ("elt_multiply", ReturnType UInt, [UInt; UInt]) ;
-  add_unqualified ("elt_multiply", ReturnType UReal, [UReal; UReal]) ;
-  add_unqualified ("elt_multiply", ReturnType UVector, [UVector; UVector]) ;
+    ("elt_divide", ReturnType URowVector, [URowVector; URowVector], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UVector, [UVector; UReal], AoS) ;
   add_unqualified
-    ("elt_multiply", ReturnType URowVector, [URowVector; URowVector]) ;
-  add_unqualified ("elt_multiply", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_binary_vec_int_int "falling_factorial" ;
-  add_binary_vec_real_int "falling_factorial" ;
-  add_binary_vec "fdim" ;
-  add_ternary_vec "fma" ;
-  add_binary_vec "fmax" ;
-  add_binary_vec "fmin" ;
-  add_binary_vec "fmod" ;
-  add_binary_vec_real_real "gamma_p" ;
-  add_binary_vec_real_real "gamma_q" ;
+    ("elt_divide", ReturnType URowVector, [URowVector; UReal], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UMatrix, [UMatrix; UReal], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UVector, [UReal; UVector], AoS) ;
   add_unqualified
-    ( "gaussian_dlm_obs_log"
-    , ReturnType UReal
-    , [UMatrix; UMatrix; UMatrix; UMatrix; UMatrix; UVector; UMatrix] ) ;
+    ("elt_divide", ReturnType URowVector, [UReal; URowVector], AoS) ;
+  add_unqualified ("elt_divide", ReturnType UMatrix, [UReal; UMatrix], AoS) ;
+  add_unqualified ("elt_multiply", ReturnType UInt, [UInt; UInt], AoS) ;
+  add_unqualified ("elt_multiply", ReturnType UReal, [UReal; UReal], AoS) ;
+  add_unqualified ("elt_multiply", ReturnType UVector, [UVector; UVector], AoS) ;
+  add_unqualified
+    ("elt_multiply", ReturnType URowVector, [URowVector; URowVector], AoS) ;
+  add_unqualified ("elt_multiply", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_binary_vec_int_int "falling_factorial" AoS ;
+  add_binary_vec_real_int "falling_factorial" AoS ;
+  add_binary_vec "fdim" AoS ;
+  add_ternary_vec "fma" AoS ;
+  add_binary_vec "fmax" AoS ;
+  add_binary_vec "fmin" AoS ;
+  add_binary_vec "fmod" AoS ;
+  add_binary_vec_real_real "gamma_p" AoS ;
+  add_binary_vec_real_real "gamma_q" AoS ;
   add_unqualified
     ( "gaussian_dlm_obs_log"
     , ReturnType UReal
-    , [UMatrix; UMatrix; UMatrix; UVector; UMatrix; UVector; UMatrix] ) ;
+    , [UMatrix; UMatrix; UMatrix; UMatrix; UMatrix; UVector; UMatrix]
+    , AoS ) ;
+  add_unqualified
+    ( "gaussian_dlm_obs_log"
+    , ReturnType UReal
+    , [UMatrix; UMatrix; UMatrix; UVector; UMatrix; UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
     ( "gaussian_dlm_obs_lpdf"
     , ReturnType UReal
-    , [UMatrix; UMatrix; UMatrix; UMatrix; UMatrix; UVector; UMatrix] ) ;
+    , [UMatrix; UMatrix; UMatrix; UMatrix; UMatrix; UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
     ( "gaussian_dlm_obs_lpdf"
     , ReturnType UReal
-    , [UMatrix; UMatrix; UMatrix; UVector; UMatrix; UVector; UMatrix] ) ;
-  add_unqualified ("gp_dot_prod_cov", ReturnType UMatrix, [UArray UReal; UReal]) ;
+    , [UMatrix; UMatrix; UMatrix; UVector; UMatrix; UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("gp_dot_prod_cov", ReturnType UMatrix, [UArray UReal; UArray UReal; UReal]) ;
-  add_unqualified
-    ("gp_dot_prod_cov", ReturnType UMatrix, [UArray UReal; UArray UReal; UReal]) ;
-  add_unqualified
-    ("gp_dot_prod_cov", ReturnType UMatrix, [UArray UVector; UReal]) ;
+    ("gp_dot_prod_cov", ReturnType UMatrix, [UArray UReal; UReal], AoS) ;
   add_unqualified
     ( "gp_dot_prod_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal] ) ;
+    , [UArray UReal; UArray UReal; UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_exp_quad_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal]) ;
+    ( "gp_dot_prod_cov"
+    , ReturnType UMatrix
+    , [UArray UReal; UArray UReal; UReal]
+    , AoS ) ;
+  add_unqualified
+    ("gp_dot_prod_cov", ReturnType UMatrix, [UArray UVector; UReal], AoS) ;
+  add_unqualified
+    ( "gp_dot_prod_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UArray UVector; UReal]
+    , AoS ) ;
+  add_unqualified
+    ("gp_exp_quad_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal], AoS) ;
   add_unqualified
     ( "gp_exp_quad_cov"
     , ReturnType UMatrix
-    , [UArray UReal; UArray UReal; UReal; UReal] ) ;
+    , [UArray UReal; UArray UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_exp_quad_cov", ReturnType UMatrix, [UArray UVector; UReal; UReal]) ;
-  add_unqualified
-    ( "gp_exp_quad_cov"
-    , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UReal] ) ;
+    ("gp_exp_quad_cov", ReturnType UMatrix, [UArray UVector; UReal; UReal], AoS) ;
   add_unqualified
     ( "gp_exp_quad_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UVector; UArray UVector; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_exp_quad_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_matern32_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal]) ;
+    ( "gp_exp_quad_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
+  add_unqualified
+    ("gp_matern32_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal], AoS) ;
   add_unqualified
     ( "gp_matern32_cov"
     , ReturnType UMatrix
-    , [UArray UReal; UArray UReal; UReal; UReal] ) ;
+    , [UArray UReal; UArray UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_matern32_cov", ReturnType UMatrix, [UArray UVector; UReal; UReal]) ;
-  add_unqualified
-    ( "gp_matern32_cov"
-    , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UReal] ) ;
+    ("gp_matern32_cov", ReturnType UMatrix, [UArray UVector; UReal; UReal], AoS) ;
   add_unqualified
     ( "gp_matern32_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UVector; UArray UVector; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_matern32_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_matern52_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal]) ;
+    ( "gp_matern32_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
+  add_unqualified
+    ("gp_matern52_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal], AoS) ;
   add_unqualified
     ( "gp_matern52_cov"
     , ReturnType UMatrix
-    , [UArray UReal; UArray UReal; UReal; UReal] ) ;
+    , [UArray UReal; UArray UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_matern52_cov", ReturnType UMatrix, [UArray UVector; UReal; UReal]) ;
-  add_unqualified
-    ( "gp_matern52_cov"
-    , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UReal] ) ;
+    ("gp_matern52_cov", ReturnType UMatrix, [UArray UVector; UReal; UReal], AoS) ;
   add_unqualified
     ( "gp_matern52_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UVector; UArray UVector; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_matern52_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_exponential_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal]) ;
+    ( "gp_matern52_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_exponential_cov"
     , ReturnType UMatrix
-    , [UArray UReal; UArray UReal; UReal; UReal] ) ;
-  add_unqualified
-    ("gp_exponential_cov", ReturnType UMatrix, [UArray UVector; UReal; UReal]) ;
-  add_unqualified
-    ( "gp_exponential_cov"
-    , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UReal] ) ;
+    , [UArray UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_exponential_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UReal; UArray UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_exponential_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UArray UReal] ) ;
+    , [UArray UVector; UReal; UReal]
+    , AoS ) ;
   add_unqualified
-    ("gp_periodic_cov", ReturnType UMatrix, [UArray UReal; UReal; UReal; UReal]) ;
+    ( "gp_exponential_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UArray UVector; UReal; UReal]
+    , AoS ) ;
+  add_unqualified
+    ( "gp_exponential_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
+  add_unqualified
+    ( "gp_exponential_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UArray UVector; UReal; UArray UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_periodic_cov"
     , ReturnType UMatrix
-    , [UArray UReal; UArray UReal; UReal; UReal; UReal] ) ;
+    , [UArray UReal; UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_periodic_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UReal; UReal; UReal] ) ;
+    , [UArray UReal; UArray UReal; UReal; UReal; UReal]
+    , AoS ) ;
   add_unqualified
     ( "gp_periodic_cov"
     , ReturnType UMatrix
-    , [UArray UVector; UArray UVector; UReal; UReal; UReal] ) ;
+    , [UArray UVector; UReal; UReal; UReal]
+    , AoS ) ;
+  add_unqualified
+    ( "gp_periodic_cov"
+    , ReturnType UMatrix
+    , [UArray UVector; UArray UVector; UReal; UReal; UReal]
+    , AoS ) ;
   (* ; add_nullary ("get_lp")   *)
-  add_unqualified ("head", ReturnType URowVector, [URowVector; UInt]) ;
-  add_unqualified ("head", ReturnType UVector, [UVector; UInt]) ;
+  add_unqualified ("head", ReturnType URowVector, [URowVector; UInt], AoS) ;
+  add_unqualified ("head", ReturnType UVector, [UVector; UInt], AoS) ;
   List.iter
     ~f:(fun t ->
       List.iter
@@ -1079,29 +1304,35 @@ let () =
           add_unqualified
             ( "head"
             , ReturnType (bare_array_type (t, j))
-            , [bare_array_type (t, j); UInt] ) )
+            , [bare_array_type (t, j); UInt]
+            , AoS ) )
         (List.range 1 4) )
     bare_types ;
   add_unqualified
-    ("hmm_marginal", ReturnType UReal, [UMatrix; UMatrix; UVector]) ;
+    ("hmm_marginal", ReturnType UReal, [UMatrix; UMatrix; UVector], AoS) ;
   add_qualified
     ( "hmm_hidden_state_prob"
     , ReturnType UMatrix
-    , [(DataOnly, UMatrix); (DataOnly, UMatrix); (DataOnly, UVector)] ) ;
+    , [(DataOnly, UMatrix); (DataOnly, UMatrix); (DataOnly, UVector)]
+    , AoS ) ;
   add_unqualified
-    ("hmm_latent_rng", ReturnType (UArray UInt), [UMatrix; UMatrix; UVector]) ;
+    ( "hmm_latent_rng"
+    , ReturnType (UArray UInt)
+    , [UMatrix; UMatrix; UVector]
+    , AoS ) ;
   add_unqualified
-    ("hypergeometric_log", ReturnType UReal, [UInt; UInt; UInt; UInt]) ;
+    ("hypergeometric_log", ReturnType UReal, [UInt; UInt; UInt; UInt], AoS) ;
   add_unqualified
-    ("hypergeometric_lpmf", ReturnType UReal, [UInt; UInt; UInt; UInt]) ;
-  add_unqualified ("hypergeometric_rng", ReturnType UInt, [UInt; UInt; UInt]) ;
-  add_binary_vec "hypot" ;
-  add_unqualified ("identity_matrix", ReturnType UMatrix, [UInt]) ;
-  add_unqualified ("if_else", ReturnType UInt, [UInt; UInt; UInt]) ;
-  add_unqualified ("if_else", ReturnType UReal, [UInt; UReal; UReal]) ;
-  add_unqualified ("inc_beta", ReturnType UReal, [UReal; UReal; UReal]) ;
-  add_unqualified ("int_step", ReturnType UInt, [UReal]) ;
-  add_unqualified ("int_step", ReturnType UInt, [UInt]) ;
+    ("hypergeometric_lpmf", ReturnType UReal, [UInt; UInt; UInt; UInt], AoS) ;
+  add_unqualified
+    ("hypergeometric_rng", ReturnType UInt, [UInt; UInt; UInt], AoS) ;
+  add_binary_vec "hypot" AoS ;
+  add_unqualified ("identity_matrix", ReturnType UMatrix, [UInt], AoS) ;
+  add_unqualified ("if_else", ReturnType UInt, [UInt; UInt; UInt], AoS) ;
+  add_unqualified ("if_else", ReturnType UReal, [UInt; UReal; UReal], AoS) ;
+  add_unqualified ("inc_beta", ReturnType UReal, [UReal; UReal; UReal], AoS) ;
+  add_unqualified ("int_step", ReturnType UInt, [UReal], AoS) ;
+  add_unqualified ("int_step", ReturnType UInt, [UInt], AoS) ;
   add_qualified
     ( "integrate_1d"
     , ReturnType UReal
@@ -1111,10 +1342,12 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType UReal
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UReal); (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
-      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
+      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
+    , AoS ) ;
   add_qualified
     ( "integrate_1d"
     , ReturnType UReal
@@ -1124,11 +1357,12 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType UReal
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UReal); (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal) ]
-    ) ;
+    , AoS ) ;
   add_qualified
     ( "integrate_ode"
     , ReturnType (UArray (UArray UReal))
@@ -1139,12 +1373,14 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal)
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
-      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
+      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
+    , AoS ) ;
   add_qualified
     ( "integrate_ode_adams"
     , ReturnType (UArray (UArray UReal))
@@ -1155,12 +1391,14 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal)
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
-      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
+      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
+    , AoS ) ;
   add_qualified
     ( "integrate_ode_adams"
     , ReturnType (UArray (UArray UReal))
@@ -1171,13 +1409,15 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal)
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
-      ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;
+      ; (DataOnly, UReal); (DataOnly, UReal) ]
+    , AoS ) ;
   add_qualified
     ( "integrate_ode_bdf"
     , ReturnType (UArray (UArray UReal))
@@ -1188,12 +1428,14 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal)
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
-      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
+      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
+    , AoS ) ;
   add_qualified
     ( "integrate_ode_bdf"
     , ReturnType (UArray (UArray UReal))
@@ -1204,13 +1446,15 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal)
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
-      ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;
+      ; (DataOnly, UReal); (DataOnly, UReal) ]
+    , AoS ) ;
   add_qualified
     ( "integrate_ode_rk45"
     , ReturnType (UArray (UArray UReal))
@@ -1221,12 +1465,14 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal)
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
-      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ] ) ;
+      ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
+    , AoS ) ;
   add_qualified
     ( "integrate_ode_rk45"
     , ReturnType (UArray (UArray UReal))
@@ -1237,85 +1483,96 @@ let () =
               ; (AutoDiffable, UArray UReal)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType (UArray UReal)
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UReal)
       ; (AutoDiffable, UArray UReal)
       ; (AutoDiffable, UArray UReal)
       ; (DataOnly, UArray UReal); (DataOnly, UArray UInt); (DataOnly, UReal)
-      ; (DataOnly, UReal); (DataOnly, UReal) ] ) ;
+      ; (DataOnly, UReal); (DataOnly, UReal) ]
+    , AoS ) ;
   add_unqualified
-    ("inv_wishart_log", ReturnType UReal, [UMatrix; UReal; UMatrix]) ;
+    ("inv_wishart_log", ReturnType UReal, [UMatrix; UReal; UMatrix], AoS) ;
   add_unqualified
-    ("inv_wishart_lpdf", ReturnType UReal, [UMatrix; UReal; UMatrix]) ;
-  add_unqualified ("inv_wishart_rng", ReturnType UMatrix, [UReal; UMatrix]) ;
-  add_unqualified ("inverse", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("inverse_spd", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("is_inf", ReturnType UInt, [UReal]) ;
-  add_unqualified ("is_nan", ReturnType UInt, [UReal]) ;
-  add_binary_vec "lbeta" ;
-  add_binary "lchoose" ;
-  add_binary_vec_real_int "ldexp" ;
+    ("inv_wishart_lpdf", ReturnType UReal, [UMatrix; UReal; UMatrix], AoS) ;
+  add_unqualified ("inv_wishart_rng", ReturnType UMatrix, [UReal; UMatrix], AoS) ;
+  add_unqualified ("inverse", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("inverse_spd", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("is_inf", ReturnType UInt, [UReal], AoS) ;
+  add_unqualified ("is_nan", ReturnType UInt, [UReal], AoS) ;
+  add_binary_vec "lbeta" AoS ;
+  add_binary "lchoose" AoS ;
+  add_binary_vec_real_int "ldexp" AoS ;
   add_qualified
     ( "linspaced_int_array"
     , ReturnType (UArray UInt)
-    , [(DataOnly, UInt); (DataOnly, UInt); (DataOnly, UInt)] ) ;
+    , [(DataOnly, UInt); (DataOnly, UInt); (DataOnly, UInt)]
+    , AoS ) ;
   add_qualified
     ( "linspaced_array"
     , ReturnType (UArray UReal)
-    , [(DataOnly, UInt); (DataOnly, UReal); (DataOnly, UReal)] ) ;
+    , [(DataOnly, UInt); (DataOnly, UReal); (DataOnly, UReal)]
+    , AoS ) ;
   add_qualified
     ( "linspaced_row_vector"
     , ReturnType URowVector
-    , [(DataOnly, UInt); (DataOnly, UReal); (DataOnly, UReal)] ) ;
+    , [(DataOnly, UInt); (DataOnly, UReal); (DataOnly, UReal)]
+    , AoS ) ;
   add_qualified
     ( "linspaced_vector"
     , ReturnType UVector
-    , [(DataOnly, UInt); (DataOnly, UReal); (DataOnly, UReal)] ) ;
-  add_unqualified ("lkj_corr_cholesky_log", ReturnType UReal, [UMatrix; UReal]) ;
-  add_unqualified ("lkj_corr_cholesky_lpdf", ReturnType UReal, [UMatrix; UReal]) ;
-  add_unqualified ("lkj_corr_cholesky_rng", ReturnType UMatrix, [UInt; UReal]) ;
-  add_unqualified ("lkj_corr_log", ReturnType UReal, [UMatrix; UReal]) ;
-  add_unqualified ("lkj_corr_lpdf", ReturnType UReal, [UMatrix; UReal]) ;
-  add_unqualified ("lkj_corr_rng", ReturnType UMatrix, [UInt; UReal]) ;
+    , [(DataOnly, UInt); (DataOnly, UReal); (DataOnly, UReal)]
+    , AoS ) ;
   add_unqualified
-    ("lkj_cov_log", ReturnType UReal, [UMatrix; UVector; UVector; UReal]) ;
-  add_binary_vec_int_real "lmgamma" ;
-  add_binary_vec "lmultiply" ;
+    ("lkj_corr_cholesky_log", ReturnType UReal, [UMatrix; UReal], AoS) ;
+  add_unqualified
+    ("lkj_corr_cholesky_lpdf", ReturnType UReal, [UMatrix; UReal], AoS) ;
+  add_unqualified
+    ("lkj_corr_cholesky_rng", ReturnType UMatrix, [UInt; UReal], AoS) ;
+  add_unqualified ("lkj_corr_log", ReturnType UReal, [UMatrix; UReal], AoS) ;
+  add_unqualified ("lkj_corr_lpdf", ReturnType UReal, [UMatrix; UReal], AoS) ;
+  add_unqualified ("lkj_corr_rng", ReturnType UMatrix, [UInt; UReal], AoS) ;
+  add_unqualified
+    ("lkj_cov_log", ReturnType UReal, [UMatrix; UVector; UVector; UReal], AoS) ;
+  add_binary_vec_int_real "lmgamma" AoS ;
+  add_binary_vec "lmultiply" AoS ;
   add_nullary "log10" ;
   add_nullary "log2" ;
-  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix]) ;
-  add_binary_vec "log_diff_exp" ;
-  add_binary_vec "log_falling_factorial" ;
-  add_binary_vec "log_inv_logit_diff" ;
-  add_ternary "log_mix" ;
+  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], AoS) ;
+  add_binary_vec "log_diff_exp" AoS ;
+  add_binary_vec "log_falling_factorial" AoS ;
+  add_binary_vec "log_inv_logit_diff" AoS ;
+  add_ternary "log_mix" AoS ;
   List.iter
     ~f:(fun v1 ->
       List.iter
-        ~f:(fun v2 -> add_unqualified ("log_mix", ReturnType UReal, [v1; v2]))
+        ~f:(fun v2 ->
+          add_unqualified ("log_mix", ReturnType UReal, [v1; v2], AoS) )
         (List.tl_exn vector_types) ;
-      add_unqualified ("log_mix", ReturnType UReal, [v1; UArray UVector]) ;
-      add_unqualified ("log_mix", ReturnType UReal, [v1; UArray URowVector]) )
+      add_unqualified ("log_mix", ReturnType UReal, [v1; UArray UVector], AoS) ;
+      add_unqualified
+        ("log_mix", ReturnType UReal, [v1; UArray URowVector], AoS) )
     (List.tl_exn vector_types) ;
-  add_binary_vec "log_modified_bessel_first_kind" ;
-  add_binary_vec "log_rising_factorial" ;
-  add_unqualified ("log_softmax", ReturnType UVector, [UVector]) ;
-  add_unqualified ("log_sum_exp", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("log_sum_exp", ReturnType UReal, [UVector]) ;
-  add_unqualified ("log_sum_exp", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("log_sum_exp", ReturnType UReal, [UMatrix]) ;
-  add_binary "log_sum_exp" ;
+  add_binary_vec "log_modified_bessel_first_kind" AoS ;
+  add_binary_vec "log_rising_factorial" AoS ;
+  add_unqualified ("log_softmax", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("log_sum_exp", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("log_sum_exp", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("log_sum_exp", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("log_sum_exp", ReturnType UReal, [UMatrix], AoS) ;
+  add_binary "log_sum_exp" AoS ;
   let logical_binops =
     [ "logical_or"; "logical_and"; "logical_eq"; "logical_neq"; "logical_lt"
     ; "logical_lte"; "logical_gt"; "logical_gte" ]
   in
   List.iter
     ~f:(fun t1 ->
-      add_unqualified ("logical_negation", ReturnType UInt, [t1]) ;
+      add_unqualified ("logical_negation", ReturnType UInt, [t1], AoS) ;
       List.iter
         ~f:(fun t2 ->
           List.iter
-            ~f:(fun o -> add_unqualified (o, ReturnType UInt, [t1; t2]))
+            ~f:(fun o -> add_unqualified (o, ReturnType UInt, [t1; t2], AoS))
             logical_binops )
         primitive_types )
     primitive_types ;
@@ -1328,346 +1585,440 @@ let () =
             ( [ (AutoDiffable, UVector); (AutoDiffable, UVector)
               ; (DataOnly, UArray UReal); (DataOnly, UArray UInt) ]
             , ReturnType UVector
-            , FnPlain ) )
+            , FnPlain
+            , Common.Helpers.AoS ) )
       ; (AutoDiffable, UVector)
       ; (AutoDiffable, UArray UVector)
       ; (DataOnly, UArray (UArray UReal))
-      ; (DataOnly, UArray (UArray UInt)) ] ) ;
-  add_unqualified ("matrix_exp", ReturnType UMatrix, [UMatrix]) ;
+      ; (DataOnly, UArray (UArray UInt)) ]
+    , AoS ) ;
+  add_unqualified ("matrix_exp", ReturnType UMatrix, [UMatrix], AoS) ;
   add_unqualified
-    ("matrix_exp_multiply", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("matrix_power", ReturnType UMatrix, [UMatrix; UInt]) ;
-  add_unqualified ("max", ReturnType UInt, [UArray UInt]) ;
-  add_unqualified ("max", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("max", ReturnType UReal, [UVector]) ;
-  add_unqualified ("max", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("max", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("max", ReturnType UInt, [UInt; UInt]) ;
-  add_unqualified ("mdivide_left", ReturnType UVector, [UMatrix; UVector]) ;
-  add_unqualified ("mdivide_left", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("mdivide_left_spd", ReturnType UVector, [UMatrix; UVector]) ;
-  add_unqualified ("mdivide_left_spd", ReturnType UMatrix, [UMatrix; UMatrix]) ;
+    ("matrix_exp_multiply", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("matrix_power", ReturnType UMatrix, [UMatrix; UInt], AoS) ;
+  add_unqualified ("max", ReturnType UInt, [UArray UInt], AoS) ;
+  add_unqualified ("max", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("max", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("max", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("max", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("max", ReturnType UInt, [UInt; UInt], AoS) ;
+  add_unqualified ("mdivide_left", ReturnType UVector, [UMatrix; UVector], AoS) ;
+  add_unqualified ("mdivide_left", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
   add_unqualified
-    ("mdivide_left_tri_low", ReturnType UMatrix, [UMatrix; UMatrix]) ;
+    ("mdivide_left_spd", ReturnType UVector, [UMatrix; UVector], AoS) ;
   add_unqualified
-    ("mdivide_left_tri_low", ReturnType UVector, [UMatrix; UVector]) ;
+    ("mdivide_left_spd", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
   add_unqualified
-    ("mdivide_right", ReturnType URowVector, [URowVector; UMatrix]) ;
-  add_unqualified ("mdivide_right_spd", ReturnType UMatrix, [UMatrix; UMatrix]) ;
+    ("mdivide_left_tri_low", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
   add_unqualified
-    ("mdivide_right_spd", ReturnType URowVector, [URowVector; UMatrix]) ;
-  add_unqualified ("mdivide_right", ReturnType UMatrix, [UMatrix; UMatrix]) ;
+    ("mdivide_left_tri_low", ReturnType UVector, [UMatrix; UVector], AoS) ;
   add_unqualified
-    ("mdivide_right_tri_low", ReturnType URowVector, [URowVector; UMatrix]) ;
+    ("mdivide_right", ReturnType URowVector, [URowVector; UMatrix], AoS) ;
   add_unqualified
-    ("mdivide_right_tri_low", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("mean", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("mean", ReturnType UReal, [UVector]) ;
-  add_unqualified ("mean", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("mean", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("min", ReturnType UInt, [UArray UInt]) ;
-  add_unqualified ("min", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("min", ReturnType UReal, [UVector]) ;
-  add_unqualified ("min", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("min", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("min", ReturnType UInt, [UInt; UInt]) ;
-  add_unqualified ("minus", ReturnType UInt, [UInt]) ;
-  add_unqualified ("minus", ReturnType UReal, [UReal]) ;
-  add_unqualified ("minus", ReturnType UVector, [UVector]) ;
-  add_unqualified ("minus", ReturnType URowVector, [URowVector]) ;
-  add_unqualified ("minus", ReturnType UMatrix, [UMatrix]) ;
-  add_binary_vec_int_real "modified_bessel_first_kind" ;
-  add_binary_vec_int_real "modified_bessel_second_kind" ;
-  add_unqualified ("modulus", ReturnType UInt, [UInt; UInt]) ;
-  add_unqualified ("multi_normal_rng", ReturnType UVector, [UVector; UMatrix]) ;
+    ("mdivide_right_spd", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
   add_unqualified
-    ("multi_normal_rng", ReturnType (UArray UVector), [UArray UVector; UMatrix]) ;
+    ("mdivide_right_spd", ReturnType URowVector, [URowVector; UMatrix], AoS) ;
+  add_unqualified ("mdivide_right", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
   add_unqualified
-    ("multi_normal_rng", ReturnType UVector, [URowVector; UMatrix]) ;
+    ("mdivide_right_tri_low", ReturnType URowVector, [URowVector; UMatrix], AoS) ;
+  add_unqualified
+    ("mdivide_right_tri_low", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("mean", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("mean", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("mean", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("mean", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("min", ReturnType UInt, [UArray UInt], AoS) ;
+  add_unqualified ("min", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("min", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("min", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("min", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("min", ReturnType UInt, [UInt; UInt], AoS) ;
+  add_unqualified ("minus", ReturnType UInt, [UInt], AoS) ;
+  add_unqualified ("minus", ReturnType UReal, [UReal], AoS) ;
+  add_unqualified ("minus", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("minus", ReturnType URowVector, [URowVector], AoS) ;
+  add_unqualified ("minus", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_binary_vec_int_real "modified_bessel_first_kind" AoS ;
+  add_binary_vec_int_real "modified_bessel_second_kind" AoS ;
+  add_unqualified ("modulus", ReturnType UInt, [UInt; UInt], AoS) ;
+  add_unqualified
+    ("multi_normal_rng", ReturnType UVector, [UVector; UMatrix], AoS) ;
   add_unqualified
     ( "multi_normal_rng"
     , ReturnType (UArray UVector)
-    , [UArray URowVector; UMatrix] ) ;
+    , [UArray UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("multi_normal_cholesky_rng", ReturnType UVector, [UVector; UMatrix]) ;
+    ("multi_normal_rng", ReturnType UVector, [URowVector; UMatrix], AoS) ;
+  add_unqualified
+    ( "multi_normal_rng"
+    , ReturnType (UArray UVector)
+    , [UArray URowVector; UMatrix]
+    , AoS ) ;
+  add_unqualified
+    ("multi_normal_cholesky_rng", ReturnType UVector, [UVector; UMatrix], AoS) ;
   add_unqualified
     ( "multi_normal_cholesky_rng"
     , ReturnType (UArray UVector)
-    , [UArray UVector; UMatrix] ) ;
+    , [UArray UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("multi_normal_cholesky_rng", ReturnType UVector, [URowVector; UMatrix]) ;
+    ( "multi_normal_cholesky_rng"
+    , ReturnType UVector
+    , [URowVector; UMatrix]
+    , AoS ) ;
   add_unqualified
     ( "multi_normal_cholesky_rng"
     , ReturnType (UArray UVector)
-    , [UArray URowVector; UMatrix] ) ;
+    , [UArray URowVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("multi_student_t_rng", ReturnType UVector, [UReal; UVector; UMatrix]) ;
-  add_unqualified
-    ( "multi_student_t_rng"
-    , ReturnType (UArray UVector)
-    , [UReal; UArray UVector; UMatrix] ) ;
-  add_unqualified
-    ("multi_student_t_rng", ReturnType UVector, [UReal; URowVector; UMatrix]) ;
+    ("multi_student_t_rng", ReturnType UVector, [UReal; UVector; UMatrix], AoS) ;
   add_unqualified
     ( "multi_student_t_rng"
     , ReturnType (UArray UVector)
-    , [UReal; UArray URowVector; UMatrix] ) ;
+    , [UReal; UArray UVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("multinomial_log", ReturnType UReal, [bare_array_type (UInt, 1); UVector]) ;
+    ( "multi_student_t_rng"
+    , ReturnType UVector
+    , [UReal; URowVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("multinomial_lpmf", ReturnType UReal, [bare_array_type (UInt, 1); UVector]) ;
+    ( "multi_student_t_rng"
+    , ReturnType (UArray UVector)
+    , [UReal; UArray URowVector; UMatrix]
+    , AoS ) ;
   add_unqualified
-    ("multinomial_rng", ReturnType (bare_array_type (UInt, 1)), [UVector; UInt]) ;
+    ( "multinomial_log"
+    , ReturnType UReal
+    , [bare_array_type (UInt, 1); UVector]
+    , AoS ) ;
   add_unqualified
-    ("multinomial_logit_log", ReturnType UReal, [UArray UInt; UVector]) ;
+    ( "multinomial_lpmf"
+    , ReturnType UReal
+    , [bare_array_type (UInt, 1); UVector]
+    , AoS ) ;
   add_unqualified
-    ("multinomial_logit_lpmf", ReturnType UReal, [UArray UInt; UVector]) ;
+    ( "multinomial_rng"
+    , ReturnType (bare_array_type (UInt, 1))
+    , [UVector; UInt]
+    , AoS ) ;
   add_unqualified
-    ("multinomial_logit_rng", ReturnType (UArray UInt), [UVector; UInt]) ;
-  add_unqualified ("multinomial_log", ReturnType UReal, [UArray UInt; UVector]) ;
-  add_unqualified ("multinomial_lpmf", ReturnType UReal, [UArray UInt; UVector]) ;
-  add_unqualified ("multinomial_rng", ReturnType (UArray UInt), [UVector; UInt]) ;
-  add_unqualified ("multiply", ReturnType UInt, [UInt; UInt]) ;
-  add_unqualified ("multiply", ReturnType UReal, [UReal; UReal]) ;
-  add_unqualified ("multiply", ReturnType UVector, [UVector; UReal]) ;
-  add_unqualified ("multiply", ReturnType URowVector, [URowVector; UReal]) ;
-  add_unqualified ("multiply", ReturnType UMatrix, [UMatrix; UReal]) ;
-  add_unqualified ("multiply", ReturnType UReal, [URowVector; UVector]) ;
-  add_unqualified ("multiply", ReturnType UMatrix, [UVector; URowVector]) ;
-  add_unqualified ("multiply", ReturnType UVector, [UMatrix; UVector]) ;
-  add_unqualified ("multiply", ReturnType URowVector, [URowVector; UMatrix]) ;
-  add_unqualified ("multiply", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("multiply", ReturnType UVector, [UReal; UVector]) ;
-  add_unqualified ("multiply", ReturnType URowVector, [UReal; URowVector]) ;
-  add_unqualified ("multiply", ReturnType UMatrix, [UReal; UMatrix]) ;
-  add_binary_vec "multiply_log" ;
+    ("multinomial_logit_log", ReturnType UReal, [UArray UInt; UVector], AoS) ;
   add_unqualified
-    ("multiply_lower_tri_self_transpose", ReturnType UMatrix, [UMatrix]) ;
+    ("multinomial_logit_lpmf", ReturnType UReal, [UArray UInt; UVector], AoS) ;
+  add_unqualified
+    ("multinomial_logit_rng", ReturnType (UArray UInt), [UVector; UInt], AoS) ;
+  add_unqualified
+    ("multinomial_log", ReturnType UReal, [UArray UInt; UVector], AoS) ;
+  add_unqualified
+    ("multinomial_lpmf", ReturnType UReal, [UArray UInt; UVector], AoS) ;
+  add_unqualified
+    ("multinomial_rng", ReturnType (UArray UInt), [UVector; UInt], AoS) ;
+  add_unqualified ("multiply", ReturnType UInt, [UInt; UInt], AoS) ;
+  add_unqualified ("multiply", ReturnType UReal, [UReal; UReal], AoS) ;
+  add_unqualified ("multiply", ReturnType UVector, [UVector; UReal], AoS) ;
+  add_unqualified ("multiply", ReturnType URowVector, [URowVector; UReal], AoS) ;
+  add_unqualified ("multiply", ReturnType UMatrix, [UMatrix; UReal], AoS) ;
+  add_unqualified ("multiply", ReturnType UReal, [URowVector; UVector], AoS) ;
+  add_unqualified ("multiply", ReturnType UMatrix, [UVector; URowVector], AoS) ;
+  add_unqualified ("multiply", ReturnType UVector, [UMatrix; UVector], AoS) ;
+  add_unqualified
+    ("multiply", ReturnType URowVector, [URowVector; UMatrix], AoS) ;
+  add_unqualified ("multiply", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("multiply", ReturnType UVector, [UReal; UVector], AoS) ;
+  add_unqualified ("multiply", ReturnType URowVector, [UReal; URowVector], AoS) ;
+  add_unqualified ("multiply", ReturnType UMatrix, [UReal; UMatrix], AoS) ;
+  add_binary_vec "multiply_log" AoS ;
+  add_unqualified
+    ("multiply_lower_tri_self_transpose", ReturnType UMatrix, [UMatrix], AoS) ;
   add_unqualified
     ( "neg_binomial_2_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UMatrix; UReal; UVector; UReal] ) ;
+    , [UArray UInt; UMatrix; UReal; UVector; UReal]
+    , AoS ) ;
   add_unqualified
     ( "neg_binomial_2_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UMatrix; UVector; UVector; UReal] ) ;
+    , [UArray UInt; UMatrix; UVector; UVector; UReal]
+    , AoS ) ;
   add_unqualified
     ( "neg_binomial_2_log_glm_lpmf"
     , ReturnType UReal
-    , [UInt; UMatrix; UReal; UVector; UReal] ) ;
+    , [UInt; UMatrix; UReal; UVector; UReal]
+    , AoS ) ;
   add_unqualified
     ( "neg_binomial_2_log_glm_lpmf"
     , ReturnType UReal
-    , [UInt; UMatrix; UVector; UVector; UReal] ) ;
+    , [UInt; UMatrix; UVector; UVector; UReal]
+    , AoS ) ;
   add_unqualified
     ( "neg_binomial_2_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UReal; UVector; UReal] ) ;
+    , [UArray UInt; URowVector; UReal; UVector; UReal]
+    , AoS ) ;
   add_unqualified
     ( "neg_binomial_2_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UVector; UVector; UReal] ) ;
+    , [UArray UInt; URowVector; UVector; UVector; UReal]
+    , AoS ) ;
   add_nullary "negative_infinity" ;
   add_unqualified
     ( "normal_id_glm_lpdf"
     , ReturnType UReal
-    , [UVector; UMatrix; UReal; UVector; UReal] ) ;
+    , [UVector; UMatrix; UReal; UVector; UReal]
+    , AoS ) ;
   add_unqualified
     ( "normal_id_glm_lpdf"
     , ReturnType UReal
-    , [UVector; UMatrix; UVector; UVector; UReal] ) ;
+    , [UVector; UMatrix; UVector; UVector; UReal]
+    , AoS ) ;
   add_unqualified
     ( "normal_id_glm_lpdf"
     , ReturnType UReal
-    , [UReal; UMatrix; UReal; UVector; UVector] ) ;
+    , [UReal; UMatrix; UReal; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "normal_id_glm_lpdf"
     , ReturnType UReal
-    , [UReal; UMatrix; UVector; UVector; UVector] ) ;
+    , [UReal; UMatrix; UVector; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "normal_id_glm_lpdf"
     , ReturnType UReal
-    , [UVector; URowVector; UReal; UVector; UVector] ) ;
+    , [UVector; URowVector; UReal; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "normal_id_glm_lpdf"
     , ReturnType UReal
-    , [UVector; URowVector; UVector; UVector; UVector] ) ;
+    , [UVector; URowVector; UVector; UVector; UVector]
+    , AoS ) ;
   add_nullary "not_a_number" ;
-  add_unqualified ("num_elements", ReturnType UInt, [UMatrix]) ;
-  add_unqualified ("num_elements", ReturnType UInt, [UVector]) ;
-  add_unqualified ("num_elements", ReturnType UInt, [URowVector]) ;
+  add_unqualified ("num_elements", ReturnType UInt, [UMatrix], AoS) ;
+  add_unqualified ("num_elements", ReturnType UInt, [UVector], AoS) ;
+  add_unqualified ("num_elements", ReturnType UInt, [URowVector], AoS) ;
   List.iter
     ~f:(fun i ->
       List.iter
         ~f:(fun t ->
           add_unqualified
-            ("num_elements", ReturnType UInt, [bare_array_type (t, i)]) )
+            ("num_elements", ReturnType UInt, [bare_array_type (t, i)], AoS) )
         bare_types )
     (List.range 1 10) ;
-  add_unqualified ("one_hot_int_array", ReturnType (UArray UInt), [UInt; UInt]) ;
-  add_unqualified ("one_hot_array", ReturnType (UArray UReal), [UInt; UInt]) ;
-  add_unqualified ("one_hot_row_vector", ReturnType URowVector, [UInt; UInt]) ;
-  add_unqualified ("one_hot_vector", ReturnType UVector, [UInt; UInt]) ;
-  add_unqualified ("ones_int_array", ReturnType (UArray UInt), [UInt]) ;
-  add_unqualified ("ones_array", ReturnType (UArray UReal), [UInt]) ;
-  add_unqualified ("ones_row_vector", ReturnType URowVector, [UInt]) ;
-  add_unqualified ("ones_vector", ReturnType UVector, [UInt]) ;
+  add_unqualified
+    ("one_hot_int_array", ReturnType (UArray UInt), [UInt; UInt], AoS) ;
+  add_unqualified
+    ("one_hot_array", ReturnType (UArray UReal), [UInt; UInt], AoS) ;
+  add_unqualified
+    ("one_hot_row_vector", ReturnType URowVector, [UInt; UInt], AoS) ;
+  add_unqualified ("one_hot_vector", ReturnType UVector, [UInt; UInt], AoS) ;
+  add_unqualified ("ones_int_array", ReturnType (UArray UInt), [UInt], AoS) ;
+  add_unqualified ("ones_array", ReturnType (UArray UReal), [UInt], AoS) ;
+  add_unqualified ("ones_row_vector", ReturnType URowVector, [UInt], AoS) ;
+  add_unqualified ("ones_vector", ReturnType UVector, [UInt], AoS) ;
   add_unqualified
     ( "ordered_logistic_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UMatrix; UVector; UVector] ) ;
+    , [UArray UInt; UMatrix; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "ordered_logistic_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UVector; UVector] ) ;
+    , [UArray UInt; URowVector; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "ordered_logistic_glm_lpmf"
     , ReturnType UReal
-    , [UInt; UMatrix; UVector; UVector] ) ;
+    , [UInt; UMatrix; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "ordered_logistic_glm_lpmf"
     , ReturnType UReal
-    , [UInt; URowVector; UVector; UVector] ) ;
+    , [UInt; URowVector; UVector; UVector]
+    , AoS ) ;
   add_unqualified
-    ("ordered_logistic_log", ReturnType UReal, [UInt; UReal; UVector]) ;
-  add_unqualified
-    ("ordered_logistic_log", ReturnType UReal, [UArray UInt; UVector; UVector]) ;
+    ("ordered_logistic_log", ReturnType UReal, [UInt; UReal; UVector], AoS) ;
   add_unqualified
     ( "ordered_logistic_log"
     , ReturnType UReal
-    , [UArray UInt; UVector; UArray UVector] ) ;
+    , [UArray UInt; UVector; UVector]
+    , AoS ) ;
   add_unqualified
-    ("ordered_logistic_lpmf", ReturnType UReal, [UInt; UReal; UVector]) ;
+    ( "ordered_logistic_log"
+    , ReturnType UReal
+    , [UArray UInt; UVector; UArray UVector]
+    , AoS ) ;
   add_unqualified
-    ("ordered_logistic_lpmf", ReturnType UReal, [UArray UInt; UVector; UVector]) ;
+    ("ordered_logistic_lpmf", ReturnType UReal, [UInt; UReal; UVector], AoS) ;
   add_unqualified
     ( "ordered_logistic_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UVector; UArray UVector] ) ;
-  add_unqualified ("ordered_logistic_rng", ReturnType UInt, [UReal; UVector]) ;
+    , [UArray UInt; UVector; UVector]
+    , AoS ) ;
   add_unqualified
-    ("ordered_probit_log", ReturnType UReal, [UInt; UReal; UVector]) ;
+    ( "ordered_logistic_lpmf"
+    , ReturnType UReal
+    , [UArray UInt; UVector; UArray UVector]
+    , AoS ) ;
   add_unqualified
-    ("ordered_probit_log", ReturnType UReal, [UArray UInt; UVector; UVector]) ;
+    ("ordered_logistic_rng", ReturnType UInt, [UReal; UVector], AoS) ;
+  add_unqualified
+    ("ordered_probit_log", ReturnType UReal, [UInt; UReal; UVector], AoS) ;
   add_unqualified
     ( "ordered_probit_log"
     , ReturnType UReal
-    , [UArray UInt; UVector; UArray UVector] ) ;
+    , [UArray UInt; UVector; UVector]
+    , AoS ) ;
   add_unqualified
-    ("ordered_probit_lpmf", ReturnType UReal, [UInt; UReal; UVector]) ;
+    ( "ordered_probit_log"
+    , ReturnType UReal
+    , [UArray UInt; UVector; UArray UVector]
+    , AoS ) ;
   add_unqualified
-    ("ordered_probit_lpmf", ReturnType UReal, [UArray UInt; UReal; UVector]) ;
+    ("ordered_probit_lpmf", ReturnType UReal, [UInt; UReal; UVector], AoS) ;
   add_unqualified
     ( "ordered_probit_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UReal; UArray UVector] ) ;
-  add_unqualified ("ordered_probit_rng", ReturnType UInt, [UReal; UVector]) ;
-  add_binary_vec_real_real "owens_t" ;
+    , [UArray UInt; UReal; UVector]
+    , AoS ) ;
+  add_unqualified
+    ( "ordered_probit_lpmf"
+    , ReturnType UReal
+    , [UArray UInt; UReal; UArray UVector]
+    , AoS ) ;
+  add_unqualified ("ordered_probit_rng", ReturnType UInt, [UReal; UVector], AoS) ;
+  add_binary_vec_real_real "owens_t" AoS ;
   add_nullary "pi" ;
-  add_unqualified ("plus", ReturnType UInt, [UInt]) ;
-  add_unqualified ("plus", ReturnType UReal, [UReal]) ;
-  add_unqualified ("plus", ReturnType UVector, [UVector]) ;
-  add_unqualified ("plus", ReturnType URowVector, [URowVector]) ;
-  add_unqualified ("plus", ReturnType UMatrix, [UMatrix]) ;
+  add_unqualified ("plus", ReturnType UInt, [UInt], AoS) ;
+  add_unqualified ("plus", ReturnType UReal, [UReal], AoS) ;
+  add_unqualified ("plus", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("plus", ReturnType URowVector, [URowVector], AoS) ;
+  add_unqualified ("plus", ReturnType UMatrix, [UMatrix], AoS) ;
   add_unqualified
     ( "poisson_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UMatrix; UReal; UVector] ) ;
+    , [UArray UInt; UMatrix; UReal; UVector]
+    , AoS ) ;
   add_unqualified
     ( "poisson_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; UMatrix; UVector; UVector] ) ;
-  add_unqualified
-    ("poisson_log_glm_lpmf", ReturnType UReal, [UInt; UMatrix; UReal; UVector]) ;
-  add_unqualified
-    ( "poisson_log_glm_lpmf"
-    , ReturnType UReal
-    , [UInt; UMatrix; UVector; UVector] ) ;
+    , [UArray UInt; UMatrix; UVector; UVector]
+    , AoS ) ;
   add_unqualified
     ( "poisson_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UReal; UVector] ) ;
+    , [UInt; UMatrix; UReal; UVector]
+    , AoS ) ;
   add_unqualified
     ( "poisson_log_glm_lpmf"
     , ReturnType UReal
-    , [UArray UInt; URowVector; UVector; UVector] ) ;
+    , [UInt; UMatrix; UVector; UVector]
+    , AoS ) ;
+  add_unqualified
+    ( "poisson_log_glm_lpmf"
+    , ReturnType UReal
+    , [UArray UInt; URowVector; UReal; UVector]
+    , AoS ) ;
+  add_unqualified
+    ( "poisson_log_glm_lpmf"
+    , ReturnType UReal
+    , [UArray UInt; URowVector; UVector; UVector]
+    , AoS ) ;
   add_nullary "positive_infinity" ;
-  add_binary_vec "pow" ;
-  add_unqualified ("prod", ReturnType UInt, [UArray UInt]) ;
-  add_unqualified ("prod", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("prod", ReturnType UReal, [UVector]) ;
-  add_unqualified ("prod", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("prod", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("quad_form", ReturnType UReal, [UMatrix; UVector]) ;
-  add_unqualified ("quad_form", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("quad_form_sym", ReturnType UReal, [UMatrix; UVector]) ;
-  add_unqualified ("quad_form_sym", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("quad_form_diag", ReturnType UMatrix, [UMatrix; UVector]) ;
-  add_unqualified ("quad_form_diag", ReturnType UMatrix, [UMatrix; URowVector]) ;
+  add_binary_vec "pow" AoS ;
+  add_unqualified ("prod", ReturnType UInt, [UArray UInt], AoS) ;
+  add_unqualified ("prod", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("prod", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("prod", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("prod", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("quad_form", ReturnType UReal, [UMatrix; UVector], AoS) ;
+  add_unqualified ("quad_form", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("quad_form_sym", ReturnType UReal, [UMatrix; UVector], AoS) ;
+  add_unqualified ("quad_form_sym", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified
+    ("quad_form_diag", ReturnType UMatrix, [UMatrix; UVector], AoS) ;
+  add_unqualified
+    ("quad_form_diag", ReturnType UMatrix, [UMatrix; URowVector], AoS) ;
   add_qualified
     ( "quantile"
     , ReturnType UReal
-    , [(DataOnly, UArray UReal); (DataOnly, UReal)] ) ;
+    , [(DataOnly, UArray UReal); (DataOnly, UReal)]
+    , AoS ) ;
   add_qualified
     ( "quantile"
     , ReturnType (UArray UReal)
-    , [(DataOnly, UArray UReal); (DataOnly, UArray UReal)] ) ;
+    , [(DataOnly, UArray UReal); (DataOnly, UArray UReal)]
+    , AoS ) ;
   add_qualified
-    ("quantile", ReturnType UReal, [(DataOnly, UVector); (DataOnly, UReal)]) ;
+    ( "quantile"
+    , ReturnType UReal
+    , [(DataOnly, UVector); (DataOnly, UReal)]
+    , AoS ) ;
   add_qualified
     ( "quantile"
     , ReturnType (UArray UReal)
-    , [(DataOnly, UVector); (DataOnly, UArray UReal)] ) ;
+    , [(DataOnly, UVector); (DataOnly, UArray UReal)]
+    , AoS ) ;
   add_qualified
-    ("quantile", ReturnType UReal, [(DataOnly, URowVector); (DataOnly, UReal)]) ;
+    ( "quantile"
+    , ReturnType UReal
+    , [(DataOnly, URowVector); (DataOnly, UReal)]
+    , AoS ) ;
   add_qualified
     ( "quantile"
     , ReturnType (UArray UReal)
-    , [(DataOnly, URowVector); (DataOnly, UArray UReal)] ) ;
-  add_unqualified ("rank", ReturnType UInt, [UArray UInt; UInt]) ;
-  add_unqualified ("rank", ReturnType UInt, [UArray UReal; UInt]) ;
-  add_unqualified ("rank", ReturnType UInt, [UVector; UInt]) ;
-  add_unqualified ("rank", ReturnType UInt, [URowVector; UInt]) ;
-  add_unqualified ("append_row", ReturnType UMatrix, [UMatrix; UMatrix]) ;
-  add_unqualified ("append_row", ReturnType UMatrix, [URowVector; UMatrix]) ;
-  add_unqualified ("append_row", ReturnType UMatrix, [UMatrix; URowVector]) ;
-  add_unqualified ("append_row", ReturnType UMatrix, [URowVector; URowVector]) ;
-  add_unqualified ("append_row", ReturnType UVector, [UVector; UVector]) ;
-  add_unqualified ("append_row", ReturnType UVector, [UReal; UVector]) ;
-  add_unqualified ("append_row", ReturnType UVector, [UVector; UReal]) ;
+    , [(DataOnly, URowVector); (DataOnly, UArray UReal)]
+    , AoS ) ;
+  add_unqualified ("rank", ReturnType UInt, [UArray UInt; UInt], AoS) ;
+  add_unqualified ("rank", ReturnType UInt, [UArray UReal; UInt], AoS) ;
+  add_unqualified ("rank", ReturnType UInt, [UVector; UInt], AoS) ;
+  add_unqualified ("rank", ReturnType UInt, [URowVector; UInt], AoS) ;
+  add_unqualified ("append_row", ReturnType UMatrix, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("append_row", ReturnType UMatrix, [URowVector; UMatrix], AoS) ;
+  add_unqualified ("append_row", ReturnType UMatrix, [UMatrix; URowVector], AoS) ;
+  add_unqualified
+    ("append_row", ReturnType UMatrix, [URowVector; URowVector], AoS) ;
+  add_unqualified ("append_row", ReturnType UVector, [UVector; UVector], AoS) ;
+  add_unqualified ("append_row", ReturnType UVector, [UReal; UVector], AoS) ;
+  add_unqualified ("append_row", ReturnType UVector, [UVector; UReal], AoS) ;
   List.iter
     ~f:(fun t ->
       add_unqualified
-        ("rep_array", ReturnType (bare_array_type (t, 1)), [t; UInt]) ;
+        ("rep_array", ReturnType (bare_array_type (t, 1)), [t; UInt], AoS) ;
       add_unqualified
-        ("rep_array", ReturnType (bare_array_type (t, 2)), [t; UInt; UInt]) ;
+        ("rep_array", ReturnType (bare_array_type (t, 2)), [t; UInt; UInt], AoS) ;
       add_unqualified
         ( "rep_array"
         , ReturnType (bare_array_type (t, 3))
-        , [t; UInt; UInt; UInt] ) ;
+        , [t; UInt; UInt; UInt]
+        , AoS ) ;
       List.iter
         ~f:(fun j ->
           add_unqualified
             ( "rep_array"
             , ReturnType (bare_array_type (t, j + 1))
-            , [bare_array_type (t, j); UInt] ) ;
+            , [bare_array_type (t, j); UInt]
+            , AoS ) ;
           add_unqualified
             ( "rep_array"
             , ReturnType (bare_array_type (t, j + 2))
-            , [bare_array_type (t, j); UInt; UInt] ) ;
+            , [bare_array_type (t, j); UInt; UInt]
+            , AoS ) ;
           add_unqualified
             ( "rep_array"
             , ReturnType (bare_array_type (t, j + 3))
-            , [bare_array_type (t, j); UInt; UInt; UInt] ) )
+            , [bare_array_type (t, j); UInt; UInt; UInt]
+            , AoS ) )
         (List.range 1 3) )
     bare_types ;
-  add_unqualified ("rep_matrix", ReturnType UMatrix, [UReal; UInt; UInt]) ;
-  add_unqualified ("rep_matrix", ReturnType UMatrix, [UVector; UInt]) ;
-  add_unqualified ("rep_matrix", ReturnType UMatrix, [URowVector; UInt]) ;
-  add_unqualified ("rep_row_vector", ReturnType URowVector, [UReal; UInt]) ;
-  add_unqualified ("rep_vector", ReturnType UVector, [UReal; UInt]) ;
-  add_unqualified ("reverse", ReturnType UVector, [UVector]) ;
-  add_unqualified ("reverse", ReturnType URowVector, [URowVector]) ;
+  add_unqualified ("rep_matrix", ReturnType UMatrix, [UReal; UInt; UInt], AoS) ;
+  add_unqualified ("rep_matrix", ReturnType UMatrix, [UVector; UInt], AoS) ;
+  add_unqualified ("rep_matrix", ReturnType UMatrix, [URowVector; UInt], AoS) ;
+  add_unqualified ("rep_row_vector", ReturnType URowVector, [UReal; UInt], AoS) ;
+  add_unqualified ("rep_vector", ReturnType UVector, [UReal; UInt], AoS) ;
+  add_unqualified ("reverse", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("reverse", ReturnType URowVector, [URowVector], AoS) ;
   List.iter
     ~f:(fun i ->
       List.iter
@@ -1675,30 +2026,37 @@ let () =
           add_unqualified
             ( "reverse"
             , ReturnType (bare_array_type (t, i))
-            , [bare_array_type (t, i)] ) )
+            , [bare_array_type (t, i)]
+            , AoS ) )
         bare_types )
     (List.range 1 8) ;
-  add_binary_vec_int_int "rising_factorial" ;
-  add_binary_vec_real_int "rising_factorial" ;
-  add_unqualified ("row", ReturnType URowVector, [UMatrix; UInt]) ;
-  add_unqualified ("rows", ReturnType UInt, [UVector]) ;
-  add_unqualified ("rows", ReturnType UInt, [URowVector]) ;
-  add_unqualified ("rows", ReturnType UInt, [UMatrix]) ;
-  add_unqualified ("rows_dot_product", ReturnType UVector, [UVector; UVector]) ;
+  add_binary_vec_int_int "rising_factorial" AoS ;
+  add_binary_vec_real_int "rising_factorial" AoS ;
+  add_unqualified ("row", ReturnType URowVector, [UMatrix; UInt], AoS) ;
+  add_unqualified ("rows", ReturnType UInt, [UVector], AoS) ;
+  add_unqualified ("rows", ReturnType UInt, [URowVector], AoS) ;
+  add_unqualified ("rows", ReturnType UInt, [UMatrix], AoS) ;
   add_unqualified
-    ("rows_dot_product", ReturnType UVector, [URowVector; URowVector]) ;
-  add_unqualified ("rows_dot_product", ReturnType UVector, [UMatrix; UMatrix]) ;
-  add_unqualified ("rows_dot_self", ReturnType UVector, [UVector]) ;
-  add_unqualified ("rows_dot_self", ReturnType UVector, [URowVector]) ;
-  add_unqualified ("rows_dot_self", ReturnType UVector, [UMatrix]) ;
+    ("rows_dot_product", ReturnType UVector, [UVector; UVector], AoS) ;
   add_unqualified
-    ("scale_matrix_exp_multiply", ReturnType UMatrix, [UReal; UMatrix; UMatrix]) ;
-  add_unqualified ("sd", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("sd", ReturnType UReal, [UVector]) ;
-  add_unqualified ("sd", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("sd", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("segment", ReturnType URowVector, [URowVector; UInt; UInt]) ;
-  add_unqualified ("segment", ReturnType UVector, [UVector; UInt; UInt]) ;
+    ("rows_dot_product", ReturnType UVector, [URowVector; URowVector], AoS) ;
+  add_unqualified
+    ("rows_dot_product", ReturnType UVector, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("rows_dot_self", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("rows_dot_self", ReturnType UVector, [URowVector], AoS) ;
+  add_unqualified ("rows_dot_self", ReturnType UVector, [UMatrix], AoS) ;
+  add_unqualified
+    ( "scale_matrix_exp_multiply"
+    , ReturnType UMatrix
+    , [UReal; UMatrix; UMatrix]
+    , AoS ) ;
+  add_unqualified ("sd", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("sd", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("sd", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("sd", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified
+    ("segment", ReturnType URowVector, [URowVector; UInt; UInt], AoS) ;
+  add_unqualified ("segment", ReturnType UVector, [UVector; UInt; UInt], AoS) ;
   List.iter
     ~f:(fun t ->
       List.iter
@@ -1706,72 +2064,85 @@ let () =
           add_unqualified
             ( "segment"
             , ReturnType (bare_array_type (t, j))
-            , [bare_array_type (t, j); UInt; UInt] ) )
+            , [bare_array_type (t, j); UInt; UInt]
+            , AoS ) )
         (List.range 1 4) )
     bare_types ;
-  add_unqualified ("singular_values", ReturnType UVector, [UMatrix]) ;
+  add_unqualified ("singular_values", ReturnType UVector, [UMatrix], AoS) ;
   List.iter
     ~f:(fun i ->
       List.iter
         ~f:(fun t ->
-          add_unqualified ("size", ReturnType UInt, [bare_array_type (t, i)])
-          )
+          add_unqualified
+            ("size", ReturnType UInt, [bare_array_type (t, i)], AoS) )
         bare_types )
     (List.range 1 8) ;
   List.iter
-    ~f:(fun t -> add_unqualified ("size", ReturnType UInt, [t]))
+    ~f:(fun t -> add_unqualified ("size", ReturnType UInt, [t], AoS))
     bare_types ;
-  add_unqualified ("softmax", ReturnType UVector, [UVector]) ;
-  add_unqualified ("sort_asc", ReturnType (UArray UInt), [UArray UInt]) ;
-  add_unqualified ("sort_asc", ReturnType (UArray UReal), [UArray UReal]) ;
-  add_unqualified ("sort_asc", ReturnType UVector, [UVector]) ;
-  add_unqualified ("sort_asc", ReturnType URowVector, [URowVector]) ;
-  add_unqualified ("sort_desc", ReturnType (UArray UInt), [UArray UInt]) ;
-  add_unqualified ("sort_desc", ReturnType (UArray UReal), [UArray UReal]) ;
-  add_unqualified ("sort_desc", ReturnType UVector, [UVector]) ;
-  add_unqualified ("sort_desc", ReturnType URowVector, [URowVector]) ;
-  add_unqualified ("sort_indices_asc", ReturnType (UArray UInt), [UArray UInt]) ;
-  add_unqualified ("sort_indices_asc", ReturnType (UArray UInt), [UArray UReal]) ;
-  add_unqualified ("sort_indices_asc", ReturnType (UArray UInt), [UVector]) ;
-  add_unqualified ("sort_indices_asc", ReturnType (UArray UInt), [URowVector]) ;
-  add_unqualified ("sort_indices_desc", ReturnType (UArray UInt), [UArray UInt]) ;
+  add_unqualified ("softmax", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("sort_asc", ReturnType (UArray UInt), [UArray UInt], AoS) ;
+  add_unqualified ("sort_asc", ReturnType (UArray UReal), [UArray UReal], AoS) ;
+  add_unqualified ("sort_asc", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("sort_asc", ReturnType URowVector, [URowVector], AoS) ;
+  add_unqualified ("sort_desc", ReturnType (UArray UInt), [UArray UInt], AoS) ;
+  add_unqualified ("sort_desc", ReturnType (UArray UReal), [UArray UReal], AoS) ;
+  add_unqualified ("sort_desc", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("sort_desc", ReturnType URowVector, [URowVector], AoS) ;
   add_unqualified
-    ("sort_indices_desc", ReturnType (UArray UInt), [UArray UReal]) ;
-  add_unqualified ("sort_indices_desc", ReturnType (UArray UInt), [UVector]) ;
-  add_unqualified ("sort_indices_desc", ReturnType (UArray UInt), [URowVector]) ;
-  add_unqualified ("squared_distance", ReturnType UReal, [UReal; UReal]) ;
-  add_unqualified ("squared_distance", ReturnType UReal, [UVector; UVector]) ;
+    ("sort_indices_asc", ReturnType (UArray UInt), [UArray UInt], AoS) ;
   add_unqualified
-    ("squared_distance", ReturnType UReal, [URowVector; URowVector]) ;
-  add_unqualified ("squared_distance", ReturnType UReal, [UVector; URowVector]) ;
-  add_unqualified ("squared_distance", ReturnType UReal, [URowVector; UVector]) ;
+    ("sort_indices_asc", ReturnType (UArray UInt), [UArray UReal], AoS) ;
+  add_unqualified ("sort_indices_asc", ReturnType (UArray UInt), [UVector], AoS) ;
+  add_unqualified
+    ("sort_indices_asc", ReturnType (UArray UInt), [URowVector], AoS) ;
+  add_unqualified
+    ("sort_indices_desc", ReturnType (UArray UInt), [UArray UInt], AoS) ;
+  add_unqualified
+    ("sort_indices_desc", ReturnType (UArray UInt), [UArray UReal], AoS) ;
+  add_unqualified
+    ("sort_indices_desc", ReturnType (UArray UInt), [UVector], AoS) ;
+  add_unqualified
+    ("sort_indices_desc", ReturnType (UArray UInt), [URowVector], AoS) ;
+  add_unqualified ("squared_distance", ReturnType UReal, [UReal; UReal], AoS) ;
+  add_unqualified
+    ("squared_distance", ReturnType UReal, [UVector; UVector], AoS) ;
+  add_unqualified
+    ("squared_distance", ReturnType UReal, [URowVector; URowVector], AoS) ;
+  add_unqualified
+    ("squared_distance", ReturnType UReal, [UVector; URowVector], AoS) ;
+  add_unqualified
+    ("squared_distance", ReturnType UReal, [URowVector; UVector], AoS) ;
   add_nullary "sqrt2" ;
-  add_unqualified ("sub_col", ReturnType UVector, [UMatrix; UInt; UInt; UInt]) ;
   add_unqualified
-    ("sub_row", ReturnType URowVector, [UMatrix; UInt; UInt; UInt]) ;
+    ("sub_col", ReturnType UVector, [UMatrix; UInt; UInt; UInt], AoS) ;
+  add_unqualified
+    ("sub_row", ReturnType URowVector, [UMatrix; UInt; UInt; UInt], AoS) ;
   List.iter
     ~f:(fun i ->
       add_unqualified
         ( "subtract"
         , ReturnType (List.nth_exn bare_types i)
-        , [List.nth_exn bare_types i; List.nth_exn bare_types i] ) )
+        , [List.nth_exn bare_types i; List.nth_exn bare_types i]
+        , AoS ) )
     (List.range 0 bare_types_size) ;
-  add_unqualified ("subtract", ReturnType UVector, [UVector; UReal]) ;
-  add_unqualified ("subtract", ReturnType URowVector, [URowVector; UReal]) ;
-  add_unqualified ("subtract", ReturnType UMatrix, [UMatrix; UReal]) ;
-  add_unqualified ("subtract", ReturnType UVector, [UReal; UVector]) ;
-  add_unqualified ("subtract", ReturnType URowVector, [UReal; URowVector]) ;
-  add_unqualified ("subtract", ReturnType UMatrix, [UReal; UMatrix]) ;
-  add_unqualified ("sum", ReturnType UInt, [UArray UInt]) ;
-  add_unqualified ("sum", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("sum", ReturnType UReal, [UVector]) ;
-  add_unqualified ("sum", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("sum", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("svd_U", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("svd_V", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("symmetrize_from_lower_tri", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("tail", ReturnType URowVector, [URowVector; UInt]) ;
-  add_unqualified ("tail", ReturnType UVector, [UVector; UInt]) ;
+  add_unqualified ("subtract", ReturnType UVector, [UVector; UReal], AoS) ;
+  add_unqualified ("subtract", ReturnType URowVector, [URowVector; UReal], AoS) ;
+  add_unqualified ("subtract", ReturnType UMatrix, [UMatrix; UReal], AoS) ;
+  add_unqualified ("subtract", ReturnType UVector, [UReal; UVector], AoS) ;
+  add_unqualified ("subtract", ReturnType URowVector, [UReal; URowVector], AoS) ;
+  add_unqualified ("subtract", ReturnType UMatrix, [UReal; UMatrix], AoS) ;
+  add_unqualified ("sum", ReturnType UInt, [UArray UInt], AoS) ;
+  add_unqualified ("sum", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("sum", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("sum", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("sum", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("svd_U", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("svd_V", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified
+    ("symmetrize_from_lower_tri", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("tail", ReturnType URowVector, [URowVector; UInt], AoS) ;
+  add_unqualified ("tail", ReturnType UVector, [UVector; UInt], AoS) ;
   List.iter
     ~f:(fun t ->
       List.iter
@@ -1779,71 +2150,83 @@ let () =
           add_unqualified
             ( "tail"
             , ReturnType (bare_array_type (t, j))
-            , [bare_array_type (t, j); UInt] ) )
+            , [bare_array_type (t, j); UInt]
+            , AoS ) )
         (List.range 1 4) )
     bare_types ;
-  add_unqualified ("tcrossprod", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("to_array_1d", ReturnType (UArray UReal), [UMatrix]) ;
-  add_unqualified ("to_array_1d", ReturnType (UArray UReal), [UVector]) ;
-  add_unqualified ("to_array_1d", ReturnType (UArray UReal), [URowVector]) ;
+  add_unqualified ("tcrossprod", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("to_array_1d", ReturnType (UArray UReal), [UMatrix], AoS) ;
+  add_unqualified ("to_array_1d", ReturnType (UArray UReal), [UVector], AoS) ;
+  add_unqualified ("to_array_1d", ReturnType (UArray UReal), [URowVector], AoS) ;
   List.iter
     ~f:(fun i ->
       add_unqualified
-        ("to_array_1d", ReturnType (UArray UReal), [bare_array_type (UReal, i)]) ;
+        ( "to_array_1d"
+        , ReturnType (UArray UReal)
+        , [bare_array_type (UReal, i)]
+        , AoS ) ;
       add_unqualified
-        ("to_array_1d", ReturnType (UArray UInt), [bare_array_type (UInt, i)])
-      )
+        ( "to_array_1d"
+        , ReturnType (UArray UInt)
+        , [bare_array_type (UInt, i)]
+        , AoS ) )
     (List.range 1 10) ;
   add_unqualified
-    ("to_array_2d", ReturnType (bare_array_type (UReal, 2)), [UMatrix]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UMatrix; UInt; UInt]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UMatrix; UInt; UInt; UInt]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UVector]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt; UInt]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [URowVector]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UArray URowVector]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [URowVector; UInt; UInt]) ;
+    ("to_array_2d", ReturnType (bare_array_type (UReal, 2)), [UMatrix], AoS) ;
+  add_unqualified ("to_matrix", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("to_matrix", ReturnType UMatrix, [UMatrix; UInt; UInt], AoS) ;
   add_unqualified
-    ("to_matrix", ReturnType UMatrix, [URowVector; UInt; UInt; UInt]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UArray UReal; UInt; UInt]) ;
+    ("to_matrix", ReturnType UMatrix, [UMatrix; UInt; UInt; UInt], AoS) ;
+  add_unqualified ("to_matrix", ReturnType UMatrix, [UVector], AoS) ;
+  add_unqualified ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt], AoS) ;
   add_unqualified
-    ("to_matrix", ReturnType UMatrix, [UArray UReal; UInt; UInt; UInt]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [UArray UInt; UInt; UInt]) ;
+    ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt; UInt], AoS) ;
+  add_unqualified ("to_matrix", ReturnType UMatrix, [URowVector], AoS) ;
+  add_unqualified ("to_matrix", ReturnType UMatrix, [UArray URowVector], AoS) ;
   add_unqualified
-    ("to_matrix", ReturnType UMatrix, [UArray UInt; UInt; UInt; UInt]) ;
+    ("to_matrix", ReturnType UMatrix, [URowVector; UInt; UInt], AoS) ;
   add_unqualified
-    ("to_matrix", ReturnType UMatrix, [bare_array_type (UReal, 2)]) ;
-  add_unqualified ("to_matrix", ReturnType UMatrix, [bare_array_type (UInt, 2)]) ;
-  add_unqualified ("to_row_vector", ReturnType URowVector, [UMatrix]) ;
-  add_unqualified ("to_row_vector", ReturnType URowVector, [UVector]) ;
-  add_unqualified ("to_row_vector", ReturnType URowVector, [URowVector]) ;
-  add_unqualified ("to_row_vector", ReturnType URowVector, [UArray UReal]) ;
-  add_unqualified ("to_row_vector", ReturnType URowVector, [UArray UInt]) ;
-  add_unqualified ("to_vector", ReturnType UVector, [UMatrix]) ;
-  add_unqualified ("to_vector", ReturnType UVector, [UVector]) ;
-  add_unqualified ("to_vector", ReturnType UVector, [URowVector]) ;
-  add_unqualified ("to_vector", ReturnType UVector, [UArray UReal]) ;
-  add_unqualified ("to_vector", ReturnType UVector, [UArray UInt]) ;
-  add_unqualified ("trace", ReturnType UReal, [UMatrix]) ;
+    ("to_matrix", ReturnType UMatrix, [URowVector; UInt; UInt; UInt], AoS) ;
   add_unqualified
-    ("trace_gen_quad_form", ReturnType UReal, [UMatrix; UMatrix; UMatrix]) ;
-  add_unqualified ("trace_quad_form", ReturnType UReal, [UMatrix; UVector]) ;
-  add_unqualified ("trace_quad_form", ReturnType UReal, [UMatrix; UMatrix]) ;
-  add_unqualified ("transpose", ReturnType URowVector, [UVector]) ;
-  add_unqualified ("transpose", ReturnType UVector, [URowVector]) ;
-  add_unqualified ("transpose", ReturnType UMatrix, [UMatrix]) ;
-  add_unqualified ("uniform_simplex", ReturnType UVector, [UInt]) ;
-  add_unqualified ("variance", ReturnType UReal, [UArray UReal]) ;
-  add_unqualified ("variance", ReturnType UReal, [UVector]) ;
-  add_unqualified ("variance", ReturnType UReal, [URowVector]) ;
-  add_unqualified ("variance", ReturnType UReal, [UMatrix]) ;
-  add_unqualified ("wishart_rng", ReturnType UMatrix, [UReal; UMatrix]) ;
-  add_unqualified ("zeros_int_array", ReturnType (UArray UInt), [UInt]) ;
-  add_unqualified ("zeros_array", ReturnType (UArray UReal), [UInt]) ;
-  add_unqualified ("zeros_row_vector", ReturnType URowVector, [UInt]) ;
-  add_unqualified ("zeros_vector", ReturnType UVector, [UInt]) ;
+    ("to_matrix", ReturnType UMatrix, [UArray UReal; UInt; UInt], AoS) ;
+  add_unqualified
+    ("to_matrix", ReturnType UMatrix, [UArray UReal; UInt; UInt; UInt], AoS) ;
+  add_unqualified
+    ("to_matrix", ReturnType UMatrix, [UArray UInt; UInt; UInt], AoS) ;
+  add_unqualified
+    ("to_matrix", ReturnType UMatrix, [UArray UInt; UInt; UInt; UInt], AoS) ;
+  add_unqualified
+    ("to_matrix", ReturnType UMatrix, [bare_array_type (UReal, 2)], AoS) ;
+  add_unqualified
+    ("to_matrix", ReturnType UMatrix, [bare_array_type (UInt, 2)], AoS) ;
+  add_unqualified ("to_row_vector", ReturnType URowVector, [UMatrix], AoS) ;
+  add_unqualified ("to_row_vector", ReturnType URowVector, [UVector], AoS) ;
+  add_unqualified ("to_row_vector", ReturnType URowVector, [URowVector], AoS) ;
+  add_unqualified ("to_row_vector", ReturnType URowVector, [UArray UReal], AoS) ;
+  add_unqualified ("to_row_vector", ReturnType URowVector, [UArray UInt], AoS) ;
+  add_unqualified ("to_vector", ReturnType UVector, [UMatrix], AoS) ;
+  add_unqualified ("to_vector", ReturnType UVector, [UVector], AoS) ;
+  add_unqualified ("to_vector", ReturnType UVector, [URowVector], AoS) ;
+  add_unqualified ("to_vector", ReturnType UVector, [UArray UReal], AoS) ;
+  add_unqualified ("to_vector", ReturnType UVector, [UArray UInt], AoS) ;
+  add_unqualified ("trace", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified
+    ("trace_gen_quad_form", ReturnType UReal, [UMatrix; UMatrix; UMatrix], AoS) ;
+  add_unqualified ("trace_quad_form", ReturnType UReal, [UMatrix; UVector], AoS) ;
+  add_unqualified ("trace_quad_form", ReturnType UReal, [UMatrix; UMatrix], AoS) ;
+  add_unqualified ("transpose", ReturnType URowVector, [UVector], AoS) ;
+  add_unqualified ("transpose", ReturnType UVector, [URowVector], AoS) ;
+  add_unqualified ("transpose", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified ("uniform_simplex", ReturnType UVector, [UInt], AoS) ;
+  add_unqualified ("variance", ReturnType UReal, [UArray UReal], AoS) ;
+  add_unqualified ("variance", ReturnType UReal, [UVector], AoS) ;
+  add_unqualified ("variance", ReturnType UReal, [URowVector], AoS) ;
+  add_unqualified ("variance", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("wishart_rng", ReturnType UMatrix, [UReal; UMatrix], AoS) ;
+  add_unqualified ("zeros_int_array", ReturnType (UArray UInt), [UInt], AoS) ;
+  add_unqualified ("zeros_array", ReturnType (UArray UReal), [UInt], AoS) ;
+  add_unqualified ("zeros_row_vector", ReturnType URowVector, [UInt], AoS) ;
+  add_unqualified ("zeros_vector", ReturnType UVector, [UInt], AoS) ;
   (* Now add all the manually added stuff to the main hashtable used
      for type-checking *)
   Hashtbl.iteri manual_stan_math_signatures ~f:(fun ~key ~data ->

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -308,7 +308,7 @@ module Helpers = struct
         let rows =
           Expr.Fixed.
             { meta= emeta'
-            ; pattern= FunApp (StanLib ("rows", FnPlain), [iteratee]) }
+            ; pattern= FunApp (StanLib ("rows", FnPlain, AoS), [iteratee]) }
         in
         mk_for_iteratee rows (fun e -> for_each bodyfn e smeta) iteratee smeta
     | UArray _ -> mk_for_iteratee (len iteratee) bodyfn iteratee smeta
@@ -356,10 +356,10 @@ module Helpers = struct
   let rec for_scalar st bodyfn var smeta =
     match st with
     | SizedType.SInt | SReal -> bodyfn var
-    | SVector d | SRowVector d -> mk_for_iteratee d bodyfn var smeta
-    | SMatrix (d1, d2) ->
+    | SVector (_, d) | SRowVector (_, d) -> mk_for_iteratee d bodyfn var smeta
+    | SMatrix (mem_pattern, d1, d2) ->
         mk_for_iteratee d1
-          (fun e -> for_scalar (SRowVector d2) bodyfn e smeta)
+          (fun e -> for_scalar (SRowVector (mem_pattern, d2)) bodyfn e smeta)
           var smeta
     | SArray (t, d) ->
         mk_for_iteratee d (fun e -> for_scalar t bodyfn e smeta) var smeta
@@ -379,9 +379,9 @@ module Helpers = struct
       | SizedType.SArray (t, d) ->
           let bodyfn' var = mk_for_iteratee d bodyfn var smeta in
           go t bodyfn' var smeta
-      | SMatrix (d1, d2) ->
+      | SMatrix (mem_pattern, d1, d2) ->
           let bodyfn' var = mk_for_iteratee d1 bodyfn var smeta in
-          go (SRowVector d2) bodyfn' var smeta
+          go (SRowVector (mem_pattern, d2)) bodyfn' var smeta
       | _ -> for_scalar st bodyfn var smeta
     in
     go st (Fn.compose bodyfn invert_index_order) var smeta

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -8,7 +8,11 @@ type t =
   | URowVector
   | UMatrix
   | UArray of t
-  | UFun of (autodifftype * t) list * returntype * bool Fun_kind.suffix
+  | UFun of
+      (autodifftype * t) list
+      * returntype
+      * bool Fun_kind.suffix
+      * Common.Helpers.mem_pattern
   | UMathLibraryFunction
 
 and autodifftype = DataOnly | AutoDiffable
@@ -49,7 +53,7 @@ let rec pp ppf = function
       let ut2, d = unwind_array_type ut in
       let array_str = "[" ^ String.make d ',' ^ "]" in
       Fmt.pf ppf "array%s %a" array_str pp ut2
-  | UFun (argtypes, rt, _) ->
+  | UFun (argtypes, rt, _, _) ->
       Fmt.pf ppf {|@[<h>(%a) => %a@]|}
         Fmt.(list pp_fun_arg ~sep:comma)
         argtypes pp_returntype rt
@@ -80,7 +84,7 @@ let check_of_same_type_mod_conv name t1 t2 =
   else
     match (t1, t2) with
     | UReal, UInt -> true
-    | UFun (l1, rt1, s1), UFun (l2, rt2, s2) -> (
+    | UFun (l1, rt1, s1, _), UFun (l2, rt2, s2, _) -> (
         s1 = s2 && rt1 = rt2
         &&
         match

--- a/src/stan_math_backend/Cpp_Json.ml
+++ b/src/stan_math_backend/Cpp_Json.ml
@@ -9,9 +9,9 @@ let rec sizedtype_to_json (st : Expr.Typed.t SizedType.t) : Yojson.Basic.t =
   match st with
   | SInt -> `Assoc [("name", `String "int")]
   | SReal -> `Assoc [("name", `String "real")]
-  | SVector d | SRowVector d ->
+  | SVector (_, d) | SRowVector (_, d) ->
       `Assoc [("name", `String "vector"); ("length", `String (emit_cpp_expr d))]
-  | SMatrix (d1, d2) ->
+  | SMatrix (_, d1, d2) ->
       `Assoc
         [ ("name", `String "matrix")
         ; ("rows", `String (emit_cpp_expr d1))
@@ -35,7 +35,9 @@ let%expect_test "outvar to json pretty" =
        vector[N] var_one[K];
      }
   *)
-  ("var_one", SArray (SVector (var "N"), var "K"), Parameters)
+  ( "var_one"
+  , SArray (SVector (Common.Helpers.AoS, var "N"), var "K")
+  , Parameters )
   |> out_var_json |> Yojson.Basic.pretty_to_string |> print_endline ;
   [%expect
     {|
@@ -67,7 +69,7 @@ let out_var_interpolated_json_str vars =
 let%expect_test "outvar to json" =
   let var x = {Expr.Fixed.pattern= Var x; meta= Expr.Typed.Meta.empty} in
   [ ( "var_one"
-    , SizedType.SArray (SVector (var "N"), var "K")
+    , SizedType.SArray (SVector (AoS, var "N"), var "K")
     , Program.Parameters ) ]
   |> out_var_interpolated_json_str |> print_endline ;
   [%expect

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -937,7 +937,7 @@ let is_fun_used_with_variadic_fn variadic_fn_test p =
   let rec find_functors_expr accum Expr.Fixed.({pattern; _}) =
     String.Set.union accum
       ( match pattern with
-      | FunApp (StanLib (x, FnPlain), {pattern= Var f; _} :: _)
+      | FunApp (StanLib (x, FnPlain, _), {pattern= Var f; _} :: _)
         when variadic_fn_test x ->
           String.Set.of_list [Utils.stdlib_distribution_name f]
       | x -> Expr.Fixed.Pattern.fold find_functors_expr accum x )

--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -53,8 +53,9 @@ let rec pp_initialize ppf (st, adtype) =
   match st with
   | SizedType.SInt -> pf ppf "std::numeric_limits<int>::min()"
   | SReal -> pf ppf "%s" init_nan
-  | SVector d | SRowVector d -> pf ppf "%a(%a)" pp_st (st, adtype) pp_expr d
-  | SMatrix (d1, d2) ->
+  | SVector (_, d) | SRowVector (_, d) ->
+      pf ppf "%a(%a)" pp_st (st, adtype) pp_expr d
+  | SMatrix (_, d1, d2) ->
       pf ppf "%a(%a, %a)" pp_st (st, adtype) pp_expr d1 pp_expr d2
   | SArray (t, d) ->
       pf ppf "%a(%a, %a)" pp_st (st, adtype) pp_expr d pp_initialize (t, adtype)
@@ -72,7 +73,7 @@ let%expect_test "set size mat array" =
   let int = Expr.Helpers.int in
   strf "@[<v>%a@]" pp_assign_sized
     ( "d"
-    , SArray (SArray (SMatrix (int 2, int 3), int 4), int 5)
+    , SArray (SArray (SMatrix (AoS, int 2, int 3), int 4), int 5)
     , DataOnly
     , false )
   |> print_endline ;
@@ -83,7 +84,7 @@ let%expect_test "set size mat array" =
   let int = Expr.Helpers.int in
   strf "@[<v>%a@]" pp_assign_sized
     ( "d"
-    , SArray (SArray (SMatrix (int 2, int 3), int 4), int 5)
+    , SArray (SArray (SMatrix (AoS, int 2, int 3), int 4), int 5)
     , DataOnly
     , true )
   |> print_endline ;
@@ -113,10 +114,10 @@ let pp_assign_data ppf
   in
   let pp_placement_new ppf (decl_id, st) =
     match st with
-    | SizedType.SVector d | SRowVector d ->
+    | SizedType.SVector (_, d) | SRowVector (_, d) ->
         pf ppf "@[<hov 2>new (&%s) Eigen::Map<%a>(%s__.data(), %a);@]@,"
           decl_id pp_st (st, DataOnly) decl_id pp_expr d
-    | SMatrix (d1, d2) ->
+    | SMatrix (_, d1, d2) ->
         pf ppf "@[<hov 2>new (&%s) Eigen::Map<%a>(%s__.data(), %a, %a);@]@,"
           decl_id pp_st (st, DataOnly) decl_id pp_expr d1 pp_expr d2
     | _ -> ()
@@ -137,7 +138,9 @@ let%expect_test "set size map int array no initialize" =
 let%expect_test "set size map mat array" =
   let int = Expr.Helpers.int in
   strf "@[<v>%a@]" pp_assign_data
-    ("darrmat", SArray (SArray (SMatrix (int 2, int 3), int 4), int 5), true)
+    ( "darrmat"
+    , SArray (SArray (SMatrix (AoS, int 2, int 3), int 4), int 5)
+    , true )
   |> print_endline ;
   [%expect
     {|
@@ -146,7 +149,7 @@ let%expect_test "set size map mat array" =
 
 let%expect_test "set size map mat" =
   let int = Expr.Helpers.int in
-  strf "@[<v>%a@]" pp_assign_data ("dmat", SMatrix (int 2, int 3), false)
+  strf "@[<v>%a@]" pp_assign_data ("dmat", SMatrix (AoS, int 2, int 3), false)
   |> print_endline ;
   [%expect
     {|
@@ -334,7 +337,7 @@ let rec pp_statement (ppf : Format.formatter) Stmt.Fixed.({pattern; meta}) =
       let fname, extra_args = trans_math_fn f in
       pf ppf "%s(@[<hov>%a@]);" fname (list ~sep:comma pp_expr)
         (extra_args @ args)
-  | NRFunApp (StanLib (fname, _), args) ->
+  | NRFunApp (StanLib (fname, _, _), args) ->
       pf ppf "%s(@[<hov>%a@]);" fname (list ~sep:comma pp_expr) args
   | NRFunApp (UserDefined (fname, suffix), args) ->
       pf ppf "%a;" pp_user_defined_fun (fname, suffix, args)

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -51,7 +51,8 @@ let opencl_supported_functions =
 let opencl_suffix = "_opencl__"
 
 let to_matrix_cl e =
-  Expr.Fixed.{e with pattern= FunApp (StanLib ("to_matrix_cl", FnPlain), [e])}
+  Expr.Fixed.
+    {e with pattern= FunApp (StanLib ("to_matrix_cl", FnPlain, AoS), [e])}
 
 let rec switch_expr_to_opencl available_cl_vars (Expr.Fixed.({pattern; _}) as e)
     =
@@ -78,9 +79,13 @@ let rec switch_expr_to_opencl available_cl_vars (Expr.Fixed.({pattern; _}) as e)
   in
   let is_fn_opencl_supported f = Set.mem opencl_supported_functions f in
   match pattern with
-  | FunApp (StanLib (f, sfx), args) when is_fn_opencl_supported f ->
+  | FunApp (StanLib (f, sfx, mem_pattern), args) when is_fn_opencl_supported f
+    ->
       let trigger = Map.find opencl_trigger_restrictions f in
-      {e with pattern= FunApp (StanLib (f, sfx), maybe_map_args args trigger)}
+      { e with
+        pattern=
+          FunApp (StanLib (f, sfx, mem_pattern), maybe_map_args args trigger)
+      }
   | x ->
       { e with
         pattern=
@@ -171,8 +176,8 @@ let read_constrain_dims constrain_transform st =
   let rec constrain_get_dims st =
     match st with
     | SizedType.SInt | SReal -> []
-    | SVector d | SRowVector d -> [d]
-    | SMatrix (_, dim2) -> [dim2]
+    | SVector (_, d) | SRowVector (_, d) -> [d]
+    | SMatrix (_, _, dim2) -> [dim2]
     | SArray (t, dim) -> dim :: constrain_get_dims t
   in
   match constrain_transform with
@@ -202,7 +207,10 @@ let param_read smeta
       Expr.(
         Helpers.(
           internal_funapp
-            (FnReadParam {constrain= out_trans; dims})
+            (FnReadParam
+               { constrain= out_trans
+               ; dims
+               ; mem_pattern= SizedType.get_mem_pattern cst })
             []
             Typed.Meta.{emeta with type_= ut}))
     in
@@ -357,8 +365,10 @@ let rec map_fn_names s =
     let pattern =
       Expr.Fixed.(
         match e.pattern with
-        | FunApp (StanLib (f, sfx), a) when Map.mem fn_name_map f ->
-            Pattern.FunApp (StanLib (Map.find_exn fn_name_map f, sfx), a)
+        | FunApp (StanLib (f, sfx, mem_pattern), a) when Map.mem fn_name_map f
+          ->
+            Pattern.FunApp
+              (StanLib (Map.find_exn fn_name_map f, sfx, mem_pattern), a)
         | expr -> Pattern.map map_fn_names_expr expr)
     in
     {e with pattern}
@@ -366,8 +376,10 @@ let rec map_fn_names s =
   let stmt =
     Stmt.Fixed.(
       match s.pattern with
-      | NRFunApp (StanLib (f, sfx), a) when Map.mem fn_name_map f ->
-          Pattern.NRFunApp (StanLib (Map.find_exn fn_name_map f, sfx), a)
+      | NRFunApp (StanLib (f, sfx, mem_pattern), a) when Map.mem fn_name_map f
+        ->
+          Pattern.NRFunApp
+            (StanLib (Map.find_exn fn_name_map f, sfx, mem_pattern), a)
       | stmt -> Pattern.map map_fn_names_expr map_fn_names stmt)
   in
   {s with pattern= stmt}
@@ -401,7 +413,7 @@ let%expect_test "collect vars expr" =
   let args = List.map ~f:mkvar ["y"; "x_opencl__"; "z"; "w_opencl__"] in
   let fnapp =
     Expr.
-      { Fixed.pattern= FunApp (StanLib ("print", FnPlain), args)
+      { Fixed.pattern= FunApp (StanLib ("print", FnPlain, AoS), args)
       ; meta= Typed.Meta.empty }
   in
   Stmt.Fixed.{pattern= TargetPE fnapp; meta= Location_span.empty}

--- a/src/tfp_backend/Code_gen.ml
+++ b/src/tfp_backend/Code_gen.ml
@@ -19,14 +19,14 @@ let rec pp_expr ppf {Expr.Fixed.pattern; _} =
   | Var ident -> string ppf ident
   | Lit (Str, s) -> pf ppf "%S" s
   | Lit (_, s) -> pf ppf "tf__.cast(%s, tf__.float64)" s
-  | FunApp (StanLib (f, _), obs :: dist_params)
+  | FunApp (StanLib (f, _, _), obs :: dist_params)
     when f = Transform_mir.dist_prefix ^ "CholeskyLKJ" ->
       pf ppf "%s(@[<hov>(%a).shape[0], %a@]).log_prob(%a)" f pp_expr obs
         (list ~sep:comma pp_expr) dist_params pp_expr obs
-  | FunApp (StanLib (f, _), obs :: dist_params)
+  | FunApp (StanLib (f, _, _), obs :: dist_params)
     when String.is_prefix ~prefix:Transform_mir.dist_prefix f ->
       pf ppf "%a.log_prob(%a)" pp_call (f, pp_expr, dist_params) pp_expr obs
-  | FunApp (StanLib (f, _), args)
+  | FunApp (StanLib (f, _, _), args)
     when Operator.of_string_opt f |> Option.is_some -> (
     match
       ( Operator.of_string_opt f |> Option.value_exn |> pystring_of_operator
@@ -36,7 +36,7 @@ let rec pp_expr ppf {Expr.Fixed.pattern; _} =
     | op, [unary] -> pf ppf "%s%a" op pp_paren unary
     | op, args ->
         raise_s [%message "Need to implement" op (args : Expr.Typed.t list)] )
-  | FunApp ((UserDefined (fname, _) | StanLib (fname, _)), args) ->
+  | FunApp ((UserDefined (fname, _) | StanLib (fname, _, _)), args) ->
       pp_call ppf (fname, pp_expr, args)
   | FunApp (CompilerInternal _, _) as e ->
       raise_s
@@ -65,8 +65,8 @@ and pp_indices ppf = function
 and pp_paren ppf expr =
   match expr.Expr.Fixed.pattern with
   | TernaryIf _ | EAnd _ | EOr _ -> pf ppf "(%a)" pp_expr expr
-  | FunApp (StanLib (f, _), _) when Operator.of_string_opt f |> Option.is_some
-    ->
+  | FunApp (StanLib (f, _, _), _)
+    when Operator.of_string_opt f |> Option.is_some ->
       pf ppf "(%a)" pp_expr expr
   | _ -> pp_expr ppf expr
 
@@ -75,7 +75,7 @@ let rec pp_stmt ppf s =
   | Assignment ((lhs, _, indices), rhs) ->
       pf ppf "%s%a = %a" lhs pp_indices indices pp_expr rhs
   | TargetPE rhs -> pf ppf "target += tf__.reduce_sum(%a)" pp_expr rhs
-  | NRFunApp (StanLib (f, _), args) | NRFunApp (UserDefined (f, _), args) ->
+  | NRFunApp (StanLib (f, _, _), args) | NRFunApp (UserDefined (f, _), args) ->
       pp_call ppf (f, pp_expr, args)
   | Break -> pf ppf "break"
   | Continue -> pf ppf "continue"

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -10,7 +10,7 @@
          (((pattern
             (IfElse
              ((pattern
-               (FunApp (StanLib Equals__ FnPlain)
+               (FunApp (StanLib Equals__ FnPlain AoS)
                 (((pattern (Var n))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                  ((pattern (Lit Int 0))
@@ -26,13 +26,13 @@
           ((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern (Var n))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern
                     (FunApp (UserDefined foo FnPlain)
                      (((pattern
-                        (FunApp (StanLib Minus__ FnPlain)
+                        (FunApp (StanLib Minus__ FnPlain AoS)
                          (((pattern (Var n))
                            (meta
                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -93,9 +93,9 @@
                 ((pattern (Lit Int 2))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              ((pattern
-               (FunApp (StanLib Minus__ FnPlain)
+               (FunApp (StanLib Minus__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib PMinus__ FnPlain)
+                   (FunApp (StanLib PMinus__ FnPlain AoS)
                     (((pattern
                        (Indexed
                         ((pattern (Var y))
@@ -111,7 +111,7 @@
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern
-                   (FunApp (StanLib Times__ FnPlain)
+                   (FunApp (StanLib Times__ FnPlain AoS)
                     (((pattern
                        (Indexed
                         ((pattern (Var theta))
@@ -228,7 +228,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib normal_rng FnRng)
+                (FunApp (StanLib normal_rng FnRng AoS)
                  (((pattern (Var mu))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -247,7 +247,7 @@
          (((pattern
             (TargetPE
              ((pattern
-               (FunApp (StanLib normal_log (FnLpdf false))
+               (FunApp (StanLib normal_log (FnLpdf false) AoS)
                 (((pattern (Var u))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -260,12 +260,12 @@
           ((pattern
             (TargetPE
              ((pattern
-               (FunApp (StanLib uniform_lpdf (FnLpdf true))
+               (FunApp (StanLib uniform_lpdf (FnLpdf true) AoS)
                 (((pattern (Var u))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern
-                   (FunApp (StanLib PMinus__ FnPlain)
+                   (FunApp (StanLib PMinus__ FnPlain AoS)
                     (((pattern (Lit Int 100))
                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -637,7 +637,7 @@
                    (Decl (decl_adtype AutoDiffable) (decl_id vs)
                     (decl_type
                      (Sized
-                      (SMatrix
+                      (SMatrix AoS
                        ((pattern (Lit Int 2))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -653,7 +653,7 @@
                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                     (upper
                      ((pattern
-                       (FunApp (StanLib rows FnPlain)
+                       (FunApp (StanLib rows FnPlain AoS)
                         (((pattern (Var vs))
                           (meta
                            ((type_ UMatrix) (loc <opaque>)
@@ -743,7 +743,7 @@
                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                     (upper
                      ((pattern
-                       (FunApp (StanLib rows FnPlain)
+                       (FunApp (StanLib rows FnPlain AoS)
                         (((pattern (Var vs))
                           (meta
                            ((type_ UMatrix) (loc <opaque>)
@@ -842,7 +842,7 @@
                    (Decl (decl_adtype AutoDiffable) (decl_id vs)
                     (decl_type
                      (Sized
-                      (SVector
+                      (SVector AoS
                        ((pattern (Lit Int 2))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -968,7 +968,7 @@
                    (Decl (decl_adtype AutoDiffable) (decl_id vs)
                     (decl_type
                      (Sized
-                      (SRowVector
+                      (SRowVector AoS
                        ((pattern (Lit Int 2))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -1197,7 +1197,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib rep_array FnPlain)
+                (FunApp (StanLib rep_array FnPlain AoS)
                  (((pattern (Var t))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1217,11 +1217,11 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Plus__ FnPlain)
+                (FunApp (StanLib Plus__ FnPlain AoS)
                  (((pattern (Var x))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
-                  ((pattern (FunApp (StanLib target FnTarget) ()))
+                  ((pattern (FunApp (StanLib target FnTarget AoS) ()))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1260,9 +1260,9 @@
           ((pattern
             (Assignment (abs_diff UReal ())
              ((pattern
-               (FunApp (StanLib fabs FnPlain)
+               (FunApp (StanLib fabs FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Minus__ FnPlain)
+                   (FunApp (StanLib Minus__ FnPlain AoS)
                     (((pattern (Var x))
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1276,11 +1276,11 @@
           ((pattern
             (Assignment (avg_scale UReal ())
              ((pattern
-               (FunApp (StanLib Divide__ FnPlain)
+               (FunApp (StanLib Divide__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Plus__ FnPlain)
+                   (FunApp (StanLib Plus__ FnPlain AoS)
                     (((pattern
-                       (FunApp (StanLib fabs FnPlain)
+                       (FunApp (StanLib fabs FnPlain AoS)
                         (((pattern (Var x))
                           (meta
                            ((type_ UReal) (loc <opaque>)
@@ -1288,7 +1288,7 @@
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                      ((pattern
-                       (FunApp (StanLib fabs FnPlain)
+                       (FunApp (StanLib fabs FnPlain AoS)
                         (((pattern (Var y))
                           (meta
                            ((type_ UReal) (loc <opaque>)
@@ -1304,9 +1304,9 @@
           ((pattern
             (IfElse
              ((pattern
-               (FunApp (StanLib Greater__ FnPlain)
+               (FunApp (StanLib Greater__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Divide__ FnPlain)
+                   (FunApp (StanLib Divide__ FnPlain AoS)
                     (((pattern (Var abs_diff))
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1343,9 +1343,9 @@
           ((pattern
             (IfElse
              ((pattern
-               (FunApp (StanLib Less__ FnPlain)
+               (FunApp (StanLib Less__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Divide__ FnPlain)
+                   (FunApp (StanLib Divide__ FnPlain AoS)
                     (((pattern (Var abs_diff))
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1382,7 +1382,7 @@
           ((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Divide__ FnPlain)
+                (FunApp (StanLib Divide__ FnPlain AoS)
                  (((pattern (Var abs_diff))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1403,7 +1403,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Transpose__ FnPlain)
+                (FunApp (StanLib Transpose__ FnPlain AoS)
                  (((pattern
                     (FunApp (CompilerInternal FnMakeRowVec)
                      (((pattern (Lit Int 1))
@@ -1462,7 +1462,7 @@
               ((pattern (Lit Str "rows(mat)"))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib rows FnPlain)
+                (FunApp (StanLib rows FnPlain AoS)
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1475,7 +1475,7 @@
               ((pattern (Lit Str "cols(mat)"))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib cols FnPlain)
+                (FunApp (StanLib cols FnPlain AoS)
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1485,15 +1485,15 @@
             (Decl (decl_adtype AutoDiffable) (decl_id o)
              (decl_type
               (Sized
-               (SMatrix
+               (SMatrix AoS
                 ((pattern
-                  (FunApp (StanLib rows FnPlain)
+                  (FunApp (StanLib rows FnPlain AoS)
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern
-                  (FunApp (StanLib cols FnPlain)
+                  (FunApp (StanLib cols FnPlain AoS)
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1854,7 +1854,7 @@
               (Sized
                (SArray
                 (SArray
-                 (SMatrix
+                 (SMatrix AoS
                   ((pattern (Lit Int 40))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Lit Int 50))
@@ -2006,7 +2006,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Transpose__ FnPlain)
+                (FunApp (StanLib Transpose__ FnPlain AoS)
                  (((pattern
                     (FunApp (CompilerInternal FnMakeRowVec)
                      (((pattern (Lit Int 1))
@@ -2054,7 +2054,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id l)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 10))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
@@ -2062,7 +2062,7 @@
           ((pattern
             (Assignment (l UVector ())
              ((pattern
-               (FunApp (StanLib Times__ FnPlain)
+               (FunApp (StanLib Times__ FnPlain AoS)
                 (((pattern (Var mu))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -2086,7 +2086,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id l)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 10))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
@@ -2094,12 +2094,12 @@
           ((pattern
             (Assignment (l UVector ())
              ((pattern
-               (FunApp (StanLib Times__ FnPlain)
+               (FunApp (StanLib Times__ FnPlain AoS)
                 (((pattern (Var mu))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern
-                   (FunApp (StanLib Transpose__ FnPlain)
+                   (FunApp (StanLib Transpose__ FnPlain AoS)
                     (((pattern
                        (FunApp (CompilerInternal FnMakeRowVec)
                         (((pattern (Lit Int 1))
@@ -2180,7 +2180,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id f_x)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 2))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
@@ -2192,7 +2192,7 @@
                 ((pattern (Lit Int 1))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              ((pattern
-               (FunApp (StanLib Minus__ FnPlain)
+               (FunApp (StanLib Minus__ FnPlain AoS)
                 (((pattern
                    (Indexed
                     ((pattern (Var x))
@@ -2224,7 +2224,7 @@
                 ((pattern (Lit Int 2))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              ((pattern
-               (FunApp (StanLib Minus__ FnPlain)
+               (FunApp (StanLib Minus__ FnPlain AoS)
                 (((pattern
                    (Indexed
                     ((pattern (Var x))
@@ -2267,7 +2267,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id lpmf)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 1))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
@@ -2320,12 +2320,12 @@
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_vec
-    (SVector
+    (SVector AoS
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_1d_vec
     (SArray
-     (SVector
+     (SVector AoS
       ((pattern (Var N))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var N))
@@ -2334,7 +2334,7 @@
     (SArray
      (SArray
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var K))
@@ -2344,12 +2344,12 @@
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_row_vec
-    (SRowVector
+    (SRowVector AoS
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_1d_row_vec
     (SArray
-     (SRowVector
+     (SRowVector AoS
       ((pattern (Var N))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var N))
@@ -2358,7 +2358,7 @@
     (SArray
      (SArray
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var K))
@@ -2370,7 +2370,7 @@
    (d_ar_mat
     (SArray
      (SArray
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -2380,12 +2380,12 @@
      ((pattern (Lit Int 4))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_simplex
-    (SVector
+    (SVector AoS
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_1d_simplex
     (SArray
-     (SVector
+     (SVector AoS
       ((pattern (Var N))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var N))
@@ -2394,7 +2394,7 @@
     (SArray
      (SArray
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var K))
@@ -2404,20 +2404,20 @@
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_cfcov_54
-    (SMatrix
+    (SMatrix AoS
      ((pattern (Lit Int 5))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
      ((pattern (Lit Int 4))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_cfcov_33
-    (SMatrix
+    (SMatrix AoS
      ((pattern (Lit Int 3))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
      ((pattern (Lit Int 3))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_cfcov_33_ar
     (SArray
-     (SMatrix
+     (SMatrix AoS
       ((pattern (Lit Int 3))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
       ((pattern (Lit Int 3))
@@ -2469,14 +2469,14 @@
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_matrix
-    (SMatrix
+    (SMatrix AoS
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_matrix_array
     (SArray
-     (SMatrix
+     (SMatrix AoS
       ((pattern (Var d_int))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
       ((pattern (Var d_int))
@@ -2486,7 +2486,7 @@
    (d_matrix_array_2d
     (SArray
      (SArray
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Var d_int))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Var d_int))
@@ -2499,7 +2499,7 @@
     (SArray
      (SArray
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Var d_int))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Var d_int))
@@ -2511,12 +2511,12 @@
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_vector
-    (SVector
+    (SVector AoS
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_vector_array
     (SArray
-     (SVector
+     (SVector AoS
       ((pattern (Var d_int))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var d_int))
@@ -2524,7 +2524,7 @@
    (d_vector_array_2d
     (SArray
      (SArray
-      (SVector
+      (SVector AoS
        ((pattern (Var d_int))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       ((pattern (Lit Int 2))
@@ -2535,7 +2535,7 @@
     (SArray
      (SArray
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var d_int))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
@@ -2545,12 +2545,12 @@
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_row_vector
-    (SRowVector
+    (SRowVector AoS
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_row_vector_array
     (SArray
-     (SRowVector
+     (SRowVector AoS
       ((pattern (Var d_int))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var d_int))
@@ -2558,7 +2558,7 @@
    (d_row_vector_array_2d
     (SArray
      (SArray
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var d_int))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       ((pattern (Lit Int 2))
@@ -2569,7 +2569,7 @@
     (SArray
      (SArray
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var d_int))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
@@ -2643,7 +2643,7 @@
         (trans
          (Upper
           ((pattern
-            (FunApp (StanLib Times__ FnPlain)
+            (FunApp (StanLib Times__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Var M))
@@ -2654,7 +2654,7 @@
          ((pattern (Var K))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Var M))
@@ -2853,7 +2853,7 @@
         (trans
          (Lower
           ((pattern
-            (FunApp (StanLib PMinus__ FnPlain)
+            (FunApp (StanLib PMinus__ FnPlain AoS)
              (((pattern (Lit Real 2.0))
                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
@@ -2862,7 +2862,7 @@
          ((pattern (Var J))
           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
       (((pattern
-         (FunApp (StanLib PMinus__ FnPlain)
+         (FunApp (StanLib PMinus__ FnPlain AoS)
           (((pattern (Lit Real 2.0))
             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -2955,7 +2955,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -2983,7 +2983,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -3033,7 +3033,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -3057,7 +3057,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -3085,7 +3085,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -3135,7 +3135,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -3152,7 +3152,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -3390,7 +3390,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -3427,7 +3427,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -3508,7 +3508,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -3598,7 +3598,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -3618,7 +3618,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -3648,7 +3648,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -3844,7 +3844,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_matrix)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Var d_int))
@@ -3883,7 +3883,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -3925,7 +3925,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Var d_int))
@@ -3970,7 +3970,7 @@
         (SArray
          (SArray
           (SArray
-           (SMatrix
+           (SMatrix AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Var d_int))
@@ -3996,7 +3996,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_vector)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -4024,7 +4024,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -4055,7 +4055,7 @@
        (Sized
         (SArray
          (SArray
-          (SVector
+          (SVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -4089,7 +4089,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -4113,7 +4113,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_row_vector)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -4141,7 +4141,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -4172,7 +4172,7 @@
        (Sized
         (SArray
          (SArray
-          (SRowVector
+          (SRowVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -4206,7 +4206,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -4260,7 +4260,7 @@
    ((pattern
      (Assignment (td_1dk (UArray UInt) ())
       ((pattern
-        (FunApp (StanLib rep_array FnPlain)
+        (FunApp (StanLib rep_array FnPlain AoS)
          (((pattern (Lit Int 1))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -4283,7 +4283,7 @@
    ((pattern
      (Assignment (td_b UReal ())
       ((pattern
-        (FunApp (StanLib Times__ FnPlain)
+        (FunApp (StanLib Times__ FnPlain AoS)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var J))
@@ -4308,7 +4308,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -4332,7 +4332,7 @@
      (Decl (decl_adtype DataOnly) (decl_id td_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -4360,7 +4360,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -4410,7 +4410,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -4425,7 +4425,7 @@
      (Decl (decl_adtype DataOnly) (decl_id td_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 5))
@@ -4436,7 +4436,7 @@
      (Decl (decl_adtype DataOnly) (decl_id td_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -4447,7 +4447,7 @@
      (Decl (decl_adtype DataOnly) (decl_id x)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -4456,7 +4456,7 @@
      (Decl (decl_adtype DataOnly) (decl_id y)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -4627,7 +4627,7 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Divide__ FnPlain)
+                (FunApp (StanLib Divide__ FnPlain AoS)
                  (((pattern (Lit Real 1.0))
                    (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Var N))
@@ -4657,7 +4657,7 @@
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                       ((pattern
-                        (FunApp (StanLib Divide__ FnPlain)
+                        (FunApp (StanLib Divide__ FnPlain AoS)
                          (((pattern (Lit Real 1.0))
                            (meta
                             ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
@@ -4720,7 +4720,8 @@
                                            ((type_ UInt) (loc <opaque>)
                                             (adlevel DataOnly)))))))
                                       ((pattern
-                                        (FunApp (StanLib Divide__ FnPlain)
+                                        (FunApp
+                                         (StanLib Divide__ FnPlain AoS)
                                          (((pattern (Lit Real 1.0))
                                            (meta
                                             ((type_ UReal) (loc <opaque>)
@@ -4767,7 +4768,7 @@
                      (Decl (decl_adtype DataOnly) (decl_id l_mat)
                       (decl_type
                        (Sized
-                        (SMatrix
+                        (SMatrix AoS
                          ((pattern (Lit Int 2))
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -4823,13 +4824,13 @@
    ((pattern
      (Assignment (td_cfcov_54 UMatrix ())
       ((pattern
-        (FunApp (StanLib diag_matrix FnPlain)
+        (FunApp (StanLib diag_matrix FnPlain AoS)
          (((pattern
-            (FunApp (StanLib rep_vector FnPlain)
+            (FunApp (StanLib rep_vector FnPlain AoS)
              (((pattern (Lit Int 1))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib rows FnPlain)
+                (FunApp (StanLib rows FnPlain AoS)
                  (((pattern (Var td_cfcov_54))
                    (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -4839,13 +4840,13 @@
    ((pattern
      (Assignment (td_cfcov_33 UMatrix ())
       ((pattern
-        (FunApp (StanLib diag_matrix FnPlain)
+        (FunApp (StanLib diag_matrix FnPlain AoS)
          (((pattern
-            (FunApp (StanLib rep_vector FnPlain)
+            (FunApp (StanLib rep_vector FnPlain AoS)
              (((pattern (Lit Int 1))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib rows FnPlain)
+                (FunApp (StanLib rows FnPlain AoS)
                  (((pattern (Var td_cfcov_33))
                    (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -4862,7 +4863,7 @@
          (Decl (decl_adtype DataOnly) (decl_id blocked_tdata_vs)
           (decl_type
            (Sized
-            (SRowVector
+            (SRowVector AoS
              ((pattern (Lit Int 2))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
           (initialize true)))
@@ -5194,7 +5195,7 @@
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_matrix)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Var d_int))
@@ -5233,7 +5234,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -5275,7 +5276,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Var d_int))
@@ -5320,7 +5321,7 @@
         (SArray
          (SArray
           (SArray
-           (SMatrix
+           (SMatrix AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Var d_int))
@@ -5346,7 +5347,7 @@
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_vector)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -5374,7 +5375,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -5405,7 +5406,7 @@
        (Sized
         (SArray
          (SArray
-          (SVector
+          (SVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -5439,7 +5440,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -5463,7 +5464,7 @@
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_row_vector)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -5491,7 +5492,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -5523,7 +5524,7 @@
        (Sized
         (SArray
          (SArray
-          (SRowVector
+          (SRowVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -5558,7 +5559,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -5572,7 +5573,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -5582,7 +5583,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -5592,7 +5593,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -5602,7 +5603,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -5612,7 +5613,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array))
            (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -5622,7 +5623,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array))
            (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -5632,7 +5633,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_2d))
            (meta
             ((type_ (UArray (UArray UInt))) (loc <opaque>)
@@ -5645,7 +5646,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_2d))
            (meta
             ((type_ (UArray (UArray UInt))) (loc <opaque>)
@@ -5659,7 +5660,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UInt)))) (loc <opaque>)
@@ -5674,7 +5675,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UInt)))) (loc <opaque>)
@@ -5688,7 +5689,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array))
@@ -5698,7 +5699,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array))
@@ -5708,7 +5709,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_2d))
@@ -5721,7 +5722,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_2d))
@@ -5735,7 +5736,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_3d))
@@ -5750,7 +5751,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_3d))
@@ -5764,7 +5765,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array))
@@ -5774,7 +5775,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array))
@@ -5784,7 +5785,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_2d))
@@ -5797,7 +5798,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_2d))
@@ -5811,7 +5812,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_3d))
@@ -5826,7 +5827,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_3d))
@@ -5840,7 +5841,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array))
            (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -5850,7 +5851,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array))
            (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -5860,7 +5861,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_2d))
            (meta
             ((type_ (UArray (UArray UReal))) (loc <opaque>)
@@ -5873,7 +5874,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_2d))
            (meta
             ((type_ (UArray (UArray UReal))) (loc <opaque>)
@@ -5887,7 +5888,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -5902,7 +5903,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -5916,7 +5917,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array))
            (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array))
@@ -5926,7 +5927,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array))
            (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array))
@@ -5936,7 +5937,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_2d))
            (meta
             ((type_ (UArray (UArray UInt))) (loc <opaque>)
@@ -5951,7 +5952,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_2d))
            (meta
             ((type_ (UArray (UArray UReal))) (loc <opaque>)
@@ -5967,7 +5968,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UInt)))) (loc <opaque>)
@@ -5984,7 +5985,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -6000,7 +6001,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -6010,7 +6011,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -6020,7 +6021,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6032,7 +6033,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6044,7 +6045,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6056,7 +6057,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array))
            (meta
             ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -6067,7 +6068,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array))
            (meta
             ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -6079,7 +6080,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_2d))
            (meta
             ((type_ (UArray (UArray UVector))) (loc <opaque>)
@@ -6093,7 +6094,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_2d))
            (meta
             ((type_ (UArray (UArray UVector))) (loc <opaque>)
@@ -6108,7 +6109,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -6124,7 +6125,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -6138,7 +6139,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6148,7 +6149,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6158,7 +6159,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array))
@@ -6169,7 +6170,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array))
@@ -6181,7 +6182,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_2d))
@@ -6195,7 +6196,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_2d))
@@ -6210,7 +6211,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_3d))
@@ -6226,7 +6227,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_3d))
@@ -6240,7 +6241,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6250,7 +6251,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6262,7 +6263,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -6274,7 +6275,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array))
            (meta
             ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -6287,7 +6288,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_2d))
            (meta
             ((type_ (UArray (UArray UVector))) (loc <opaque>)
@@ -6304,7 +6305,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -6320,7 +6321,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector))
            (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -6330,7 +6331,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector))
            (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -6340,7 +6341,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array))
            (meta
             ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -6351,7 +6352,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array))
            (meta
             ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -6363,7 +6364,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_2d))
            (meta
             ((type_ (UArray (UArray URowVector))) (loc <opaque>)
@@ -6378,7 +6379,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_2d))
            (meta
             ((type_ (UArray (UArray URowVector))) (loc <opaque>)
@@ -6394,7 +6395,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -6410,7 +6411,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -6424,7 +6425,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector))
@@ -6434,7 +6435,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector))
@@ -6444,7 +6445,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array))
@@ -6455,7 +6456,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array))
@@ -6467,7 +6468,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_2d))
@@ -6482,7 +6483,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_2d))
@@ -6498,7 +6499,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_3d))
@@ -6514,7 +6515,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_3d))
@@ -6528,7 +6529,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector))
            (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector))
@@ -6538,7 +6539,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array))
            (meta
             ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -6551,7 +6552,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_2d))
            (meta
             ((type_ (UArray (UArray URowVector))) (loc <opaque>)
@@ -6569,7 +6570,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -6585,7 +6586,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -6595,7 +6596,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -6605,7 +6606,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -6617,7 +6618,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -6629,7 +6630,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array))
            (meta
             ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly))))
@@ -6640,7 +6641,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array))
            (meta
             ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly))))
@@ -6652,7 +6653,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_2d))
            (meta
             ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -6666,7 +6667,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_2d))
            (meta
             ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -6681,7 +6682,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UMatrix)))) (loc <opaque>)
@@ -6697,7 +6698,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UMatrix)))) (loc <opaque>)
@@ -6711,7 +6712,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -6721,7 +6722,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -6731,7 +6732,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array))
@@ -6742,7 +6743,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array))
@@ -6754,7 +6755,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_2d))
@@ -6768,7 +6769,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_2d))
@@ -6783,7 +6784,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_3d))
@@ -6799,7 +6800,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_3d))
@@ -6813,7 +6814,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -6823,7 +6824,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array))
            (meta
             ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly))))
@@ -6836,7 +6837,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_2d))
            (meta
             ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -6853,7 +6854,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UMatrix)))) (loc <opaque>)
@@ -6869,7 +6870,7 @@
    ((pattern
      (Assignment (td_int UInt ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -6879,7 +6880,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -7459,7 +7460,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
     (meta <opaque>))
    ((pattern
-     (NRFunApp (StanLib check_greater_or_equal FnPlain)
+     (NRFunApp (StanLib check_greater_or_equal FnPlain AoS)
       (((pattern (Lit Str "cholesky_factor_cov p_cfcov_54"))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Str "num rows (must be greater or equal to num cols)"))
@@ -7470,7 +7471,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
     (meta <opaque>))
    ((pattern
-     (NRFunApp (StanLib check_greater_or_equal FnPlain)
+     (NRFunApp (StanLib check_greater_or_equal FnPlain AoS)
       (((pattern (Lit Str "cholesky_factor_cov p_cfcov_33"))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Str "num rows (must be greater or equal to num cols)"))
@@ -7490,7 +7491,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
     (meta <opaque>))
    ((pattern
-     (NRFunApp (StanLib check_greater_or_equal FnPlain)
+     (NRFunApp (StanLib check_greater_or_equal FnPlain AoS)
       (((pattern (Lit Str "cholesky_factor_cov p_cfcov_33_ar"))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Str "num rows (must be greater or equal to num cols)"))
@@ -8036,7 +8037,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8046,7 +8047,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -8060,7 +8061,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -8075,7 +8076,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8085,7 +8086,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -8099,7 +8100,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -8114,7 +8115,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -8127,7 +8128,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -8142,7 +8143,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8152,7 +8153,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -8166,7 +8167,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -8181,7 +8182,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -8192,7 +8193,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -8204,7 +8205,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -8217,7 +8218,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id x_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8226,7 +8227,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id y_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8259,7 +8260,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8269,7 +8270,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -8283,7 +8284,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -8298,7 +8299,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8308,7 +8309,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -8322,7 +8323,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -8337,7 +8338,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -8350,7 +8351,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -8365,7 +8366,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8375,7 +8376,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -8389,7 +8390,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -8404,7 +8405,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -8415,7 +8416,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -8427,7 +8428,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -8440,7 +8441,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id theta_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8511,7 +8512,7 @@
    ((pattern
      (Assignment (tp_mat UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_cfcov_54))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_mat))
@@ -8523,7 +8524,7 @@
    ((pattern
      (Assignment (tp_vec UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vec))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_vec))
@@ -8636,9 +8637,9 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern
-                    (FunApp (StanLib PMinus__ FnPlain)
+                    (FunApp (StanLib PMinus__ FnPlain AoS)
                      (((pattern (Lit Real 1.0))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -8662,7 +8663,7 @@
    ((pattern
      (Assignment (tp_row_vec URowVector ())
       ((pattern
-        (FunApp (StanLib Transpose__ FnPlain)
+        (FunApp (StanLib Transpose__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern (Var tp_1d_vec))
@@ -8691,14 +8692,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -8713,14 +8714,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -8741,14 +8742,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -8769,14 +8770,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -8791,14 +8792,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -8819,14 +8820,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -8841,14 +8842,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -8869,7 +8870,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -8879,7 +8880,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltDivide__ FnPlain)
+        (FunApp (StanLib EltDivide__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -9431,7 +9432,7 @@
          (Decl (decl_adtype AutoDiffable) (decl_id tmp)
           (decl_type
            (Sized
-            (SVector
+            (SVector AoS
              ((pattern (Lit Int 0))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
           (initialize true)))
@@ -9441,7 +9442,7 @@
           (decl_type
            (Sized
             (SArray
-             (SVector
+             (SVector AoS
               ((pattern (Lit Int 0))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
              ((pattern (Lit Int 0))
@@ -9475,7 +9476,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var p_real))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
               ((pattern (Lit Int 0))
@@ -9487,7 +9488,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var offset_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -9501,7 +9502,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var no_offset_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -9515,7 +9516,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var offset_no_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -9529,9 +9530,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_real_1d_ar))
                    (meta
                     ((type_ (UArray UReal)) (loc <opaque>)
@@ -9557,9 +9558,9 @@
               (((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_1d_vec))
@@ -9589,9 +9590,9 @@
                ((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_1d_row_vec))
@@ -9621,9 +9622,9 @@
                ((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_1d_simplex))
@@ -9678,9 +9679,10 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
-                                        (FunApp (StanLib to_vector FnPlain)
+                                        (FunApp
+                                         (StanLib to_vector FnPlain AoS)
                                          (((pattern
                                             (Indexed
                                              ((pattern (Var p_3d_vec))
@@ -9750,9 +9752,10 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
-                                        (FunApp (StanLib to_vector FnPlain)
+                                        (FunApp
+                                         (StanLib to_vector FnPlain AoS)
                                          (((pattern
                                             (Indexed
                                              ((pattern (Var p_3d_row_vec))
@@ -9824,9 +9827,10 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
-                                        (FunApp (StanLib to_vector FnPlain)
+                                        (FunApp
+                                         (StanLib to_vector FnPlain AoS)
                                          (((pattern
                                             (Indexed
                                              ((pattern (Var p_3d_simplex))
@@ -9896,7 +9900,7 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
                                         (Indexed
                                          ((pattern (Var p_real_3d_ar))
@@ -9988,9 +9992,9 @@
                       (((pattern
                          (TargetPE
                           ((pattern
-                            (FunApp (StanLib normal_lpdf (FnLpdf true))
+                            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                              (((pattern
-                                (FunApp (StanLib to_vector FnPlain)
+                                (FunApp (StanLib to_vector FnPlain AoS)
                                  (((pattern
                                     (Indexed
                                      ((pattern (Var p_ar_mat))
@@ -10044,9 +10048,9 @@
               (((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_cfcov_33_ar))
@@ -10078,9 +10082,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_vec))
                    (meta
                     ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -10094,9 +10098,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_row_vec))
                    (meta
                     ((type_ URowVector) (loc <opaque>)
@@ -10111,9 +10115,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_simplex))
                    (meta
                     ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -10127,9 +10131,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_cfcov_54))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -10143,9 +10147,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_cfcov_33))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -10159,14 +10163,14 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib map_rect FnPlain)
+            (FunApp (StanLib map_rect FnPlain AoS)
              (((pattern (Var binomialf))
                (meta
                 ((type_
                   (UFun
                    ((AutoDiffable UVector) (AutoDiffable UVector)
                     (DataOnly (UArray UReal)) (DataOnly (UArray UInt)))
-                   (ReturnType UVector) FnPlain))
+                   (ReturnType UVector) FnPlain AoS))
                  (loc <opaque>) (adlevel AutoDiffable))))
               ((pattern (Var tmp))
                (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -10253,7 +10257,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10263,7 +10267,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -10277,7 +10281,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -10292,7 +10296,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10302,7 +10306,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -10316,7 +10320,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -10331,7 +10335,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -10344,7 +10348,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -10359,7 +10363,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10369,7 +10373,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -10383,7 +10387,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -10398,7 +10402,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -10409,7 +10413,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -10421,7 +10425,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -10434,7 +10438,7 @@
      (Decl (decl_adtype DataOnly) (decl_id x_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10443,7 +10447,7 @@
      (Decl (decl_adtype DataOnly) (decl_id y_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10476,7 +10480,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10486,7 +10490,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -10500,7 +10504,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -10515,7 +10519,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10525,7 +10529,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -10539,7 +10543,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -10554,7 +10558,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -10567,7 +10571,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -10582,7 +10586,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10592,7 +10596,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -10606,7 +10610,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -10621,7 +10625,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -10632,7 +10636,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -10644,7 +10648,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -10657,7 +10661,7 @@
      (Decl (decl_adtype DataOnly) (decl_id theta_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -10669,7 +10673,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib PNot__ FnPlain)
+        (FunApp (StanLib PNot__ FnPlain AoS)
          (((pattern
             (EOr
              ((pattern (Var emit_transformed_parameters__))
@@ -10742,7 +10746,7 @@
    ((pattern
      (Assignment (tp_mat UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_cfcov_54))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_mat))
@@ -10754,7 +10758,7 @@
    ((pattern
      (Assignment (tp_vec UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vec))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_vec))
@@ -10867,9 +10871,9 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern
-                    (FunApp (StanLib PMinus__ FnPlain)
+                    (FunApp (StanLib PMinus__ FnPlain AoS)
                      (((pattern (Lit Real 1.0))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -10893,7 +10897,7 @@
    ((pattern
      (Assignment (tp_row_vec URowVector ())
       ((pattern
-        (FunApp (StanLib Transpose__ FnPlain)
+        (FunApp (StanLib Transpose__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern (Var tp_1d_vec))
@@ -10922,14 +10926,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -10944,14 +10948,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -10972,14 +10976,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -11000,14 +11004,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -11022,14 +11026,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -11050,14 +11054,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -11072,14 +11076,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -11100,7 +11104,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -11110,7 +11114,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltDivide__ FnPlain)
+        (FunApp (StanLib EltDivide__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -11655,7 +11659,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib PNot__ FnPlain)
+        (FunApp (StanLib PNot__ FnPlain AoS)
          (((pattern (Var emit_generated_quantities__))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -11713,7 +11717,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -11723,7 +11727,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -11737,7 +11741,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -11752,7 +11756,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -11762,7 +11766,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -11776,7 +11780,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -11793,7 +11797,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -11808,7 +11812,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -11818,7 +11822,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -11832,7 +11836,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -11847,7 +11851,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -11858,7 +11862,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -11870,7 +11874,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -11905,7 +11909,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -11919,7 +11923,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -11933,7 +11937,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -11947,7 +11951,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -11961,7 +11965,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -11975,7 +11979,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -11989,7 +11993,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -12003,7 +12007,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Lit Int 4))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Lit Int 3))
@@ -12015,7 +12019,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Lit Int 2))
@@ -12217,9 +12221,9 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern
-                    (FunApp (StanLib PMinus__ FnPlain)
+                    (FunApp (StanLib PMinus__ FnPlain AoS)
                      (((pattern (Lit Real 1.0))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -12292,7 +12296,7 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp (StanLib normal_rng FnRng)
+                                (FunApp (StanLib normal_rng FnRng AoS)
                                  (((pattern (Lit Int 0))
                                    (meta
                                     ((type_ UInt) (loc <opaque>)
@@ -12318,7 +12322,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
        ((pattern
-         (FunApp (StanLib size FnPlain)
+         (FunApp (StanLib size FnPlain AoS)
           (((pattern (Var indices))
             (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
@@ -12332,7 +12336,7 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
                ((pattern
-                 (FunApp (StanLib size FnPlain)
+                 (FunApp (StanLib size FnPlain AoS)
                   (((pattern (Var indices))
                     (meta
                      ((type_ (UArray UInt)) (loc <opaque>)
@@ -12411,7 +12415,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib NEquals__ FnPlain)
+        (FunApp (StanLib NEquals__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern
@@ -12481,7 +12485,7 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
                ((pattern
-                 (FunApp (StanLib size FnPlain)
+                 (FunApp (StanLib size FnPlain AoS)
                   (((pattern (Var indices))
                     (meta
                      ((type_ (UArray UInt)) (loc <opaque>)
@@ -12548,7 +12552,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib NEquals__ FnPlain)
+        (FunApp (StanLib NEquals__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern
@@ -12604,7 +12608,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
        ((pattern
-         (FunApp (StanLib size FnPlain)
+         (FunApp (StanLib size FnPlain AoS)
           (((pattern (Var indices))
             (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
@@ -12630,7 +12634,7 @@
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
                        ((pattern
-                         (FunApp (StanLib size FnPlain)
+                         (FunApp (StanLib size FnPlain AoS)
                           (((pattern (Var indices))
                             (meta
                              ((type_ (UArray UInt)) (loc <opaque>)
@@ -12727,7 +12731,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib NEquals__ FnPlain)
+        (FunApp (StanLib NEquals__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern
@@ -13456,11 +13460,11 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (p_vec
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters)
@@ -13471,14 +13475,14 @@
    (p_1d_vec
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -13489,7 +13493,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -13502,7 +13506,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -13514,25 +13518,25 @@
      (out_block Parameters) (out_trans Identity)))
    (p_row_vec
     ((out_unconstrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
    (p_1d_row_vec
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -13543,7 +13547,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -13556,7 +13560,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -13568,13 +13572,13 @@
      (out_block Parameters) (out_trans Identity)))
    (p_mat
     ((out_unconstrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -13584,7 +13588,7 @@
     ((out_unconstrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -13596,7 +13600,7 @@
      (out_constrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -13614,25 +13618,25 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (p_simplex
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Minus__ FnPlain)
+         (FunApp (StanLib Minus__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Simplex)))
    (p_1d_simplex
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Minus__ FnPlain)
+          (FunApp (StanLib Minus__ FnPlain AoS)
            (((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Lit Int 1))
@@ -13642,7 +13646,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -13653,9 +13657,9 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern
-            (FunApp (StanLib Minus__ FnPlain)
+            (FunApp (StanLib Minus__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Lit Int 1))
@@ -13671,7 +13675,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -13683,20 +13687,20 @@
      (out_block Parameters) (out_trans Simplex)))
    (p_cfcov_54
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 4))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 4))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -13713,9 +13717,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 5))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 4))
@@ -13726,7 +13730,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -13734,20 +13738,20 @@
      (out_block Parameters) (out_trans CholeskyCov)))
    (p_cfcov_33
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 3))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 3))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -13764,9 +13768,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 3))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 3))
@@ -13777,7 +13781,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -13786,20 +13790,20 @@
    (p_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Plus__ FnPlain)
+          (FunApp (StanLib Plus__ FnPlain AoS)
            (((pattern
-              (FunApp (StanLib Plus__ FnPlain)
+              (FunApp (StanLib Plus__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Divide__ FnPlain)
+                  (FunApp (StanLib Divide__ FnPlain AoS)
                    (((pattern
-                      (FunApp (StanLib Times__ FnPlain)
+                      (FunApp (StanLib Times__ FnPlain AoS)
                        (((pattern (Lit Int 3))
                          (meta
                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                         ((pattern
-                          (FunApp (StanLib Minus__ FnPlain)
+                          (FunApp (StanLib Minus__ FnPlain AoS)
                            (((pattern (Lit Int 3))
                              (meta
                               ((type_ UInt) (loc <opaque>)
@@ -13818,9 +13822,9 @@
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern
-              (FunApp (StanLib Times__ FnPlain)
+              (FunApp (StanLib Times__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Minus__ FnPlain)
+                  (FunApp (StanLib Minus__ FnPlain AoS)
                    (((pattern (Lit Int 3))
                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                     ((pattern (Lit Int 3))
@@ -13834,7 +13838,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -13844,21 +13848,21 @@
      (out_block Parameters) (out_trans CholeskyCov)))
    (x_p
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
    (y_p
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
@@ -13904,11 +13908,11 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (tp_vec
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters)
@@ -13919,14 +13923,14 @@
    (tp_1d_vec
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -13937,7 +13941,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -13950,7 +13954,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -13962,25 +13966,25 @@
      (out_block TransformedParameters) (out_trans Identity)))
    (tp_row_vec
     ((out_unconstrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))
    (tp_1d_row_vec
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -13991,7 +13995,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14004,7 +14008,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14016,13 +14020,13 @@
      (out_block TransformedParameters) (out_trans Identity)))
    (tp_mat
     ((out_unconstrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -14032,7 +14036,7 @@
     ((out_unconstrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -14044,7 +14048,7 @@
      (out_constrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -14062,25 +14066,25 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (tp_simplex
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Minus__ FnPlain)
+         (FunApp (StanLib Minus__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Simplex)))
    (tp_1d_simplex
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Minus__ FnPlain)
+          (FunApp (StanLib Minus__ FnPlain AoS)
            (((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Lit Int 1))
@@ -14090,7 +14094,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -14101,9 +14105,9 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern
-            (FunApp (StanLib Minus__ FnPlain)
+            (FunApp (StanLib Minus__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Lit Int 1))
@@ -14119,7 +14123,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14131,20 +14135,20 @@
      (out_block TransformedParameters) (out_trans Simplex)))
    (tp_cfcov_54
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 4))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 4))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -14161,9 +14165,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 5))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 4))
@@ -14174,7 +14178,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -14182,20 +14186,20 @@
      (out_block TransformedParameters) (out_trans CholeskyCov)))
    (tp_cfcov_33
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 3))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 3))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -14212,9 +14216,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 3))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 3))
@@ -14225,7 +14229,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -14234,20 +14238,20 @@
    (tp_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Plus__ FnPlain)
+          (FunApp (StanLib Plus__ FnPlain AoS)
            (((pattern
-              (FunApp (StanLib Plus__ FnPlain)
+              (FunApp (StanLib Plus__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Divide__ FnPlain)
+                  (FunApp (StanLib Divide__ FnPlain AoS)
                    (((pattern
-                      (FunApp (StanLib Times__ FnPlain)
+                      (FunApp (StanLib Times__ FnPlain AoS)
                        (((pattern (Lit Int 3))
                          (meta
                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                         ((pattern
-                          (FunApp (StanLib Minus__ FnPlain)
+                          (FunApp (StanLib Minus__ FnPlain AoS)
                            (((pattern (Lit Int 3))
                              (meta
                               ((type_ UInt) (loc <opaque>)
@@ -14266,9 +14270,9 @@
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern
-              (FunApp (StanLib Times__ FnPlain)
+              (FunApp (StanLib Times__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Minus__ FnPlain)
+                  (FunApp (StanLib Minus__ FnPlain AoS)
                    (((pattern (Lit Int 3))
                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                     ((pattern (Lit Int 3))
@@ -14282,7 +14286,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -14292,11 +14296,11 @@
      (out_block TransformedParameters) (out_trans CholeskyCov)))
    (theta_p
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))
@@ -14351,11 +14355,11 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (gq_vec
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block GeneratedQuantities)
@@ -14366,14 +14370,14 @@
    (gq_1d_vec
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -14384,7 +14388,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14397,7 +14401,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14409,25 +14413,25 @@
      (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_row_vec
     ((out_unconstrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_1d_row_vec
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -14438,7 +14442,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14451,7 +14455,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14465,7 +14469,7 @@
     ((out_unconstrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -14477,7 +14481,7 @@
      (out_constrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -14495,25 +14499,25 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (gq_simplex
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Minus__ FnPlain)
+         (FunApp (StanLib Minus__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block GeneratedQuantities) (out_trans Simplex)))
    (gq_1d_simplex
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Minus__ FnPlain)
+          (FunApp (StanLib Minus__ FnPlain AoS)
            (((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Lit Int 1))
@@ -14523,7 +14527,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -14534,9 +14538,9 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern
-            (FunApp (StanLib Minus__ FnPlain)
+            (FunApp (StanLib Minus__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Lit Int 1))
@@ -14552,7 +14556,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -14564,20 +14568,20 @@
      (out_block GeneratedQuantities) (out_trans Simplex)))
    (gq_cfcov_54
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 4))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 4))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -14594,9 +14598,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 5))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 4))
@@ -14607,7 +14611,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -14615,20 +14619,20 @@
      (out_block GeneratedQuantities) (out_trans CholeskyCov)))
    (gq_cfcov_33
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 3))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 3))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -14645,9 +14649,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 3))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 3))
@@ -14658,7 +14662,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -14667,20 +14671,20 @@
    (gq_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Plus__ FnPlain)
+          (FunApp (StanLib Plus__ FnPlain AoS)
            (((pattern
-              (FunApp (StanLib Plus__ FnPlain)
+              (FunApp (StanLib Plus__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Divide__ FnPlain)
+                  (FunApp (StanLib Divide__ FnPlain AoS)
                    (((pattern
-                      (FunApp (StanLib Times__ FnPlain)
+                      (FunApp (StanLib Times__ FnPlain AoS)
                        (((pattern (Lit Int 3))
                          (meta
                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                         ((pattern
-                          (FunApp (StanLib Minus__ FnPlain)
+                          (FunApp (StanLib Minus__ FnPlain AoS)
                            (((pattern (Lit Int 3))
                              (meta
                               ((type_ UInt) (loc <opaque>)
@@ -14699,9 +14703,9 @@
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern
-              (FunApp (StanLib Times__ FnPlain)
+              (FunApp (StanLib Times__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Minus__ FnPlain)
+                  (FunApp (StanLib Minus__ FnPlain AoS)
                    (((pattern (Lit Int 3))
                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                     ((pattern (Lit Int 3))
@@ -14715,7 +14719,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -14736,7 +14740,7 @@
    (indexing_mat
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14745,7 +14749,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14756,7 +14760,7 @@
    (idx_res1
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14765,7 +14769,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14776,7 +14780,7 @@
    (idx_res2
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14785,7 +14789,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14796,7 +14800,7 @@
    (idx_res3
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -14805,7 +14809,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -14816,7 +14820,7 @@
    (idx_res11
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14825,7 +14829,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14836,7 +14840,7 @@
    (idx_res21
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14845,7 +14849,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -14856,7 +14860,7 @@
    (idx_res31
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -14865,7 +14869,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -14876,14 +14880,14 @@
    (idx_res4
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Lit Int 4))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Lit Int 4))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
@@ -14892,14 +14896,14 @@
    (idx_res5
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Lit Int 2))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Lit Int 2))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 2))

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -10,7 +10,7 @@
          (((pattern
             (IfElse
              ((pattern
-               (FunApp (StanLib Equals__ FnPlain)
+               (FunApp (StanLib Equals__ FnPlain AoS)
                 (((pattern (Var n))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                  ((pattern (Lit Int 0))
@@ -29,13 +29,13 @@
           ((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern (Var n))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern
                     (FunApp (UserDefined foo FnPlain)
                      (((pattern
-                        (FunApp (StanLib Minus__ FnPlain)
+                        (FunApp (StanLib Minus__ FnPlain AoS)
                          (((pattern (Var n))
                            (meta
                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -96,9 +96,9 @@
                 ((pattern (Lit Int 2))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              ((pattern
-               (FunApp (StanLib Minus__ FnPlain)
+               (FunApp (StanLib Minus__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib PMinus__ FnPlain)
+                   (FunApp (StanLib PMinus__ FnPlain AoS)
                     (((pattern
                        (Indexed
                         ((pattern (Var y))
@@ -114,7 +114,7 @@
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern
-                   (FunApp (StanLib Times__ FnPlain)
+                   (FunApp (StanLib Times__ FnPlain AoS)
                     (((pattern
                        (Indexed
                         ((pattern (Var theta))
@@ -231,7 +231,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib normal_rng FnRng)
+                (FunApp (StanLib normal_rng FnRng AoS)
                  (((pattern (Var mu))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -250,7 +250,7 @@
          (((pattern
             (TargetPE
              ((pattern
-               (FunApp (StanLib normal_log (FnLpdf false))
+               (FunApp (StanLib normal_log (FnLpdf false) AoS)
                 (((pattern (Var u))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -263,12 +263,12 @@
           ((pattern
             (TargetPE
              ((pattern
-               (FunApp (StanLib uniform_lpdf (FnLpdf true))
+               (FunApp (StanLib uniform_lpdf (FnLpdf true) AoS)
                 (((pattern (Var u))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern
-                   (FunApp (StanLib PMinus__ FnPlain)
+                   (FunApp (StanLib PMinus__ FnPlain AoS)
                     (((pattern (Lit Int 100))
                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -655,7 +655,7 @@
                    (Decl (decl_adtype AutoDiffable) (decl_id vs)
                     (decl_type
                      (Sized
-                      (SMatrix
+                      (SMatrix AoS
                        ((pattern (Lit Int 2))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -671,7 +671,7 @@
                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                     (upper
                      ((pattern
-                       (FunApp (StanLib rows FnPlain)
+                       (FunApp (StanLib rows FnPlain AoS)
                         (((pattern (Var vs))
                           (meta
                            ((type_ UMatrix) (loc <opaque>)
@@ -761,7 +761,7 @@
                       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                     (upper
                      ((pattern
-                       (FunApp (StanLib rows FnPlain)
+                       (FunApp (StanLib rows FnPlain AoS)
                         (((pattern (Var vs))
                           (meta
                            ((type_ UMatrix) (loc <opaque>)
@@ -860,7 +860,7 @@
                    (Decl (decl_adtype AutoDiffable) (decl_id vs)
                     (decl_type
                      (Sized
-                      (SVector
+                      (SVector AoS
                        ((pattern (Lit Int 2))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -986,7 +986,7 @@
                    (Decl (decl_adtype AutoDiffable) (decl_id vs)
                     (decl_type
                      (Sized
-                      (SRowVector
+                      (SRowVector AoS
                        ((pattern (Lit Int 2))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -1215,7 +1215,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib rep_array FnPlain)
+                (FunApp (StanLib rep_array FnPlain AoS)
                  (((pattern (Var t))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1235,11 +1235,11 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Plus__ FnPlain)
+                (FunApp (StanLib Plus__ FnPlain AoS)
                  (((pattern (Var x))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
-                  ((pattern (FunApp (StanLib target FnTarget) ()))
+                  ((pattern (FunApp (StanLib target FnTarget AoS) ()))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1278,9 +1278,9 @@
           ((pattern
             (Assignment (abs_diff UReal ())
              ((pattern
-               (FunApp (StanLib fabs FnPlain)
+               (FunApp (StanLib fabs FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Minus__ FnPlain)
+                   (FunApp (StanLib Minus__ FnPlain AoS)
                     (((pattern (Var x))
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1294,11 +1294,11 @@
           ((pattern
             (Assignment (avg_scale UReal ())
              ((pattern
-               (FunApp (StanLib Divide__ FnPlain)
+               (FunApp (StanLib Divide__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Plus__ FnPlain)
+                   (FunApp (StanLib Plus__ FnPlain AoS)
                     (((pattern
-                       (FunApp (StanLib fabs FnPlain)
+                       (FunApp (StanLib fabs FnPlain AoS)
                         (((pattern (Var x))
                           (meta
                            ((type_ UReal) (loc <opaque>)
@@ -1306,7 +1306,7 @@
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                      ((pattern
-                       (FunApp (StanLib fabs FnPlain)
+                       (FunApp (StanLib fabs FnPlain AoS)
                         (((pattern (Var y))
                           (meta
                            ((type_ UReal) (loc <opaque>)
@@ -1322,9 +1322,9 @@
           ((pattern
             (IfElse
              ((pattern
-               (FunApp (StanLib Greater__ FnPlain)
+               (FunApp (StanLib Greater__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Divide__ FnPlain)
+                   (FunApp (StanLib Divide__ FnPlain AoS)
                     (((pattern (Var abs_diff))
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1368,9 +1368,9 @@
           ((pattern
             (IfElse
              ((pattern
-               (FunApp (StanLib Less__ FnPlain)
+               (FunApp (StanLib Less__ FnPlain AoS)
                 (((pattern
-                   (FunApp (StanLib Divide__ FnPlain)
+                   (FunApp (StanLib Divide__ FnPlain AoS)
                     (((pattern (Var abs_diff))
                       (meta
                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1414,7 +1414,7 @@
           ((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Divide__ FnPlain)
+                (FunApp (StanLib Divide__ FnPlain AoS)
                  (((pattern (Var abs_diff))
                    (meta
                     ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -1435,7 +1435,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Transpose__ FnPlain)
+                (FunApp (StanLib Transpose__ FnPlain AoS)
                  (((pattern
                     (FunApp (CompilerInternal FnMakeRowVec)
                      (((pattern (Lit Int 1))
@@ -1494,7 +1494,7 @@
               ((pattern (Lit Str "rows(mat)"))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib rows FnPlain)
+                (FunApp (StanLib rows FnPlain AoS)
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1507,7 +1507,7 @@
               ((pattern (Lit Str "cols(mat)"))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib cols FnPlain)
+                (FunApp (StanLib cols FnPlain AoS)
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1517,15 +1517,15 @@
             (Decl (decl_adtype AutoDiffable) (decl_id o)
              (decl_type
               (Sized
-               (SMatrix
+               (SMatrix AoS
                 ((pattern
-                  (FunApp (StanLib rows FnPlain)
+                  (FunApp (StanLib rows FnPlain AoS)
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
                 ((pattern
-                  (FunApp (StanLib cols FnPlain)
+                  (FunApp (StanLib cols FnPlain AoS)
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -1886,7 +1886,7 @@
               (Sized
                (SArray
                 (SArray
-                 (SMatrix
+                 (SMatrix AoS
                   ((pattern (Lit Int 40))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Lit Int 50))
@@ -2038,7 +2038,7 @@
          (((pattern
             (Return
              (((pattern
-                (FunApp (StanLib Transpose__ FnPlain)
+                (FunApp (StanLib Transpose__ FnPlain AoS)
                  (((pattern
                     (FunApp (CompilerInternal FnMakeRowVec)
                      (((pattern (Lit Int 1))
@@ -2086,7 +2086,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id l)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 10))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize false)))
@@ -2094,7 +2094,7 @@
           ((pattern
             (Assignment (l UVector ())
              ((pattern
-               (FunApp (StanLib Times__ FnPlain)
+               (FunApp (StanLib Times__ FnPlain AoS)
                 (((pattern (Var mu))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
@@ -2118,7 +2118,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id l)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 10))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize false)))
@@ -2126,12 +2126,12 @@
           ((pattern
             (Assignment (l UVector ())
              ((pattern
-               (FunApp (StanLib Times__ FnPlain)
+               (FunApp (StanLib Times__ FnPlain AoS)
                 (((pattern (Var mu))
                   (meta
                    ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                  ((pattern
-                   (FunApp (StanLib Transpose__ FnPlain)
+                   (FunApp (StanLib Transpose__ FnPlain AoS)
                     (((pattern
                        (FunApp (CompilerInternal FnMakeRowVec)
                         (((pattern (Lit Int 1))
@@ -2212,7 +2212,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id f_x)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 2))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
@@ -2224,7 +2224,7 @@
                 ((pattern (Lit Int 1))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              ((pattern
-               (FunApp (StanLib Minus__ FnPlain)
+               (FunApp (StanLib Minus__ FnPlain AoS)
                 (((pattern
                    (Indexed
                     ((pattern (Var x))
@@ -2256,7 +2256,7 @@
                 ((pattern (Lit Int 2))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              ((pattern
-               (FunApp (StanLib Minus__ FnPlain)
+               (FunApp (StanLib Minus__ FnPlain AoS)
                 (((pattern
                    (Indexed
                     ((pattern (Var x))
@@ -2299,7 +2299,7 @@
             (Decl (decl_adtype AutoDiffable) (decl_id lpmf)
              (decl_type
               (Sized
-               (SVector
+               (SVector AoS
                 ((pattern (Lit Int 1))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
@@ -2352,12 +2352,12 @@
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_vec
-    (SVector
+    (SVector AoS
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_1d_vec
     (SArray
-     (SVector
+     (SVector AoS
       ((pattern (Var N))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var N))
@@ -2366,7 +2366,7 @@
     (SArray
      (SArray
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var K))
@@ -2376,12 +2376,12 @@
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_row_vec
-    (SRowVector
+    (SRowVector AoS
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_1d_row_vec
     (SArray
-     (SRowVector
+     (SRowVector AoS
       ((pattern (Var N))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var N))
@@ -2390,7 +2390,7 @@
     (SArray
      (SArray
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var K))
@@ -2402,7 +2402,7 @@
    (d_ar_mat
     (SArray
      (SArray
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -2412,12 +2412,12 @@
      ((pattern (Lit Int 4))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_simplex
-    (SVector
+    (SVector AoS
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_1d_simplex
     (SArray
-     (SVector
+     (SVector AoS
       ((pattern (Var N))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var N))
@@ -2426,7 +2426,7 @@
     (SArray
      (SArray
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var K))
@@ -2436,20 +2436,20 @@
      ((pattern (Var N))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_cfcov_54
-    (SMatrix
+    (SMatrix AoS
      ((pattern (Lit Int 5))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
      ((pattern (Lit Int 4))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_cfcov_33
-    (SMatrix
+    (SMatrix AoS
      ((pattern (Lit Int 3))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
      ((pattern (Lit Int 3))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_cfcov_33_ar
     (SArray
-     (SMatrix
+     (SMatrix AoS
       ((pattern (Lit Int 3))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
       ((pattern (Lit Int 3))
@@ -2501,14 +2501,14 @@
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_matrix
-    (SMatrix
+    (SMatrix AoS
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_matrix_array
     (SArray
-     (SMatrix
+     (SMatrix AoS
       ((pattern (Var d_int))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
       ((pattern (Var d_int))
@@ -2518,7 +2518,7 @@
    (d_matrix_array_2d
     (SArray
      (SArray
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Var d_int))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Var d_int))
@@ -2531,7 +2531,7 @@
     (SArray
      (SArray
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Var d_int))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Var d_int))
@@ -2543,12 +2543,12 @@
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_vector
-    (SVector
+    (SVector AoS
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_vector_array
     (SArray
-     (SVector
+     (SVector AoS
       ((pattern (Var d_int))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var d_int))
@@ -2556,7 +2556,7 @@
    (d_vector_array_2d
     (SArray
      (SArray
-      (SVector
+      (SVector AoS
        ((pattern (Var d_int))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       ((pattern (Lit Int 2))
@@ -2567,7 +2567,7 @@
     (SArray
      (SArray
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var d_int))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
@@ -2577,12 +2577,12 @@
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_row_vector
-    (SRowVector
+    (SRowVector AoS
      ((pattern (Var d_int))
       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
    (d_row_vector_array
     (SArray
-     (SRowVector
+     (SRowVector AoS
       ((pattern (Var d_int))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
      ((pattern (Var d_int))
@@ -2590,7 +2590,7 @@
    (d_row_vector_array_2d
     (SArray
      (SArray
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var d_int))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       ((pattern (Lit Int 2))
@@ -2601,7 +2601,7 @@
     (SArray
      (SArray
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var d_int))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
@@ -2726,7 +2726,7 @@
         (trans
          (Upper
           ((pattern
-            (FunApp (StanLib Times__ FnPlain)
+            (FunApp (StanLib Times__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Var M))
@@ -2737,7 +2737,7 @@
          ((pattern (Var K))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Var M))
@@ -2942,7 +2942,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -3071,7 +3071,7 @@
         (trans
          (Lower
           ((pattern
-            (FunApp (StanLib PMinus__ FnPlain)
+            (FunApp (StanLib PMinus__ FnPlain AoS)
              (((pattern (Lit Real 2.0))
                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
@@ -3080,7 +3080,7 @@
          ((pattern (Var J))
           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
       (((pattern
-         (FunApp (StanLib PMinus__ FnPlain)
+         (FunApp (StanLib PMinus__ FnPlain AoS)
           (((pattern (Lit Real 2.0))
             (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -3261,7 +3261,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -3294,7 +3294,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -3350,7 +3350,7 @@
                ((pattern
                  (Assignment (pos__ UInt ())
                   ((pattern
-                    (FunApp (StanLib Plus__ FnPlain)
+                    (FunApp (StanLib Plus__ FnPlain AoS)
                      (((pattern (Var pos__))
                        (meta
                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -3385,7 +3385,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -3464,7 +3464,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -3524,7 +3524,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -3649,7 +3649,8 @@
                                        ((pattern
                                          (Assignment (pos__ UInt ())
                                           ((pattern
-                                            (FunApp (StanLib Plus__ FnPlain)
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
                                              (((pattern (Var pos__))
                                                (meta
                                                 ((type_ UInt) (loc <opaque>)
@@ -3684,7 +3685,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -3740,7 +3741,7 @@
                ((pattern
                  (Assignment (pos__ UInt ())
                   ((pattern
-                    (FunApp (StanLib Plus__ FnPlain)
+                    (FunApp (StanLib Plus__ FnPlain AoS)
                      (((pattern (Var pos__))
                        (meta
                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -3775,7 +3776,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -3855,7 +3856,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -3915,7 +3916,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -4042,7 +4043,8 @@
                                        ((pattern
                                          (Assignment (pos__ UInt ())
                                           ((pattern
-                                            (FunApp (StanLib Plus__ FnPlain)
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
                                              (((pattern (Var pos__))
                                                (meta
                                                 ((type_ UInt) (loc <opaque>)
@@ -4070,7 +4072,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -4194,7 +4196,8 @@
                                        ((pattern
                                          (Assignment (pos__ UInt ())
                                           ((pattern
-                                            (FunApp (StanLib Plus__ FnPlain)
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
                                              (((pattern (Var pos__))
                                                (meta
                                                 ((type_ UInt) (loc <opaque>)
@@ -4443,7 +4446,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -4499,7 +4502,7 @@
                ((pattern
                  (Assignment (pos__ UInt ())
                   ((pattern
-                    (FunApp (StanLib Plus__ FnPlain)
+                    (FunApp (StanLib Plus__ FnPlain AoS)
                      (((pattern (Var pos__))
                        (meta
                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -4543,7 +4546,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -4622,7 +4625,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -4713,7 +4716,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -4839,7 +4842,8 @@
                                        ((pattern
                                          (Assignment (pos__ UInt ())
                                           ((pattern
-                                            (FunApp (StanLib Plus__ FnPlain)
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
                                              (((pattern (Var pos__))
                                                (meta
                                                 ((type_ UInt) (loc <opaque>)
@@ -4940,7 +4944,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -5018,7 +5022,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -5048,7 +5052,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -5126,7 +5130,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -5166,7 +5170,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -5266,7 +5270,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -5455,7 +5459,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -5589,7 +5593,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -5747,7 +5751,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -5881,7 +5885,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -5923,7 +5927,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_matrix)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Var d_int))
@@ -6001,7 +6005,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -6050,7 +6054,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -6150,7 +6154,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -6203,7 +6207,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Var d_int))
@@ -6329,7 +6333,8 @@
                                        ((pattern
                                          (Assignment (pos__ UInt ())
                                           ((pattern
-                                            (FunApp (StanLib Plus__ FnPlain)
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
                                              (((pattern (Var pos__))
                                                (meta
                                                 ((type_ UInt) (loc <opaque>)
@@ -6385,7 +6390,7 @@
         (SArray
          (SArray
           (SArray
-           (SMatrix
+           (SMatrix AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Var d_int))
@@ -6544,7 +6549,8 @@
                                                  (Assignment (pos__ UInt ())
                                                   ((pattern
                                                     (FunApp
-                                                     (StanLib Plus__ FnPlain)
+                                                     (StanLib Plus__ FnPlain
+                                                      AoS)
                                                      (((pattern (Var pos__))
                                                        (meta
                                                         ((type_ UInt)
@@ -6584,7 +6590,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_vector)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -6640,7 +6646,7 @@
                ((pattern
                  (Assignment (pos__ UInt ())
                   ((pattern
-                    (FunApp (StanLib Plus__ FnPlain)
+                    (FunApp (StanLib Plus__ FnPlain AoS)
                      (((pattern (Var pos__))
                        (meta
                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -6675,7 +6681,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -6754,7 +6760,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -6795,7 +6801,7 @@
        (Sized
         (SArray
          (SArray
-          (SVector
+          (SVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -6898,7 +6904,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -6943,7 +6949,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -7069,7 +7075,8 @@
                                        ((pattern
                                          (Assignment (pos__ UInt ())
                                           ((pattern
-                                            (FunApp (StanLib Plus__ FnPlain)
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
                                              (((pattern (Var pos__))
                                                (meta
                                                 ((type_ UInt) (loc <opaque>)
@@ -7104,7 +7111,7 @@
      (Decl (decl_adtype DataOnly) (decl_id d_row_vector)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -7160,7 +7167,7 @@
                ((pattern
                  (Assignment (pos__ UInt ())
                   ((pattern
-                    (FunApp (StanLib Plus__ FnPlain)
+                    (FunApp (StanLib Plus__ FnPlain AoS)
                      (((pattern (Var pos__))
                        (meta
                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -7195,7 +7202,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -7275,7 +7282,7 @@
                        ((pattern
                          (Assignment (pos__ UInt ())
                           ((pattern
-                            (FunApp (StanLib Plus__ FnPlain)
+                            (FunApp (StanLib Plus__ FnPlain AoS)
                              (((pattern (Var pos__))
                                (meta
                                 ((type_ UInt) (loc <opaque>)
@@ -7316,7 +7323,7 @@
        (Sized
         (SArray
          (SArray
-          (SRowVector
+          (SRowVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -7420,7 +7427,7 @@
                                ((pattern
                                  (Assignment (pos__ UInt ())
                                   ((pattern
-                                    (FunApp (StanLib Plus__ FnPlain)
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
                                      (((pattern (Var pos__))
                                        (meta
                                         ((type_ UInt) (loc <opaque>)
@@ -7465,7 +7472,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -7594,7 +7601,8 @@
                                        ((pattern
                                          (Assignment (pos__ UInt ())
                                           ((pattern
-                                            (FunApp (StanLib Plus__ FnPlain)
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
                                              (((pattern (Var pos__))
                                                (meta
                                                 ((type_ UInt) (loc <opaque>)
@@ -7659,7 +7667,7 @@
    ((pattern
      (Assignment (td_1dk (UArray UInt) ())
       ((pattern
-        (FunApp (StanLib rep_array FnPlain)
+        (FunApp (StanLib rep_array FnPlain AoS)
          (((pattern (Lit Int 1))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -7682,7 +7690,7 @@
    ((pattern
      (Assignment (td_b UReal ())
       ((pattern
-        (FunApp (StanLib Times__ FnPlain)
+        (FunApp (StanLib Times__ FnPlain AoS)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var J))
@@ -7707,7 +7715,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -7731,7 +7739,7 @@
      (Decl (decl_adtype DataOnly) (decl_id td_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -7759,7 +7767,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -7809,7 +7817,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -7824,7 +7832,7 @@
      (Decl (decl_adtype DataOnly) (decl_id td_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 5))
@@ -7835,7 +7843,7 @@
      (Decl (decl_adtype DataOnly) (decl_id td_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -7846,7 +7854,7 @@
      (Decl (decl_adtype DataOnly) (decl_id x)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -7855,7 +7863,7 @@
      (Decl (decl_adtype DataOnly) (decl_id y)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8026,7 +8034,7 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Divide__ FnPlain)
+                (FunApp (StanLib Divide__ FnPlain AoS)
                  (((pattern (Lit Real 1.0))
                    (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Var N))
@@ -8056,7 +8064,7 @@
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                       ((pattern
-                        (FunApp (StanLib Divide__ FnPlain)
+                        (FunApp (StanLib Divide__ FnPlain AoS)
                          (((pattern (Lit Real 1.0))
                            (meta
                             ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
@@ -8119,7 +8127,8 @@
                                            ((type_ UInt) (loc <opaque>)
                                             (adlevel DataOnly)))))))
                                       ((pattern
-                                        (FunApp (StanLib Divide__ FnPlain)
+                                        (FunApp
+                                         (StanLib Divide__ FnPlain AoS)
                                          (((pattern (Lit Real 1.0))
                                            (meta
                                             ((type_ UReal) (loc <opaque>)
@@ -8166,7 +8175,7 @@
                      (Decl (decl_adtype DataOnly) (decl_id l_mat)
                       (decl_type
                        (Sized
-                        (SMatrix
+                        (SMatrix AoS
                          ((pattern (Lit Int 2))
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -8222,13 +8231,13 @@
    ((pattern
      (Assignment (td_cfcov_54 UMatrix ())
       ((pattern
-        (FunApp (StanLib diag_matrix FnPlain)
+        (FunApp (StanLib diag_matrix FnPlain AoS)
          (((pattern
-            (FunApp (StanLib rep_vector FnPlain)
+            (FunApp (StanLib rep_vector FnPlain AoS)
              (((pattern (Lit Int 1))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib rows FnPlain)
+                (FunApp (StanLib rows FnPlain AoS)
                  (((pattern (Var td_cfcov_54))
                    (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -8238,13 +8247,13 @@
    ((pattern
      (Assignment (td_cfcov_33 UMatrix ())
       ((pattern
-        (FunApp (StanLib diag_matrix FnPlain)
+        (FunApp (StanLib diag_matrix FnPlain AoS)
          (((pattern
-            (FunApp (StanLib rep_vector FnPlain)
+            (FunApp (StanLib rep_vector FnPlain AoS)
              (((pattern (Lit Int 1))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
-                (FunApp (StanLib rows FnPlain)
+                (FunApp (StanLib rows FnPlain AoS)
                  (((pattern (Var td_cfcov_33))
                    (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
@@ -8261,7 +8270,7 @@
          (Decl (decl_adtype DataOnly) (decl_id blocked_tdata_vs)
           (decl_type
            (Sized
-            (SRowVector
+            (SRowVector AoS
              ((pattern (Lit Int 2))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
           (initialize true)))
@@ -8593,7 +8602,7 @@
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_matrix)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Var d_int))
@@ -8632,7 +8641,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -8674,7 +8683,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Var d_int))
@@ -8719,7 +8728,7 @@
         (SArray
          (SArray
           (SArray
-           (SMatrix
+           (SMatrix AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Var d_int))
@@ -8745,7 +8754,7 @@
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_vector)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8773,7 +8782,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -8804,7 +8813,7 @@
        (Sized
         (SArray
          (SArray
-          (SVector
+          (SVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -8838,7 +8847,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -8862,7 +8871,7 @@
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_row_vector)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var d_int))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -8890,7 +8899,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var d_int))
@@ -8922,7 +8931,7 @@
        (Sized
         (SArray
          (SArray
-          (SRowVector
+          (SRowVector AoS
            ((pattern (Var d_int))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
           ((pattern (Lit Int 2))
@@ -8957,7 +8966,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var d_int))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Lit Int 3))
@@ -8971,7 +8980,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -8981,7 +8990,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -8991,7 +9000,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -9001,7 +9010,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -9011,7 +9020,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array))
            (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -9021,7 +9030,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array))
            (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -9031,7 +9040,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_2d))
            (meta
             ((type_ (UArray (UArray UInt))) (loc <opaque>)
@@ -9044,7 +9053,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_2d))
            (meta
             ((type_ (UArray (UArray UInt))) (loc <opaque>)
@@ -9058,7 +9067,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UInt)))) (loc <opaque>)
@@ -9073,7 +9082,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UInt)))) (loc <opaque>)
@@ -9087,7 +9096,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array))
@@ -9097,7 +9106,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array))
@@ -9107,7 +9116,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_2d))
@@ -9120,7 +9129,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_2d))
@@ -9134,7 +9143,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_3d))
@@ -9149,7 +9158,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array_3d))
@@ -9163,7 +9172,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array))
@@ -9173,7 +9182,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array))
@@ -9183,7 +9192,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_2d))
@@ -9196,7 +9205,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_2d))
@@ -9210,7 +9219,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_3d))
@@ -9225,7 +9234,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array_3d))
@@ -9239,7 +9248,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array))
            (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -9249,7 +9258,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array))
            (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -9259,7 +9268,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_2d))
            (meta
             ((type_ (UArray (UArray UReal))) (loc <opaque>)
@@ -9272,7 +9281,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_2d))
            (meta
             ((type_ (UArray (UArray UReal))) (loc <opaque>)
@@ -9286,7 +9295,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -9301,7 +9310,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -9315,7 +9324,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array))
            (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int_array))
@@ -9325,7 +9334,7 @@
    ((pattern
      (Assignment (transformed_data_real_array (UArray UReal) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array))
            (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real_array))
@@ -9335,7 +9344,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_2d))
            (meta
             ((type_ (UArray (UArray UInt))) (loc <opaque>)
@@ -9350,7 +9359,7 @@
    ((pattern
      (Assignment (transformed_data_real_array_2d (UArray (UArray UReal)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_2d))
            (meta
             ((type_ (UArray (UArray UReal))) (loc <opaque>)
@@ -9366,7 +9375,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UInt)))) (loc <opaque>)
@@ -9383,7 +9392,7 @@
      (Assignment
       (transformed_data_real_array_3d (UArray (UArray (UArray UReal))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -9399,7 +9408,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -9409,7 +9418,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -9419,7 +9428,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9431,7 +9440,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9443,7 +9452,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9455,7 +9464,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array))
            (meta
             ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -9466,7 +9475,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array))
            (meta
             ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -9478,7 +9487,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_2d))
            (meta
             ((type_ (UArray (UArray UVector))) (loc <opaque>)
@@ -9492,7 +9501,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_2d))
            (meta
             ((type_ (UArray (UArray UVector))) (loc <opaque>)
@@ -9507,7 +9516,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -9523,7 +9532,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -9537,7 +9546,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9547,7 +9556,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9557,7 +9566,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array))
@@ -9568,7 +9577,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array))
@@ -9580,7 +9589,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_2d))
@@ -9594,7 +9603,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_2d))
@@ -9609,7 +9618,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_3d))
@@ -9625,7 +9634,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector_array_3d))
@@ -9639,7 +9648,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9649,7 +9658,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9661,7 +9670,7 @@
    ((pattern
      (Assignment (transformed_data_vector UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vector))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_vector))
@@ -9673,7 +9682,7 @@
    ((pattern
      (Assignment (transformed_data_vector_array (UArray UVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array))
            (meta
             ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -9686,7 +9695,7 @@
      (Assignment
       (transformed_data_vector_array_2d (UArray (UArray UVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_2d))
            (meta
             ((type_ (UArray (UArray UVector))) (loc <opaque>)
@@ -9703,7 +9712,7 @@
       (transformed_data_vector_array_3d (UArray (UArray (UArray UVector)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -9719,7 +9728,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector))
            (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -9729,7 +9738,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector))
            (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -9739,7 +9748,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array))
            (meta
             ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -9750,7 +9759,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array))
            (meta
             ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -9762,7 +9771,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_2d))
            (meta
             ((type_ (UArray (UArray URowVector))) (loc <opaque>)
@@ -9777,7 +9786,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_2d))
            (meta
             ((type_ (UArray (UArray URowVector))) (loc <opaque>)
@@ -9793,7 +9802,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -9809,7 +9818,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -9823,7 +9832,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector))
@@ -9833,7 +9842,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector))
@@ -9843,7 +9852,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array))
@@ -9854,7 +9863,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array))
@@ -9866,7 +9875,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_2d))
@@ -9881,7 +9890,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_2d))
@@ -9897,7 +9906,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_3d))
@@ -9913,7 +9922,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector_array_3d))
@@ -9927,7 +9936,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector URowVector ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector))
            (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_row_vector))
@@ -9937,7 +9946,7 @@
    ((pattern
      (Assignment (transformed_data_row_vector_array (UArray URowVector) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array))
            (meta
             ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly))))
@@ -9950,7 +9959,7 @@
      (Assignment
       (transformed_data_row_vector_array_2d (UArray (UArray URowVector)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_2d))
            (meta
             ((type_ (UArray (UArray URowVector))) (loc <opaque>)
@@ -9968,7 +9977,7 @@
       (transformed_data_row_vector_array_3d
        (UArray (UArray (UArray URowVector))) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_row_vector_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -9984,7 +9993,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -9994,7 +10003,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -10004,7 +10013,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -10016,7 +10025,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -10028,7 +10037,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array))
            (meta
             ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly))))
@@ -10039,7 +10048,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array))
            (meta
             ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly))))
@@ -10051,7 +10060,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_2d))
            (meta
             ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -10065,7 +10074,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_2d))
            (meta
             ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -10080,7 +10089,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UMatrix)))) (loc <opaque>)
@@ -10096,7 +10105,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UMatrix)))) (loc <opaque>)
@@ -10110,7 +10119,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -10120,7 +10129,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -10130,7 +10139,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array))
@@ -10141,7 +10150,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array))
@@ -10153,7 +10162,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_2d))
@@ -10167,7 +10176,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_2d))
@@ -10182,7 +10191,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_3d))
@@ -10198,7 +10207,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix_array_3d))
@@ -10212,7 +10221,7 @@
    ((pattern
      (Assignment (transformed_data_matrix UMatrix ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_matrix))
@@ -10222,7 +10231,7 @@
    ((pattern
      (Assignment (transformed_data_matrix_array (UArray UMatrix) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array))
            (meta
             ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly))))
@@ -10235,7 +10244,7 @@
      (Assignment
       (transformed_data_matrix_array_2d (UArray (UArray UMatrix)) ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_2d))
            (meta
             ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -10252,7 +10261,7 @@
       (transformed_data_matrix_array_3d (UArray (UArray (UArray UMatrix)))
        ())
       ((pattern
-        (FunApp (StanLib EltPow__ FnPlain)
+        (FunApp (StanLib EltPow__ FnPlain AoS)
          (((pattern (Var d_matrix_array_3d))
            (meta
             ((type_ (UArray (UArray (UArray UMatrix)))) (loc <opaque>)
@@ -10268,7 +10277,7 @@
    ((pattern
      (Assignment (td_int UInt ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var d_int))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_int))
@@ -10278,7 +10287,7 @@
    ((pattern
      (Assignment (transformed_data_real UReal ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var d_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var d_real))
@@ -10858,7 +10867,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
     (meta <opaque>))
    ((pattern
-     (NRFunApp (StanLib check_greater_or_equal FnPlain)
+     (NRFunApp (StanLib check_greater_or_equal FnPlain AoS)
       (((pattern (Lit Str "cholesky_factor_cov p_cfcov_54"))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Str "num rows (must be greater or equal to num cols)"))
@@ -10869,7 +10878,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
     (meta <opaque>))
    ((pattern
-     (NRFunApp (StanLib check_greater_or_equal FnPlain)
+     (NRFunApp (StanLib check_greater_or_equal FnPlain AoS)
       (((pattern (Lit Str "cholesky_factor_cov p_cfcov_33"))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Str "num rows (must be greater or equal to num cols)"))
@@ -10889,7 +10898,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
     (meta <opaque>))
    ((pattern
-     (NRFunApp (StanLib check_greater_or_equal FnPlain)
+     (NRFunApp (StanLib check_greater_or_equal FnPlain AoS)
       (((pattern (Lit Str "cholesky_factor_cov p_cfcov_33_ar"))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Str "num rows (must be greater or equal to num cols)"))
@@ -11376,7 +11385,9 @@
      (Assignment (p_real UReal ())
       ((pattern
         (FunApp
-         (CompilerInternal (FnReadParam (constrain Identity) (dims ()))) ()))
+         (CompilerInternal
+          (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+         ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -11393,7 +11404,7 @@
             (Lower
              ((pattern (Var p_real))
               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-           (dims ())))
+           (dims ()) (mem_pattern AoS)))
          ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11411,7 +11422,7 @@
             (Upper
              ((pattern (Var p_upper))
               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-           (dims ())))
+           (dims ()) (mem_pattern AoS)))
          ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11438,7 +11449,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Lit Int 5))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11463,7 +11475,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Lit Int 5))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11488,7 +11501,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Lit Int 5))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11513,7 +11527,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11548,7 +11563,8 @@
              ((pattern (Var M))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var K))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -11558,7 +11574,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -11575,7 +11591,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11584,7 +11601,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -11601,7 +11618,8 @@
             (((pattern (Var N))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -11613,7 +11631,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -11638,7 +11656,8 @@
              ((pattern (Var K))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -11648,7 +11667,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -11661,7 +11680,8 @@
           (FnReadParam (constrain Identity)
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11670,7 +11690,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -11687,7 +11707,8 @@
             (((pattern (Var N))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray URowVector)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -11699,7 +11720,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -11724,7 +11745,8 @@
              ((pattern (Var K))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -11734,7 +11756,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -11751,7 +11773,8 @@
             (((pattern (Lit Int 5))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 4))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11761,7 +11784,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -11792,7 +11815,8 @@
              ((pattern (Lit Int 2))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 3))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -11802,7 +11826,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -11815,7 +11839,8 @@
           (FnReadParam (constrain Simplex)
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11824,7 +11849,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -11841,7 +11866,8 @@
             (((pattern (Var N))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -11853,7 +11879,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -11878,7 +11904,8 @@
              ((pattern (Var K))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -11888,7 +11915,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -11905,7 +11932,8 @@
             (((pattern (Lit Int 5))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 4))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11913,7 +11941,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -11930,7 +11958,8 @@
             (((pattern (Lit Int 3))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 3))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11939,7 +11968,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -11960,7 +11989,8 @@
              ((pattern (Lit Int 3))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 3))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -11969,7 +11999,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id x_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -11982,7 +12012,8 @@
           (FnReadParam (constrain Identity)
            (dims
             (((pattern (Lit Int 2))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -11990,7 +12021,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id y_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -12003,7 +12034,8 @@
           (FnReadParam (constrain Identity)
            (dims
             (((pattern (Lit Int 2))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -12035,7 +12067,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -12045,7 +12077,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -12059,7 +12091,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -12074,7 +12106,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -12084,7 +12116,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -12098,7 +12130,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -12113,7 +12145,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -12126,7 +12158,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -12141,7 +12173,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -12151,7 +12183,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -12165,7 +12197,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -12180,7 +12212,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -12191,7 +12223,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id tp_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -12203,7 +12235,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -12216,7 +12248,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id theta_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -12287,7 +12319,7 @@
    ((pattern
      (Assignment (tp_mat UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_cfcov_54))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_mat))
@@ -12299,7 +12331,7 @@
    ((pattern
      (Assignment (tp_vec UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vec))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_vec))
@@ -12412,9 +12444,9 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern
-                    (FunApp (StanLib PMinus__ FnPlain)
+                    (FunApp (StanLib PMinus__ FnPlain AoS)
                      (((pattern (Lit Real 1.0))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -12438,7 +12470,7 @@
    ((pattern
      (Assignment (tp_row_vec URowVector ())
       ((pattern
-        (FunApp (StanLib Transpose__ FnPlain)
+        (FunApp (StanLib Transpose__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern (Var tp_1d_vec))
@@ -12467,14 +12499,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -12489,14 +12521,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -12517,14 +12549,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -12545,14 +12577,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -12567,14 +12599,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -12595,14 +12627,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -12617,14 +12649,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -12645,7 +12677,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -12655,7 +12687,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltDivide__ FnPlain)
+        (FunApp (StanLib EltDivide__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -13207,7 +13239,7 @@
          (Decl (decl_adtype AutoDiffable) (decl_id tmp)
           (decl_type
            (Sized
-            (SVector
+            (SVector AoS
              ((pattern (Lit Int 0))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
           (initialize true)))
@@ -13217,7 +13249,7 @@
           (decl_type
            (Sized
             (SArray
-             (SVector
+             (SVector AoS
               ((pattern (Lit Int 0))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
              ((pattern (Lit Int 0))
@@ -13251,7 +13283,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var p_real))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
               ((pattern (Lit Int 0))
@@ -13263,7 +13295,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var offset_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -13277,7 +13309,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var no_offset_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -13291,7 +13323,7 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern (Var offset_no_multiplier))
                (meta
                 ((type_ (UArray UReal)) (loc <opaque>)
@@ -13305,9 +13337,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_real_1d_ar))
                    (meta
                     ((type_ (UArray UReal)) (loc <opaque>)
@@ -13333,9 +13365,9 @@
               (((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_1d_vec))
@@ -13365,9 +13397,9 @@
                ((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_1d_row_vec))
@@ -13397,9 +13429,9 @@
                ((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_1d_simplex))
@@ -13454,9 +13486,10 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
-                                        (FunApp (StanLib to_vector FnPlain)
+                                        (FunApp
+                                         (StanLib to_vector FnPlain AoS)
                                          (((pattern
                                             (Indexed
                                              ((pattern (Var p_3d_vec))
@@ -13526,9 +13559,10 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
-                                        (FunApp (StanLib to_vector FnPlain)
+                                        (FunApp
+                                         (StanLib to_vector FnPlain AoS)
                                          (((pattern
                                             (Indexed
                                              ((pattern (Var p_3d_row_vec))
@@ -13600,9 +13634,10 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
-                                        (FunApp (StanLib to_vector FnPlain)
+                                        (FunApp
+                                         (StanLib to_vector FnPlain AoS)
                                          (((pattern
                                             (Indexed
                                              ((pattern (Var p_3d_simplex))
@@ -13672,7 +13707,7 @@
                                  (TargetPE
                                   ((pattern
                                     (FunApp
-                                     (StanLib normal_lpdf (FnLpdf true))
+                                     (StanLib normal_lpdf (FnLpdf true) AoS)
                                      (((pattern
                                         (Indexed
                                          ((pattern (Var p_real_3d_ar))
@@ -13764,9 +13799,9 @@
                       (((pattern
                          (TargetPE
                           ((pattern
-                            (FunApp (StanLib normal_lpdf (FnLpdf true))
+                            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                              (((pattern
-                                (FunApp (StanLib to_vector FnPlain)
+                                (FunApp (StanLib to_vector FnPlain AoS)
                                  (((pattern
                                     (Indexed
                                      ((pattern (Var p_ar_mat))
@@ -13820,9 +13855,9 @@
               (((pattern
                  (TargetPE
                   ((pattern
-                    (FunApp (StanLib normal_lpdf (FnLpdf true))
+                    (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
                      (((pattern
-                        (FunApp (StanLib to_vector FnPlain)
+                        (FunApp (StanLib to_vector FnPlain AoS)
                          (((pattern
                             (Indexed
                              ((pattern (Var p_cfcov_33_ar))
@@ -13854,9 +13889,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_vec))
                    (meta
                     ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -13870,9 +13905,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_row_vec))
                    (meta
                     ((type_ URowVector) (loc <opaque>)
@@ -13887,9 +13922,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_simplex))
                    (meta
                     ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -13903,9 +13938,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_cfcov_54))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -13919,9 +13954,9 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib normal_lpdf (FnLpdf true))
+            (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
              (((pattern
-                (FunApp (StanLib to_vector FnPlain)
+                (FunApp (StanLib to_vector FnPlain AoS)
                  (((pattern (Var p_cfcov_33))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
@@ -13935,14 +13970,14 @@
        ((pattern
          (TargetPE
           ((pattern
-            (FunApp (StanLib map_rect FnPlain)
+            (FunApp (StanLib map_rect FnPlain AoS)
              (((pattern (Var binomialf))
                (meta
                 ((type_
                   (UFun
                    ((AutoDiffable UVector) (AutoDiffable UVector)
                     (DataOnly (UArray UReal)) (DataOnly (UArray UInt)))
-                   (ReturnType UVector) FnPlain))
+                   (ReturnType UVector) FnPlain AoS))
                  (loc <opaque>) (adlevel AutoDiffable))))
               ((pattern (Var tmp))
                (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -13970,7 +14005,9 @@
      (Assignment (p_real UReal ())
       ((pattern
         (FunApp
-         (CompilerInternal (FnReadParam (constrain Identity) (dims ()))) ()))
+         (CompilerInternal
+          (FnReadParam (constrain Identity) (dims ()) (mem_pattern AoS)))
+         ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -13987,7 +14024,7 @@
             (Lower
              ((pattern (Var p_real))
               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-           (dims ())))
+           (dims ()) (mem_pattern AoS)))
          ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14005,7 +14042,7 @@
             (Upper
              ((pattern (Var p_upper))
               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-           (dims ())))
+           (dims ()) (mem_pattern AoS)))
          ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14032,7 +14069,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Lit Int 5))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14057,7 +14095,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Lit Int 5))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14082,7 +14121,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Lit Int 5))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14107,7 +14147,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14142,7 +14183,8 @@
              ((pattern (Var M))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var K))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
@@ -14152,7 +14194,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -14169,7 +14211,8 @@
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14178,7 +14221,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -14195,7 +14238,8 @@
             (((pattern (Var N))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -14207,7 +14251,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -14232,7 +14276,8 @@
              ((pattern (Var K))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -14242,7 +14287,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -14255,7 +14300,8 @@
           (FnReadParam (constrain Identity)
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14264,7 +14310,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -14281,7 +14327,8 @@
             (((pattern (Var N))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray URowVector)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -14293,7 +14340,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -14318,7 +14365,8 @@
              ((pattern (Var K))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
@@ -14328,7 +14376,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -14345,7 +14393,8 @@
             (((pattern (Lit Int 5))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 4))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14355,7 +14404,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -14386,7 +14435,8 @@
              ((pattern (Lit Int 2))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 3))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
@@ -14396,7 +14446,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -14409,7 +14459,8 @@
           (FnReadParam (constrain Simplex)
            (dims
             (((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14418,7 +14469,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -14435,7 +14486,8 @@
             (((pattern (Var N))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray UVector)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -14447,7 +14499,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -14472,7 +14524,8 @@
              ((pattern (Var K))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Var N))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
@@ -14482,7 +14535,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -14499,7 +14552,8 @@
             (((pattern (Lit Int 5))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 4))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14507,7 +14561,7 @@
      (Decl (decl_adtype DataOnly) (decl_id p_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -14524,7 +14578,8 @@
             (((pattern (Lit Int 3))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 3))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14533,7 +14588,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -14554,7 +14609,8 @@
              ((pattern (Lit Int 3))
               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
              ((pattern (Lit Int 3))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta
         ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -14563,7 +14619,7 @@
      (Decl (decl_adtype DataOnly) (decl_id x_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -14576,7 +14632,8 @@
           (FnReadParam (constrain Identity)
            (dims
             (((pattern (Lit Int 2))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14584,7 +14641,7 @@
      (Decl (decl_adtype DataOnly) (decl_id y_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize false)))
@@ -14597,7 +14654,8 @@
           (FnReadParam (constrain Identity)
            (dims
             (((pattern (Lit Int 2))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+           (mem_pattern AoS)))
          ()))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
@@ -14629,7 +14687,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -14639,7 +14697,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -14653,7 +14711,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -14668,7 +14726,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -14678,7 +14736,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -14692,7 +14750,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -14707,7 +14765,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -14720,7 +14778,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -14735,7 +14793,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -14745,7 +14803,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -14759,7 +14817,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -14774,7 +14832,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -14785,7 +14843,7 @@
      (Decl (decl_adtype DataOnly) (decl_id tp_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -14797,7 +14855,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -14810,7 +14868,7 @@
      (Decl (decl_adtype DataOnly) (decl_id theta_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -15049,7 +15107,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib PNot__ FnPlain)
+        (FunApp (StanLib PNot__ FnPlain AoS)
          (((pattern
             (EOr
              ((pattern (Var emit_transformed_parameters__))
@@ -15124,7 +15182,7 @@
    ((pattern
      (Assignment (tp_mat UMatrix ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_cfcov_54))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_mat))
@@ -15136,7 +15194,7 @@
    ((pattern
      (Assignment (tp_vec UVector ())
       ((pattern
-        (FunApp (StanLib fma FnPlain)
+        (FunApp (StanLib fma FnPlain AoS)
          (((pattern (Var d_vec))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var p_vec))
@@ -15249,9 +15307,9 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern
-                    (FunApp (StanLib PMinus__ FnPlain)
+                    (FunApp (StanLib PMinus__ FnPlain AoS)
                      (((pattern (Lit Real 1.0))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -15275,7 +15333,7 @@
    ((pattern
      (Assignment (tp_row_vec URowVector ())
       ((pattern
-        (FunApp (StanLib Transpose__ FnPlain)
+        (FunApp (StanLib Transpose__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern (Var tp_1d_vec))
@@ -15304,14 +15362,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -15326,14 +15384,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -15354,14 +15412,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
@@ -15382,14 +15440,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -15404,14 +15462,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -15432,14 +15490,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -15454,14 +15512,14 @@
    ((pattern
      (Assignment (theta_p UVector ())
       ((pattern
-        (FunApp (StanLib algebra_solver FnPlain)
+        (FunApp (StanLib algebra_solver FnPlain AoS)
          (((pattern (Var algebra_system))
            (meta
             ((type_
               (UFun
                ((AutoDiffable UVector) (AutoDiffable UVector)
                 (AutoDiffable (UArray UReal)) (AutoDiffable (UArray UInt)))
-               (ReturnType UVector) FnPlain))
+               (ReturnType UVector) FnPlain AoS))
              (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x_p))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
@@ -15482,7 +15540,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltTimes__ FnPlain)
+        (FunApp (StanLib EltTimes__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -15492,7 +15550,7 @@
    ((pattern
      (Assignment (tp_real UReal ())
       ((pattern
-        (FunApp (StanLib EltDivide__ FnPlain)
+        (FunApp (StanLib EltDivide__ FnPlain AoS)
          (((pattern (Var p_real))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var p_real))
@@ -16228,7 +16286,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib PNot__ FnPlain)
+        (FunApp (StanLib PNot__ FnPlain AoS)
          (((pattern (Var emit_generated_quantities__))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -16288,7 +16346,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -16298,7 +16356,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -16312,7 +16370,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -16327,7 +16385,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -16337,7 +16395,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -16351,7 +16409,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -16368,7 +16426,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -16383,7 +16441,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -16393,7 +16451,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -16407,7 +16465,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -16422,7 +16480,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -16433,7 +16491,7 @@
      (Decl (decl_adtype DataOnly) (decl_id gq_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -16445,7 +16503,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -16480,7 +16538,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -16494,7 +16552,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -16508,7 +16566,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -16522,7 +16580,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -16536,7 +16594,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -16550,7 +16608,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -16564,7 +16622,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -16578,7 +16636,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Lit Int 4))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Lit Int 3))
@@ -16590,7 +16648,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Lit Int 2))
@@ -16792,9 +16850,9 @@
                  ((pattern (Var i))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (StanLib Times__ FnPlain)
+                (FunApp (StanLib Times__ FnPlain AoS)
                  (((pattern
-                    (FunApp (StanLib PMinus__ FnPlain)
+                    (FunApp (StanLib PMinus__ FnPlain AoS)
                      (((pattern (Lit Real 1.0))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
@@ -16867,7 +16925,7 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp (StanLib normal_rng FnRng)
+                                (FunApp (StanLib normal_rng FnRng AoS)
                                  (((pattern (Lit Int 0))
                                    (meta
                                     ((type_ UInt) (loc <opaque>)
@@ -16893,7 +16951,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
        ((pattern
-         (FunApp (StanLib size FnPlain)
+         (FunApp (StanLib size FnPlain AoS)
           (((pattern (Var indices))
             (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
@@ -16907,7 +16965,7 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
                ((pattern
-                 (FunApp (StanLib size FnPlain)
+                 (FunApp (StanLib size FnPlain AoS)
                   (((pattern (Var indices))
                     (meta
                      ((type_ (UArray UInt)) (loc <opaque>)
@@ -16986,7 +17044,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib NEquals__ FnPlain)
+        (FunApp (StanLib NEquals__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern
@@ -17059,7 +17117,7 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
                ((pattern
-                 (FunApp (StanLib size FnPlain)
+                 (FunApp (StanLib size FnPlain AoS)
                   (((pattern (Var indices))
                     (meta
                      ((type_ (UArray UInt)) (loc <opaque>)
@@ -17126,7 +17184,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib NEquals__ FnPlain)
+        (FunApp (StanLib NEquals__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern
@@ -17185,7 +17243,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
        ((pattern
-         (FunApp (StanLib size FnPlain)
+         (FunApp (StanLib size FnPlain AoS)
           (((pattern (Var indices))
             (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
@@ -17211,7 +17269,7 @@
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
                        ((pattern
-                         (FunApp (StanLib size FnPlain)
+                         (FunApp (StanLib size FnPlain AoS)
                           (((pattern (Var indices))
                             (meta
                              ((type_ (UArray UInt)) (loc <opaque>)
@@ -17308,7 +17366,7 @@
    ((pattern
      (IfElse
       ((pattern
-        (FunApp (StanLib NEquals__ FnPlain)
+        (FunApp (StanLib NEquals__ FnPlain AoS)
          (((pattern
             (Indexed
              ((pattern
@@ -18540,7 +18598,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_vec)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -18588,7 +18646,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -18657,7 +18715,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -18776,7 +18834,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_row_vec)
       (decl_type
        (Sized
-        (SRowVector
+        (SRowVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -18821,7 +18879,7 @@
       (decl_type
        (Sized
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -18891,7 +18949,7 @@
         (SArray
          (SArray
           (SArray
-           (SRowVector
+           (SRowVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -19010,7 +19068,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_mat)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -19081,7 +19139,7 @@
        (Sized
         (SArray
          (SArray
-          (SMatrix
+          (SMatrix AoS
            ((pattern (Lit Int 2))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 3))
@@ -19210,7 +19268,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_simplex)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Var N))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -19254,7 +19312,7 @@
       (decl_type
        (Sized
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var N))
@@ -19323,7 +19381,7 @@
         (SArray
          (SArray
           (SArray
-           (SVector
+           (SVector AoS
             ((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
            ((pattern (Var K))
@@ -19442,7 +19500,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_54)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 5))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 4))
@@ -19511,7 +19569,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_33)
       (decl_type
        (Sized
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 3))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -19581,7 +19639,7 @@
       (decl_type
        (Sized
         (SArray
-         (SMatrix
+         (SMatrix AoS
           ((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -19677,7 +19735,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id x_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -19720,7 +19778,7 @@
      (Decl (decl_adtype AutoDiffable) (decl_id y_p)
       (decl_type
        (Sized
-        (SVector
+        (SVector AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
       (initialize true)))
@@ -19863,11 +19921,11 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (p_vec
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters)
@@ -19878,14 +19936,14 @@
    (p_1d_vec
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -19896,7 +19954,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -19909,7 +19967,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -19921,25 +19979,25 @@
      (out_block Parameters) (out_trans Identity)))
    (p_row_vec
     ((out_unconstrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
    (p_1d_row_vec
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -19950,7 +20008,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -19963,7 +20021,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -19975,13 +20033,13 @@
      (out_block Parameters) (out_trans Identity)))
    (p_mat
     ((out_unconstrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -19991,7 +20049,7 @@
     ((out_unconstrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -20003,7 +20061,7 @@
      (out_constrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -20021,25 +20079,25 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (p_simplex
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Minus__ FnPlain)
+         (FunApp (StanLib Minus__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Simplex)))
    (p_1d_simplex
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Minus__ FnPlain)
+          (FunApp (StanLib Minus__ FnPlain AoS)
            (((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Lit Int 1))
@@ -20049,7 +20107,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -20060,9 +20118,9 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern
-            (FunApp (StanLib Minus__ FnPlain)
+            (FunApp (StanLib Minus__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Lit Int 1))
@@ -20078,7 +20136,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20090,20 +20148,20 @@
      (out_block Parameters) (out_trans Simplex)))
    (p_cfcov_54
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 4))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 4))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -20120,9 +20178,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 5))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 4))
@@ -20133,7 +20191,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -20141,20 +20199,20 @@
      (out_block Parameters) (out_trans CholeskyCov)))
    (p_cfcov_33
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 3))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 3))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -20171,9 +20229,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 3))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 3))
@@ -20184,7 +20242,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -20193,20 +20251,20 @@
    (p_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Plus__ FnPlain)
+          (FunApp (StanLib Plus__ FnPlain AoS)
            (((pattern
-              (FunApp (StanLib Plus__ FnPlain)
+              (FunApp (StanLib Plus__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Divide__ FnPlain)
+                  (FunApp (StanLib Divide__ FnPlain AoS)
                    (((pattern
-                      (FunApp (StanLib Times__ FnPlain)
+                      (FunApp (StanLib Times__ FnPlain AoS)
                        (((pattern (Lit Int 3))
                          (meta
                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                         ((pattern
-                          (FunApp (StanLib Minus__ FnPlain)
+                          (FunApp (StanLib Minus__ FnPlain AoS)
                            (((pattern (Lit Int 3))
                              (meta
                               ((type_ UInt) (loc <opaque>)
@@ -20225,9 +20283,9 @@
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern
-              (FunApp (StanLib Times__ FnPlain)
+              (FunApp (StanLib Times__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Minus__ FnPlain)
+                  (FunApp (StanLib Minus__ FnPlain AoS)
                    (((pattern (Lit Int 3))
                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                     ((pattern (Lit Int 3))
@@ -20241,7 +20299,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -20251,21 +20309,21 @@
      (out_block Parameters) (out_trans CholeskyCov)))
    (x_p
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
    (y_p
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))
@@ -20311,11 +20369,11 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (tp_vec
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters)
@@ -20326,14 +20384,14 @@
    (tp_1d_vec
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -20344,7 +20402,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20357,7 +20415,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20369,25 +20427,25 @@
      (out_block TransformedParameters) (out_trans Identity)))
    (tp_row_vec
     ((out_unconstrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))
    (tp_1d_row_vec
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -20398,7 +20456,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20411,7 +20469,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20423,13 +20481,13 @@
      (out_block TransformedParameters) (out_trans Identity)))
    (tp_mat
     ((out_unconstrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -20439,7 +20497,7 @@
     ((out_unconstrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -20451,7 +20509,7 @@
      (out_constrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -20469,25 +20527,25 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (tp_simplex
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Minus__ FnPlain)
+         (FunApp (StanLib Minus__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Simplex)))
    (tp_1d_simplex
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Minus__ FnPlain)
+          (FunApp (StanLib Minus__ FnPlain AoS)
            (((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Lit Int 1))
@@ -20497,7 +20555,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -20508,9 +20566,9 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern
-            (FunApp (StanLib Minus__ FnPlain)
+            (FunApp (StanLib Minus__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Lit Int 1))
@@ -20526,7 +20584,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20538,20 +20596,20 @@
      (out_block TransformedParameters) (out_trans Simplex)))
    (tp_cfcov_54
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 4))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 4))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -20568,9 +20626,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 5))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 4))
@@ -20581,7 +20639,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -20589,20 +20647,20 @@
      (out_block TransformedParameters) (out_trans CholeskyCov)))
    (tp_cfcov_33
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 3))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 3))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -20619,9 +20677,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 3))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 3))
@@ -20632,7 +20690,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -20641,20 +20699,20 @@
    (tp_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Plus__ FnPlain)
+          (FunApp (StanLib Plus__ FnPlain AoS)
            (((pattern
-              (FunApp (StanLib Plus__ FnPlain)
+              (FunApp (StanLib Plus__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Divide__ FnPlain)
+                  (FunApp (StanLib Divide__ FnPlain AoS)
                    (((pattern
-                      (FunApp (StanLib Times__ FnPlain)
+                      (FunApp (StanLib Times__ FnPlain AoS)
                        (((pattern (Lit Int 3))
                          (meta
                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                         ((pattern
-                          (FunApp (StanLib Minus__ FnPlain)
+                          (FunApp (StanLib Minus__ FnPlain AoS)
                            (((pattern (Lit Int 3))
                              (meta
                               ((type_ UInt) (loc <opaque>)
@@ -20673,9 +20731,9 @@
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern
-              (FunApp (StanLib Times__ FnPlain)
+              (FunApp (StanLib Times__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Minus__ FnPlain)
+                  (FunApp (StanLib Minus__ FnPlain AoS)
                    (((pattern (Lit Int 3))
                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                     ((pattern (Lit Int 3))
@@ -20689,7 +20747,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -20699,11 +20757,11 @@
      (out_block TransformedParameters) (out_trans CholeskyCov)))
    (theta_p
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))
@@ -20758,11 +20816,11 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (gq_vec
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block GeneratedQuantities)
@@ -20773,14 +20831,14 @@
    (gq_1d_vec
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -20791,7 +20849,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20804,7 +20862,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20816,25 +20874,25 @@
      (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_row_vec
     ((out_unconstrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SRowVector
+      (SRowVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block GeneratedQuantities) (out_trans Identity)))
    (gq_1d_row_vec
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -20845,7 +20903,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20858,7 +20916,7 @@
       (SArray
        (SArray
         (SArray
-         (SRowVector
+         (SRowVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20872,7 +20930,7 @@
     ((out_unconstrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -20884,7 +20942,7 @@
      (out_constrained_st
       (SArray
        (SArray
-        (SMatrix
+        (SMatrix AoS
          ((pattern (Lit Int 2))
           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
          ((pattern (Lit Int 3))
@@ -20902,25 +20960,25 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
    (gq_simplex
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Minus__ FnPlain)
+         (FunApp (StanLib Minus__ FnPlain AoS)
           (((pattern (Var N))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern (Lit Int 1))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SVector
+      (SVector AoS
        ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block GeneratedQuantities) (out_trans Simplex)))
    (gq_1d_simplex
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Minus__ FnPlain)
+          (FunApp (StanLib Minus__ FnPlain AoS)
            (((pattern (Var N))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Lit Int 1))
@@ -20930,7 +20988,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Var N))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Var N))
@@ -20941,9 +20999,9 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern
-            (FunApp (StanLib Minus__ FnPlain)
+            (FunApp (StanLib Minus__ FnPlain AoS)
              (((pattern (Var N))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Lit Int 1))
@@ -20959,7 +21017,7 @@
       (SArray
        (SArray
         (SArray
-         (SVector
+         (SVector AoS
           ((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
          ((pattern (Var K))
@@ -20971,20 +21029,20 @@
      (out_block GeneratedQuantities) (out_trans Simplex)))
    (gq_cfcov_54
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 4))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 4))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -21001,9 +21059,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 5))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 4))
@@ -21014,7 +21072,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 4))
@@ -21022,20 +21080,20 @@
      (out_block GeneratedQuantities) (out_trans CholeskyCov)))
    (gq_cfcov_33
     ((out_unconstrained_st
-      (SVector
+      (SVector AoS
        ((pattern
-         (FunApp (StanLib Plus__ FnPlain)
+         (FunApp (StanLib Plus__ FnPlain AoS)
           (((pattern
-             (FunApp (StanLib Plus__ FnPlain)
+             (FunApp (StanLib Plus__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Divide__ FnPlain)
+                 (FunApp (StanLib Divide__ FnPlain AoS)
                   (((pattern
-                     (FunApp (StanLib Times__ FnPlain)
+                     (FunApp (StanLib Times__ FnPlain AoS)
                       (((pattern (Lit Int 3))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                        ((pattern
-                         (FunApp (StanLib Minus__ FnPlain)
+                         (FunApp (StanLib Minus__ FnPlain AoS)
                           (((pattern (Lit Int 3))
                             (meta
                              ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -21052,9 +21110,9 @@
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
            ((pattern
-             (FunApp (StanLib Times__ FnPlain)
+             (FunApp (StanLib Times__ FnPlain AoS)
               (((pattern
-                 (FunApp (StanLib Minus__ FnPlain)
+                 (FunApp (StanLib Minus__ FnPlain AoS)
                   (((pattern (Lit Int 3))
                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                    ((pattern (Lit Int 3))
@@ -21065,7 +21123,7 @@
             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
-      (SMatrix
+      (SMatrix AoS
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
        ((pattern (Lit Int 3))
@@ -21074,20 +21132,20 @@
    (gq_cfcov_33_ar
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern
-          (FunApp (StanLib Plus__ FnPlain)
+          (FunApp (StanLib Plus__ FnPlain AoS)
            (((pattern
-              (FunApp (StanLib Plus__ FnPlain)
+              (FunApp (StanLib Plus__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Divide__ FnPlain)
+                  (FunApp (StanLib Divide__ FnPlain AoS)
                    (((pattern
-                      (FunApp (StanLib Times__ FnPlain)
+                      (FunApp (StanLib Times__ FnPlain AoS)
                        (((pattern (Lit Int 3))
                          (meta
                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                         ((pattern
-                          (FunApp (StanLib Minus__ FnPlain)
+                          (FunApp (StanLib Minus__ FnPlain AoS)
                            (((pattern (Lit Int 3))
                              (meta
                               ((type_ UInt) (loc <opaque>)
@@ -21106,9 +21164,9 @@
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern
-              (FunApp (StanLib Times__ FnPlain)
+              (FunApp (StanLib Times__ FnPlain AoS)
                (((pattern
-                  (FunApp (StanLib Minus__ FnPlain)
+                  (FunApp (StanLib Minus__ FnPlain AoS)
                    (((pattern (Lit Int 3))
                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                     ((pattern (Lit Int 3))
@@ -21122,7 +21180,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -21143,7 +21201,7 @@
    (indexing_mat
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21152,7 +21210,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21163,7 +21221,7 @@
    (idx_res1
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21172,7 +21230,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21183,7 +21241,7 @@
    (idx_res2
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21192,7 +21250,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21203,7 +21261,7 @@
    (idx_res3
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -21212,7 +21270,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -21223,7 +21281,7 @@
    (idx_res11
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21232,7 +21290,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21243,7 +21301,7 @@
    (idx_res21
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21252,7 +21310,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 4))
@@ -21263,7 +21321,7 @@
    (idx_res31
     ((out_unconstrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -21272,7 +21330,7 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SMatrix
+       (SMatrix AoS
         ((pattern (Lit Int 3))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
         ((pattern (Lit Int 3))
@@ -21283,14 +21341,14 @@
    (idx_res4
     ((out_unconstrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Lit Int 4))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SRowVector
+       (SRowVector AoS
         ((pattern (Lit Int 4))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 3))
@@ -21299,14 +21357,14 @@
    (idx_res5
     ((out_unconstrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Lit Int 2))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 2))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_constrained_st
       (SArray
-       (SVector
+       (SVector AoS
         ((pattern (Lit Int 2))
          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
        ((pattern (Lit Int 2))

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2076,18 +2076,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           lcm_sym122__ = rvalue(first, "first", index_uni(1));
           if (logical_gt(lcm_sym122__, 0)) {
             lcm_sym128__ = rvalue(last, "last", index_uni(1));
-            lcm_sym104__ = (lcm_sym122__ + 1);
-            if (logical_gte(lcm_sym128__, lcm_sym104__)) {
+            if (logical_gte(lcm_sym128__, (lcm_sym122__ + 1))) {
               current_statement__ = 24;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
                   rvalue(phi, "phi",
-                    index_uni(1), index_uni((lcm_sym104__ - 1)))));
-              lcm_sym102__ = (lcm_sym104__ + 1);
+                    index_uni(1), index_uni(((lcm_sym122__ + 1) - 1)))));
+              lcm_sym102__ = ((lcm_sym122__ + 1) + 1);
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(
-                  rvalue(y, "y", index_uni(1), index_uni(lcm_sym104__)),
-                  rvalue(p, "p", index_uni(1), index_uni((lcm_sym104__ - 1)))));
+                  rvalue(y, "y", index_uni(1), index_uni((lcm_sym122__ + 1))),
+                  rvalue(p, "p",
+                    index_uni(1), index_uni(((lcm_sym122__ + 1) - 1)))));
               for (int t = lcm_sym102__; t <= lcm_sym128__; ++t) {
                 current_statement__ = 24;
                 lp_accum__.add(
@@ -2110,19 +2110,19 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             lcm_sym121__ = rvalue(first, "first", index_uni(i));
             if (logical_gt(lcm_sym121__, 0)) {
               lcm_sym127__ = rvalue(last, "last", index_uni(i));
-              lcm_sym103__ = (lcm_sym121__ + 1);
-              if (logical_gte(lcm_sym127__, lcm_sym103__)) {
+              if (logical_gte(lcm_sym127__, (lcm_sym121__ + 1))) {
                 current_statement__ = 24;
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(1,
                     rvalue(phi, "phi",
-                      index_uni(i), index_uni((lcm_sym103__ - 1)))));
-                lcm_sym101__ = (lcm_sym103__ + 1);
+                      index_uni(i), index_uni(((lcm_sym121__ + 1) - 1)))));
+                lcm_sym101__ = ((lcm_sym121__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
-                    rvalue(y, "y", index_uni(i), index_uni(lcm_sym103__)),
+                    rvalue(y, "y",
+                      index_uni(i), index_uni((lcm_sym121__ + 1))),
                     rvalue(p, "p",
-                      index_uni(i), index_uni((lcm_sym103__ - 1)))));
+                      index_uni(i), index_uni(((lcm_sym121__ + 1) - 1)))));
                 for (int t = lcm_sym101__; t <= lcm_sym127__; ++t) {
                   current_statement__ = 24;
                   lp_accum__.add(
@@ -9034,18 +9034,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           lcm_sym122__ = rvalue(first, "first", index_uni(1));
           if (logical_gt(lcm_sym122__, 0)) {
             lcm_sym128__ = rvalue(last, "last", index_uni(1));
-            lcm_sym104__ = (lcm_sym122__ + 1);
-            if (logical_gte(lcm_sym128__, lcm_sym104__)) {
+            if (logical_gte(lcm_sym128__, (lcm_sym122__ + 1))) {
               current_statement__ = 29;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
                   rvalue(phi, "phi",
-                    index_uni(1), index_uni((lcm_sym104__ - 1)))));
-              lcm_sym102__ = (lcm_sym104__ + 1);
+                    index_uni(1), index_uni(((lcm_sym122__ + 1) - 1)))));
+              lcm_sym102__ = ((lcm_sym122__ + 1) + 1);
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(
-                  rvalue(y, "y", index_uni(1), index_uni(lcm_sym104__)),
-                  rvalue(p, "p", index_uni(1), index_uni((lcm_sym104__ - 1)))));
+                  rvalue(y, "y", index_uni(1), index_uni((lcm_sym122__ + 1))),
+                  rvalue(p, "p",
+                    index_uni(1), index_uni(((lcm_sym122__ + 1) - 1)))));
               for (int t = lcm_sym102__; t <= lcm_sym128__; ++t) {
                 current_statement__ = 29;
                 lp_accum__.add(
@@ -9068,19 +9068,19 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             lcm_sym121__ = rvalue(first, "first", index_uni(i));
             if (logical_gt(lcm_sym121__, 0)) {
               lcm_sym127__ = rvalue(last, "last", index_uni(i));
-              lcm_sym103__ = (lcm_sym121__ + 1);
-              if (logical_gte(lcm_sym127__, lcm_sym103__)) {
+              if (logical_gte(lcm_sym127__, (lcm_sym121__ + 1))) {
                 current_statement__ = 29;
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(1,
                     rvalue(phi, "phi",
-                      index_uni(i), index_uni((lcm_sym103__ - 1)))));
-                lcm_sym101__ = (lcm_sym103__ + 1);
+                      index_uni(i), index_uni(((lcm_sym121__ + 1) - 1)))));
+                lcm_sym101__ = ((lcm_sym121__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
-                    rvalue(y, "y", index_uni(i), index_uni(lcm_sym103__)),
+                    rvalue(y, "y",
+                      index_uni(i), index_uni((lcm_sym121__ + 1))),
                     rvalue(p, "p",
-                      index_uni(i), index_uni((lcm_sym103__ - 1)))));
+                      index_uni(i), index_uni(((lcm_sym121__ + 1) - 1)))));
                 for (int t = lcm_sym101__; t <= lcm_sym127__; ++t) {
                   current_statement__ = 29;
                   lp_accum__.add(
@@ -10459,12 +10459,12 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             bernoulli_lpmf<propto__>(1,
               rvalue(phi, "phi",
                 index_uni(1), index_uni(((lcm_sym111__ + 1) - 1)))));
-          lcm_sym93__ = ((lcm_sym111__ + 1) + 1);
+          lcm_sym94__ = ((lcm_sym111__ + 1) + 1);
           lp_accum__.add(
             bernoulli_lpmf<propto__>(
               rvalue(y, "y", index_uni(1), index_uni((lcm_sym111__ + 1))),
               rvalue(p, "p", index_uni(1), index_uni((lcm_sym111__ + 1)))));
-          for (int t = lcm_sym93__; t <= lcm_sym113__; ++t) {
+          for (int t = lcm_sym94__; t <= lcm_sym113__; ++t) {
             current_statement__ = 97;
             lp_accum__.add(
               bernoulli_lpmf<propto__>(1,
@@ -10481,10 +10481,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
           bernoulli_lpmf<propto__>(1,
             rvalue(chi, "chi", index_uni(1), index_uni(lcm_sym113__))));
       } else {
-        lcm_sym94__ = (lcm_sym115__ + 1);
-        validate_non_negative_index("lp", "n_occasions + 1", lcm_sym94__);
+        lcm_sym92__ = (lcm_sym115__ + 1);
+        validate_non_negative_index("lp", "n_occasions + 1", lcm_sym92__);
         Eigen::Matrix<local_scalar_t__, -1, 1> lp;
-        lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym94__);
+        lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym92__);
         stan::math::fill(lp, DUMMY_VAR__);
         
         current_statement__ = 102;
@@ -10528,7 +10528,7 @@ js_super_lp(const std::vector<std::vector<int>>& y,
         } 
         current_statement__ = 85;
         assign(lp, bernoulli_lpmf<false>(0, psi),
-          "assigning variable lp", index_uni(lcm_sym94__));
+          "assigning variable lp", index_uni(lcm_sym92__));
         current_statement__ = 86;
         lp_accum__.add(log_sum_exp(lp));
       }
@@ -10634,12 +10634,12 @@ js_super_lp(const std::vector<std::vector<int>>& y,
               bernoulli_lpmf<propto__>(1,
                 rvalue(phi, "phi",
                   index_uni(i), index_uni(((lcm_sym110__ + 1) - 1)))));
-            lcm_sym92__ = ((lcm_sym110__ + 1) + 1);
+            lcm_sym93__ = ((lcm_sym110__ + 1) + 1);
             lp_accum__.add(
               bernoulli_lpmf<propto__>(
                 rvalue(y, "y", index_uni(i), index_uni((lcm_sym110__ + 1))),
                 rvalue(p, "p", index_uni(i), index_uni((lcm_sym110__ + 1)))));
-            for (int t = lcm_sym92__; t <= lcm_sym112__; ++t) {
+            for (int t = lcm_sym93__; t <= lcm_sym112__; ++t) {
               current_statement__ = 97;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
@@ -10656,10 +10656,10 @@ js_super_lp(const std::vector<std::vector<int>>& y,
             bernoulli_lpmf<propto__>(1,
               rvalue(chi, "chi", index_uni(i), index_uni(lcm_sym112__))));
         } else {
-          lcm_sym94__ = (lcm_sym115__ + 1);
-          validate_non_negative_index("lp", "n_occasions + 1", lcm_sym94__);
+          lcm_sym92__ = (lcm_sym115__ + 1);
+          validate_non_negative_index("lp", "n_occasions + 1", lcm_sym92__);
           Eigen::Matrix<local_scalar_t__, -1, 1> lp;
-          lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym94__);
+          lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym92__);
           stan::math::fill(lp, DUMMY_VAR__);
           
           current_statement__ = 102;
@@ -10705,7 +10705,7 @@ js_super_lp(const std::vector<std::vector<int>>& y,
           } 
           current_statement__ = 85;
           assign(lp, bernoulli_lpmf<false>(0, psi),
-            "assigning variable lp", index_uni(lcm_sym94__));
+            "assigning variable lp", index_uni(lcm_sym92__));
           current_statement__ = 86;
           lp_accum__.add(log_sum_exp(lp));
         }
@@ -11221,9 +11221,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       double lcm_sym237__;
       double lcm_sym236__;
       int lcm_sym235__;
-      double lcm_sym234__;
+      int lcm_sym234__;
       int lcm_sym233__;
-      int lcm_sym232__;
+      double lcm_sym232__;
       double lcm_sym231__;
       double lcm_sym230__;
       double lcm_sym229__;
@@ -11770,14 +11770,14 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   bernoulli_lpmf<propto__>(1,
                     rvalue(lcm_sym257__, "lcm_sym257__",
                       index_uni(1), index_uni(((lcm_sym260__ + 1) - 1)))));
-                lcm_sym233__ = ((lcm_sym260__ + 1) + 1);
+                lcm_sym235__ = ((lcm_sym260__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
                     rvalue(y, "y",
                       index_uni(1), index_uni((lcm_sym260__ + 1))),
                     rvalue(p, "p",
                       index_uni(1), index_uni((lcm_sym260__ + 1)))));
-                for (int inline_sym30__ = lcm_sym233__;
+                for (int inline_sym30__ = lcm_sym235__;
                      inline_sym30__ <= lcm_sym266__; ++inline_sym30__) {
                   current_statement__ = 97;
                   lp_accum__.add(
@@ -11797,11 +11797,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   rvalue(inline_sym15__, "inline_sym15__",
                     index_uni(1), index_uni(lcm_sym266__))));
             } else {
-              lcm_sym235__ = (lcm_sym275__ + 1);
+              lcm_sym233__ = (lcm_sym275__ + 1);
               validate_non_negative_index("lp", "n_occasions + 1",
-                                          lcm_sym235__);
+                                          lcm_sym233__);
               Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym29__;
-              inline_sym29__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym235__);
+              inline_sym29__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym233__);
               stan::math::fill(inline_sym29__, DUMMY_VAR__);
               
               lcm_sym268__ = rvalue(nu, "nu", index_uni(1));
@@ -11851,7 +11851,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               } 
               current_statement__ = 85;
               assign(inline_sym29__, bernoulli_lpmf<false>(0, psi),
-                "assigning variable inline_sym29__", index_uni(lcm_sym235__));
+                "assigning variable inline_sym29__", index_uni(lcm_sym233__));
               current_statement__ = 86;
               lp_accum__.add(log_sum_exp(inline_sym29__));
             }
@@ -11972,7 +11972,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                       rvalue(lcm_sym257__, "lcm_sym257__",
                         index_uni(inline_sym31__),
                           index_uni(((lcm_sym259__ + 1) - 1)))));
-                  lcm_sym232__ = ((lcm_sym259__ + 1) + 1);
+                  lcm_sym234__ = ((lcm_sym259__ + 1) + 1);
                   lp_accum__.add(
                     bernoulli_lpmf<propto__>(
                       rvalue(y, "y",
@@ -11981,7 +11981,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                       rvalue(p, "p",
                         index_uni(inline_sym31__),
                           index_uni((lcm_sym259__ + 1)))));
-                  for (int inline_sym30__ = lcm_sym232__;
+                  for (int inline_sym30__ = lcm_sym234__;
                        inline_sym30__ <= lcm_sym265__; ++inline_sym30__) {
                     current_statement__ = 97;
                     lp_accum__.add(
@@ -12004,11 +12004,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     rvalue(inline_sym15__, "inline_sym15__",
                       index_uni(inline_sym31__), index_uni(lcm_sym265__))));
               } else {
-                lcm_sym235__ = (lcm_sym275__ + 1);
+                lcm_sym233__ = (lcm_sym275__ + 1);
                 validate_non_negative_index("lp", "n_occasions + 1",
-                                            lcm_sym235__);
+                                            lcm_sym233__);
                 Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym29__;
-                inline_sym29__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym235__);
+                inline_sym29__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym233__);
                 stan::math::fill(inline_sym29__, DUMMY_VAR__);
                 
                 current_statement__ = 102;
@@ -12063,7 +12063,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 } 
                 current_statement__ = 85;
                 assign(inline_sym29__, bernoulli_lpmf<false>(0, psi),
-                  "assigning variable inline_sym29__", index_uni(lcm_sym235__));
+                  "assigning variable inline_sym29__", index_uni(lcm_sym233__));
                 current_statement__ = 86;
                 lp_accum__.add(log_sum_exp(inline_sym29__));
               }
@@ -16333,18 +16333,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           lcm_sym122__ = rvalue(first, "first", index_uni(1));
           if (logical_gt(lcm_sym122__, 0)) {
             lcm_sym128__ = rvalue(last, "last", index_uni(1));
-            lcm_sym104__ = (lcm_sym122__ + 1);
-            if (logical_gte(lcm_sym128__, lcm_sym104__)) {
+            if (logical_gte(lcm_sym128__, (lcm_sym122__ + 1))) {
               current_statement__ = 24;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
                   rvalue(phi, "phi",
-                    index_uni(1), index_uni((lcm_sym104__ - 1)))));
-              lcm_sym102__ = (lcm_sym104__ + 1);
+                    index_uni(1), index_uni(((lcm_sym122__ + 1) - 1)))));
+              lcm_sym102__ = ((lcm_sym122__ + 1) + 1);
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(
-                  rvalue(y, "y", index_uni(1), index_uni(lcm_sym104__)),
-                  rvalue(p, "p", index_uni(1), index_uni((lcm_sym104__ - 1)))));
+                  rvalue(y, "y", index_uni(1), index_uni((lcm_sym122__ + 1))),
+                  rvalue(p, "p",
+                    index_uni(1), index_uni(((lcm_sym122__ + 1) - 1)))));
               for (int t = lcm_sym102__; t <= lcm_sym128__; ++t) {
                 current_statement__ = 24;
                 lp_accum__.add(
@@ -16367,19 +16367,19 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             lcm_sym121__ = rvalue(first, "first", index_uni(i));
             if (logical_gt(lcm_sym121__, 0)) {
               lcm_sym127__ = rvalue(last, "last", index_uni(i));
-              lcm_sym103__ = (lcm_sym121__ + 1);
-              if (logical_gte(lcm_sym127__, lcm_sym103__)) {
+              if (logical_gte(lcm_sym127__, (lcm_sym121__ + 1))) {
                 current_statement__ = 24;
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(1,
                     rvalue(phi, "phi",
-                      index_uni(i), index_uni((lcm_sym103__ - 1)))));
-                lcm_sym101__ = (lcm_sym103__ + 1);
+                      index_uni(i), index_uni(((lcm_sym121__ + 1) - 1)))));
+                lcm_sym101__ = ((lcm_sym121__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
-                    rvalue(y, "y", index_uni(i), index_uni(lcm_sym103__)),
+                    rvalue(y, "y",
+                      index_uni(i), index_uni((lcm_sym121__ + 1))),
                     rvalue(p, "p",
-                      index_uni(i), index_uni((lcm_sym103__ - 1)))));
+                      index_uni(i), index_uni(((lcm_sym121__ + 1) - 1)))));
                 for (int t = lcm_sym101__; t <= lcm_sym127__; ++t) {
                   current_statement__ = 24;
                   lp_accum__.add(
@@ -17714,12 +17714,12 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             bernoulli_lpmf<propto__>(1,
               rvalue(phi, "phi",
                 index_uni(1), index_uni(((lcm_sym117__ + 1) - 1)))));
-          lcm_sym100__ = ((lcm_sym117__ + 1) + 1);
+          lcm_sym101__ = ((lcm_sym117__ + 1) + 1);
           lp_accum__.add(
             bernoulli_lpmf<propto__>(
               rvalue(y, "y", index_uni(1), index_uni((lcm_sym117__ + 1))),
               rvalue(p, "p", index_uni(1), index_uni((lcm_sym117__ + 1)))));
-          for (int t = lcm_sym100__; t <= lcm_sym119__; ++t) {
+          for (int t = lcm_sym101__; t <= lcm_sym119__; ++t) {
             current_statement__ = 96;
             lp_accum__.add(
               bernoulli_lpmf<propto__>(1,
@@ -17736,10 +17736,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
           bernoulli_lpmf<propto__>(1,
             rvalue(chi, "chi", index_uni(1), index_uni(lcm_sym119__))));
       } else {
-        lcm_sym101__ = (lcm_sym121__ + 1);
-        validate_non_negative_index("lp", "n_occasions + 1", lcm_sym101__);
+        lcm_sym99__ = (lcm_sym121__ + 1);
+        validate_non_negative_index("lp", "n_occasions + 1", lcm_sym99__);
         Eigen::Matrix<local_scalar_t__, -1, 1> lp;
-        lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym101__);
+        lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym99__);
         stan::math::fill(lp, DUMMY_VAR__);
         
         current_statement__ = 82;
@@ -17783,7 +17783,7 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
         } 
         current_statement__ = 84;
         assign(lp, bernoulli_lpmf<false>(1, prod(lcm_sym80__)),
-          "assigning variable lp", index_uni(lcm_sym101__));
+          "assigning variable lp", index_uni(lcm_sym99__));
         current_statement__ = 85;
         lp_accum__.add(log_sum_exp(lp));
       }
@@ -17888,12 +17888,12 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
               bernoulli_lpmf<propto__>(1,
                 rvalue(phi, "phi",
                   index_uni(i), index_uni(((lcm_sym116__ + 1) - 1)))));
-            lcm_sym99__ = ((lcm_sym116__ + 1) + 1);
+            lcm_sym100__ = ((lcm_sym116__ + 1) + 1);
             lp_accum__.add(
               bernoulli_lpmf<propto__>(
                 rvalue(y, "y", index_uni(i), index_uni((lcm_sym116__ + 1))),
                 rvalue(p, "p", index_uni(i), index_uni((lcm_sym116__ + 1)))));
-            for (int t = lcm_sym99__; t <= lcm_sym118__; ++t) {
+            for (int t = lcm_sym100__; t <= lcm_sym118__; ++t) {
               current_statement__ = 96;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
@@ -17910,10 +17910,10 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
             bernoulli_lpmf<propto__>(1,
               rvalue(chi, "chi", index_uni(i), index_uni(lcm_sym118__))));
         } else {
-          lcm_sym101__ = (lcm_sym121__ + 1);
-          validate_non_negative_index("lp", "n_occasions + 1", lcm_sym101__);
+          lcm_sym99__ = (lcm_sym121__ + 1);
+          validate_non_negative_index("lp", "n_occasions + 1", lcm_sym99__);
           Eigen::Matrix<local_scalar_t__, -1, 1> lp;
-          lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym101__);
+          lp = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym99__);
           stan::math::fill(lp, DUMMY_VAR__);
           
           current_statement__ = 82;
@@ -17958,7 +17958,7 @@ jolly_seber_lp(const std::vector<std::vector<int>>& y,
           } 
           current_statement__ = 84;
           assign(lp, bernoulli_lpmf<false>(1, prod(lcm_sym80__)),
-            "assigning variable lp", index_uni(lcm_sym101__));
+            "assigning variable lp", index_uni(lcm_sym99__));
           current_statement__ = 85;
           lp_accum__.add(log_sum_exp(lp));
         }
@@ -19042,14 +19042,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   bernoulli_lpmf<propto__>(1,
                     rvalue(phi, "phi",
                       index_uni(1), index_uni(((lcm_sym266__ + 1) - 1)))));
-                lcm_sym240__ = ((lcm_sym266__ + 1) + 1);
+                lcm_sym241__ = ((lcm_sym266__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
                     rvalue(y, "y",
                       index_uni(1), index_uni((lcm_sym266__ + 1))),
                     rvalue(lcm_sym262__, "lcm_sym262__",
                       index_uni(1), index_uni((lcm_sym266__ + 1)))));
-                for (int inline_sym37__ = lcm_sym240__;
+                for (int inline_sym37__ = lcm_sym241__;
                      inline_sym37__ <= lcm_sym272__; ++inline_sym37__) {
                   current_statement__ = 96;
                   lp_accum__.add(
@@ -19070,11 +19070,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   rvalue(inline_sym22__, "inline_sym22__",
                     index_uni(1), index_uni(lcm_sym272__))));
             } else {
-              lcm_sym241__ = (lcm_sym278__ + 1);
+              lcm_sym239__ = (lcm_sym278__ + 1);
               validate_non_negative_index("lp", "n_occasions + 1",
-                                          lcm_sym241__);
+                                          lcm_sym239__);
               Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym36__;
-              inline_sym36__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym241__);
+              inline_sym36__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym239__);
               stan::math::fill(inline_sym36__, DUMMY_VAR__);
               
               current_statement__ = 82;
@@ -19126,7 +19126,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               current_statement__ = 84;
               assign(inline_sym36__,
                 bernoulli_lpmf<false>(1, prod(lcm_sym216__)),
-                "assigning variable inline_sym36__", index_uni(lcm_sym241__));
+                "assigning variable inline_sym36__", index_uni(lcm_sym239__));
               current_statement__ = 85;
               lp_accum__.add(log_sum_exp(inline_sym36__));
             }
@@ -19248,7 +19248,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                       rvalue(phi, "phi",
                         index_uni(inline_sym38__),
                           index_uni(((lcm_sym265__ + 1) - 1)))));
-                  lcm_sym239__ = ((lcm_sym265__ + 1) + 1);
+                  lcm_sym240__ = ((lcm_sym265__ + 1) + 1);
                   lp_accum__.add(
                     bernoulli_lpmf<propto__>(
                       rvalue(y, "y",
@@ -19257,7 +19257,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                       rvalue(lcm_sym262__, "lcm_sym262__",
                         index_uni(inline_sym38__),
                           index_uni((lcm_sym265__ + 1)))));
-                  for (int inline_sym37__ = lcm_sym239__;
+                  for (int inline_sym37__ = lcm_sym240__;
                        inline_sym37__ <= lcm_sym271__; ++inline_sym37__) {
                     current_statement__ = 96;
                     lp_accum__.add(
@@ -19280,11 +19280,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     rvalue(inline_sym22__, "inline_sym22__",
                       index_uni(inline_sym38__), index_uni(lcm_sym271__))));
               } else {
-                lcm_sym241__ = (lcm_sym278__ + 1);
+                lcm_sym239__ = (lcm_sym278__ + 1);
                 validate_non_negative_index("lp", "n_occasions + 1",
-                                            lcm_sym241__);
+                                            lcm_sym239__);
                 Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym36__;
-                inline_sym36__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym241__);
+                inline_sym36__ = Eigen::Matrix<local_scalar_t__, -1, 1>(lcm_sym239__);
                 stan::math::fill(inline_sym36__, DUMMY_VAR__);
                 
                 current_statement__ = 82;
@@ -19338,7 +19338,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 current_statement__ = 84;
                 assign(inline_sym36__,
                   bernoulli_lpmf<false>(1, prod(lcm_sym216__)),
-                  "assigning variable inline_sym36__", index_uni(lcm_sym241__));
+                  "assigning variable inline_sym36__", index_uni(lcm_sym239__));
                 current_statement__ = 85;
                 lp_accum__.add(log_sum_exp(inline_sym36__));
               }
@@ -22701,18 +22701,18 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
           lcm_sym113__ = rvalue(first, "first", index_uni(1));
           if (logical_gt(lcm_sym113__, 0)) {
             lcm_sym119__ = rvalue(last, "last", index_uni(1));
-            lcm_sym99__ = (lcm_sym113__ + 1);
-            if (logical_gte(lcm_sym119__, lcm_sym99__)) {
+            if (logical_gte(lcm_sym119__, (lcm_sym113__ + 1))) {
               current_statement__ = 24;
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(1,
                   rvalue(phi, "phi",
-                    index_uni(1), index_uni((lcm_sym99__ - 1)))));
-              lcm_sym97__ = (lcm_sym99__ + 1);
+                    index_uni(1), index_uni(((lcm_sym113__ + 1) - 1)))));
+              lcm_sym97__ = ((lcm_sym113__ + 1) + 1);
               lp_accum__.add(
                 bernoulli_lpmf<propto__>(
-                  rvalue(y, "y", index_uni(1), index_uni(lcm_sym99__)),
-                  rvalue(p, "p", index_uni(1), index_uni((lcm_sym99__ - 1)))));
+                  rvalue(y, "y", index_uni(1), index_uni((lcm_sym113__ + 1))),
+                  rvalue(p, "p",
+                    index_uni(1), index_uni(((lcm_sym113__ + 1) - 1)))));
               for (int t = lcm_sym97__; t <= lcm_sym119__; ++t) {
                 current_statement__ = 24;
                 lp_accum__.add(
@@ -22735,19 +22735,19 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             lcm_sym112__ = rvalue(first, "first", index_uni(i));
             if (logical_gt(lcm_sym112__, 0)) {
               lcm_sym118__ = rvalue(last, "last", index_uni(i));
-              lcm_sym98__ = (lcm_sym112__ + 1);
-              if (logical_gte(lcm_sym118__, lcm_sym98__)) {
+              if (logical_gte(lcm_sym118__, (lcm_sym112__ + 1))) {
                 current_statement__ = 24;
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(1,
                     rvalue(phi, "phi",
-                      index_uni(i), index_uni((lcm_sym98__ - 1)))));
-                lcm_sym96__ = (lcm_sym98__ + 1);
+                      index_uni(i), index_uni(((lcm_sym112__ + 1) - 1)))));
+                lcm_sym96__ = ((lcm_sym112__ + 1) + 1);
                 lp_accum__.add(
                   bernoulli_lpmf<propto__>(
-                    rvalue(y, "y", index_uni(i), index_uni(lcm_sym98__)),
+                    rvalue(y, "y",
+                      index_uni(i), index_uni((lcm_sym112__ + 1))),
                     rvalue(p, "p",
-                      index_uni(i), index_uni((lcm_sym98__ - 1)))));
+                      index_uni(i), index_uni(((lcm_sym112__ + 1) - 1)))));
                 for (int t = lcm_sym96__; t <= lcm_sym118__; ++t) {
                   current_statement__ = 24;
                   lp_accum__.add(
@@ -26282,22 +26282,22 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             }
           }
           {
-            lcm_sym49__ = (2 + 2);
-            if (logical_gte(lcm_sym49__, 2)) {
+            lcm_sym48__ = (2 + 2);
+            if (logical_gte(lcm_sym48__, 2)) {
               lcm_sym52__ = (2 * 2);
               if (logical_gte(lcm_sym52__, 2)) {
                 {
-                  lcm_sym48__ = (2 + 1);
+                  lcm_sym49__ = (2 + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
+                  for (int k = lcm_sym49__; k <= lcm_sym52__; ++k) {
                     current_statement__ = 15;
                     lp_accum__.add(53);
                   }
                 }
               } else {
-                lcm_sym48__ = (2 + 1);
+                lcm_sym49__ = (2 + 1);
               }
-              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+              for (int j = lcm_sym49__; j <= lcm_sym48__; ++j) {
                 lcm_sym53__ = (j * 2);
                 if (logical_gte(lcm_sym53__, j)) {
                   lcm_sym51__ = (j + 1);
@@ -26311,22 +26311,22 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             } 
           }
           {
-            lcm_sym49__ = (3 + 2);
-            if (logical_gte(lcm_sym49__, 3)) {
+            lcm_sym48__ = (3 + 2);
+            if (logical_gte(lcm_sym48__, 3)) {
               lcm_sym52__ = (3 * 2);
               if (logical_gte(lcm_sym52__, 3)) {
                 {
-                  lcm_sym48__ = (3 + 1);
+                  lcm_sym49__ = (3 + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
+                  for (int k = lcm_sym49__; k <= lcm_sym52__; ++k) {
                     current_statement__ = 15;
                     lp_accum__.add(53);
                   }
                 }
               } else {
-                lcm_sym48__ = (3 + 1);
+                lcm_sym49__ = (3 + 1);
               }
-              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+              for (int j = lcm_sym49__; j <= lcm_sym48__; ++j) {
                 lcm_sym53__ = (j * 2);
                 if (logical_gte(lcm_sym53__, j)) {
                   lcm_sym51__ = (j + 1);
@@ -26340,22 +26340,22 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             } 
           }
           {
-            lcm_sym49__ = (4 + 2);
-            if (logical_gte(lcm_sym49__, 4)) {
+            lcm_sym48__ = (4 + 2);
+            if (logical_gte(lcm_sym48__, 4)) {
               lcm_sym52__ = (4 * 2);
               if (logical_gte(lcm_sym52__, 4)) {
                 {
-                  lcm_sym48__ = (4 + 1);
+                  lcm_sym49__ = (4 + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
+                  for (int k = lcm_sym49__; k <= lcm_sym52__; ++k) {
                     current_statement__ = 15;
                     lp_accum__.add(53);
                   }
                 }
               } else {
-                lcm_sym48__ = (4 + 1);
+                lcm_sym49__ = (4 + 1);
               }
-              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+              for (int j = lcm_sym49__; j <= lcm_sym48__; ++j) {
                 lcm_sym53__ = (j * 2);
                 if (logical_gte(lcm_sym53__, j)) {
                   lcm_sym51__ = (j + 1);
@@ -26369,22 +26369,22 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             } 
           }
           {
-            lcm_sym49__ = (5 + 2);
-            if (logical_gte(lcm_sym49__, 5)) {
+            lcm_sym48__ = (5 + 2);
+            if (logical_gte(lcm_sym48__, 5)) {
               lcm_sym52__ = (5 * 2);
               if (logical_gte(lcm_sym52__, 5)) {
                 {
-                  lcm_sym48__ = (5 + 1);
+                  lcm_sym49__ = (5 + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
+                  for (int k = lcm_sym49__; k <= lcm_sym52__; ++k) {
                     current_statement__ = 15;
                     lp_accum__.add(53);
                   }
                 }
               } else {
-                lcm_sym48__ = (5 + 1);
+                lcm_sym49__ = (5 + 1);
               }
-              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+              for (int j = lcm_sym49__; j <= lcm_sym48__; ++j) {
                 lcm_sym53__ = (j * 2);
                 if (logical_gte(lcm_sym53__, j)) {
                   lcm_sym51__ = (j + 1);

--- a/test/unit/Factor_graph.ml
+++ b/test/unit/Factor_graph.ml
@@ -104,7 +104,7 @@ let%expect_test "Factor graph complex example" =
 ((factor_map
   ((((TargetTerm
       ((pattern
-        (FunApp (StanLib Times__ FnPlain)
+        (FunApp (StanLib Times__ FnPlain AoS)
          (((pattern (Var f))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var f))
@@ -114,7 +114,7 @@ let%expect_test "Factor graph complex example" =
     ((VVar f)))
    (((TargetTerm
       ((pattern
-        (FunApp (StanLib Times__ FnPlain)
+        (FunApp (StanLib Times__ FnPlain AoS)
          (((pattern (Var z))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var e))
@@ -124,7 +124,7 @@ let%expect_test "Factor graph complex example" =
     ((VVar a) (VVar b) (VVar c) (VVar d) (VVar e)))
    (((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var a))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var b))
@@ -136,7 +136,7 @@ let%expect_test "Factor graph complex example" =
     ((VVar a) (VVar b)))
    (((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var b))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Lit Int 0))
@@ -148,7 +148,7 @@ let%expect_test "Factor graph complex example" =
     ((VVar b)))
    (((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var c))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var x))
@@ -160,7 +160,7 @@ let%expect_test "Factor graph complex example" =
     ((VVar a) (VVar c)))
    (((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var d))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var c))
@@ -174,7 +174,7 @@ let%expect_test "Factor graph complex example" =
   (((VVar a)
     (((TargetTerm
        ((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var z))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var e))
@@ -183,7 +183,7 @@ let%expect_test "Factor graph complex example" =
       21)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var a))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var b))
@@ -194,7 +194,7 @@ let%expect_test "Factor graph complex example" =
       10)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var c))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var x))
@@ -206,7 +206,7 @@ let%expect_test "Factor graph complex example" =
    ((VVar b)
     (((TargetTerm
        ((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var z))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var e))
@@ -215,7 +215,7 @@ let%expect_test "Factor graph complex example" =
       21)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var a))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var b))
@@ -226,7 +226,7 @@ let%expect_test "Factor graph complex example" =
       10)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var b))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Lit Int 0))
@@ -237,7 +237,7 @@ let%expect_test "Factor graph complex example" =
       9)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var d))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var c))
@@ -249,7 +249,7 @@ let%expect_test "Factor graph complex example" =
    ((VVar c)
     (((TargetTerm
        ((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var z))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var e))
@@ -258,7 +258,7 @@ let%expect_test "Factor graph complex example" =
       21)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var c))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var x))
@@ -269,7 +269,7 @@ let%expect_test "Factor graph complex example" =
       17)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var d))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var c))
@@ -281,7 +281,7 @@ let%expect_test "Factor graph complex example" =
    ((VVar d)
     (((TargetTerm
        ((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var z))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var e))
@@ -290,7 +290,7 @@ let%expect_test "Factor graph complex example" =
       21)
      ((TargetTerm
        ((pattern
-         (FunApp (StanLib normal_lpdf (FnLpdf true))
+         (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
           (((pattern (Var d))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var c))
@@ -302,7 +302,7 @@ let%expect_test "Factor graph complex example" =
    ((VVar e)
     (((TargetTerm
        ((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var z))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var e))
@@ -312,7 +312,7 @@ let%expect_test "Factor graph complex example" =
    ((VVar f)
     (((TargetTerm
        ((pattern
-         (FunApp (StanLib Times__ FnPlain)
+         (FunApp (StanLib Times__ FnPlain AoS)
           (((pattern (Var f))
             (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
            ((pattern (Var f))
@@ -361,7 +361,7 @@ let%expect_test "Priors complex example" =
 (((VVar a)
   ((((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var a))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Lit Int 0))
@@ -372,7 +372,7 @@ let%expect_test "Priors complex example" =
      9)
     ((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var e))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var a))
@@ -383,7 +383,7 @@ let%expect_test "Priors complex example" =
      14)
     ((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var f))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var a))
@@ -395,7 +395,7 @@ let%expect_test "Priors complex example" =
  ((VVar b)
   ((((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var b))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var a))
@@ -406,7 +406,7 @@ let%expect_test "Priors complex example" =
      10)
     ((TargetTerm
       ((pattern
-        (FunApp (StanLib normal_lpdf (FnLpdf true))
+        (FunApp (StanLib normal_lpdf (FnLpdf true) AoS)
          (((pattern (Var d))
            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
           ((pattern (Var b))

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -271,7 +271,7 @@ let%expect_test "list collapsing" =
              (((pattern
                 (Return
                  (((pattern
-                    (FunApp (StanLib Pow__ FnPlain)
+                    (FunApp (StanLib Pow__ FnPlain AoS)
                      (((pattern (Var z))
                        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                       ((pattern (Lit Int 2))
@@ -372,7 +372,7 @@ let%expect_test "list collapsing" =
                    ((pattern
                      (Assignment (inline_sym3__ UReal ())
                       ((pattern
-                        (FunApp (StanLib Pow__ FnPlain)
+                        (FunApp (StanLib Pow__ FnPlain AoS)
                          (((pattern (Lit Int 53))
                            (meta
                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -401,7 +401,7 @@ let%expect_test "list collapsing" =
        ((pattern
          (IfElse
           ((pattern
-            (FunApp (StanLib PNot__ FnPlain)
+            (FunApp (StanLib PNot__ FnPlain AoS)
              (((pattern
                 (EOr
                  ((pattern (Var emit_transformed_parameters__))
@@ -415,7 +415,7 @@ let%expect_test "list collapsing" =
        ((pattern
          (IfElse
           ((pattern
-            (FunApp (StanLib PNot__ FnPlain)
+            (FunApp (StanLib PNot__ FnPlain AoS)
              (((pattern (Var emit_generated_quantities__))
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -3118,7 +3118,7 @@ let%expect_test "block fixing" =
         (((pattern
            (IfElse
             ((pattern
-              (FunApp (StanLib PNot__ FnPlain)
+              (FunApp (StanLib PNot__ FnPlain AoS)
                (((pattern
                   (EOr
                    ((pattern (Var emit_transformed_parameters__))
@@ -3132,7 +3132,7 @@ let%expect_test "block fixing" =
          ((pattern
            (IfElse
             ((pattern
-              (FunApp (StanLib PNot__ FnPlain)
+              (FunApp (StanLib PNot__ FnPlain AoS)
                (((pattern (Var emit_generated_quantities__))
                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -3316,7 +3316,7 @@ let%expect_test "adlevel_optimization expressions" =
            ((pattern
              (IfElse
               ((pattern
-                (FunApp (StanLib Greater__ FnPlain)
+                (FunApp (StanLib Greater__ FnPlain AoS)
                  (((pattern (Lit Int 1))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Lit Int 2))
@@ -3325,7 +3325,7 @@ let%expect_test "adlevel_optimization expressions" =
               ((pattern
                 (Assignment (y UReal ())
                  ((pattern
-                   (FunApp (StanLib Plus__ FnPlain)
+                   (FunApp (StanLib Plus__ FnPlain AoS)
                     (((pattern (Var y))
                       (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                      ((pattern (Var x))
@@ -3335,7 +3335,7 @@ let%expect_test "adlevel_optimization expressions" =
               (((pattern
                  (Assignment (y UReal ())
                   ((pattern
-                    (FunApp (StanLib Plus__ FnPlain)
+                    (FunApp (StanLib Plus__ FnPlain AoS)
                      (((pattern (Var y))
                        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
                       ((pattern (Var w))
@@ -3346,7 +3346,7 @@ let%expect_test "adlevel_optimization expressions" =
            ((pattern
              (IfElse
               ((pattern
-                (FunApp (StanLib Greater__ FnPlain)
+                (FunApp (StanLib Greater__ FnPlain AoS)
                  (((pattern (Lit Int 2))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Lit Int 1))
@@ -3362,7 +3362,7 @@ let%expect_test "adlevel_optimization expressions" =
            ((pattern
              (IfElse
               ((pattern
-                (FunApp (StanLib Greater__ FnPlain)
+                (FunApp (StanLib Greater__ FnPlain AoS)
                  (((pattern (Lit Int 3))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Lit Int 1))

--- a/test/unit/Parse_tests.ml
+++ b/test/unit/Parse_tests.ml
@@ -134,7 +134,7 @@ let%expect_test "parse indices, two different colons" =
             (VarDecl
              (decl_type
               (Sized
-               (SMatrix ((expr (IntNumeral 5)) (emeta ((loc <opaque>))))
+               (SMatrix AoS ((expr (IntNumeral 5)) (emeta ((loc <opaque>))))
                 ((expr (IntNumeral 5)) (emeta ((loc <opaque>)))))))
              (transformation Identity) (identifier ((name x) (id_loc <opaque>)))
              (initial_value ()) (is_global false)))

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -19,8 +19,8 @@ let%expect_test "udf" =
         (Some
            ( w
            @@ FunApp
-                (StanLib ("add", FnPlain), [w @@ Var "x"; w @@ Lit (Int, "1")])
-           ))
+                ( StanLib ("add", FnPlain, AoS)
+                , [w @@ Var "x"; w @@ Lit (Int, "1")] ) ))
       |> with_no_loc |> List.return |> Stmt.Fixed.Pattern.Block |> with_no_loc
       |> Some
   ; fdloc= Location_span.empty }
@@ -78,8 +78,8 @@ let%expect_test "udf-expressions" =
         (Some
            ( w
            @@ FunApp
-                (StanLib ("add", FnPlain), [w @@ Var "x"; w @@ Lit (Int, "1")])
-           ))
+                ( StanLib ("add", FnPlain, AoS)
+                , [w @@ Var "x"; w @@ Lit (Int, "1")] ) ))
       |> with_no_loc |> List.return |> Stmt.Fixed.Pattern.Block |> with_no_loc
       |> Some
   ; fdloc= Location_span.empty }


### PR DESCRIPTION
This is a subset of #898. There's a lot of stuff going on in that PR so I think it's smarter to do it in smaller pieces.

This PR adds the `Common.Helpers.mem_pattern` type and uses it in the necessary types that we need for optimization of the tmir and printing the C++ the uses `SoA` (Struct of Arrays). The largest change is to `Stan_math_signatures`, where the `StanLib` types there now have an extra space in their tuple for a `mem_pattern`.

Everything here is set to `AoS` (Array of Structs) and so while the mir and tmir have changed, the C++ should not. That said, the C++ from the optimizer has changed slightly, though only the names of the symbol ticks have changed while the actual code has not changed at all.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Adds types used for deducing memory patterns

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)


