### PR TITLE
fix transform inits input and output sizes

### DIFF
--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -367,9 +367,17 @@ let pp_validate_data ppf (name, st) =
 
 let pp_mul ppf () = pf ppf " * "
 
-let get_param_st lst =
+let get_unconstrained_param_st lst =
   match lst with
   | _, {Program.out_block= Parameters; out_unconstrained_st= st; _} -> (
+    match SizedType.get_dims_io st with
+    | [] -> Some [Expr.Helpers.loop_bottom]
+    | ls -> Some ls )
+  | _ -> None
+
+let get_constrained_param_st lst =
+  match lst with
+  | _, {Program.out_block= Parameters; out_constrained_st= st; _} -> (
     match SizedType.get_dims_io st with
     | [] -> Some [Expr.Helpers.loop_bottom]
     | ls -> Some ls )
@@ -425,7 +433,9 @@ let pp_ctor ppf p =
         pp_located_error ppf
           (pp_block, (list ~sep:cut pp_stmt_topdecl_size_only, prepare_data)) ;
         cut ppf () ;
-        let output_params = List.filter_map ~f:get_param_st output_vars in
+        let output_params =
+          List.filter_map ~f:get_unconstrained_param_st output_vars
+        in
         let pp_plus ppf () = pf ppf " + " in
         let pp_set_params ppf pars =
           (list ~sep:pp_plus pp_num_param) ppf pars
@@ -857,37 +867,54 @@ let pp_transform_inits ppf {Program.output_vars; _} =
   in
   let param_names = List.filter_map ~f:list_names output_vars in
   let list_len = List.length param_names in
-  let output_params = List.filter_map ~f:get_param_st output_vars in
+  let constrained_params =
+    List.filter_map ~f:get_constrained_param_st output_vars
+  in
   let get_names ppf () =
-    let add_param = fmt "%S" in
-    pf ppf "@[<hov -1> constexpr std::array<const char*, %i> names__{%a};@,"
+    let add_param = fmt "%S@," in
+    pf ppf "@[<hov 2> constexpr std::array<const char*, %i> names__{%a};@]@,"
       list_len
       (list ~sep:comma add_param)
       param_names
   in
-  let get_sizes ppf () =
-    match output_params with
-    | [] -> pf ppf " const std::array<Eigen::Index, 0> num_params__{};@]@,"
+  let get_constrain_param_size_arr ppf () =
+    match constrained_params with
+    | [] ->
+        pf ppf
+          "@[<hov 2> const std::array<Eigen::Index, 0> \
+           constrain_param_sizes__{};@]@,"
     | _ ->
         let pp_set_params ppf pars = (list ~sep:comma pp_num_param) ppf pars in
-        pf ppf " const std::array<Eigen::Index, %i> num_params__{%a};@]@,"
-          list_len pp_set_params output_params
+        pf ppf
+          "@[<hov 2> const std::array<Eigen::Index, %i> \
+           constrain_param_sizes__{%a};@]@,"
+          list_len pp_set_params constrained_params
+  in
+  let get_constrained_param_size ppf () =
+    pf ppf
+      "@[<hov 2> const auto num_constrained_params__ = std::accumulate(@, \
+       constrain_param_sizes__.begin(),@,@ constrain_param_sizes__.end(), \
+       0);@]@,"
   in
   let pp_body ppf =
     pf ppf "%a" (list ~sep:cut string)
