### PR TITLE
Display lexer warnings the same as others

### DIFF
--- a/src/frontend/Frontend_utils.ml
+++ b/src/frontend/Frontend_utils.ml
@@ -28,9 +28,7 @@ let typed_ast_of_string_exn s =
 let get_ast_or_exit ?printed_filename ?(print_warnings = true) filename =
   let res, warnings = Parse.parse_file Parser.Incremental.program filename in
   if print_warnings then
-    Fmt.epr "%a"
-      (Fmt.list ~sep:Fmt.nop (Warnings.pp ?printed_filename))
-      warnings ;
+    (Warnings.pp_warnings ?printed_filename) Fmt.stderr warnings ;
   match res with
   | Result.Ok ast -> ast
   | Result.Error err -> Errors.pp Fmt.stderr err ; exit 1

--- a/src/middle/Warnings.ml
+++ b/src/middle/Warnings.ml
@@ -9,7 +9,4 @@ let pp ?printed_filename ppf (span, message) =
 
 let pp_warnings ?printed_filename ppf warnings =
   if List.length warnings > 0 then
-    Fmt.(
-      pf ppf "@[<v>%a@]%a"
-        (list ~sep:cut (pp ?printed_filename))
-        warnings cut ())
+    Fmt.(pf ppf "@[<v>%a@]@." (list ~sep:cut (pp ?printed_filename)) warnings)

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -569,7 +569,8 @@ Invalid character found.
 Warning in 'good_all.stan', line 1, column 0: Comments beginning with # are deprecated. Please use // in place of # for line comments.
 Warning in 'good_all.stan', line 2, column 0: Comments beginning with # are deprecated. Please use // in place of # for line comments.
 Warning in 'good_all.stan', line 3, column 0: Comments beginning with # are deprecated. Please use // in place of # for line comments.
