### PR TITLE
Cleanup fatal_error usage

### DIFF
--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -23,7 +23,9 @@ let apply_prefix_operator_int (op : string) i =
         | "PPlus__" -> i
         | "PMinus__" -> -i
         | "PNot__" -> if i = 0 then 1 else 0
-        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
+        | s ->
+            Common.FatalError.fatal_error_msg
+              [%message "Not an int prefix operator: " s] ) )
 
 let apply_prefix_operator_real (op : string) i =
   Expr.Fixed.Pattern.Lit
@@ -32,7 +34,9 @@ let apply_prefix_operator_real (op : string) i =
         ( match op with
         | "PPlus__" -> i
         | "PMinus__" -> -.i
-        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
+        | s ->
+            Common.FatalError.fatal_error_msg
+              [%message "Not a real prefix operator: " s] ) )
 
 let apply_operator_int (op : string) i1 i2 =
   Expr.Fixed.Pattern.Lit
@@ -50,7 +54,9 @@ let apply_operator_int (op : string) i1 i2 =
         | "Leq__" -> Bool.to_int (i1 <= i2)
         | "Greater__" -> Bool.to_int (i1 > i2)
         | "Geq__" -> Bool.to_int (i1 >= i2)
-        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
+        | s ->
+            Common.FatalError.fatal_error_msg
+              [%message "Not an int operator: " s] ) )
 
 let apply_arithmetic_operator_real (op : string) r1 r2 =
   Expr.Fixed.Pattern.Lit
@@ -61,7 +67,9 @@ let apply_arithmetic_operator_real (op : string) r1 r2 =
         | "Minus__" -> r1 -. r2
         | "Times__" -> r1 *. r2
         | "Divide__" -> r1 /. r2
-        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
+        | s ->
+            Common.FatalError.fatal_error_msg
+              [%message "Not a real operator: " s] ) )
 
 let apply_logical_operator_real (op : string) r1 r2 =
   Expr.Fixed.Pattern.Lit
@@ -74,7 +82,9 @@ let apply_logical_operator_real (op : string) r1 r2 =
         | "Leq__" -> Bool.to_int (r1 <= r2)
         | "Greater__" -> Bool.to_int (r1 > r2)
         | "Geq__" -> Bool.to_int (r1 >= r2)
-        | s -> Common.FatalError.fatal_error_msg [%message s] ) )
+        | s ->
+            Common.FatalError.fatal_error_msg
+              [%message "Not a logical operator: " s] ) )
 
 let is_multi_index = function
   | Index.MultiIndex _ | Upfrom _ | Between _ | All -> true

--- a/src/common/FatalError.ml
+++ b/src/common/FatalError.ml
@@ -11,7 +11,3 @@ let fatal_error_msg message =
           "Fatal error: this should never happen. Please file a bug on \
            https://github.com/stan-dev/stanc3/issues/new."]; message ] in
   raise_s augmented
-
-(** A version of [fatal_error_msg] with an empty message.
-  The resulting error only includes the issues link *)
-let fatal_error () = fatal_error_msg [%message]

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -81,9 +81,7 @@ let mk_typed_expression ~expr ~loc ~type_ ~ad_level =
 
 let expr_loc_lub exprs =
   match List.map ~f:(fun e -> e.emeta.loc) exprs with
-  | [] ->
-      Common.FatalError.fatal_error_msg
-        [%message "Can't find location lub for empty list"]
+  | [] -> Location_span.empty
   | [hd] -> hd
   | x1 :: tl -> List.fold ~init:x1 ~f:Location_span.merge tl
 

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -374,7 +374,9 @@ let trans_decl {transform_action; dadlevel} smeta decl_type transform identifier
   if Utils.is_user_ident decl_id then
     let constrain_checks =
       match transform_action with
