### PR TITLE
Fix typo in file not found error

### DIFF
--- a/src/middle/Errors.ml
+++ b/src/middle/Errors.ml
@@ -60,7 +60,8 @@ let pp_syntax_error ?printed_filename ppf = function
         pp_context_with_message (message, loc)
 
 let pp ?printed_filename ppf = function
-  | FileNotFound f -> Fmt.pf ppf "Cannot not open file %s@." f
+  | FileNotFound f ->
+      Fmt.pf ppf "Error: file '%s' not found or cannot be opened@." f
   | Syntax_error e -> pp_syntax_error ?printed_filename ppf e
   | Semantic_error e -> pp_semantic_error ?printed_filename ppf e
 

--- a/test/integration/cli-args/notfound.expected
+++ b/test/integration/cli-args/notfound.expected
@@ -1,2 +1,2 @@
   $ ../../../../install/default/bin/stanc notfound.stan
-Cannot not open file notfound.stan
+Error: file 'notfound.stan' not found or cannot be opened


### PR DESCRIPTION
Currently we print out "Cannot not open...". This fixes the double negative and changes the message to be a bit more informative and in line with our other errors/warnings.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Fixed a typo in the error message displayed when a file cannot be found

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
