### PR TITLE
Note that function arguments must be both unsized *and* unconstrained

### DIFF
--- a/src/frontend/parser.messages
+++ b/src/frontend/parser.messages
@@ -3004,6 +3004,7 @@ program: FUNCTIONBLOCK LBRACE VOID TRUNCATE LPAREN RPAREN VOID
 
 Either "{" statement "}" is expected for a function definition or ";" for a function forward declaration.
 
+program: FUNCTIONBLOCK LBRACE VOID TRUNCATE LPAREN WHILE
 program: FUNCTIONBLOCK LBRACE VOID TRUNCATE LPAREN VECTOR IDENTIFIER COMMA WHILE
 ##
 ## Ends in an error in state: 501.
@@ -3014,7 +3015,7 @@ program: FUNCTIONBLOCK LBRACE VOID TRUNCATE LPAREN VECTOR IDENTIFIER COMMA WHILE
 ## arg_decl COMMA
 ##
 
-An argument declaration (unsized type followed by identifier) is expected.
+An argument declaration (unsized and unconstrained type followed by identifier) is expected.
 
 program: FUNCTIONBLOCK LBRACE VOID TRUNCATE LPAREN VECTOR IDENTIFIER WHILE
 ##
@@ -3040,18 +3041,6 @@ program: FUNCTIONBLOCK LBRACE VOID TRUNCATE LPAREN VECTOR LBRACK RBRACK LBRACK
 ##
 
 An identifier is expected as a function argument name.
-
-program: FUNCTIONBLOCK LBRACE VOID TRUNCATE LPAREN WHILE
-##
-## Ends in an error in state: 60.
-##
-## function_def -> return_type decl_identifier LPAREN . loption(separated_nonempty_list(COMMA,arg_decl)) RPAREN statement [ VOID VECTOR ROWVECTOR REAL RBRACE MATRIX INT EOF COMPLEX ARRAY ]
-##
-## The known suffix of the stack is as follows:
-## return_type decl_identifier LPAREN
-##
-
-(Non-void) type expected in function argument declaration.
 
 program: FUNCTIONBLOCK LBRACE VOID TRUNCATE WHILE
 ##

--- a/test/integration/bad/new/fundef-bad10.stan
+++ b/test/integration/bad/new/fundef-bad10.stan
@@ -1,0 +1,5 @@
+functions {
+   void foo(corr_matrix x){
+     return;
+   }
+}

--- a/test/integration/bad/new/stanc.expected
+++ b/test/integration/bad/new/stanc.expected
@@ -7,7 +7,7 @@ Syntax error in 'arg-decl-bad1.stan', line 2, column 16 to column 21, parsing er
      3:  }
    -------------------------------------------------
 
-An argument declaration (unsized type followed by identifier) is expected.
+An argument declaration (unsized and unconstrained type followed by identifier) is expected.
   $ ../../../../../install/default/bin/stanc blocks-bad1.stan
 Syntax error in 'blocks-bad1.stan', line 1, column 5 to column 10, parsing error:
    -------------------------------------------------
@@ -202,6 +202,17 @@ Syntax error in 'fundef-bad1.stan', line 1, column 20 to column 25, parsing erro
    -------------------------------------------------
 
 List of commas expected.
+  $ ../../../../../install/default/bin/stanc fundef-bad10.stan
+Syntax error in 'fundef-bad10.stan', line 2, column 12 to column 23, parsing error:
+   -------------------------------------------------
+     1:  functions {
+     2:     void foo(corr_matrix x){
+                     ^
+     3:       return;
+     4:     }
+   -------------------------------------------------
+
+An argument declaration (unsized and unconstrained type followed by identifier) is expected.
   $ ../../../../../install/default/bin/stanc fundef-bad2.stan
 Syntax error in 'fundef-bad2.stan', line 1, column 25 to column 26, parsing error:
    -------------------------------------------------
@@ -249,7 +260,7 @@ Syntax error in 'fundef-bad7.stan', line 1, column 21 to column 26, parsing erro
                               ^
    -------------------------------------------------
 
-(Non-void) type expected in function argument declaration.
+An argument declaration (unsized and unconstrained type followed by identifier) is expected.
   $ ../../../../../install/default/bin/stanc fundef-bad8.stan
 Semantic error in 'fundef-bad8.stan', line 1, column 17 to column 22:
    -------------------------------------------------

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -977,7 +977,7 @@ Syntax error in 'functions-bad0.stan', line 2, column 11 to column 15, parsing e
      4:    }
    -------------------------------------------------
 
-(Non-void) type expected in function argument declaration.
+An argument declaration (unsized and unconstrained type followed by identifier) is expected.
   $ ../../../../install/default/bin/stanc functions-bad1.stan
 Semantic error in 'functions-bad1.stan', line 6, column 7 to column 11:
    -------------------------------------------------


### PR DESCRIPTION
This came up on the forums [here](https://discourse.mc-stan.org/t/within-chain-parallelization-not-working-with-cmdstanr-on-linux-server/25203/7?u=wardbrian)

We currently generate a warning that just says the type must be unsized, which is confusing when you declare something like `corr_matrix` without sizes. I've added a test that does just this as well.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Improve error messages when a user tries to declare a function argument as a constrained type

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
