### PR TITLE
User-defined densities allowed over nested and complex values.

### DIFF
--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -69,9 +69,8 @@ let update_suffix name type_ =
   let open String in
   if is_suffix ~suffix:"_cdf_log" name then drop_suffix name 8 ^ "_lcdf"
   else if is_suffix ~suffix:"_ccdf_log" name then drop_suffix name 9 ^ "_lccdf"
-  else if Middle.UnsizedType.is_real_type type_ then
-    drop_suffix name 4 ^ "_lpdf"
-  else drop_suffix name 4 ^ "_lpmf"
+  else if Middle.UnsizedType.is_int_type type_ then drop_suffix name 4 ^ "_lpmf"
+  else drop_suffix name 4 ^ "_lpdf"
 
 let find_udf_log_suffix = function
   | { stmt= FunDef {funname= {name; _}; arguments= (_, type_, _) :: _; _}

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -59,7 +59,7 @@ let context block =
 let calculate_autodifftype cf origin ut =
   match origin with
   | Env.(Param | TParam | Model | Functions)
-    when not (UnsizedType.contains_int ut || cf.current_block = GQuant) ->
+    when not (UnsizedType.is_int_type ut || cf.current_block = GQuant) ->
       UnsizedType.AutoDiffable
   | _ -> DataOnly
 
@@ -1137,7 +1137,7 @@ and verify_transformed_param_ty loc cf is_global unsized_ty =
   if
     is_global
     && (cf.current_block = Param || cf.current_block = TParam)
-    && UnsizedType.contains_int unsized_ty
+    && UnsizedType.is_int_type unsized_ty
   then Semantic_error.transformed_params_int loc |> error
 
 and check_sizedtype cf tenv sizedty =
@@ -1268,7 +1268,7 @@ and verify_pdf_fundef_first_arg_ty loc id arg_tys =
   if String.is_suffix id.name ~suffix:"_lpdf" then
     let rt = List.hd arg_tys |> Option.map ~f:snd in
     match rt with
-    | Some rt when UnsizedType.is_real_type rt -> ()
+    | Some rt when not (UnsizedType.is_int_type rt) -> ()
     | _ -> Semantic_error.prob_density_non_real_variate loc rt |> error
 
 and verify_pmf_fundef_first_arg_ty loc id arg_tys =

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -130,13 +130,9 @@ let rec common_type = function
   | _, _ -> None
 
 (* -- Helpers -- *)
-let is_real_type = function
-  | UReal | UVector | URowVector | UMatrix
-   |UArray UReal
-   |UArray UVector
-   |UArray URowVector
-   |UArray UMatrix ->
-      true
+let rec is_real_type = function
+  | UReal | UVector | URowVector | UMatrix -> true
+  | UArray x -> is_real_type x
   | _ -> false
 
 let rec is_autodiffable = function
@@ -145,16 +141,14 @@ let rec is_autodiffable = function
   | _ -> false
 
 let is_scalar_type = function UReal | UInt -> true | _ -> false
-let is_int_type = function UInt | UArray UInt -> true | _ -> false
+
+let rec is_int_type ut =
+  match ut with UInt -> true | UArray ut -> is_int_type ut | _ -> false
 
 let is_eigen_type ut =
   match ut with UVector | URowVector | UMatrix -> true | _ -> false
 
 let is_fun_type = function UFun _ | UMathLibraryFunction -> true | _ -> false
-
-(** Detect if type contains an integer *)
-let rec contains_int ut =
-  match ut with UInt -> true | UArray ut -> contains_int ut | _ -> false
 
 let rec is_indexing_matrix = function
   | UArray t, _ :: idcs -> is_indexing_matrix (t, idcs)

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -56,7 +56,7 @@ let pp_located ppf _ =
 (** Detect if argument requires C++ template *)
 let arg_needs_template = function
   | UnsizedType.DataOnly, _, t -> UnsizedType.is_eigen_type t
-  | _, _, t when UnsizedType.contains_int t -> false
+  | _, _, t when UnsizedType.is_int_type t -> false
   | _ -> true
 
 (** Print template arguments for C++ functions that need templates
@@ -107,7 +107,7 @@ let pp_promoted_scalar ppf args =
 let pp_returntype ppf arg_types rt =
   let scalar = str "%a" pp_promoted_scalar arg_types in
   match rt with
-  | Some ut when UnsizedType.contains_int ut ->
+  | Some ut when UnsizedType.is_int_type ut ->
       pf ppf "%a@," pp_unsizedtype_custom_scalar ("int", ut)
   | Some ut -> pf ppf "%a@," pp_unsizedtype_custom_scalar (scalar, ut)
   | None -> pf ppf "void@,"

--- a/test/integration/good/fun-defs-lpdf.stan
+++ b/test/integration/good/fun-defs-lpdf.stan
@@ -5,13 +5,17 @@ functions {
   real foo_bar_lpdf(array[,,,] real x){
     return 1.0;
   }
-  real baz_foo_lpdf(complex z){
-    return get_imag(z);
+  real baz_foo_lpdf(complex z, real a){
+    return get_imag(z) * a;
   }
 }
 parameters {
   real y;
+  complex z;
+  array[1,1,1,1] real arr;
 }
 model {
   y ~ bar_baz(3.2);
+  z ~ baz_foo(1.5);
+  arr ~ foo_bar();
 }

--- a/test/integration/good/fun-defs-lpdf.stan
+++ b/test/integration/good/fun-defs-lpdf.stan
@@ -2,6 +2,12 @@ functions {
   real bar_baz_lpdf(real a, real b) {
     return a / b;
   }
+  real foo_bar_lpdf(array[,,,] real x){
+    return 1.0;
+  }
+  real baz_foo_lpdf(complex z){
+    return get_imag(z);
+  }
 }
 parameters {
   real y;

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -3013,6 +3013,12 @@ functions {
   real bar_baz_lpdf(real a, real b) {
     return a / b;
   }
+  real foo_bar_lpdf(array[,,,] real x) {
+    return 1.0;
+  }
+  real baz_foo_lpdf(complex z) {
+    return get_imag(z);
+  }
 }
 parameters {
   real y;

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -3016,15 +3016,19 @@ functions {
   real foo_bar_lpdf(array[,,,] real x) {
     return 1.0;
   }
-  real baz_foo_lpdf(complex z) {
-    return get_imag(z);
+  real baz_foo_lpdf(complex z, real a) {
+    return get_imag(z) * a;
   }
 }
 parameters {
   real y;
+  complex z;
+  array[1, 1, 1, 1] real arr;
 }
 model {
   y ~ bar_baz(3.2);
+  z ~ baz_foo(1.5);
+  arr ~ foo_bar();
 }
 
   $ ../../../../install/default/bin/stanc --auto-format fun-return-typ1.stan


### PR DESCRIPTION
Closes #1045. The is_int_type and is_real_types now check the type recursively to handle nesting, and `lpdf` is defined not by 'takes a real as the first argument' but (properly) as 'does _not_ take an int as the first argument'

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made
      This is consistent with the final paragraph given [here](https://mc-stan.org/docs/2_28/stan-users-guide/user-defined-probability-functions.html) already

## Release notes

Allow user-defined densities over complex arguments and deeply nested arguments.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
