### PR TITLE
Standardize internal compiler error messages

### DIFF
--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -241,7 +241,9 @@ let fwd_traverse_statement stmt ~init ~f =
 let vexpr_of_expr_exn Expr.Fixed.({pattern; _}) =
   match pattern with
   | Var s -> VVar s
-  | _ -> raise (Failure "Non-var expression found, but var expected")
+  | _ ->
+      Common.FatalError.fatal_error_msg
+        [%message "FNon-var expression found, but var expected"]
 
 (** See interface file *)
 let rec expr_var_set Expr.Fixed.({pattern; meta}) =
@@ -291,7 +293,9 @@ let expr_assigned_var Expr.Fixed.({pattern; _}) =
   match pattern with
   | Var s -> VVar s
   | Indexed ({pattern= Var s; _}, _) -> VVar s
-  | _ -> raise (Failure "Unimplemented: analysis of assigning to non-var")
+  | _ ->
+      Common.FatalError.fatal_error_msg
+        [%message "Unimplemented: analysis of assigning to non-var"]
 
 (** See interface file *)
 let rec summation_terms (Expr.Fixed.({pattern; _}) as rhs) =

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -243,7 +243,7 @@ let vexpr_of_expr_exn Expr.Fixed.({pattern; _}) =
   | Var s -> VVar s
   | _ ->
       Common.FatalError.fatal_error_msg
-        [%message "FNon-var expression found, but var expected"]
+        [%message "Non-var expression found, but var expected"]
 
 (** See interface file *)
 let rec expr_var_set Expr.Fixed.({pattern; meta}) =

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -148,13 +148,13 @@ let handle_early_returns opt_var b =
                 ; meta= Location_span.empty }
             ; {pattern= Break; meta= Location_span.empty} ]
       | Some _, None ->
-          raise_s
+          Common.FatalError.fatal_error_msg
             [%message
               ( "Function should return a value but found an empty return \
                  statement."
                 : string )]
       | None, Some _ ->
-          raise_s
+          Common.FatalError.fatal_error_msg
             [%message
               ( "Expected a void function but found a non-empty return \
                  statement."
@@ -364,7 +364,8 @@ let rec inline_function_statement propto adt fim Stmt.Fixed.({pattern; meta}) =
               | Var x -> (x, [])
               | Indexed ({pattern= Var x; _}, l) -> (x, l)
               | _ as w ->
-                  raise_s [%sexp (w : Expr.Typed.t Expr.Fixed.Pattern.t)]
+                  Common.FatalError.fatal_error_msg
+                    [%sexp (w : Expr.Typed.t Expr.Fixed.Pattern.t)]
             in
             slist_concat_no_loc
               (dl2 @ dl1 @ sl2 @ sl1)

--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -22,7 +22,7 @@ let apply_prefix_operator_int (op : string) i =
         | "PPlus__" -> i
         | "PMinus__" -> -i
         | "PNot__" -> if i = 0 then 1 else 0
-        | s -> raise_s [%sexp (s : string)] ) )
+        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
 
 let apply_prefix_operator_real (op : string) i =
   Expr.Fixed.Pattern.Lit
@@ -31,7 +31,7 @@ let apply_prefix_operator_real (op : string) i =
         ( match op with
         | "PPlus__" -> i
         | "PMinus__" -> -.i
-        | s -> raise_s [%sexp (s : string)] ) )
+        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
 
 let apply_operator_int (op : string) i1 i2 =
   Expr.Fixed.Pattern.Lit
@@ -49,7 +49,7 @@ let apply_operator_int (op : string) i1 i2 =
         | "Leq__" -> Bool.to_int (i1 <= i2)
         | "Greater__" -> Bool.to_int (i1 > i2)
         | "Geq__" -> Bool.to_int (i1 >= i2)
-        | s -> raise_s [%sexp (s : string)] ) )
+        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
 
 let apply_arithmetic_operator_real (op : string) r1 r2 =
   Expr.Fixed.Pattern.Lit
@@ -60,7 +60,7 @@ let apply_arithmetic_operator_real (op : string) r1 r2 =
         | "Minus__" -> r1 -. r2
         | "Times__" -> r1 *. r2
         | "Divide__" -> r1 /. r2
-        | s -> raise_s [%sexp (s : string)] ) )
+        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
 
 let apply_logical_operator_real (op : string) r1 r2 =
   Expr.Fixed.Pattern.Lit
@@ -73,7 +73,7 @@ let apply_logical_operator_real (op : string) r1 r2 =
         | "Leq__" -> Bool.to_int (r1 <= r2)
         | "Greater__" -> Bool.to_int (r1 > r2)
         | "Geq__" -> Bool.to_int (r1 >= r2)
