### PR TITLE
List volumes only for running containers when building multiarch

### DIFF
--- a/scripts/build_multiarch_stanc3.sh
+++ b/scripts/build_multiarch_stanc3.sh
@@ -26,7 +26,7 @@ SHA=$(skopeo inspect --raw docker://stanorg/stanc3:multiarch | jq '.manifests | 
 docker run --rm --privileged multiarch/qemu-user-static --reset
 
 # Run docker, inheriting mounted volumes from sibling container (including stanc3 directory), and build stanc3
-docker run --volumes-from=$(docker ps -aqf "ancestor=stanorg/stanc3:static"):rw stanorg/stanc3:multiarch@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static"
+docker run --volumes-from=$(docker ps -qf "ancestor=stanorg/stanc3:static"):rw stanorg/stanc3:multiarch@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static"
 
 # Update ownership of build folders
 chown -R opam: _build


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

There is an edge case where when we're building multiarch in listing of docker volumes to attach we're listing all containers (including inactive) so that can result in a broken docker run command generated, this PR is supposed to fix that by listing only running containers, since we're having 1 executor/runner that will always be one.

Example:

```
~home/serban-nicusor-toptal$ docker ps -aqf "ancestor=stanorg/stanc3:static"
14b082be5021
1cb3db4a06ff
6562418e57b8
8bc2eb99e616
9fb896708856
d4cdf602d5e7
944eeb1dca29
```

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
