### PR TITLE
Clear lexing stack before parsing starts

### DIFF
--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -14,7 +14,10 @@ let include_stack = Stack.create ()
 let include_paths : string list ref = ref []
 let included_files : string list ref = ref []
 let size () = Stack.length include_stack
-let init buf = Stack.push include_stack buf
+
+let init buf =
+  Stack.clear include_stack ;
+  Stack.push include_stack buf
 
 let current_buffer () =
   let buf = Stack.top_exn include_stack in

--- a/test/stancjs/good_after_bad.js
+++ b/test/stancjs/good_after_bad.js
@@ -1,0 +1,33 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+
+
+let bad = `
+parameters {
+	real y;
+}
+model {
+    y ~ std_normal();
+}
+model {
+    y ~ std_normal();
+}
+`
+
+let basic_bad = stanc.stanc("basic_bad", bad, []);
+utils.print_error(basic_bad)
+
+// we now test a syntactically valid model to make sure the parser has cleared its state
+
+let basic_model = `
+parameters {
+	real y;
+}
+model {
+    y ~ std_normal();
+}
+`
+
+let basic = stanc.stanc("basic", basic_model);
+utils.print_error(basic)

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -149,6 +149,10 @@ real test_rng(real a) {
 real test_lpdf(real a, real b) {
   return normal_lpdf(a | b, 1);
 }
+$ node good_after_bad.js
+Syntax error in 'string', line 8, column 0 to column 5, parsing error:
+Expected "generated quantities {" or end of file after end of model block.
+
 $ node info.js
 { "inputs": { "a": { "type": "int", "dimensions": 0},
               "b": { "type": "real", "dimensions": 0},


### PR DESCRIPTION
This fixes an issue first spotted by @spinkney in #577. The preprocessing stack is never cleared, so in particular a subsequent parse will inherit anything left on the stack. This is only possible to trigger in the Javascript compiler.

Removing the change in `Preprocessor.ml` makes the new test fail like so:

```
Syntax error in 'string', line 8, column 0 to column 5, parsing error:
Expected "generated quantities {" or end of file after end of model block.

Syntax error in 'string', line 8, column 6 to column 7, parsing error:
Expected "generated quantities {" or end of file after end of model block.
```

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Fix an issue with parser errors 'sticking around' on subsequent runs, which primarily affected the Javascript compiler

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