-        | s -> raise_s [%sexp (s : string)] ) )
+        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
 
 let is_multi_index = function
   | Index.MultiIndex _ | Upfrom _ | Between _ | All -> true
@@ -1021,9 +1021,9 @@ let rec simplify_index_expr pattern =
                  ; meta }
                , outer_tl ))
       | inner_singles, (([] | Single _ :: _) as multis) ->
-          raise_s
+          Common.FatalError.fatal_error_msg
             [%message
-              "Impossible! There must be a multi-index."
+              " There must be a multi-index."
                 (inner_singles : Expr.Typed.t Index.t list)
                 (multis : Expr.Typed.t Index.t list)] )
     | e -> e)

--- a/src/common/Common.ml
+++ b/src/common/Common.ml
@@ -13,3 +13,4 @@ module Specialized = Specialized
 (* General helpers *)
 module Gensym = Gensym
 module Helpers = Helpers
+module FatalError = FatalError

--- a/src/common/Common.mli
+++ b/src/common/Common.mli
@@ -17,3 +17,4 @@ module Specialized : module type of Specialized
 
 module Gensym : module type of Gensym
 module Helpers : module type of Helpers
+module FatalError = FatalError

--- a/src/common/Common.mli
+++ b/src/common/Common.mli
@@ -17,4 +17,4 @@ module Specialized : module type of Specialized
 
 module Gensym : module type of Gensym
 module Helpers : module type of Helpers
-module FatalError = FatalError
+module FatalError : module type of FatalError

--- a/src/common/FatalError.ml
+++ b/src/common/FatalError.ml
@@ -2,7 +2,7 @@
 
 open Core_kernel
 
-(** Equivalent to [Common.FatalError.fatal_error_msg] but prepends a stanc specific
+(** Equivalent to [raise_s] but prepends a stanc specific
   message asking users to report a bug *)
 let fatal_error_msg message =
   let augmented =

--- a/src/common/FatalError.ml
+++ b/src/common/FatalError.ml
@@ -1,0 +1,18 @@
+(** Internal compiler errors *)
+
+open Core_kernel
+
+(** Equivalent to [Common.FatalError.fatal_error_msg] but prepends a stanc specific
+  message asking users to report a bug *)
+let fatal_error_msg message =
+  let augmented =
+    Sexplib0.Sexp.List
+      [ [%message
+          "Fatal error: this should never happen. Please file a bug on \
+           https://github.com/stan-dev/stanc3/issues/new."]; message ]
+  in
+  raise_s augmented
+
+(** A version of [fatal_error_msg] with an empty message.
+  The resulting error only includes the issues link *)
+let fatal_error () = fatal_error_msg [%message]

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -81,7 +81,9 @@ let mk_typed_expression ~expr ~loc ~type_ ~ad_level =
 
 let expr_loc_lub exprs =
   match List.map ~f:(fun e -> e.emeta.loc) exprs with
-  | [] -> raise_s [%message "Can't find location lub for empty list"]
+  | [] ->
+      Common.FatalError.fatal_error_msg
+        [%message "Can't find location lub for empty list"]
   | [hd] -> hd
   | x1 :: tl -> List.fold ~init:x1 ~f:Location_span.merge tl
 
@@ -286,7 +288,9 @@ let rec lvalue_of_expr {expr; emeta} =
       ( match expr with
       | Variable s -> LVariable s
       | Indexed (l, i) -> LIndexed (lvalue_of_expr l, i)
-      | _ -> failwith "Trying to convert illegal expression to lval." )
+      | _ ->
+          Common.FatalError.fatal_error_msg
+            [%message "Trying to convert illegal expression to lval."] )
   ; lmeta= emeta }
 
 let rec id_of_lvalue {lval; _} =

--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -17,18 +17,10 @@ exception SyntaxError of syntax_error
     [msg], occurring in location [loc]. *)
 exception SemanticError of Semantic_error.t
 
-(** Exception [FatalError [msg]] indicates an error that should never happen with message
-    [msg]. *)
-exception FatalError of string
-
 type t =
   | FileNotFound of string
   | Syntax_error of syntax_error
   | Semantic_error of Semantic_error.t
-
-(** A fatal error reported by the toplevel *)
-let fatal_error ?(msg = "") _ =
-  raise (FatalError ("This should never happen. Please file a bug. " ^ msg))
 
 let pp_context_with_message ppf (msg, loc) =
   Fmt.pf ppf "%a@,%s" (Fmt.option Fmt.string)

