### PR TITLE
Better pretty-printing for long constraints

### DIFF
--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -329,14 +329,15 @@ let pp_sizedtype ppf = function
 
 let pp_transformation ppf = function
   | Middle.Transformation.Identity -> Fmt.pf ppf ""
-  | Lower e -> Fmt.pf ppf "<lower=%a>" pp_expression e
-  | Upper e -> Fmt.pf ppf "<upper=%a>" pp_expression e
+  | Lower e -> Fmt.pf ppf "<@[lower=%a@]>" pp_expression e
+  | Upper e -> Fmt.pf ppf "<@[upper=%a@]>" pp_expression e
   | LowerUpper (e1, e2) ->
-      Fmt.pf ppf "<lower=%a, upper=%a>" pp_expression e1 pp_expression e2
-  | Offset e -> Fmt.pf ppf "<offset=%a>" pp_expression e
-  | Multiplier e -> Fmt.pf ppf "<multiplier=%a>" pp_expression e
+      Fmt.pf ppf "<@[lower=%a,@ upper=%a@]>" pp_expression e1 pp_expression e2
+  | Offset e -> Fmt.pf ppf "<@[offset=%a@]>" pp_expression e
+  | Multiplier e -> Fmt.pf ppf "<@[multiplier=%a@]>" pp_expression e
   | OffsetMultiplier (e1, e2) ->
-      Fmt.pf ppf "<offset=%a, multiplier=%a>" pp_expression e1 pp_expression e2
+      Fmt.pf ppf "<@[offset=%a,@ multiplier=%a@]>" pp_expression e1
+        pp_expression e2
   | Ordered -> Fmt.pf ppf ""
   | PositiveOrdered -> Fmt.pf ppf ""
   | Simplex -> Fmt.pf ppf ""

--- a/test/integration/canonicalize/canonical.expected
+++ b/test/integration/canonicalize/canonical.expected
@@ -128,3 +128,31 @@ model {
 }
 
 Warning in 'parenthesize.stan', line 6, column 13: The function `if_else` is deprecated. Use the conditional operator (x ? y : z) instead.
+  $ ../../../../install/default/bin/stanc --print-canonical squaremc.stan
+/*
+ * BUGS Volume 3, funshapes, square minus circle
+ * http://www.openbugs.net/Examples/Funshapes.html
+ *
+ * first draw raw samples from diamond-like shape reflected per
+ * quadrant, then reflect in transformed parameters
+ *
+ * unfortunate redundancy in 1-sqrt() term because we can't
+ * get local variables into parameter declarations
+ */
+parameters {
+  real<lower=-1, upper=1> x_raw;
+  real<lower=-(1 - sqrt(1 - square(1 - fabs(x_raw)))),
+       upper=(1 - sqrt(1 - square(1 - fabs(x_raw))))> y_raw;
+}
+transformed parameters {
+  real<lower=-1, upper=1> x;
+  real<lower=-1, upper=1> y;
+  x = ((x_raw > 0) ? 1 : -1) - x_raw;
+  y = ((y_raw > 0) ? 1 : -1) - y_raw;
+}
+model {
+  target += log1m(sqrt(1 - square(1 - fabs(x_raw))));
+}
+
+Warning in 'squaremc.stan', line 19, column 7: The function `if_else` is deprecated. Use the conditional operator (x ? y : z) instead.
+Warning in 'squaremc.stan', line 20, column 7: The function `if_else` is deprecated. Use the conditional operator (x ? y : z) instead.

