### PR TITLE
Properly verify a variable name isn't in use

### DIFF
--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -110,8 +110,9 @@ let verify_name_fresh_var loc tenv name =
   if Utils.is_unnormalized_distribution name then
     Semantic_error.ident_has_unnormalized_suffix loc name |> error
   else if
-    Env.mem tenv name
-    && not (Stan_math_signatures.is_stan_math_function_name name)
+    List.exists (Env.find tenv name) ~f:(function
+      | {kind= `StanMath; _} -> false
+      | _ -> true )
   then Semantic_error.ident_in_use loc name |> error
 
 (** verify that the variable being declared is previous unused.

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -111,7 +111,8 @@ let verify_name_fresh_var loc tenv name =
     Semantic_error.ident_has_unnormalized_suffix loc name |> error
   else if
     List.exists (Env.find tenv name) ~f:(function
-      | {kind= `StanMath; _} -> false
+      | {kind= `StanMath; _} ->
+          false (* user variables can shadow library names *)
       | _ -> true )
   then Semantic_error.ident_in_use loc name |> error
 

--- a/test/integration/bad/lang/reused_name.stan
+++ b/test/integration/bad/lang/reused_name.stan
@@ -1,0 +1,5 @@
+generated quantities {
+    vector[3] e;
+    // e is selected because it is also a Stan-math function 'e()'
+    vector[3] e;
+}

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -696,6 +696,17 @@ Expected an expression inside "[" and "]" but found a statement. Indexing should
   var[1 + i]
 not
   var[for (n in 1:N) ...]
+  $ ../../../../../install/default/bin/stanc reused_name.stan
+Semantic error in 'reused_name.stan', line 4, column 14 to column 15:
+   -------------------------------------------------
+     2:      vector[3] e;
+     3:      // e is selected because it is also a Stan-math function 'e()'
+     4:      vector[3] e;
+                       ^
+     5:  }
+   -------------------------------------------------
+
+Identifier 'e' is already in use.
   $ ../../../../../install/default/bin/stanc unterminated_comment.stan
 Syntax error in 'unterminated_comment.stan', line 4, column -1, lexing error:
    -------------------------------------------------


### PR DESCRIPTION
Silly mistake on my part when merging the symbol table in #995.  Realized it would be a 1 line fix so I decided not to wait @rok-cesnovar. 

Closes #1060 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Fixes a bug not in the last release (#1060)

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
