### PR TITLE
Upgrade GHA for building binaries to work with OCaml 4.12

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -12,7 +12,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container:
-      image: ocaml/opam2:alpine-3.9-ocaml-4.07
+      image: ocaml/opam2:4.12
       options: --user root
     steps:    
       - name: Checkout stanc3
@@ -25,14 +25,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.opam"
-          key: linux-stanc-binary-4.07
+          key: linux-stanc-binary-4.12.0
 
       - name: Install dependencies
         run: |
-          sudo apk update
-          sudo apk add build-base bzip2 git tar curl ca-certificates openssl m4 bash
           opam init --disable-sandboxing -y
-          opam switch 4.07.0 || opam switch create 4.07.0
+          opam switch 4.12.0 || opam switch create 4.12.0
           eval $(opam env)
           opam repo add internet https://opam.ocaml.org
           opam update
@@ -44,24 +42,16 @@ jobs:
           dune subst
           dune build @install --profile static
           mv _build/default/src/stanc/stanc.exe linux-stanc
-          mv _build/default/src/stan2tfp/stan2tfp.exe linux-stan2tfp
-      
+
       - name: Upload Linux stanc
         uses: actions/upload-artifact@v2
         with:
           name: linux-stanc
-          path: linux-stanc            
-
-      - name: Upload Linux stan2tfp
-        uses: actions/upload-artifact@v2
-        with:
-          name: linux-stan2tfp
-          path: linux-stan2tfp
-
+          path: linux-stanc
   windows:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:bionic
+      image: stanorg/stanc3:debian
       options: --user root
     steps:    
       - name: Checkout stanc3
@@ -74,7 +64,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.opam"
-          key: windows-stanc-binary-4.07
+          key: windows-stanc-binary-4.12.0
 
       - name: Install dependencies
         run: |
@@ -83,14 +73,14 @@ jobs:
           unzip pkg-config libpcre3-dev mingw-w64 gcc wget gawk bubblewrap
           wget https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux
           sudo install opam-2.0.4-x86_64-linux /usr/local/bin/opam
-          opam init --comp 4.02.3 --disable-sandboxing -y
+          opam init $1 --disable-sandboxing -y
           eval $(opam env)
-          opam switch 4.07.0 || opam switch create 4.07.0
+          opam switch stanc || opam switch create stanc ocaml-base-compiler.4.12.0
           eval $(opam env)
-          opam update
           bash -x scripts/install_build_deps_windows.sh
-          eval $(opam env)
-          opam install -y js_of_ocaml-compiler.3.4.0 js_of_ocaml-ppx.3.4.0 js_of_ocaml.3.4.0
+          eval $(opam env)  
+          opam pin -y js_of_ocaml-ppx 3.11.0
+          opam install -y js_of_ocaml-ppx
 
       - name: Build Windows binaries
         run: |
@@ -98,7 +88,6 @@ jobs:
           dune subst
           dune build -x windows
           mv _build/default.windows/src/stanc/stanc.exe windows-stanc
-          mv _build/default.windows/src/stan2tfp/stan2tfp.exe windows-stan2tfp
 
       - name: Build stanc.js
         run: |
@@ -112,12 +101,6 @@ jobs:
         with:
           name: windows-stanc
           path: windows-stanc
-
-      - name: Upload Windows stan2tfp
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows-stan2tfp
-          path: windows-stan2tfp
 
       - name: Upload stanc.js
         uses: actions/upload-artifact@v2
@@ -137,7 +120,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.opam"
-          key: macOS-stanc-binary-4.07
+          key: macOS-stanc-binary-4.12.0
 
       - name: Install dependencies
         run: |
@@ -145,7 +128,7 @@ jobs:
           brew install opam
           opam init --disable-sandboxing -y
           eval $(opam env)
-          opam switch 4.07.0 || opam switch create 4.07.0          
+          opam switch 4.12.0 || opam switch create 4.12.0          
           eval $(opam env)
           bash -x scripts/install_build_deps.sh
 
@@ -155,16 +138,9 @@ jobs:
           dune subst
           dune build @install
           mv _build/default/src/stanc/stanc.exe mac-stanc
