### PR TITLE
Fixed odoc job permission issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -645,7 +645,7 @@ pipeline {
             agent {
                 docker {
                     image 'stanorg/stanc3:static-ocaml-update'
-                    label 'linux-ec2'
+                    label 'gg-linux'
                     //Forces image to ignore entrypoint
                     args "-u 1000 --entrypoint=\'\'"
                 }
@@ -653,7 +653,7 @@ pipeline {
             steps {
                 retry(3) {
                     checkout([$class: 'GitSCM',
-                        branches: [[name: '*/gh-pages']],
+                        branches: [],
                         doGenerateSubmoduleConfigurations: false,
                         extensions: [],
                         submoduleCfg: [],
@@ -700,11 +700,11 @@ pipeline {
                         git add -f doc
                         git commit -m "auto generated docs from Jenkins"
                         git subtree push --prefix doc/ https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/stanc3.git gh-pages
+                        rm -rf *
                     """
                 }
 
             }
-            post { always { deleteDir() } }
         }
     }
     post {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Fixed odoc job in the pipeline, we had a permission issue because in the upstream opam 4.12 image they changed a little the groups to as it was with 4.07

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
