### PR TITLE
Fix typechecker issue with unreachable statements, emit warning

### DIFF
--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1099,24 +1099,22 @@ and check_loop_body cf tenv loop_var loop_var_ty loop_body =
 and check_block loc cf tenv stmts =
   let _, checked_stmts =
     List.fold_map stmts ~init:tenv ~f:(check_statement cf) in
-  let stmts = list_until_escape checked_stmts in
   let return_type =
-    stmts
+    checked_stmts |> list_until_escape
     |> List.map ~f:(fun s -> s.smeta.return_type)
     |> List.fold ~init:NoReturnType
          ~f:(try_compute_block_statement_returntype loc) in
-  mk_typed_statement ~stmt:(Block stmts) ~return_type ~loc
+  mk_typed_statement ~stmt:(Block checked_stmts) ~return_type ~loc
 
 and check_profile loc cf tenv name stmts =
   let _, checked_stmts =
     List.fold_map stmts ~init:tenv ~f:(check_statement cf) in
-  let stmts = list_until_escape checked_stmts in
   let return_type =
-    stmts
+    checked_stmts |> list_until_escape
     |> List.map ~f:(fun s -> s.smeta.return_type)
     |> List.fold ~init:NoReturnType
          ~f:(try_compute_block_statement_returntype loc) in
-  mk_typed_statement ~stmt:(Profile (name, stmts)) ~return_type ~loc
+  mk_typed_statement ~stmt:(Profile (name, checked_stmts)) ~return_type ~loc
 
 (* variable declarations *)
 and verify_valid_transformation_for_type loc is_global sized_ty trans =

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -962,7 +962,11 @@ let rec stmt_is_escape {stmt; _} =
 
 and list_until_escape xs =
   let rec aux accu = function
-    | next :: next' :: _ when stmt_is_escape next' ->
+    | [next; next'] when stmt_is_escape next' -> List.rev (next' :: next :: accu)
+    | next :: next' :: unreachable :: _ when stmt_is_escape next' ->
+        add_warning unreachable.smeta.loc
+          "Unreachable statement (following a reject, break, continue, or \
+           return) found, is this intended?" ;
         List.rev (next' :: next :: accu)
     | next :: rest -> aux (next :: accu) rest
     | [] -> List.rev accu in

--- a/test/integration/good/lang/good_early_reject.stan
+++ b/test/integration/good/lang/good_early_reject.stan
@@ -1,0 +1,9 @@
+functions {
+    real test(real k) {
+        if (k < 0)
+            ;
+        reject("test");
+
+        return k;
+    }
+}

--- a/test/integration/good/lang/good_early_reject.stan
+++ b/test/integration/good/lang/good_early_reject.stan
@@ -1,9 +1,0 @@
-functions {
-    real test(real k) {
-        if (k < 0)
-            ;
-        reject("test");
-
-        return k;
-    }
-}

--- a/test/integration/good/lang/pretty.expected
+++ b/test/integration/good/lang/pretty.expected
@@ -20,6 +20,17 @@ model {
     y[i] ~ multi_normal(mu[i], Sigma[i]);
 }
 
+  $ ../../../../../install/default/bin/stanc --auto-format good_early_reject.stan
+functions {
+  real test(real k) {
+    if (k < 0) 
+      ;
+    reject("test");
+    
+    return k;
+  }
+}
+
   $ ../../../../../install/default/bin/stanc --auto-format good_fun_name.stan
 parameters {
   real e;

--- a/test/integration/good/lang/pretty.expected
+++ b/test/integration/good/lang/pretty.expected
@@ -20,17 +20,6 @@ model {
     y[i] ~ multi_normal(mu[i], Sigma[i]);
 }
 
-  $ ../../../../../install/default/bin/stanc --auto-format good_early_reject.stan
-functions {
-  real test(real k) {
-    if (k < 0) 
-      ;
-    reject("test");
-    
-    return k;
-  }
-}
-
   $ ../../../../../install/default/bin/stanc --auto-format good_fun_name.stan
 parameters {
   real e;
@@ -620,3 +609,16 @@ generated quantities {
   xgq = 2713;
 }
 
+  $ ../../../../../install/default/bin/stanc --auto-format unreachable_statement.stan
+functions {
+  void foo(real x) {
+    if (x) 
+      ; // bug - misplaced ; makes the next statement unconditional
+    reject("Cannot be 0");
+    return;
+  }
+}
+
+Warning in 'unreachable_statement.stan', line 5, column 5: Unreachable
+    statement (following a reject, break, continue, or return) found, is this
+    intended?

--- a/test/integration/good/lang/unreachable_statement.stan
+++ b/test/integration/good/lang/unreachable_statement.stan
@@ -1,0 +1,7 @@
+functions {
+   void foo(real x){
+     if(x) ; // bug - misplaced ; makes the next statement unconditional
+       reject("Cannot be 0");
+     return;
+   }
+}


### PR DESCRIPTION
This fixes #1062. The issue made me realize it would probably be good if the typechecker warned you when there were unreachable statements, as they are almost always unintentional (the model which provoked #1062 did so because it had an unconditional `reject` which was probably a bug).

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Issue a warning when a user has a model with unreachable statements, such as code following a `return` statement.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