-      [ " std::vector<double> params_r_flat__(num_params_r__);"
+      [ " std::vector<double> params_r_flat__(num_constrained_params__);"
       ; " Eigen::Index size_iter__ = 0;"; " Eigen::Index flat_iter__ = 0;"
       ; " for (auto&& param_name__ : names__) {"
       ; "   const auto param_vec__ = context.vals_r(param_name__);"
-      ; "   for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {"
+      ; "   for (Eigen::Index i = 0; i < \
+         constrain_param_sizes__[size_iter__]; ++i) {"
       ; "     params_r_flat__[flat_iter__] = param_vec__[i];"
       ; "     ++flat_iter__;"; "   }"; "   ++size_iter__;"; " }"
-      ; " vars.resize(params_r_flat__.size());"
+      ; " vars.resize(num_params_r__);"
       ; " transform_inits_impl(params_r_flat__, params_i, vars, pstream__);" ]
   in
   let cv_attr = ["const"] in
-  let blah ppf = pf ppf "%a %a" get_names () get_sizes in
-  pp_method ppf "void" "transform_inits" params blah
+  let intro ppf =
+    pf ppf "%a %a %a" get_names () get_constrain_param_size_arr ()
+      get_constrained_param_size
+  in
+  pp_method ppf "void" "transform_inits" params intro
     (fun ppf -> pp_body ppf)
     ~cv_attr
 

--- a/test/integration/cli-args/filename_good.expected
+++ b/test/integration/cli-args/filename_good.expected
@@ -281,20 +281,22 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1617,22 +1617,24 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 9> names__{"alpha_v", "beta", "cuts",
-   "sigma", "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
-     const std::array<Eigen::Index, 9> num_params__{k, k, k, 1, 1, 1, 
-   (n * k), (n * k), n};
+      "sigma", "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
+      const std::array<Eigen::Index, 9> constrain_param_sizes__{k, k, 
+       k, 1, 1, 1, (n * k), (n * k), n};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -411,22 +411,24 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
                               std::vector<int>& params_i,
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
-     constexpr std::array<const char*, 3> names__{"mu", "tau",
-   "theta_tilde"};  const std::array<Eigen::Index, 3> num_params__{1, 
-   1, J};
+     constexpr std::array<const char*, 3> names__{"mu", "tau", "theta_tilde"
+      };
+      const std::array<Eigen::Index, 3> constrain_param_sizes__{1, 1, J};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -743,20 +745,22 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"bar"};
-     const std::array<Eigen::Index, 1> num_params__{1};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -3365,22 +3369,24 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 4> names__{"p_r", "p_complex",
-   "p_complex_array", "p_complex_array_2d"};
-     const std::array<Eigen::Index, 4> num_params__{1, 2, (2 * 2),
-   (2 * 3 * 2)};
+      "p_complex_array", "p_complex_array_2d"};
+      const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 2, 
+       (2 * 2), (2 * 3 * 2)};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -3761,20 +3767,22 @@ class conditional_expression_types_model final : public model_base_crtp<conditio
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"a", "b"};
-     const std::array<Eigen::Index, 2> num_params__{2, 2};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{2, 2};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -4215,22 +4223,24 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
                               std::vector<int>& params_i,
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
-     constexpr std::array<const char*, 3> names__{"mu", "tau",
-   "theta_tilde"};  const std::array<Eigen::Index, 3> num_params__{1, 
-   1, J};
+     constexpr std::array<const char*, 3> names__{"mu", "tau", "theta_tilde"
+      };
+      const std::array<Eigen::Index, 3> constrain_param_sizes__{1, 1, J};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -4690,20 +4700,22 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"xx"};
-     const std::array<Eigen::Index, 1> num_params__{3};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{3};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -13128,30 +13140,30 @@ class mother_model final : public model_base_crtp<mother_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 24> names__{"p_real", "p_upper",
-   "p_lower", "offset_multiplier", "no_offset_multiplier",
-   "offset_no_multiplier", "p_real_1d_ar", "p_real_3d_ar", "p_vec",
-   "p_1d_vec", "p_3d_vec", "p_row_vec", "p_1d_row_vec", "p_3d_row_vec",
-   "p_mat", "p_ar_mat", "p_simplex", "p_1d_simplex", "p_3d_simplex",
-   "p_cfcov_54", "p_cfcov_33", "p_cfcov_33_ar", "x_p", "y_p"};
-     const std::array<Eigen::Index, 24> num_params__{1, 1, 1, 5, 5, 5, 
-   N, (N * M * K), N, (N * N), (N * M * K * N), N, (N * N), (N * M * K * N),
-   (5 * 4), (4 * 5 * 2 * 3), (N - 1), (N * (N - 1)), (N * M * K * (N - 1)),
-   ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)),
-   ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3)),
-   (K * ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))), 2, 2};
+      "p_lower", "offset_multiplier", "no_offset_multiplier",
+      "offset_no_multiplier", "p_real_1d_ar", "p_real_3d_ar", "p_vec",
+      "p_1d_vec", "p_3d_vec", "p_row_vec", "p_1d_row_vec", "p_3d_row_vec",
+      "p_mat", "p_ar_mat", "p_simplex", "p_1d_simplex", "p_3d_simplex",
+      "p_cfcov_54", "p_cfcov_33", "p_cfcov_33_ar", "x_p", "y_p"};
+      const std::array<Eigen::Index, 24> constrain_param_sizes__{1, 1, 
+       1, 5, 5, 5, N, (N * M * K), N, (N * N), (N * M * K * N), N, (N * N),
+       (N * M * K * N), (5 * 4), (4 * 5 * 2 * 3), N, (N * N), (N * M * K * N)
+       , (5 * 4), (3 * 3), (K * 3 * 3), 2, 2};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -14921,22 +14933,24 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 7> names__{"y0_p", "theta_p", "x_p",
-   "x_p_v", "shared_params_p", "job_params_p", "x_r"};
-     const std::array<Eigen::Index, 7> num_params__{2, 1, 1, 2, 3, (3 * 3), 
-   1};
+      "x_p_v", "shared_params_p", "job_params_p", "x_r"};
+      const std::array<Eigen::Index, 7> constrain_param_sizes__{2, 1, 
+       1, 2, 3, (3 * 3), 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -19060,20 +19074,22 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 3> names__{"r", "ra", "v"};
-     const std::array<Eigen::Index, 3> num_params__{1, N, N};
+      const std::array<Eigen::Index, 3> constrain_param_sizes__{1, N, N};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -19713,21 +19729,24 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 6> names__{"alpha", "beta", "gamma",
-   "delta", "z_init", "sigma"};
-     const std::array<Eigen::Index, 6> num_params__{1, 1, 1, 1, 2, 2};
+      "delta", "z_init", "sigma"};
+      const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 
+       1, 1, 2, 2};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -21258,22 +21277,24 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 9> names__{"alpha_v", "beta", "cuts",
-   "sigma", "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
-     const std::array<Eigen::Index, 9> num_params__{k, k, k, 1, 1, 1, 
-   (n * k), (n * k), n};
+      "sigma", "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
+      const std::array<Eigen::Index, 9> constrain_param_sizes__{k, k, 
+       k, 1, 1, 1, (n * k), (n * k), n};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -21689,21 +21710,23 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"L_Omega", "z1"};
-     const std::array<Eigen::Index, 2> num_params__{(nt * ((2 * (2 - 1)) / 2))
-   , NS};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{(nt * 2 * 2),
+       NS};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -22014,20 +22037,22 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -22588,20 +22613,22 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 3> names__{"y1", "y2", "y3"};
-     const std::array<Eigen::Index, 3> num_params__{N, N, N};
+      const std::array<Eigen::Index, 3> constrain_param_sizes__{N, N, N};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -24889,24 +24916,27 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 16> names__{"a8", "a7", "a6", "a5",
-   "a4", "a3", "a2", "a1", "y8", "y7", "y6", "y5", "y4", "y3", "y2", "y1"};
-     const std::array<Eigen::Index, 16> num_params__{(N * N * N * N),
-   (N * N * N), (N * N * N), (N * N), (N * N * N), (N * N), (N * N), 
-   N, (N * N * N * N), (N * N * N), (N * N * N), (N * N), (N * N * N),
-   (N * N), (N * N), N};
+      "a4", "a3", "a2", "a1", "y8", "y7", "y6", "y5", "y4", "y3", "y2", "y1"
+      };
+      const std::array<Eigen::Index, 16> constrain_param_sizes__{(N * N * N * N)
+       , (N * N * N), (N * N * N), (N * N), (N * N * N), (N * N), (N * N), 
+       N, (N * N * N * N), (N * N * N), (N * N * N), (N * N), (N * N * N),
+       (N * N), (N * N), N};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -28594,23 +28624,25 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 13> names__{"y1", "y2", "y3", "y4",
-   "y5", "y6", "y7", "y8", "y9", "y10", "y11", "y12", "y17"};
-     const std::array<Eigen::Index, 13> num_params__{N, (N * N), (N * N),
-   (N * N * N), (N * N), (N * N * N), (N * N * N), (N * N * N * N), 1, 
-   N, N, (N * N), (N * N * N)};
+      "y5", "y6", "y7", "y8", "y9", "y10", "y11", "y12", "y17"};
+      const std::array<Eigen::Index, 13> constrain_param_sizes__{N, (N * N),
+       (N * N), (N * N * N), (N * N), (N * N * N), (N * N * N),
+       (N * N * N * N), 1, N, N, (N * N), (N * N * N)};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -29076,20 +29108,22 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -29440,20 +29474,22 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"x"};
-     const std::array<Eigen::Index, 1> num_params__{1};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -32053,25 +32089,27 @@ class transform_model final : public model_base_crtp<transform_model> {
                               std::vector<int>& params_i,
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
-     constexpr std::array<const char*, 18> names__{"p_1", "p_2", "p_3",
-   "p_4", "p_5", "p_6", "p_7", "p_8", "p_9", "p_10", "pv_1", "pv_2", "pv_3",
-   "pr_1", "pr_2", "pr_3", "pm_1", "pm_2"};
-     const std::array<Eigen::Index, 18> num_params__{k, k, k, k, k, k, 
-   k, k, (m * k), (n * m * k), k, (m * k), (n * m * k), k, (m * k),
-   (n * m * k), (m * k), (n * m * k)};
+     constexpr std::array<const char*, 18> names__{"p_1", "p_2", "p_3", "p_4"
+      , "p_5", "p_6", "p_7", "p_8", "p_9", "p_10", "pv_1", "pv_2", "pv_3",
+      "pr_1", "pr_2", "pr_3", "pm_1", "pm_2"};
+      const std::array<Eigen::Index, 18> constrain_param_sizes__{k, k, 
+       k, k, k, k, k, k, (m * k), (n * m * k), k, (m * k), (n * m * k), 
+       k, (m * k), (n * m * k), (m * k), (n * m * k)};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -32513,20 +32551,22 @@ class truncate_model final : public model_base_crtp<truncate_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"m", "y"};
-     const std::array<Eigen::Index, 2> num_params__{1, 1};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -32868,20 +32908,22 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"x"};
-     const std::array<Eigen::Index, 1> num_params__{1};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -33228,20 +33270,22 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"x"};
-     const std::array<Eigen::Index, 1> num_params__{1};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -428,20 +428,22 @@ class simple_function_model final : public model_base_crtp<simple_function_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -666,20 +666,22 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 4> names__{"y", "y0", "t0", "times"};
-     const std::array<Eigen::Index, 4> num_params__{1, N, 1, N};
+      const std::array<Eigen::Index, 4> constrain_param_sizes__{1, N, 1, N};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -6251,22 +6251,24 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 6> names__{"p_real", "p_real_array",
-   "p_matrix", "p_vector", "p_row_vector", "y_p"};
-     const std::array<Eigen::Index, 6> num_params__{1, d_int, (d_int * d_int)
-   , d_int, d_int, 1};
+      "p_matrix", "p_vector", "p_row_vector", "y_p"};
+      const std::array<Eigen::Index, 6> constrain_param_sizes__{1, d_int,
+       (d_int * d_int), d_int, d_int, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -6941,22 +6943,24 @@ class restricted_model final : public model_base_crtp<restricted_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 6> names__{"p_real", "p_real_array",
-   "p_matrix", "p_vector", "p_row_vector", "y_p"};
-     const std::array<Eigen::Index, 6> num_params__{1, d_int, (d_int * d_int)
-   , d_int, d_int, 1};
+      "p_matrix", "p_vector", "p_row_vector", "y_p"};
+      const std::array<Eigen::Index, 6> constrain_param_sizes__{1, d_int,
+       (d_int * d_int), d_int, d_int, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -453,20 +453,22 @@ class simple_function_model final : public model_base_crtp<simple_function_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 3> names__{"rho", "alpha", "sigma"};
-     const std::array<Eigen::Index, 3> num_params__{1, 1, 1};
+      const std::array<Eigen::Index, 3> constrain_param_sizes__{1, 1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -763,21 +763,23 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 4> names__{"beta", "gamma", "xi",
-   "delta"};  const std::array<Eigen::Index, 4> num_params__{1, 1, 1, 
-   1};
+      "delta"};
+      const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -2871,20 +2873,22 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-     const std::array<Eigen::Index, 2> num_params__{1, max_age};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -4111,24 +4115,27 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 16> names__{"sigma", "sigma_age",
-   "sigma_edu", "sigma_state", "sigma_region", "sigma_age_edu", "b_0",
-   "b_female", "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu",
-   "b_region", "b_age_edu", "b_hat"};
-     const std::array<Eigen::Index, 16> num_params__{1, 1, 1, 1, 1, 1, 
-   1, 1, 1, 1, 1, n_age, n_edu, n_region, (n_age * n_edu), n_state};
+      "sigma_edu", "sigma_state", "sigma_region", "sigma_age_edu", "b_0",
+      "b_female", "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu",
+      "b_region", "b_age_edu", "b_hat"};
+      const std::array<Eigen::Index, 16> constrain_param_sizes__{1, 1, 
+       1, 1, 1, 1, 1, 1, 1, 1, 1, n_age, n_edu, n_region, (n_age * n_edu),
+       n_state};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -4472,20 +4479,22 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -4824,20 +4833,22 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -5313,20 +5324,22 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 3> names__{"mu", "sigma", "theta"};
-     const std::array<Eigen::Index, 3> num_params__{2, 2, 1};
+      const std::array<Eigen::Index, 3> constrain_param_sizes__{2, 2, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -5750,20 +5763,22 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 3> names__{"mu", "theta", "tau"};
-     const std::array<Eigen::Index, 3> num_params__{1, J, 1};
+      const std::array<Eigen::Index, 3> constrain_param_sizes__{1, J, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -7006,22 +7021,24 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 11> names__{"a", "b", "c", "d", "e",
-   "beta", "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
-     const std::array<Eigen::Index, 11> num_params__{n_age, n_edu, n_age_edu,
-   n_state, n_region_full, 5, 1, 1, 1, 1, 1};
+      "beta", "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
+      const std::array<Eigen::Index, 11> constrain_param_sizes__{n_age, 
+       n_edu, n_age_edu, n_state, n_region_full, 5, 1, 1, 1, 1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -7812,20 +7829,23 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"tau_phi", "phi_std_raw"};
-     const std::array<Eigen::Index, 2> num_params__{1, phi_std_raw_1dim__};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{1,
+       phi_std_raw_1dim__};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -9827,21 +9847,24 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 4> names__{"mean_phi", "mean_p",
-   "epsilon", "sigma"};  const std::array<Eigen::Index, 4> num_params__{
-   1, 1, nind, 1};
+      "epsilon", "sigma"};
+      const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 
+       nind, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -13250,23 +13273,25 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                               std::vector<int>& params_i,
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
-     constexpr std::array<const char*, 6> names__{"mean_phi", "mean_p",
-   "psi", "beta", "epsilon", "sigma"};
-     const std::array<Eigen::Index, 6> num_params__{1, 1, 1, n_occasions, 
-   M, 1};
+     constexpr std::array<const char*, 6> names__{"mean_phi", "mean_p", "psi"
+      , "beta", "epsilon", "sigma"};
+      const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 
+       1, n_occasions, M, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -14373,21 +14398,23 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"pi", "theta"};
-     const std::array<Eigen::Index, 2> num_params__{(K - 1),
-   (J * K * (K - 1))};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{K,
+       (J * K * K)};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -15051,21 +15078,24 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 6> names__{"beta0", "beta1",
-   "tau_theta", "tau_phi", "theta_std", "phi_std_raw"};
-     const std::array<Eigen::Index, 6> num_params__{1, 1, 1, 1, N, N};
+      "tau_theta", "tau_phi", "theta_std", "phi_std_raw"};
+      const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 
+       1, 1, N, N};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -17156,20 +17186,22 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-     const std::array<Eigen::Index, 2> num_params__{1, max_age};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -20487,22 +20519,24 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 5> names__{"mean_phi", "mean_p",
-   "gamma", "epsilon", "sigma"};
-     const std::array<Eigen::Index, 5> num_params__{1, 1, n_occasions,
-   epsilon_1dim__, 1};
+      "gamma", "epsilon", "sigma"};
+      const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1,
+       n_occasions, epsilon_1dim__, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -20840,20 +20874,22 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -21187,20 +21223,22 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"x"};
-     const std::array<Eigen::Index, 1> num_params__{1};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -21560,20 +21598,22 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"theta"};
-     const std::array<Eigen::Index, 1> num_params__{J};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{J};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -23470,20 +23510,22 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 2> names__{"mean_phi", "mean_p"};
-     const std::array<Eigen::Index, 2> num_params__{1, 1};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -23992,20 +24034,22 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 1> names__{"mu"};
-     const std::array<Eigen::Index, 1> num_params__{1};
+      const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -24917,21 +24961,23 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 4> names__{"alpha_occ", "beta_occ",
-   "alpha_p", "beta_p"};  const std::array<Eigen::Index, 4> num_params__{
-   1, 1, 1, 1};
+      "alpha_p", "beta_p"};
+      const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -25749,22 +25795,24 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 8> names__{"beta", "eta1", "eta2",
-   "mu_a1", "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
-     const std::array<Eigen::Index, 8> num_params__{1, J, J, 1, 1, 1, 
-   1, 1};
+      "mu_a1", "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
+      const std::array<Eigen::Index, 8> constrain_param_sizes__{1, J, 
+       J, 1, 1, 1, 1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -26948,21 +26996,24 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 5> names__{"theta", "phi", "x_matrix",
-   "x_vector", "x_cov"};  const std::array<Eigen::Index, 5> num_params__{
-   1, 1, (3 * 2), 2, 3};
+      "x_vector", "x_cov"};
+      const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1, 
+       (3 * 2), 2, (2 * 2)};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -27675,22 +27726,24 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 5> names__{"a", "beta", "mu_a",
-   "sigma_a", "sigma_y"};
-     const std::array<Eigen::Index, 5> num_params__{n_pair, 2, 1, 1, 
-   1};
+      "sigma_a", "sigma_y"};
+      const std::array<Eigen::Index, 5> constrain_param_sizes__{n_pair, 
+       2, 1, 1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -28496,21 +28549,24 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 6> names__{"alpha0", "alpha1",
-   "alpha2", "alpha12", "tau", "b"};
-     const std::array<Eigen::Index, 6> num_params__{1, 1, 1, 1, 1, (I * K)};
+      "alpha2", "alpha12", "tau", "b"};
+      const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 
+       1, 1, 1, (I * K)};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     
@@ -29113,20 +29169,22 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
                               std::vector<double>& vars,
                               std::ostream* pstream__ = nullptr) const {
      constexpr std::array<const char*, 0> names__{};
-     const std::array<Eigen::Index, 0> num_params__{};
+      const std::array<Eigen::Index, 0> constrain_param_sizes__{};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
     
-     std::vector<double> params_r_flat__(num_params_r__);
+     std::vector<double> params_r_flat__(num_constrained_params__);
      Eigen::Index size_iter__ = 0;
      Eigen::Index flat_iter__ = 0;
      for (auto&& param_name__ : names__) {
        const auto param_vec__ = context.vals_r(param_name__);
-       for (Eigen::Index i = 0; i < num_params__[size_iter__]; ++i) {
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
          params_r_flat__[flat_iter__] = param_vec__[i];
          ++flat_iter__;
        }
        ++size_iter__;
      }
-     vars.resize(params_r_flat__.size());
+     vars.resize(num_params_r__);
      transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
     } // transform_inits() 
     


### PR DESCRIPTION
Fix for transform inits so that the input vector is the same as the number of constrained parameters while the output vector is the size of the number of unconstrained params

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