-      | Constrain | Unconstrain -> Common.FatalError.fatal_error ()
+      | Constrain | Unconstrain ->
+          Common.FatalError.fatal_error_msg
+            [%message "Constraints must use trans_sizedtype_decl instead"]
       | Check ->
           check_transform_shape decl_id decl_var smeta transform
           @ check_decl decl_var dt decl_id transform smeta dadlevel

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -268,7 +268,9 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
           Fmt.pf ppf "%a)" pp_list_of_expression (es, loc) )
   | CondDistApp (_, id, es) -> (
     match es with
-    | [] -> Common.FatalError.fatal_error ()
+    | [] ->
+        Common.FatalError.fatal_error_msg
+          [%message "CondDistApp with no arguments: " id.name]
     | e :: es' ->
         with_hbox ppf (fun () ->
             let begin_loc =
@@ -333,7 +335,8 @@ let pp_sizedtype ppf = function
   | SRowVector (_, e) -> Fmt.pf ppf "row_vector[%a]" pp_expression e
   | SMatrix (_, e1, e2) ->
       Fmt.pf ppf "matrix[%a, %a]" pp_expression e1 pp_expression e2
-  | SArray _ -> Common.FatalError.fatal_error ()
+  | SArray _ ->
+      Common.FatalError.fatal_error_msg [%message "Error printing array type"]
 
 let pp_transformation ppf = function
   | Middle.Transformation.Identity -> Fmt.pf ppf ""
@@ -610,7 +613,10 @@ let check_correctness ?(bare_functions = false) prog pretty =
     then failwith "Unequal!"
   with _ ->
     Common.FatalError.fatal_error_msg
-      [%message (prog : Ast.untyped_program) pretty]
+      [%message
+        "Pretty-printed program does match the original!"
+          (prog : Ast.untyped_program)
+          pretty]
 
 let pp_typed_expression ppf e =
   pp_expression ppf (untyped_expression_of_typed_expression e)

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -220,7 +220,10 @@ module Helpers = struct
       | Indexed (e, indices) -> Indexed (e, indices @ [i])
       | _ ->
           (* These should go away with Ryan's LHS *)
-          Common.FatalError.fatal_error () in
+          Common.FatalError.fatal_error_msg
+            [%message
+              "Expected Var or Indexed but found " (e : Typed.Meta.t Fixed.t)]
+    in
     Fixed.{meta; pattern}
 
   (** TODO: Make me tail recursive *)

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -101,9 +101,9 @@ let rec pp_unsizedtype_custom_scalar ppf (scalar, ut) =
   | UMatrix -> pf ppf "Eigen::Matrix<%s, -1, -1>" scalar
   | URowVector -> pf ppf "Eigen::Matrix<%s, 1, -1>" scalar
   | UVector -> pf ppf "Eigen::Matrix<%s, -1, 1>" scalar
-  | x ->
+  | UMathLibraryFunction | UFun _ ->
       Common.FatalError.fatal_error_msg
-        [%message (x : UnsizedType.t) "not implemented"]
+        [%message "Function types not implemented"]
 
 let pp_unsizedtype_custom_scalar_eigen_exprs ppf (scalar, ut) =
   match ut with
@@ -113,9 +113,9 @@ let pp_unsizedtype_custom_scalar_eigen_exprs ppf (scalar, ut) =
   | UArray t ->
       (* Expressions are not accepted for arrays of Eigen::Matrix *)
       pf ppf "std::vector<%a>" pp_unsizedtype_custom_scalar (scalar, t)
-  | x ->
+  | UMathLibraryFunction | UFun _ ->
       Common.FatalError.fatal_error_msg
-        [%message (x : UnsizedType.t) "not implemented"]
+        [%message "Function types not implemented"]
 
 let pp_unsizedtype_local ppf (adtype, ut) =
   let s = local_scalar ut adtype in
@@ -421,14 +421,6 @@ and gen_fun_app suffix ppf fname es mem_pattern =
     |> List.filter_opt |> List.hd |> Option.value ~default in
   pf ppf "@[<hov 2>%a@]" pp es
 
-and pp_constrain_funapp constrain_or_un_str constraint_flavor ppf = function
-  | var :: args ->
-      pf ppf "@[<hov 2>stan::math::%s_%s(@,%a@])" constraint_flavor
-        constrain_or_un_str (list ~sep:comma pp_expr) (var :: args)
-  | es ->
-      Common.FatalError.fatal_error_msg
-        [%message "Bad constraint " (es : Expr.Typed.t list)]
-
 and pp_user_defined_fun ppf (f, suffix, es) =
   let extra_args = suffix_args suffix @ ["pstream__"] in
   let sep = if List.is_empty es then "" else ", " in
@@ -449,7 +441,9 @@ and pp_compiler_internal_fn ad ut f ppf es =
         | UnsizedType.UArray ut -> ut
         | _ ->
             Common.FatalError.fatal_error_msg
-              [%message "Array literal must have array type"] in
+              [%message
+                "Array literal must have array type but found "
+                  (ut : UnsizedType.t)] in
       pp_array_literal ut ppf es
   | FnMakeRowVec -> (
     match ut with


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [X] OR, no user-facing changes were made

Removes `FatalError.fatal_error` in favor of `FatalError.fatal_error_msg`, refactors to remove a few fatal error branches, and elaborates some other fatal error messages.
Also fixes an issue with `--debug-generate-data` if the data block has extra semicolons.
```stan
data {
  real x;; // compiles to C++ but --debug-generate-data crashes
}
```

## Copyright and Licensing
Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