-Warning in 'good_all.stan', line 4, column 0: Comments beginning with # are deprecated. Please use // in place of # for line comments.Semantic error in 'good_all.stan', line 25, column 2 to column 8:
+Warning in 'good_all.stan', line 4, column 0: Comments beginning with # are deprecated. Please use // in place of # for line comments.
+Semantic error in 'good_all.stan', line 25, column 2 to column 8:
    -------------------------------------------------
     23:  
     24:  model {

--- a/test/integration/bad/new/stanc.expected
+++ b/test/integration/bad/new/stanc.expected
@@ -105,7 +105,8 @@ Syntax error in 'blocks-bad9.stan', line 1, column 19 to column 23, parsing erro
 
 Expect a statement or top-level variable declaration.
   $ ../../../../../install/default/bin/stanc compound-assign-decl-bad1.stan
-Warning in 'compound-assign-decl-bad1.stan', line 1, column 18: assignment operator <- is deprecated in the Stan language; use = instead.Syntax error in 'compound-assign-decl-bad1.stan', line 1, column 18 to column 20, parsing error:
+Warning in 'compound-assign-decl-bad1.stan', line 1, column 18: assignment operator <- is deprecated in the Stan language; use = instead.
+Syntax error in 'compound-assign-decl-bad1.stan', line 1, column 18 to column 20, parsing error:
    -------------------------------------------------
      1:  model { real T[1] <- {5.0};}
                            ^
@@ -113,7 +114,8 @@ Warning in 'compound-assign-decl-bad1.stan', line 1, column 18: assignment opera
 
 Expected  ";" or assignment.
   $ ../../../../../install/default/bin/stanc compound-assign-decl-bad2.stan
-Warning in 'compound-assign-decl-bad2.stan', line 1, column 29: assignment operator <- is deprecated in the Stan language; use = instead.Syntax error in 'compound-assign-decl-bad2.stan', line 1, column 29 to column 31, parsing error:
+Warning in 'compound-assign-decl-bad2.stan', line 1, column 29: assignment operator <- is deprecated in the Stan language; use = instead.
+Syntax error in 'compound-assign-decl-bad2.stan', line 1, column 29 to column 31, parsing error:
    -------------------------------------------------
      1:  transformed data { real T[1] <- {1.1};}
                                       ^
@@ -1149,7 +1151,8 @@ Syntax error in 'ill-formed-statement20.stan', line 1, column 23 to column 28, p
 
 Expected "(" after "for".
   $ ../../../../../install/default/bin/stanc ill-formed-statement21.stan
-Warning in 'ill-formed-statement21.stan', line 1, column 19: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.Syntax error in 'ill-formed-statement21.stan', line 1, column 28 to column 33, parsing error:
+Warning in 'ill-formed-statement21.stan', line 1, column 19: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.
+Syntax error in 'ill-formed-statement21.stan', line 1, column 28 to column 33, parsing error:
    -------------------------------------------------
      1:  transformed data { get_lp ( while
                                      ^
@@ -1157,7 +1160,8 @@ Warning in 'ill-formed-statement21.stan', line 1, column 19: get_lp() function i
 
 Expected ")" after "get_lp(".
   $ ../../../../../install/default/bin/stanc ill-formed-statement22.stan
-Warning in 'ill-formed-statement22.stan', line 1, column 19: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.Syntax error in 'ill-formed-statement22.stan', line 1, column 26 to column 31, parsing error:
+Warning in 'ill-formed-statement22.stan', line 1, column 19: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.
+Syntax error in 'ill-formed-statement22.stan', line 1, column 26 to column 31, parsing error:
    -------------------------------------------------
      1:  transformed data { get_lp while
                                    ^
@@ -1213,7 +1217,8 @@ Syntax error in 'ill-formed-statement28.stan', line 1, column 25 to column 26, p
 
 Ill-formed expression. Expression expected after "(", for test of conditional control flow construct.
   $ ../../../../../install/default/bin/stanc ill-formed-statement29.stan
-Warning in 'ill-formed-statement29.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Syntax error in 'ill-formed-statement29.stan', line 1, column 43 to column 48, parsing error:
+Warning in 'ill-formed-statement29.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Syntax error in 'ill-formed-statement29.stan', line 1, column 43 to column 48, parsing error:
    -------------------------------------------------
      1:  transformed data { increment_log_prob ( 1) while}
                                                     ^
@@ -1229,7 +1234,8 @@ Syntax error in 'ill-formed-statement3.stan', line 1, column 36 to column 40, pa
 
 Ill-formed statement. Expected statement after ")"  for the loop body of the for loop..
   $ ../../../../../install/default/bin/stanc ill-formed-statement30.stan
-Warning in 'ill-formed-statement30.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Syntax error in 'ill-formed-statement30.stan', line 1, column 42 to column 47, parsing error:
+Warning in 'ill-formed-statement30.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Syntax error in 'ill-formed-statement30.stan', line 1, column 42 to column 47, parsing error:
    -------------------------------------------------
      1:  transformed data { increment_log_prob ( 1 while}
                                                    ^
@@ -1237,7 +1243,8 @@ Warning in 'ill-formed-statement30.stan', line 1, column 19: increment_log_prob(
 
 Ill-formed statement. Expected expression followed by ");" after "(".
   $ ../../../../../install/default/bin/stanc ill-formed-statement31.stan
-Warning in 'ill-formed-statement31.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Syntax error in 'ill-formed-statement31.stan', line 1, column 44 to column 49, parsing error:
+Warning in 'ill-formed-statement31.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Syntax error in 'ill-formed-statement31.stan', line 1, column 44 to column 49, parsing error:
    -------------------------------------------------
      1:  transformed data { increment_log_prob ( T ) while
                                                      ^
@@ -1245,7 +1252,8 @@ Warning in 'ill-formed-statement31.stan', line 1, column 19: increment_log_prob(
 
 Ill-formed statement. Expected ";" after ")".
   $ ../../../../../install/default/bin/stanc ill-formed-statement32.stan
-Warning in 'ill-formed-statement32.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Syntax error in 'ill-formed-statement32.stan', line 1, column 42 to column 43, parsing error:
+Warning in 'ill-formed-statement32.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Syntax error in 'ill-formed-statement32.stan', line 1, column 42 to column 43, parsing error:
    -------------------------------------------------
      1:  transformed data { increment_log_prob ( T ~
                                                    ^
@@ -1253,7 +1261,8 @@ Warning in 'ill-formed-statement32.stan', line 1, column 19: increment_log_prob(
 
 Ill-formed statement. Expected expression followed by ");" after "(".
   $ ../../../../../install/default/bin/stanc ill-formed-statement33.stan
-Warning in 'ill-formed-statement33.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Syntax error in 'ill-formed-statement33.stan', line 1, column 40 to column 45, parsing error:
+Warning in 'ill-formed-statement33.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Syntax error in 'ill-formed-statement33.stan', line 1, column 40 to column 45, parsing error:
    -------------------------------------------------
      1:  transformed data { increment_log_prob ( while
                                                  ^
@@ -1261,7 +1270,8 @@ Warning in 'ill-formed-statement33.stan', line 1, column 19: increment_log_prob(
 
 Ill-formed statement. Expected expression followed by ");" after "(".
   $ ../../../../../install/default/bin/stanc ill-formed-statement34.stan
-Warning in 'ill-formed-statement34.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Syntax error in 'ill-formed-statement34.stan', line 1, column 39 to column 44, parsing error:
+Warning in 'ill-formed-statement34.stan', line 1, column 19: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Syntax error in 'ill-formed-statement34.stan', line 1, column 39 to column 44, parsing error:
    -------------------------------------------------
      1:  transformed data { increment_log_prob  while
                                                 ^

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -731,7 +731,8 @@ Syntax error in 'err-if-else.stan', line 3, column 8 to column 9, parsing error:
 
 Expected ")" after test expression of conditional control flow construct.
   $ ../../../../install/default/bin/stanc err-incr-log-prob-scope.stan
-Warning in 'err-incr-log-prob-scope.stan', line 4, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Semantic error in 'err-incr-log-prob-scope.stan', line 4, column 2 to column 24:
+Warning in 'err-incr-log-prob-scope.stan', line 4, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Semantic error in 'err-incr-log-prob-scope.stan', line 4, column 2 to column 24:
    -------------------------------------------------
      2:    real x;
      3:    x = 2.0;
@@ -1002,7 +1003,8 @@ Semantic error in 'functions-bad11.stan', line 3, column 4 to column 20:
 
 Target can only be accessed in the model block or in definitions of functions with the suffix _lp.
   $ ../../../../install/default/bin/stanc functions-bad12.stan
-Warning in 'functions-bad12.stan', line 3, column 4: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Semantic error in 'functions-bad12.stan', line 3, column 4 to column 42:
+Warning in 'functions-bad12.stan', line 3, column 4: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Semantic error in 'functions-bad12.stan', line 3, column 4 to column 42:
    -------------------------------------------------
      1:  functions {
      2:    void badlp(real x) {
@@ -1039,7 +1041,8 @@ Semantic error in 'functions-bad14.stan', line 5, column 6 to column 9:
 Identifier 'abc' is already in use.
   $ ../../../../install/default/bin/stanc functions-bad15.stan
 Warning in 'functions-bad15.stan', line 3, column 4: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
-Warning in 'functions-bad15.stan', line 10, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Semantic error in 'functions-bad15.stan', line 10, column 21 to column 38:
+Warning in 'functions-bad15.stan', line 10, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Semantic error in 'functions-bad15.stan', line 10, column 21 to column 38:
    -------------------------------------------------
      8:  }
      9:  model {
@@ -1278,7 +1281,8 @@ Semantic error in 'get-lp-target-data.stan', line 2, column 19 to column 27:
 
 Target can only be accessed in the model block or in definitions of functions with the suffix _lp.
   $ ../../../../install/default/bin/stanc get_lp_bad_scope1.stan
-Warning in 'get_lp_bad_scope1.stan', line 3, column 6: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.Semantic error in 'get_lp_bad_scope1.stan', line 3, column 6 to column 14:
+Warning in 'get_lp_bad_scope1.stan', line 3, column 6: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.
+Semantic error in 'get_lp_bad_scope1.stan', line 3, column 6 to column 14:
    -------------------------------------------------
      1:  transformed data {
      2:    real y;
@@ -1290,7 +1294,8 @@ Warning in 'get_lp_bad_scope1.stan', line 3, column 6: get_lp() function is depr
 
 Target can only be accessed in the model block or in definitions of functions with the suffix _lp.
   $ ../../../../install/default/bin/stanc get_lp_bad_scope2.stan
-Warning in 'get_lp_bad_scope2.stan', line 3, column 15: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.Semantic error in 'get_lp_bad_scope2.stan', line 3, column 15 to column 23:
+Warning in 'get_lp_bad_scope2.stan', line 3, column 15: get_lp() function is deprecated. It will be removed in a future release. Use target() instead.
+Semantic error in 'get_lp_bad_scope2.stan', line 3, column 15 to column 23:
    -------------------------------------------------
      1:  functions {
      2:    real foo(real x) {
@@ -2038,7 +2043,8 @@ Semantic error in 'row_vector_expr_bad2.stan', line 5, column 25 to column 26:
 
 Row_vector expression must have all int or real entries. Found type row_vector.
   $ ../../../../install/default/bin/stanc signature_function_known.stan
-Warning in 'signature_function_known.stan', line 8, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Semantic error in 'signature_function_known.stan', line 8, column 21 to column 50:
+Warning in 'signature_function_known.stan', line 8, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Semantic error in 'signature_function_known.stan', line 8, column 21 to column 50:
    -------------------------------------------------
      6:  }
      7:  model {
@@ -2062,7 +2068,8 @@ Available signatures:
   The first argument must be array[] int but got vector
 (Additional signatures omitted)
   $ ../../../../install/default/bin/stanc signature_function_unknown.stan
-Warning in 'signature_function_unknown.stan', line 8, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.Semantic error in 'signature_function_unknown.stan', line 8, column 21 to column 45:
+Warning in 'signature_function_unknown.stan', line 8, column 2: increment_log_prob(...); is deprecated and will be removed in the future. Use target += ...; instead.
+Semantic error in 'signature_function_unknown.stan', line 8, column 21 to column 45:
    -------------------------------------------------
      6:  }
      7:  model {


### PR DESCRIPTION
This is somewhat of a follow on to #982. If we don't get it in 2.28 that's probably okay.  
We were outputting input warnings with a piece of code that duplicated `Warnings.pp_warnings` but not as well. The result was that the newlines were not properly handled. This was especially noticeable if you had a warning and error in the same file, as the error would just get appended to the line rather than following it. 

See changed test output for examples

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Display errors on separate lines from warnings if both exist

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