--- a/src/frontend/Errors.mli
+++ b/src/frontend/Errors.mli
@@ -22,13 +22,6 @@ type t =
 val pp : ?printed_filename:string -> t Fmt.t
 val to_string : t -> string
 
-(** Exception for Fatal Errors. These should perhaps be left unhandled,
-    so we can trace their origin. *)
-exception FatalError of string
-
-val fatal_error : ?msg:string -> unit -> 'a
-(** Throw a fatal error reported by the toplevel *)
-
 val pp_syntax_error :
   ?printed_filename:string -> Format.formatter -> syntax_error -> unit
 (** A syntax error message used when handling a SyntaxError *)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -175,7 +175,9 @@ module TypeError = struct
           | "lupdf" -> "lupmf"
           | "lpmf" -> "lpdf"
           | "lupmf" -> "lupdf"
-          | _ -> raise_s [%message "This should never happen."]
+          | _ ->
+              Common.FatalError.fatal_error_msg
+                [%message "Bad suffix:" (suffix : string)]
         in
         Fmt.pf ppf
           "Function '%s_%s' is not implemented for distribution '%s', use \

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1216,9 +1216,8 @@ and check_var_decl_initial_value loc cf tenv id init_val_opt =
       match (ts.stmt, ts.smeta.return_type) with
       | Assignment {assign_rhs= ue; _}, NoReturnType -> Some ue
       | _ ->
-          raise_s
-            [%message "Internal error: check_var_decl: `Assignment` expected."]
-      )
+          Common.FatalError.fatal_error_msg
+            [%message " check_var_decl: `Assignment` expected."] )
   | None -> None
 
 and check_transformation cf tenv ut trans =
@@ -1445,7 +1444,8 @@ and check_statement (cf : context_flags_record) (tenv : Env.t)
   | Profile (name, vdsl) -> (tenv, check_profile loc cf tenv name vdsl)
   | VarDecl {decl_type= Unsized _; _} ->
       (* currently unallowed by parser *)
-      raise_s [%message "Don't support unsized declarations yet."]
+      Common.FatalError.fatal_error_msg
+        [%message "Don't support unsized declarations yet."]
   (* these two are special in that they're allowed to change the type environment *)
   | VarDecl
       { decl_type= Sized st
@@ -1495,9 +1495,9 @@ let verify_correctness_invariant (ast : untyped_program)
   let detyped = untyped_program_of_typed_program decorated_ast in
   if compare_untyped_program ast detyped = 0 then ()
   else
-    raise_s
+    Common.FatalError.fatal_error_msg
       [%message
-        "Type checked AST does not match original AST. Please file a bug!"
+        "Type checked AST does not match original AST. "
           (detyped : untyped_program)
           (ast : untyped_program)]
 

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -1,11 +1,10 @@
 (library
- (name frontend)
- (public_name stanc.frontend)
- (libraries core_kernel re menhirLib fmt middle common
-   analysis_and_optimization)
- (inline_tests)
- (preprocess
-  (pps ppx_jane ppx_deriving.fold ppx_deriving.map)))
+  (name frontend)
+  (public_name stanc.frontend)
+  (libraries core_kernel re menhirLib fmt middle common
+    analysis_and_optimization)
+  (inline_tests)
+  (preprocess (pps ppx_jane ppx_deriving.fold ppx_deriving.map)))
 
 (ocamllex lexer)
 
@@ -13,42 +12,37 @@
  (targets parsing_errors.ml)
  (deps parser.mly parser.messages)
  (action
-  (with-stdout-to
-   %{targets}
-   (run menhir --explain --strict --unused-tokens parser.mly --compile-errors
-     parser.messages))))
+  (with-stdout-to %{targets}
+   (run menhir
+    --explain
+    --strict
+    --unused-tokens parser.mly --compile-errors parser.messages))))
 
 (menhir
  (modules parser)
  (flags :standard --table --strict --unused-tokens --fixed-exception))
 
 (rule
- (with-stdout-to
-  parser_updated.messages
+ (with-stdout-to parser_updated.messages
   (run menhir %{dep:parser.mly} --update-errors %{dep:parser.messages})))
 
 (rule
- (with-stdout-to
-  parser_updated_trimmed.messages
+ (with-stdout-to parser_updated_trimmed.messages
   (run %{dep:strip_redundant_parser_state.py} %{dep:parser_updated.messages})))
 
 (rule
  (targets parser_new.messages)
  (action
-  (with-stdout-to
-   %{targets}
-   (run menhir --list-errors %{dep:parser.mly}))))
+   (with-stdout-to %{targets} (run menhir --list-errors %{dep:parser.mly}))))
 
 (alias
  (name update_messages)
  (action
   (progn
-   (run %{dep:add_missing_messages.py} %{dep:parser.mly}
-     %{dep:parser_new.messages} %{dep:parser_updated_trimmed.messages})
+   (run %{dep:add_missing_messages.py} %{dep:parser.mly} %{dep:parser_new.messages} %{dep:parser_updated_trimmed.messages})
    (diff %{dep:parser.messages} %{dep:parser_updated_trimmed.messages}))))
 
 (alias
  (name runtest)
  (action
-  (run menhir parser.mly --compare-errors %{dep:parser_new.messages}
-    --compare-errors %{dep:parser.messages})))
+  (run menhir parser.mly --compare-errors %{dep:parser_new.messages} --compare-errors %{dep:parser.messages})))

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -1,9 +1,11 @@
 (library
-  (name frontend)
-  (public_name stanc.frontend)
-  (libraries core_kernel re menhirLib fmt middle analysis_and_optimization)
-  (inline_tests)
-  (preprocess (pps ppx_jane ppx_deriving.fold ppx_deriving.map)))
+ (name frontend)
+ (public_name stanc.frontend)
+ (libraries core_kernel re menhirLib fmt middle common
+   analysis_and_optimization)
+ (inline_tests)
+ (preprocess
+  (pps ppx_jane ppx_deriving.fold ppx_deriving.map)))
 
 (ocamllex lexer)
 
