### PR TITLE
Improve pretty printing comments inside binary ops

### DIFF
--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -222,7 +222,7 @@ type 's block = {stmts: 's list; xloc: Middle.Location_span.t [@ignore]}
 and comment_type =
   | LineComment of string * Middle.Location_span.t
   | BlockComment of string list * Middle.Location_span.t
-  | Comma of Middle.Location.t
+  | Separator of Middle.Location.t
 
 and 's program =
   { functionblock: 's block option

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -223,6 +223,9 @@ and comment_type =
   | LineComment of string * Middle.Location_span.t
   | BlockComment of string list * Middle.Location_span.t
   | Separator of Middle.Location.t
+      (** Separator records the location of items like commas, operators, and keywords
+          which don't have location information stored in the AST
+          but are useful for placing comments in pretty printing *)
 
 and 's program =
   { functionblock: 's block option

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -22,13 +22,13 @@ let get_comments end_loc =
     | BlockComment (s, ({Middle.Location_span.begin_loc; _} as loc)) :: tl
       when Middle.Location.compare begin_loc end_loc < 0 ->
         (true, s, loc) :: go tl
-    | Comma loc :: tl when Middle.Location.compare loc end_loc < 0 -> go tl
+    | Separator loc :: tl when Middle.Location.compare loc end_loc <= 0 -> go tl
     | _ ->
         comments := ls ;
         [] in
   go !comments
 
-let get_comments_until_comma end_loc =
+let get_comments_until_separator end_loc =
   let rec go ls =
     match ls with
     | LineComment (s, ({Middle.Location_span.begin_loc; _} as loc)) :: tl
@@ -55,7 +55,7 @@ let remaining_comments () =
     @ List.filter_map !comments ~f:(function
         | LineComment (a, b) -> Some (false, [a], b)
         | BlockComment (a, b) -> Some (true, a, b)
-        | Comma _ -> None ) in
+        | Separator _ -> None ) in
   skipped := [] ;
   comments := [] ;
   x
@@ -109,6 +109,17 @@ let pp_spacing ?(newline = true) prev_loc next_loc ppf ls =
       let (_ : Middle.Location.t) = recurse Middle.Location.empty !skipped in
       skipped := [] ;
       Option.iter prev_loc ~f:finish
+
+let pp_maybe_space space_before ppf comments =
+  if not (List.is_empty comments) then (
+    if space_before then Fmt.sp ppf () ;
+    let rec go was_block = function
+      | ((is_block, _, _) as comment) :: tl ->
+          pp_comment ppf comment ;
+          if not is_block then Format.pp_force_newline ppf () ;
+          go is_block tl
+      | [] -> if was_block && not space_before then Fmt.sp ppf () in
+    go true comments )
 
 let wrap_fmt fmt x =
   (* Switched from Format.str_formatter partially because of
@@ -188,34 +199,24 @@ let pp_operator ppf = function
 
 let pp_list_of pp (loc_of : 'a -> Middle.Location_span.t) ppf
     (es, {Middle.Location_span.begin_loc; end_loc}) =
-  let pp_maybe_space space_before comments =
-    if not (List.is_empty comments) then (
-      if space_before then Fmt.sp ppf () ;
-      let rec go was_block = function
-        | ((is_block, _, _) as comment) :: tl ->
-            pp_comment ppf comment ;
-            if not is_block then Format.pp_force_newline ppf () ;
-            go is_block tl
-        | [] -> if was_block && not space_before then Fmt.sp ppf () in
-      go true comments ) in
   let rec go expr more =
     match more with
     | next :: rest ->
         pp ppf expr ;
         let next_loc = (loc_of next).begin_loc in
-        pp_maybe_space true (get_comments_until_comma next_loc) ;
+        pp_maybe_space true ppf (get_comments_until_separator next_loc) ;
         let comments = get_comments next_loc in
         Fmt.comma ppf () ;
-        pp_maybe_space false comments ;
+        pp_maybe_space false ppf comments ;
         go next rest
     | [] -> pp ppf expr in
   skip_comments begin_loc ;
   ( match es with
   | [] -> ()
   | e :: es ->
-      pp_maybe_space false (get_comments (loc_of e).begin_loc) ;
+      pp_maybe_space false ppf (get_comments (loc_of e).begin_loc) ;
       go e es ) ;
-  pp_maybe_space true (get_comments end_loc)
+  pp_maybe_space true ppf (get_comments end_loc)
 
 let rec pp_index ppf = function
   | All -> Fmt.pf ppf " : "
@@ -235,15 +236,27 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
       with_box ppf 0 (fun () ->
           Fmt.pf ppf "%a" pp_expression e1 ;
           Format.pp_print_space ppf () ;
-          Fmt.pf ppf "? %a" pp_expression e2 ;
+          let next_loc = e2.emeta.loc.begin_loc in
+          pp_maybe_space false ppf (get_comments_until_separator next_loc) ;
+          Fmt.pf ppf "? %a" (pp_maybe_space false) (get_comments next_loc) ;
+          pp_expression ppf e2 ;
           Format.pp_print_space ppf () ;
-          Fmt.pf ppf ": %a" pp_expression e3 )
+          let next_loc = e3.emeta.loc.begin_loc in
+          pp_maybe_space false ppf (get_comments_until_separator next_loc) ;
+          Fmt.pf ppf ": %a" (pp_maybe_space false) (get_comments next_loc) ;
+          pp_expression ppf e3 )
   | BinOp (e1, op, e2) ->
       with_box ppf 0 (fun () ->
           Fmt.pf ppf "%a" pp_expression e1 ;
           Format.pp_print_space ppf () ;
-          Fmt.pf ppf "%a %a" pp_operator op pp_expression e2 )
-  | PrefixOp (op, e) -> Fmt.pf ppf "%a%a" pp_operator op pp_expression e
+          let next_loc = e2.emeta.loc.begin_loc in
+          pp_maybe_space false ppf (get_comments_until_separator next_loc) ;
+          Fmt.pf ppf "%a " pp_operator op ;
+          pp_maybe_space false ppf (get_comments next_loc) ;
+          pp_expression ppf e2 )
+  | PrefixOp (op, e) ->
+      pp_maybe_space false ppf (get_comments e.emeta.loc.begin_loc) ;
+      Fmt.pf ppf "%a%a" pp_operator op pp_expression e
   | PostfixOp (e, op) -> Fmt.pf ppf "%a%a" pp_expression e pp_operator op
   | Variable id -> pp_identifier ppf id
   | IntNumeral i -> Fmt.pf ppf "%s" i
@@ -258,7 +271,14 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
     | [] -> Common.FatalError.fatal_error ()
     | e :: es' ->
         with_hbox ppf (fun () ->
-            Fmt.pf ppf "%a(%a | %a)" pp_identifier id pp_expression e
+            let begin_loc =
+              List.hd es'
+              |> Option.map ~f:(fun e -> e.emeta.loc.begin_loc)
+              |> Option.value ~default:loc.end_loc in
+            Fmt.pf ppf "%a(%a%a | %a%a)" pp_identifier id pp_expression e
+              (pp_maybe_space true)
+              (get_comments_until_separator begin_loc)
+              (pp_maybe_space false) (get_comments begin_loc)
               pp_list_of_expression (es', loc) ) )
   (* GetLP is deprecated *)
   | GetLP -> Fmt.pf ppf "get_lp()"
@@ -423,8 +443,10 @@ and pp_recursive_ifthenelse ppf (s, loc) =
       let newline = match s1.stmt with Block _ -> false | _ -> true in
       let loc = s1.smeta.loc.end_loc in
       pp_spacing ~newline (Some loc) (Some loc) ppf
-        (get_comments s2.smeta.loc.begin_loc) ;
-      Fmt.pf ppf "else %a" pp_recursive_ifthenelse
+        (get_comments_until_separator s2.smeta.loc.begin_loc) ;
+      Fmt.pf ppf "else %a%a" (pp_maybe_space false)
+        (get_comments s2.smeta.loc.begin_loc)
+        pp_recursive_ifthenelse
         (s2, {loc with line_num= loc.line_num + 1})
   | _ -> pp_indent_unless_block ppf (s, loc)
 

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -26,6 +26,11 @@ let comments : Ast.comment_type list ref = ref []
     comments :=
         BlockComment ( lines, Middle.Location_span.of_positions_exn (begin_pos, end_pos) )
       :: !comments
+  let add_separator lexbuf =
+    comments :=
+        Separator (Middle.Location.of_position_exn lexbuf.lex_curr_p)
+      :: !comments
+
 }
 
 (* Some auxiliary definition for variables and constants *)
@@ -100,19 +105,15 @@ rule token = parse
   | ')'                       { lexer_logger ")" ; Parser.RPAREN }
   | '['                       { lexer_logger "[" ; Parser.LBRACK }
   | ']'                       { lexer_logger "]" ; Parser.RBRACK }
-  | '<'                       { lexer_logger "<" ; Parser.LABRACK }
-  | '>'                       { lexer_logger ">" ; Parser.RABRACK }
-  | ','                       { lexer_logger "," ;
-                                comments :=
-                                  Comma (Middle.Location.of_position_exn lexbuf.lex_curr_p)
-                                  :: !comments ;
-                                Parser.COMMA }
+  | '<'                       { lexer_logger "<" ; add_separator lexbuf ; Parser.LABRACK }
+  | '>'                       { lexer_logger ">" ; add_separator lexbuf ; Parser.RABRACK }
+  | ','                       { lexer_logger "," ; add_separator lexbuf ; Parser.COMMA }
   | ';'                       { lexer_logger ";" ; Parser.SEMICOLON }
-  | '|'                       { lexer_logger "|" ; Parser.BAR }
+  | '|'                       { lexer_logger "|" ; add_separator lexbuf ; Parser.BAR }
 (* Control flow keywords *)
   | "return"                  { lexer_logger "return" ; Parser.RETURN }
   | "if"                      { lexer_logger "if" ; Parser.IF }
-  | "else"                    { lexer_logger "else" ; Parser.ELSE }
+  | "else"                    { lexer_logger "else" ; add_separator lexbuf ; Parser.ELSE }
   | "while"                   { lexer_logger "while" ; Parser.WHILE }
   | "profile"                 { lexer_logger "profile" ; Parser.PROFILE }
   | "for"                     { lexer_logger "for" ; Parser.FOR }
@@ -145,27 +146,27 @@ rule token = parse
   | "offset"                  { lexer_logger "offset" ; Parser.OFFSET }
   | "multiplier"              { lexer_logger "multiplier" ; Parser.MULTIPLIER }
 (* Operators *)
-  | '?'                       { lexer_logger "?" ; Parser.QMARK }
+  | '?'                       { lexer_logger "?" ; add_separator lexbuf ; Parser.QMARK }
   | ':'                       { lexer_logger ":" ; Parser.COLON }
   | '!'                       { lexer_logger "!" ; Parser.BANG }
-  | '-'                       { lexer_logger "-" ; Parser.MINUS }
-  | '+'                       { lexer_logger "+" ; Parser.PLUS }
-  | '^'                       { lexer_logger "^" ; Parser.HAT }
+  | '-'                       { lexer_logger "-" ; add_separator lexbuf ; Parser.MINUS }
+  | '+'                       { lexer_logger "+" ; add_separator lexbuf ; Parser.PLUS }
+  | '^'                       { lexer_logger "^" ; add_separator lexbuf ; Parser.HAT }
   | '\''                      { lexer_logger "\'" ; Parser.TRANSPOSE }
-  | '*'                       { lexer_logger "*" ; Parser.TIMES }
-  | '/'                       { lexer_logger "/" ; Parser.DIVIDE }
-  | '%'                       { lexer_logger "%" ; Parser.MODULO }
-  | "%/%"                     { lexer_logger "%/%" ; Parser.IDIVIDE }
-  | "\\"                      { lexer_logger "\\" ; Parser.LDIVIDE }
-  | ".*"                      { lexer_logger ".*" ; Parser.ELTTIMES }
-  | ".^"                      { lexer_logger ".^" ; Parser.ELTPOW }
-  | "./"                      { lexer_logger "./" ; Parser.ELTDIVIDE }
-  | "||"                      { lexer_logger "||" ; Parser.OR }
-  | "&&"                      { lexer_logger "&&" ; Parser.AND }
-  | "=="                      { lexer_logger "==" ; Parser.EQUALS }
-  | "!="                      { lexer_logger "!=" ; Parser.NEQUALS }
-  | "<="                      { lexer_logger "<=" ; Parser.LEQ }
-  | ">="                      { lexer_logger ">=" ; Parser.GEQ }
+  | '*'                       { lexer_logger "*" ; add_separator lexbuf ; Parser.TIMES }
+  | '/'                       { lexer_logger "/" ; add_separator lexbuf ; Parser.DIVIDE }
+  | '%'                       { lexer_logger "%" ; add_separator lexbuf ; Parser.MODULO }
+  | "%/%"                     { lexer_logger "%/%" ; add_separator lexbuf ; Parser.IDIVIDE }
+  | "\\"                      { lexer_logger "\\" ; add_separator lexbuf ; Parser.LDIVIDE }
+  | ".*"                      { lexer_logger ".*" ; add_separator lexbuf ; Parser.ELTTIMES }
+  | ".^"                      { lexer_logger ".^" ; add_separator lexbuf ; Parser.ELTPOW }
+  | "./"                      { lexer_logger "./" ; add_separator lexbuf ; Parser.ELTDIVIDE }
+  | "||"                      { lexer_logger "||" ; add_separator lexbuf ; Parser.OR }
+  | "&&"                      { lexer_logger "&&" ; add_separator lexbuf ; Parser.AND }
+  | "=="                      { lexer_logger "==" ; add_separator lexbuf ; Parser.EQUALS }
+  | "!="                      { lexer_logger "!=" ; add_separator lexbuf ; Parser.NEQUALS }
+  | "<="                      { lexer_logger "<=" ; add_separator lexbuf ; Parser.LEQ }
+  | ">="                      { lexer_logger ">=" ; add_separator lexbuf ; Parser.GEQ }
   | "~"                       { lexer_logger "~" ; Parser.TILDE }
 (* Assignments *)
   | '='                       { lexer_logger "=" ; Parser.ASSIGN }

--- a/test/integration/canonicalize/canonical.expected
+++ b/test/integration/canonicalize/canonical.expected
@@ -136,9 +136,8 @@ model {
   
   if (N > 5) {
     y ~ std_normal();
-  }
-  //comment before else branch
-  else {
+  } else //comment before else branch
+  {
     y ~ std_normal();
   }
   

--- a/test/integration/rstanarm/pretty.expected
+++ b/test/integration/rstanarm/pretty.expected
@@ -6541,11 +6541,11 @@ model {
         //----- etavalue and any interactions
         
         mark2 += 1;
-        if (has_assoc[1, m] == 1 || has_assoc[9, m] == 1
-            || has_assoc[13, m] == 1 || has_assoc[14, m] == 1) {
-          // etavalue
-          // etavalue * data
-          // etavalue * etavalue
+        if (has_assoc[1, m] == 1 || // etavalue
+            has_assoc[9, m] == 1 || // etavalue * data
+            has_assoc[13, m] == 1
+            || // etavalue * etavalue
+            has_assoc[14, m] == 1) {
           // etavalue * muvalue
           
           // declare and define eta at quadpoints for submodel m
@@ -6798,11 +6798,11 @@ model {
         //----- muvalue and any interactions
         
         mark2 += 1;
-        if (has_assoc[4, m] == 1 || has_assoc[11, m] == 1
-            || has_assoc[15, m] == 1 || has_assoc[16, m] == 1) {
-          // muvalue
-          // muvalue * data
-          // muvalue * etavalue
+        if (has_assoc[4, m] == 1 || // muvalue
+            has_assoc[11, m] == 1 || // muvalue * data
+            has_assoc[15, m] == 1
+            || // muvalue * etavalue
+            has_assoc[16, m] == 1) {
           // muvalue * muvalue
           
           // declare and define mu for submodel m
@@ -7256,9 +7256,9 @@ functions {
                         real SSR, real sigma, int N) {
     target += -0.5
               * (dot_self(theta - b) + N * square(intercept - ybar) + SSR)
-              / square(sigma) - N * (log(sigma) + 0.91893853320467267);
-    
-    // ^^^: 0.91... is log(sqrt(2 * pi()))
+              / square(sigma)
+              - // 0.91... is log(sqrt(2 * pi()))
+              N * (log(sigma) + 0.91893853320467267);
     return target();
   }
 }
@@ -7321,8 +7321,8 @@ transformed parameters {
       else if (prior_scale_for_intercept == 0)  // central limit theorem
         alpha[j] = z_alpha[j] * Delta_y * sqrt_inv_N[j]
                    + prior_mean_for_intercept;
-      // arbitrary informative prior
-      else 
+      else // arbitrary informative prior
+      
         alpha[j] = z_alpha[j] * prior_scale_for_intercept
                    + prior_mean_for_intercept;
     }


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [X] OR, no user-facing changes were made

See #990.
I didn't change the AST to record more info; this just extends the "array-expr" hack to binary operators. Probably has some corner cases where comments are misplaced anyway but for now I think it's an improvement over what we had before.
The logic is also not as simple as it probably could be but again, not worse than before, just more of the same.

## Copyright and Licensing
Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
