### PR TITLE
Add included files to --info

### DIFF
--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -11,6 +11,7 @@ let dup_exists l =
 
 let include_stack = Stack.create ()
 let include_paths : string list ref = ref []
+let included_files : string list ref = ref []
 
 let rec try_open_in paths fname pos =
   match paths with
@@ -26,6 +27,7 @@ let rec try_open_in paths fname pos =
     try
       let full_path = path ^ "/" ^ fname in
       ( In_channel.create full_path
+      , full_path
       , sprintf "%s, included from\n%s" full_path
           (Middle.Location.to_string
              (Middle.Location.of_position_exn
@@ -39,7 +41,7 @@ let maybe_remove_quotes str =
   else str
 
 let try_get_new_lexbuf fname pos =
-  let chan, path =
+  let chan, file, path =
     try_open_in !include_paths (maybe_remove_quotes fname) pos
   in
   let new_lexbuf = from_channel chan in
@@ -54,4 +56,5 @@ let try_get_new_lexbuf fname pos =
             , Middle.Location.of_position_exn
                 (lexeme_start_p (Stack.top_exn include_stack)) ))) ;
   Stack.push include_stack new_lexbuf ;
+  included_files := file :: !included_files ;
   new_lexbuf

--- a/src/frontend/Preprocessor.mli
+++ b/src/frontend/Preprocessor.mli
@@ -9,6 +9,9 @@ val include_stack : Lexing.lexbuf Stack.t
 val include_paths : string list ref
 (** List of paths to search for including files *)
 
+val included_files : string list ref
+(** List of files that have been included *)
+
 val try_get_new_lexbuf : string -> Lexing.position -> Lexing.lexbuf
 (** Search include paths for filename and try to create a new lexing buffer
     with that filename, record that included from specified position *)

--- a/test/integration/cli-args/dune
+++ b/test/integration/cli-args/dune
@@ -22,10 +22,10 @@
 
 (rule
  (targets info.output)
- (deps (package stanc) info.stan)
+ (deps (package stanc) info.stan included.stan includes/another_include.stan)
  (action
   (with-stdout-to %{targets}
-   (run %{bin:run_bin_on_args} "%{bin:stanc} --info " info.stan))))
+   (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=.,includes --info " info.stan))))
 
 (alias
  (name runtest)

--- a/test/integration/cli-args/dune
+++ b/test/integration/cli-args/dune
@@ -22,7 +22,7 @@
 
 (rule
  (targets info.output)
- (deps (package stanc) info.stan included.stan includes/another_include.stan)
+ (deps (package stanc) info.stan included.stan includes/recursive.stan includes/another_include.stan)
  (action
   (with-stdout-to %{targets}
    (run %{bin:run_bin_on_args} "%{bin:stanc} --include-paths=.,includes --info " info.stan))))

--- a/test/integration/cli-args/included.stan
+++ b/test/integration/cli-args/included.stan
@@ -1,0 +1,1 @@
+// nothing here

--- a/test/integration/cli-args/includes/another_include.stan
+++ b/test/integration/cli-args/includes/another_include.stan
@@ -1,0 +1,1 @@
+// nothing here either

--- a/test/integration/cli-args/includes/recursive.stan
+++ b/test/integration/cli-args/includes/recursive.stan
@@ -1,0 +1,1 @@
+#include <another_include.stan>

--- a/test/integration/cli-args/info.expected
+++ b/test/integration/cli-args/info.expected
@@ -30,5 +30,6 @@
                      "normal_lpdf",
                      "std_normal_lupdf" ],
   "included_files": [ "./included.stan",
+                      "includes/recursive.stan",
                       "includes/another_include.stan" ] }
 

--- a/test/integration/cli-args/info.expected
+++ b/test/integration/cli-args/info.expected
@@ -1,4 +1,4 @@
-  $ ../../../../install/default/bin/stanc --info  info.stan
+  $ ../../../../install/default/bin/stanc --include-paths=.,includes --info  info.stan
 { "inputs": { "a": { "type": "int", "dimensions": 0},
               "b": { "type": "real", "dimensions": 0},
               "c": { "type": "real", "dimensions": 1},
@@ -28,5 +28,7 @@
                      "normal_lccdf",
                      "normal_lcdf",
                      "normal_lpdf",
-                     "std_normal_lupdf" ] }
+                     "std_normal_lupdf" ],
+  "included_files": [ "./included.stan",
+                      "includes/another_include.stan" ] }
 

--- a/test/integration/cli-args/info.stan
+++ b/test/integration/cli-args/info.stan
@@ -1,5 +1,5 @@
 #include <included.stan>
-#include <another_include.stan>
+#include <recursive.stan>
 
 functions {
   real foo(real a) {

--- a/test/integration/cli-args/info.stan
+++ b/test/integration/cli-args/info.stan
@@ -1,3 +1,6 @@
+#include <included.stan>
+#include <another_include.stan>
+
 functions {
   real foo(real a) {
     return sin(a);

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -72,7 +72,8 @@ $ node info.js
   "transformed parameters": {  },
   "generated quantities": {  },
   "functions": [  ],
-  "distributions": [  ] }
+  "distributions": [  ],
+  "included_files": [  ] }
 
 $ node optimization.js
 Semantic error in 'string', line 3, column 4 to column 20: 


### PR DESCRIPTION
This should close #808. The files included by the preprocessor are now part of the JSON output

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Added a list of included files to the information provided by --info

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
