### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: File a bug/issue
+title: '[BUG] <title>'
+labels: ''
+assignees: ''
+---
+<!-- Thank you for submitting a bug report! -->
+
+### Current Behavior:
+<!-- A concise description of what you're experiencing. -->
+
+### Expected Behavior:
+<!-- A concise description of what you expected to happen. -->
+
+### Model Code
+<!-- If a specific model is causing this issue, it really helps if you can share it -->
+<details><summary>Model which exhibits the issue</summary>
+
+```stan
+// Please put your code here
+
+```
+</details>
+
+### Environment:
+<!--
+Example:
+- OS: Ubuntu 20.04
+- stanc: 2.28.0
+- cmdstan/rstan/other Stanversions
+-->
+
+### Anything else:
+<!--
+Links? References? Anything that will give us more context about the issue that you are encountering!
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question about using Stan, modeling, etc
+    url: https://discourse.mc-stan.org/
+    about: |
+      Ask questions and discuss with other community members here.
+      If your question involves a specific model, including it will
+      improve the quality of help the community can provide.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new feature for the language or compiler
+title: ''
+labels: 'feature'
+assignees: ''
+---
+
+<!-- Please do a quick search of existing issues to make sure that this has not been suggested before.
+    Thank you for helping us improve Stan!
+ -->
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A description of what the problem is. e.g., "I'm always frustrated when [...]" -->
+
+**Describe the solution you'd like**
+<!-- A description of what you're proposing, e.g., "The auto-formatter should allow users to set a line length" -->
+
+**Describe alternatives you've considered**
+<!-- A description of any alternative solutions to this problem or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/todo.md
+++ b/.github/ISSUE_TEMPLATE/todo.md
@@ -1,0 +1,8 @@
+---
+name: TODO Item
+about: (For existing developers) Open a generic issue related to the build process or something that needs to be worked on.
+title: ''
+labels: ''
+assignees: ''
+---
+


### PR DESCRIPTION
This adds a few issue templates to the repo to help with bug reports. When users click 'New Issue', this adds a selection screen before opening a template for them. To see what they look like, you can navigate here:
https://github.com/WardBrian/stanc3/issues/new/choose 

#### Submission Checklist

- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Added issue templates to the stanc3 repo

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
