### PR TITLE
Point Jenkins back to main docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
             }
             agent {
                 docker {
-                    image 'stanorg/stanc3:debian-ocaml-update'
+                    image 'stanorg/stanc3:debian'
                     //Forces image to ignore entrypoint
                     args "-u root --entrypoint=\'\'"
                 }
@@ -96,7 +96,7 @@ pipeline {
             }
             agent {
                 docker {
-                    image 'stanorg/stanc3:debian-ocaml-update'
+                    image 'stanorg/stanc3:debian'
                     //Forces image to ignore entrypoint
                     args "-u root --entrypoint=\'\'"
                 }
@@ -128,7 +128,7 @@ pipeline {
                 stage("Dune tests") {
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debian-ocaml-update'
+                            image 'stanorg/stanc3:debian'
                             //Forces image to ignore entrypoint
                             args "-u root --entrypoint=\'\'"
                         }
@@ -158,7 +158,7 @@ pipeline {
                 stage("stancjs tests") {
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debian-ocaml-update'
+                            image 'stanorg/stanc3:debian'
                             //Forces image to ignore entrypoint
                             args "-u root --entrypoint=\'\'"
                         }
@@ -319,14 +319,7 @@ pipeline {
 
                         stash name:'mac-exe', includes:'bin/*'
                     }
-                    post {
-                        always {
-                            runShell("""
-                            opam switch 4.07.0
-                            rm -rf ./*
-                            """)
-                            }
-                        }
+                    post { always { runShell("rm -rf ./*") }}
                 }
                 stage("Build stanc.js") {
                     when {
@@ -337,7 +330,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debian-ocaml-update'
+                            image 'stanorg/stanc3:debian'
                             //Forces image to ignore entrypoint
                             args "-u root --entrypoint=\'\'"
                         }
@@ -364,7 +357,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\'"
                         }
@@ -394,7 +387,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -425,7 +418,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -456,7 +449,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
@@ -487,7 +480,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             label 'linux-ec2'
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
@@ -519,7 +512,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             label 'linux-ec2'
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
@@ -551,7 +544,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             label 'linux-ec2'
                             args "-u 1000 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
@@ -583,7 +576,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debian-windows-ocaml-update'
+                            image 'stanorg/stanc3:debian-windows'
                             label 'linux-ec2'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\'"
@@ -644,7 +637,7 @@ pipeline {
             options { skipDefaultCheckout(true) }
             agent {
                 docker {
-                    image 'stanorg/stanc3:static-ocaml-update'
+                    image 'stanorg/stanc3:static'
                     label 'linux-ec2'
                     //Forces image to ignore entrypoint
                     args "-u 1000 --entrypoint=\'\'"

--- a/Jenkinsfile-test-binaries
+++ b/Jenkinsfile-test-binaries
@@ -56,7 +56,7 @@ pipeline {
         stage("Build") {
             agent {
                 docker {
-                    image 'stanorg/stanc3:debian-ocaml-update'
+                    image 'stanorg/stanc3:debian'
                     args "-u root --entrypoint=\'\'"
                     label 'linux-ec2'
                 }
@@ -109,7 +109,7 @@ pipeline {
                 stage("Build stanc.js") {
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debian-ocaml-update'
+                            image 'stanorg/stanc3:debian'
                             //Forces image to ignore entrypoint
                             args "-u root --entrypoint=\'\'"
                             label 'linux-ec2'
@@ -135,7 +135,7 @@ pipeline {
                 stage("Build & test a static Linux binary") {
                     agent {
                         docker {
-                            image 'stanorg/stanc3:static-ocaml-update'
+                            image 'stanorg/stanc3:static'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\'"
                             label 'linux-ec2'
@@ -168,7 +168,7 @@ pipeline {
                 stage("Build & test static Windows binary") {
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debian-windows-ocaml-update'
+                            image 'stanorg/stanc3:debian-windows'
                             label 'linux-ec2'
                             //Forces image to ignore entrypoint
                             args "-u 1000 --entrypoint=\'\'"

--- a/scripts/build_multiarch_stanc3.sh
+++ b/scripts/build_multiarch_stanc3.sh
@@ -20,13 +20,13 @@ elif [ $1 = "s390x" ]; then
 fi
 
 # Lookup the sha256 hash for the specified architecture and variant (e.g., v7 for armhf) and strip the enclosing quotations
-SHA=$(skopeo inspect --raw docker://stanorg/stanc3:multiarch-ocaml-update | jq '.manifests | .[] | select(.platform.architecture==env.DOCK_ARCH and .platform.variant==(if env.DOCK_VARIANT == "" then null else env.DOCK_VARIANT end)).digest' | tr -d '"')
+SHA=$(skopeo inspect --raw docker://stanorg/stanc3:multiarch | jq '.manifests | .[] | select(.platform.architecture==env.DOCK_ARCH and .platform.variant==(if env.DOCK_VARIANT == "" then null else env.DOCK_VARIANT end)).digest' | tr -d '"')
 
 # Register QEMU translation binaries
 docker run --rm --privileged multiarch/qemu-user-static --reset
 
 # Run docker, inheriting mounted volumes from sibling container (including stanc3 directory), and build stanc3
-docker run --volumes-from=$(docker ps -aqf "ancestor=stanorg/stanc3:static-ocaml-update"):rw stanorg/stanc3:multiarch-ocaml-update@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static"
+docker run --volumes-from=$(docker ps -aqf "ancestor=stanorg/stanc3:static"):rw stanorg/stanc3:multiarch@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static"
 
 # Update ownership of build folders
 chown -R opam: _build


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests


## Release notes

Following #1019, we have Jenkins using images like `stanorg/stanc3:static-ocaml-update`. @serban-nicusor-toptal is going to rename those back to the standard names (without `-ocaml-update`) now that it is merged, and this will go along with that.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