-          mv _build/default/src/stan2tfp/stan2tfp.exe mac-stan2tfp
       
       - name: Upload MacOS binaries
         uses: actions/upload-artifact@v2
         with:
           name: mac-stanc
           path: mac-stanc
-
-      - name: Upload MacOS binaries
-        uses: actions/upload-artifact@v2
-        with:
-          name: mac-stan2tfp
-          path: mac-stan2tfp


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

What the title says and not much more. Also removed building stan2tfp binaries. 

Sidenote: I was unable to use the stanorg/stanc3:debian docker image, as I got an error:
```
Read 505 sample input sentences and 359 error messages.
    ocamlopt src/stanc/stanc.exe (exit 2)
(cd _build/default && /github/home/.opam/4.12.0/bin/ocamlopt.opt -ccopt -static -g -o src/stanc/stanc.exe /github/home/.opam/4.12.0/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /github/home/.opam/4.12.0/lib/base/base_internalhash_types /github/home/.opam/4.12.0/lib/base/caml/caml.cmxa /github/home/.opam/4.12.0/lib/sexplib0/sexplib0.cmxa /github/home/.opam/4.12.0/lib/base/shadow_stdlib/shadow_stdlib.cmxa /github/home/.opam/4.12.0/lib/base/base.cmxa -I /github/home/.opam/4.12.0/lib/base /github/home/.opam/4.12.0/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /github/home/.opam/4.12.0/lib/ppx_compare/runtime-lib/ppx_compare_lib.cmxa /github/home/.opam/4.12.0/lib/ppx_enumerate/runtime-lib/ppx_enumerate_lib.cmxa /github/home/.opam/4.12.0/lib/ppx_hash/runtime-lib/ppx_hash_lib.cmxa /github/home/.opam/4.12.0/lib/ppx_here/runtime-lib/ppx_here_lib.cmxa /github/home/.opam/4.12.0/lib/ppx_assert/runtime-lib/ppx_assert_lib.cmxa /github/home/.opam/4.12.0/lib/ppx_bench/runtime-lib/ppx_bench_lib.cmxa /github/home/.opam/4.12.0/lib/base/md5/md5_lib.cmxa /github/home/.opam/4.12.0/lib/ocaml/unix.cmxa -I /github/home/.opam/4.12.0/lib/ocaml /github/home/.opam/4.12.0/lib/ocaml/bigarray.cmxa -I /github/home/.opam/4.12.0/lib/ocaml /github/home/.opam/4.12.0/lib/fieldslib/fieldslib.cmxa /github/home/.opam/4.12.0/lib/variantslib/variantslib.cmxa /github/home/.opam/4.12.0/lib/bin_prot/shape/bin_shape_lib.cmxa /github/home/.opam/4.12.0/lib/bin_prot/bin_prot.cmxa -I /github/home/.opam/4.12.0/lib/bin_prot /github/home/.opam/4.12.0/lib/ppx_inline_test/config/inline_test_config.cmxa /github/home/.opam/4.12.0/lib/jane-street-headers/jane_street_headers.cmxa /github/home/.opam/4.12.0/lib/time_now/time_now.cmxa -I /github/home/.opam/4.12.0/lib/time_now /github/home/.opam/4.12.0/lib/ppx_inline_test/runtime-lib/ppx_inline_test_lib.cmxa /github/home/.opam/4.12.0/lib/stdio/stdio.cmxa /github/home/.opam/4.12.0/lib/ppx_module_timer/runtime/ppx_module_timer_runtime.cmxa /github/home/.opam/4.12.0/lib/typerep/typerep_lib.cmxa /github/home/.opam/4.12.0/lib/ppx_expect/common/expect_test_common.cmxa /github/home/.opam/4.12.0/lib/ppx_expect/config_types/expect_test_config_types.cmxa /github/home/.opam/4.12.0/lib/ppx_expect/collector/expect_test_collector.cmxa -I /github/home/.opam/4.12.0/lib/ppx_expect/collector /github/home/.opam/4.12.0/lib/ppx_expect/config/expect_test_config.cmxa /github/home/.opam/4.12.0/lib/splittable_random/splittable_random.cmxa /github/home/.opam/4.12.0/lib/base_quickcheck/base_quickcheck.cmxa /github/home/.opam/4.12.0/lib/base_bigstring/base_bigstring.cmxa -I /github/home/.opam/4.12.0/lib/base_bigstring /github/home/.opam/4.12.0/lib/core_kernel/base_for_tests/base_for_tests.cmxa /github/home/.opam/4.12.0/lib/parsexp/parsexp.cmxa /github/home/.opam/4.12.0/lib/sexplib/sexplib.cmxa /github/home/.opam/4.12.0/lib/core_kernel/core_kernel.cmxa -I /github/home/.opam/4.12.0/lib/core_kernel /github/home/.opam/4.12.0/lib/re/re.cmxa /github/home/.opam/4.12.0/lib/menhirLib/menhirLib.cmxa /github/home/.opam/4.12.0/lib/stdlib-shims/stdlib_shims.cmxa /github/home/.opam/4.12.0/lib/fmt/fmt.cmxa /github/home/.opam/4.12.0/lib/ocaml/str.cmxa -I /github/home/.opam/4.12.0/lib/ocaml /github/home/.opam/4.12.0/lib/result/result.cmxa /github/home/.opam/4.12.0/lib/ppx_deriving/runtime/ppx_deriving_runtime.cmxa src/common/common.cmxa src/middle/middle.cmxa src/analysis_and_optimization/analysis_and_optimization.cmxa src/frontend/frontend.cmxa /github/home/.opam/4.12.0/lib/easy-format/easy_format.cmxa /github/home/.opam/4.12.0/lib/biniou/biniou.cmxa /github/home/.opam/4.12.0/lib/yojson/yojson.cmxa src/stan_math_backend/stan_math_backend.cmxa src/stanc/.stanc.eobjs/native/dune__exe__Stanc.cmx)
/github/home/.opam/4.12.0/lib/ocaml/libasmrun.a(unix.n.o): In function `caml_dlopen':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/runtime/unix.c:271: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(initgroups.o): In function `unix_initgroups':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/initgroups.c:35: warning: Using 'initgroups' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getgr.o): In function `unix_getgrgid':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getgr.c:65: warning: Using 'getgrgid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getgr.o): In function `unix_getgrnam':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getgr.c:50: warning: Using 'getgrnam' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getpw.o): In function `unix_getpwnam':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getpw.c:57: warning: Using 'getpwnam' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getpw.o): In function `unix_getpwuid':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getpw.c:72: warning: Using 'getpwuid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getaddrinfo.o): In function `unix_getaddrinfo':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getaddrinfo.c:111: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(gethost.o): In function `unix_gethostbyaddr':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/gethost.c:104: warning: Using 'gethostbyaddr_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(gethost.o): In function `unix_gethostbyname':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/gethost.c:145: warning: Using 'gethostbyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getproto.o): In function `unix_getprotobynumber':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getproto.c:56: warning: Using 'getprotobynumber' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getproto.o): In function `unix_getprotobyname':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getproto.c:48: warning: Using 'getprotobyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getserv.o): In function `unix_getservbyname':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getserv.c:55: warning: Using 'getservbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/github/home/.opam/4.12.0/lib/ocaml/libunix.a(getserv.o): In function `unix_getservbyport':
/github/home/.opam/4.12.0/.opam-switch/build/ocaml-base-compiler.4.12.0/otherlibs/unix/getserv.c:64: warning: Using 'getservbyport' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `sin' with pointer equality in `/usr/lib/x86_64-linux-gnu/libm-2.27.a(s_sin.o)' can not be used when making an executable; recompile with -fPIE and relink with -pie
collect2: error: ld returned 1 exit status
File "caml_startup", line 1:
Error: Error during linking (exit code 1)
```

But given that the official ocaml/opam2:4.12 image works I don't think we need to investigate this one?
The stanorg Docker image works for building the Windows binary and stancjs.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
