### PR TITLE
Always flush after semantic and lexical errors

### DIFF
--- a/src/frontend/Frontend_utils.ml
+++ b/src/frontend/Frontend_utils.ml
@@ -9,7 +9,7 @@ let untyped_ast_of_string s =
   res
 
 let emit_warnings_and_return_ast (ast, warnings) =
-  if List.length warnings > 0 then Warnings.pp_warnings Fmt.stderr warnings ;
+  Warnings.pp_warnings Fmt.stderr warnings ;
   ast
 
 let typed_ast_of_string_exn s =

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -20,7 +20,7 @@ let rec try_open_in paths fname pos =
         (Middle.Errors.SyntaxError
            (Include
               ( "Could not find include file " ^ fname
-                ^ " in specified include paths.\n"
+                ^ " in specified include paths."
               , Middle.Location.of_position_exn
                   (lexeme_start_p (Stack.top_exn include_stack)) )))
   | path :: rest_of_paths -> (
@@ -52,7 +52,7 @@ let try_get_new_lexbuf fname pos =
     raise
       (Middle.Errors.SyntaxError
          (Include
-            ( Printf.sprintf "File %s recursively included itself.\n" fname
+            ( Printf.sprintf "File %s recursively included itself." fname
             , Middle.Location.of_position_exn
                 (lexeme_start_p (Stack.top_exn include_stack)) ))) ;
   Stack.push include_stack new_lexbuf ;

--- a/src/middle/Errors.ml
+++ b/src/middle/Errors.ml
@@ -49,13 +49,13 @@ let pp_syntax_error ?printed_filename ppf = function
         pp_context_with_message
         (message, loc_span.begin_loc)
   | Lexing (_, loc) ->
-      Fmt.pf ppf "Syntax error in %s, lexing error:@,%a"
+      Fmt.pf ppf "Syntax error in %s, lexing error:@,%a@."
         (Location.to_string ?printed_filename
            {loc with col_num= loc.col_num - 1})
         pp_context_with_message
         ("Invalid character found.", loc)
   | Include (message, loc) ->
-      Fmt.pf ppf "Syntax error in %s, include error:@,%a"
+      Fmt.pf ppf "Syntax error in %s, include error:@,%a@."
         (Location.to_string loc ?printed_filename)
         pp_context_with_message (message, loc)
 

--- a/src/middle/Errors.ml
+++ b/src/middle/Errors.ml
@@ -39,7 +39,7 @@ let pp_semantic_error ?printed_filename ppf err =
   Fmt.pf ppf "Semantic error in %s:@;%a"
     (Location_span.to_string ?printed_filename loc_span)
     pp_context_with_message
-    (Fmt.strf "%a" Semantic_error.pp err, loc_span.begin_loc)
+    (Fmt.strf "%a@." Semantic_error.pp err, loc_span.begin_loc)
 
 (** A syntax error message used when handling a SyntaxError *)
 let pp_syntax_error ?printed_filename ppf = function

--- a/src/middle/Semantic_error.ml
+++ b/src/middle/Semantic_error.ml
@@ -332,10 +332,10 @@ module StatementError = struct
            of functions with the suffix _lp."
     | InvalidSamplingPDForPMF ->
         Fmt.pf ppf
-          {|
-~ statement should refer to a distribution without its "_lpdf/_lupdf" or "_lpmf/_lupmf" suffix.
-For example, "target += normal_lpdf(y, 0, 1)" should become "y ~ normal(0, 1)."
-|}
+          "~ statement should refer to a distribution without its \
+           \"_lpdf/_lupdf\" or \"_lpmf/_lupmf\" suffix.\n\
+           For example, \"target += normal_lpdf(y, 0, 1)\" should become \"y \
+           ~ normal(0, 1).\""
     | InvalidSamplingCDForCCDF name ->
         Fmt.pf ppf
           "CDF and CCDF functions may not be used with sampling notation. Use \

--- a/src/middle/Warnings.ml
+++ b/src/middle/Warnings.ml
@@ -8,5 +8,8 @@ let pp ?printed_filename ppf (span, message) =
   Fmt.pf ppf "@[<hov>Warning%s: %s@]" loc_str message
 
 let pp_warnings ?printed_filename ppf warnings =
-  Fmt.(
-    pf ppf "@[<v>%a@]%a" (list ~sep:cut (pp ?printed_filename)) warnings cut ())
+  if List.length warnings > 0 then
+    Fmt.(
+      pf ppf "@[<v>%a@]%a"
+        (list ~sep:cut (pp ?printed_filename))
+        warnings cut ())

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2150,7 +2150,6 @@ Semantic error in 'tilde-bad.stan', line 8, column 8 to column 19:
      9:  }
    -------------------------------------------------
 
-
 ~ statement should refer to a distribution without its "_lpdf/_lupdf" or "_lpmf/_lupmf" suffix.
 For example, "target += normal_lpdf(y, 0, 1)" should become "y ~ normal(0, 1)."
   $ ../../../../install/default/bin/stanc too-many-indices.stan

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -1,6 +1,7 @@
 $ node allow-undefined.js
 Semantic error in 'string', line 3, column 4 to column 20: 
 Some function is declared without specifying a definition.
+
 $ node auto-format.js
 parameters {
   real y;
@@ -12,6 +13,7 @@ model {
 $ node basic.js
 Semantic error in 'string', line 6, column 4 to column 5: 
 Identifier 'z' not in scope.
+
 $ node canonical.js
 transformed data {
   real a = lmultiply(4, 5);
@@ -47,8 +49,10 @@ $ node data-generation.js
 $ node filename.js
 Semantic error in 'good_filename', line 6, column 4 to column 5: 
 Identifier 'z' not in scope.
+
 Semantic error in 'string', line 6, column 4 to column 5: 
 Identifier 'z' not in scope.
+
 $ node info.js
 { "inputs": { "a": { "type": "int", "dimensions": 0},
               "b": { "type": "real", "dimensions": 0},
@@ -78,6 +82,7 @@ $ node info.js
 $ node optimization.js
 Semantic error in 'string', line 3, column 4 to column 20: 
 Some function is declared without specifying a definition.
+
 $ node pedantic.js
 ["Warning in 'string', line 7, column 17: Argument 10000 suggests there may be parameters that are not unit scale; consider rescaling with a multiplier (see manual section 22.12).","Warning: The parameter k was declared but was not used in the density calculation."]
 []


### PR DESCRIPTION
Currently, parsing errors always have newlines at the end, added by Menhir. Our semantic error messages and lexing error messages didn't, so they would result in a command line prompt like
```
Invalid character found.[brian@Flatiron stanc3 on master [!?]] $ 
```
This change simply adds "@." (the format newline/flush command) to the end of the non-parsing errors. Note that this doesn't effect the captured test output, so the diff doesn't have to edit every single fail test in the project.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Error messages should now always have a trailing newline.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