@@ -11,37 +13,42 @@
  (targets parsing_errors.ml)
  (deps parser.mly parser.messages)
  (action
-  (with-stdout-to %{targets}
-   (run menhir
-    --explain
-    --strict
-    --unused-tokens parser.mly --compile-errors parser.messages))))
+  (with-stdout-to
+   %{targets}
+   (run menhir --explain --strict --unused-tokens parser.mly --compile-errors
+     parser.messages))))
 
 (menhir
  (modules parser)
  (flags :standard --table --strict --unused-tokens --fixed-exception))
 
 (rule
- (with-stdout-to parser_updated.messages
+ (with-stdout-to
+  parser_updated.messages
   (run menhir %{dep:parser.mly} --update-errors %{dep:parser.messages})))
 
 (rule
- (with-stdout-to parser_updated_trimmed.messages
+ (with-stdout-to
+  parser_updated_trimmed.messages
   (run %{dep:strip_redundant_parser_state.py} %{dep:parser_updated.messages})))
 
 (rule
  (targets parser_new.messages)
  (action
-   (with-stdout-to %{targets} (run menhir --list-errors %{dep:parser.mly}))))
+  (with-stdout-to
+   %{targets}
+   (run menhir --list-errors %{dep:parser.mly}))))
 
 (alias
  (name update_messages)
  (action
   (progn
-   (run %{dep:add_missing_messages.py} %{dep:parser.mly} %{dep:parser_new.messages} %{dep:parser_updated_trimmed.messages})
+   (run %{dep:add_missing_messages.py} %{dep:parser.mly}
+     %{dep:parser_new.messages} %{dep:parser_updated_trimmed.messages})
    (diff %{dep:parser.messages} %{dep:parser_updated_trimmed.messages}))))
 
 (alias
  (name runtest)
  (action
-  (run menhir parser.mly --compare-errors %{dep:parser_new.messages} --compare-errors %{dep:parser.messages})))
+  (run menhir parser.mly --compare-errors %{dep:parser_new.messages}
+    --compare-errors %{dep:parser.messages})))

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -401,11 +401,11 @@ top_var_decl_no_assign:
       d_fn ~is_global:true
     }
   | SEMICOLON
-    { grammar_logger "top_var_decl_no_assign_skip"; 
+    { grammar_logger "top_var_decl_no_assign_skip";
       [ { stmt= Skip
         ; smeta= { loc= Location_span.of_positions_exn $loc
         }
-      }] 
+      }]
     }
 
 sized_basic_type:

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -207,7 +207,9 @@ module Helpers = struct
     | UArray t, Single _ :: tl -> infer_type_of_indexed t tl
     | UArray t, _ :: tl -> UArray (infer_type_of_indexed t tl)
     | UMatrix, [Single _; Single _] | UVector, [_] | URowVector, [_] -> UReal
-    | _ -> raise_s [%message "Can't index" (ut : UnsizedType.t)]
+    | _ ->
+        FatalError.fatal_error_msg
+          [%message "Can't index" (ut : UnsizedType.t)]
 
   (** [add_index expression index] returns an expression that (additionally)
       indexes into the input [expression] by [index].*)
@@ -218,7 +220,9 @@ module Helpers = struct
       match e.pattern with
       | Var _ -> Fixed.Pattern.Indexed (e, [i])
       | Indexed (e, indices) -> Indexed (e, indices @ [i])
