### PR TITLE
Warn for matrix^pow, suggest .^ or matrix_power()

### DIFF
--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -603,7 +603,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
                  operator %/%."
             in
             add_warning x.emeta.loc s
-        | UMatrix, (UInt | UReal), Pow ->
+        | (UArray UMatrix | UMatrix), (UInt | UReal), Pow ->
             let s =
               Fmt.strf
                 "@[<v>@[<hov 0>Found matrix^scalar:@]@   @[<hov \
@@ -614,7 +614,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
                  warning by using elementwise operator .^"
                 Fmt.text
                 "If you intended matrix exponentiation, use the function \
-                 matrix_power() instead."
+                 matrix_power(matrix,int) instead."
             in
             add_warning x.emeta.loc s
         | _ -> ()

--- a/test/integration/good/matrix_pow_warning.stan
+++ b/test/integration/good/matrix_pow_warning.stan
@@ -1,0 +1,11 @@
+data {
+   int<lower=0> N;
+   matrix[N,N] A;
+   int power;
+}
+
+transformed data {
+   matrix[N,N] A_pow = A ^ power;
+   matrix[N,N] A_pow_r = A ^ 3.5;
+
+}

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -4912,14 +4912,14 @@ Warning in 'matrix_pow_warning.stan', line 8, column 23: Found matrix^scalar:
   A ^ power
 matrix ^ number is interpreted as element-wise exponentiation. If this is
 intended, you can silence this warning by using elementwise operator .^
-If you intended matrix exponentiation, use the function matrix_power()
-instead.
+If you intended matrix exponentiation, use the function
+matrix_power(matrix,int) instead.
 Warning in 'matrix_pow_warning.stan', line 9, column 25: Found matrix^scalar:
   A ^ 3.5
 matrix ^ number is interpreted as element-wise exponentiation. If this is
 intended, you can silence this warning by using elementwise operator .^
-If you intended matrix exponentiation, use the function matrix_power()
-instead.
+If you intended matrix exponentiation, use the function
+matrix_power(matrix,int) instead.
   $ ../../../../install/default/bin/stanc --auto-format min-max-types.stan
 parameters {
   matrix[max(1, 3), min(2, 5)] a;

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -4897,6 +4897,29 @@ model {
   z ~ normal(0, 1);
 }
 
+  $ ../../../../install/default/bin/stanc --auto-format matrix_pow_warning.stan
+data {
+  int<lower=0> N;
+  matrix[N, N] A;
+  int power;
+}
+transformed data {
+  matrix[N, N] A_pow = A ^ power;
+  matrix[N, N] A_pow_r = A ^ 3.5;
+}
+
+Warning in 'matrix_pow_warning.stan', line 8, column 23: Found matrix^scalar:
+  A ^ power
+matrix ^ number is interpreted as element-wise exponentiation. If this is
+intended, you can silence this warning by using elementwise operator .^
+If you intended matrix exponentiation, use the function matrix_power()
+instead.
+Warning in 'matrix_pow_warning.stan', line 9, column 25: Found matrix^scalar:
+  A ^ 3.5
+matrix ^ number is interpreted as element-wise exponentiation. If this is
+intended, you can silence this warning by using elementwise operator .^
+If you intended matrix exponentiation, use the function matrix_power()
+instead.
   $ ../../../../install/default/bin/stanc --auto-format min-max-types.stan
 parameters {
   matrix[max(1, 3), min(2, 5)] a;


### PR DESCRIPTION
Replacement for #994, closes #604 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Emit warning for `matrix^scalar` and point users to `.^` and `matrix_power()`.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