--- a/test/integration/canonicalize/squaremc.stan
+++ b/test/integration/canonicalize/squaremc.stan
@@ -1,0 +1,24 @@
+/*
+ * BUGS Volume 3, funshapes, square minus circle
+ * http://www.openbugs.net/Examples/Funshapes.html
+ *
+ * first draw raw samples from diamond-like shape reflected per
+ * quadrant, then reflect in transformed parameters
+ *
+ * unfortunate redundancy in 1-sqrt() term because we can't
+ * get local variables into parameter declarations
+ */
+parameters {
+  real<lower=-1,upper=1> x_raw;
+  real<lower = -(1 - sqrt(1 - square(1 - fabs(x_raw)))),
+       upper =  (1 - sqrt(1 - square(1 - fabs(x_raw))))> y_raw;
+}
+transformed parameters {
+  real<lower=-1,upper=1> x;
+  real<lower=-1,upper=1> y;
+  x <- if_else(x_raw > 0, 1, -1) - x_raw;
+  y <- if_else(y_raw > 0, 1, -1) - y_raw;
+}
+model {
+  increment_log_prob(log1m(sqrt(1 - square(1 - fabs(x_raw)))));
+}

--- a/test/integration/rstanarm/pretty.expected
+++ b/test/integration/rstanarm/pretty.expected
@@ -2745,8 +2745,8 @@ transformed data {
   }
 }
 parameters {
-  array[has_intercept] real<lower=make_lower(family, link), upper=make_upper(family,
-                                                                    link)> gamma;
+  array[has_intercept] real<lower=make_lower(family, link),
+                            upper=make_upper(family, link)> gamma;
   // declares z_beta, global, local, z_b, z_T, rho, zeta, tau
   
   vector[prior_dist == 7 ? sum(num_normals) : K] z_beta;
@@ -6320,11 +6320,14 @@ parameters {
   
   // intercepts
   
-  array[intercept_type[1] > 0] real<lower=lb(intercept_type[1]), upper=ub(intercept_type[1])> yGamma1;
+  array[intercept_type[1] > 0] real<lower=lb(intercept_type[1]),
+                                    upper=ub(intercept_type[1])> yGamma1;
   
-  array[intercept_type[2] > 0] real<lower=lb(intercept_type[2]), upper=ub(intercept_type[2])> yGamma2;
+  array[intercept_type[2] > 0] real<lower=lb(intercept_type[2]),
+                                    upper=ub(intercept_type[2])> yGamma2;
   
-  array[intercept_type[3] > 0] real<lower=lb(intercept_type[3]), upper=ub(intercept_type[3])> yGamma3;
+  array[intercept_type[3] > 0] real<lower=lb(intercept_type[3]),
+                                    upper=ub(intercept_type[3])> yGamma3;
   
   // population level primitive params
   vector[yK[1]] z_yBeta1;
@@ -8991,11 +8994,14 @@ parameters {
   
   // intercepts
   
-  array[intercept_type[1] > 0] real<lower=lb(intercept_type[1]), upper=ub(intercept_type[1])> yGamma1;
+  array[intercept_type[1] > 0] real<lower=lb(intercept_type[1]),
+                                    upper=ub(intercept_type[1])> yGamma1;
   
-  array[intercept_type[2] > 0] real<lower=lb(intercept_type[2]), upper=ub(intercept_type[2])> yGamma2;
+  array[intercept_type[2] > 0] real<lower=lb(intercept_type[2]),
+                                    upper=ub(intercept_type[2])> yGamma2;
   
-  array[intercept_type[3] > 0] real<lower=lb(intercept_type[3]), upper=ub(intercept_type[3])> yGamma3;
+  array[intercept_type[3] > 0] real<lower=lb(intercept_type[3]),
+                                    upper=ub(intercept_type[3])> yGamma3;
   
   // population level primitive params
   vector[yK[1]] z_yBeta1;


### PR DESCRIPTION
I'm working on a machine-update of the example models repo, which is really testing out the pretty-printing now that we have comments preserved. Here is the latest example of weirdness (see also #967):

The [squaremc.stan](https://github.com/stan-dev/example-models/blob/master/bugs_examples/vol3/funshapes/squaremc.stan) model currently has something that gets pretty-printed to

```stan
  real<lower=-(1 - sqrt(1 - square(1 - fabs(x_raw)))), upper=(1
                                                              - sqrt(
                                                              1
                                                              - square(
                                                              1 - fabs(x_raw))))> y_raw;
```

I've fixed this and added this file to the tests (it's also a great example of what the canonicalizer can do, so it's under those tests)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Better pretty-printing for long constraints

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