-      | _ -> raise_s [%message "These should go away with Ryan's LHS"]
+      | _ ->
+          (* These should go away with Ryan's LHS *)
+          Common.FatalError.fatal_error ()
     in
     Fixed.{meta; pattern}
 

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -378,7 +378,9 @@ let dist_name_suffix udf_names name =
     |> List.hd
   with
   | Some hd -> hd
-  | None -> raise_s [%message "Couldn't find distribution " name]
+  | None ->
+      Common.FatalError.fatal_error_msg
+        [%message "Couldn't find distribution " name]
 
 let operator_to_stan_math_fns op =
   match op with

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -313,7 +313,8 @@ module Helpers = struct
         mk_for_iteratee rows (fun e -> for_each bodyfn e smeta) iteratee smeta
     | UArray _ -> mk_for_iteratee (len iteratee) bodyfn iteratee smeta
     | UMathLibraryFunction | UFun _ ->
-        raise_s [%message "can't iterate over " (iteratee : Expr.Typed.t)]
+        FatalError.fatal_error_msg
+          [%message "Can't iterate over " (iteratee : Expr.Typed.t)]
 
   let contains_fn_kind is_fn_kind ?(init = false) stmt =
     let rec aux accu Fixed.({pattern; _}) =

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -294,9 +294,12 @@ let pp_fun_def ppf Program.({fdrt; fdname; fdsuffix; fdargs; fdbody; _})
             pp_functor ppf
               ([slice; start ^ " + 1"; end_ ^ " + 1"], rest, `ReduceSum)
         | _ ->
-            raise_s
+            Common.FatalError.fatal_error_msg
               [%message
-                "Ill-formed reduce_sum call! This is bug in the compiler."]
+                "Ill-formed reduce_sum call!"
+                  ( fdargs
+                    : (UnsizedType.autodifftype * string * UnsizedType.t) list
+                    )]
       else if String.Set.mem funs_used_in_variadic_ode fdname then
         (* Produces the variadic ode functors that has the pstream argument
         as the third and not last argument *)

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -296,10 +296,7 @@ let pp_fun_def ppf Program.({fdrt; fdname; fdsuffix; fdargs; fdbody; _})
         | _ ->
             Common.FatalError.fatal_error_msg
               [%message
-                "Ill-formed reduce_sum call!"
-                  ( fdargs
-                    : (UnsizedType.autodifftype * string * UnsizedType.t) list
-                    )]
+                "Ill-formed reduce_sum call!" (fdargs : Program.fun_arg_decl)]
       else if String.Set.mem funs_used_in_variadic_ode fdname then
         (* Produces the variadic ode functors that has the pstream argument
         as the third and not last argument *)

--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -224,12 +224,10 @@ let pp_map_decl ppf (vident, ut) =
       pf ppf "Eigen::Map<Eigen::Matrix<%s, -1, 1>> %s{nullptr, 0};" scalar
         vident
   | x ->
-      raise_s
+      Common.FatalError.fatal_error_msg
         [%message
           "Error during Map data construction for " vident " of type "
-            (x : UnsizedType.t)
-            ". This should never happen, if you see this please file a bug \
-             report."]
+            (x : UnsizedType.t)]
 
 let pp_unsized_decl ppf (vident, ut, adtype) =
   let pp_type =

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -152,7 +152,8 @@ let data_read smeta (decl_id, st) =
   | UArray UInt | UArray UReal ->
       [Assignment ((decl_id, flat_type, []), readfnapp decl_var) |> swrap]
   | UFun _ | UMathLibraryFunction ->
-      raise_s [%message "Cannot read a function type."]
+      Common.FatalError.fatal_error_msg
+        [%message "Cannot read a function type."]
   | UVector | URowVector | UMatrix | UArray _ ->
       let decl, assign, flat_var =
         let decl_id = decl_id ^ "_flat__" in


### PR DESCRIPTION
This closes #76 

It adds `Common.FatalError.fatal_error_msg`, which is a drop-in replacement for `raise_s` that prepends the following message:
`Fatal error: this should never happen. Please file a bug on https://github.com/stan-dev/stanc3/issues/new.`

and `Common.FatalError.fatal_error` which is the same as the above but doesn't take in any additional message/sexp.


We previously had a Frontend.Errors.fatal_error, but it wasn't used, and it felt like it should live in Common (rather than importing the frontend into the code generator, for example).

I also updated all existing calls to either `raise_s` or `failwith` in the compiler.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

All internal compiler errors now include a link to the stanc3 issues page.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
