### PR TITLE
Fix multiarch stanc3 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,8 +277,8 @@ pipeline {
                 }
                 stage("Build stanc.js") {
                     agent {
-                        dockerfile {
-                            filename 'docker/debian/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u root --entrypoint=\'\'"
                         }
@@ -298,8 +298,8 @@ pipeline {
                 }
                 stage("Build & test a static Linux binary") {
                     agent {
-                        dockerfile {
-                            filename 'docker/static/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\'"
                         }
@@ -322,8 +322,8 @@ pipeline {
                 stage("Build & test a static Linux mips64el binary") {
                     when { anyOf { buildingTag(); branch 'master' } }
                     agent {
-                        dockerfile {
-                            filename 'docker/static/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -347,8 +347,8 @@ pipeline {
                 stage("Build & test a static Linux ppc64el binary") {
                     when { anyOf { buildingTag(); branch 'master' } }
                     agent {
-                        dockerfile {
-                            filename 'docker/static/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -372,8 +372,8 @@ pipeline {
                 stage("Build & test a static Linux s390x binary") {
                     when { anyOf { buildingTag(); branch 'master' } }
                     agent {
-                        dockerfile {
-                            filename 'docker/static/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -396,8 +396,8 @@ pipeline {
 
                 stage("Build & test a static Linux arm64 binary") {
                     agent {
-                        dockerfile {
-                            filename 'docker/static/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -421,8 +421,8 @@ pipeline {
                 stage("Build & test a static Linux armhf binary") {
                     when { anyOf { buildingTag(); branch 'master' } }
                     agent {
-                        dockerfile {
-                            filename 'docker/static/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -446,8 +446,8 @@ pipeline {
                 stage("Build & test a static Linux armel binary") {
                     when { anyOf { buildingTag(); branch 'master' } }
                     agent {
-                        dockerfile {
-                            filename 'docker/static/Dockerfile'
+                        docker {
+                            image 'andrjohns/stanc3-building:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,8 +277,8 @@ pipeline {
                 }
                 stage("Build stanc.js") {
                     agent {
-                        docker {
-                            image 'andrjohns/stanc3-building:static'
+                        dockerfile {
+                            filename 'docker/debian/Dockerfile'
                             //Forces image to ignore entrypoint
                             args "-u root --entrypoint=\'\'"
                         }

--- a/docker/multiarch/README.md
+++ b/docker/multiarch/README.md
@@ -44,5 +44,5 @@ Platforms: linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, 
 Call `buildx` with the list of target architectures and target repository (note this requires calling `docker login` first)
 
 ```
-docker buildx build -t andrjohns/stanc3-building:latest --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/mips64le,linux/s390x --push .
+docker buildx build -t andrjohns/stanc3-building:multiarch --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/mips64le,linux/s390x --push .
 ```

--- a/docker/static/Dockerfile
+++ b/docker/static/Dockerfile
@@ -21,7 +21,7 @@ LABEL distro_style="apk"
 #Install os dependencies
 RUN apk update && apk add build-base bzip2 git tar curl ca-certificates openssl m4 bash
 
-# Add a recent version of the Skopeo package, which is used for looking up the correct multiarch dockerfile
+# Add a recent version of the Skopeo package, which is used for looking up the correct multiarch docker image
 RUN curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/containers-common-0.38.11-r0.apk -o cont.apk && \
     curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/skopeo-1.3.1-r1.apk -o skopeo.apk && \
     apk add cont.apk && \

--- a/docker/static/Dockerfile
+++ b/docker/static/Dockerfile
@@ -21,6 +21,12 @@ LABEL distro_style="apk"
 #Install os dependencies
 RUN apk update && apk add build-base bzip2 git tar curl ca-certificates openssl m4 bash
 
+# Add a recent version of the Skopeo package, which is used for looking up the correct multiarch dockerfile
+RUN curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/containers-common-0.38.11-r0.apk -o cont.apk && \
+    curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/skopeo-1.3.1-r1.apk -o skopeo.apk && \
+    apk add cont.apk && \
+    apk add skopeo.apk
+
 #Switch back to the normal user
 USER opam
 

--- a/scripts/build_multiarch_stanc3.sh
+++ b/scripts/build_multiarch_stanc3.sh
@@ -19,22 +19,14 @@ elif [ $1 = "s390x" ]; then
   export DOCK_VARIANT=""
 fi
 
-# Need to use the sha256 tag to force docker to download an architecture that differs from the host
-# We'll use the skopeo package to lookup the most recent tag, but need to manually install a more recent version
-curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/containers-common-0.38.11-r0.apk -o cont.apk
-curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/skopeo-1.3.1-r0.apk -o skopeo.apk
-
-apk add cont.apk
-apk add skopeo.apk
-
 # Lookup the sha256 hash for the specified architecture and variant (e.g., v7 for armhf) and strip the enclosing quotations
-SHA=$(skopeo inspect --raw docker://andrjohns/stanc3-building:latest | jq '.manifests | .[] | select(.platform.architecture==env.DOCK_ARCH and .platform.variant==(if env.DOCK_VARIANT == "" then null else env.DOCK_VARIANT end)).digest' | tr -d '"')
+SHA=$(skopeo inspect --raw docker://andrjohns/stanc3-building:multiarch | jq '.manifests | .[] | select(.platform.architecture==env.DOCK_ARCH and .platform.variant==(if env.DOCK_VARIANT == "" then null else env.DOCK_VARIANT end)).digest' | tr -d '"')
 
 # Register QEMU translation binaries
 docker run --rm --privileged multiarch/qemu-user-static --reset
 
 # Run docker, inheriting mounted volumes from sibling container (including stanc3 directory), and build stanc3
-docker run --volumes-from=$(docker ps -q):rw andrjohns/stanc3-building:latest@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static"
+docker run --volumes-from=$(docker ps -q):rw andrjohns/stanc3-building:multiarch@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static"
 
 # Update ownership of build folders
 chown -R opam: _build


### PR DESCRIPTION
The current multiarch builds are failing because one of the files are no longer available to download. This PR fixes that by replacing the use of a dockerfile which is built and run, with a pre-built docker image that has the necessary files included

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fix automated builds of non-x86 architectures

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
