### PR TITLE
Add optimization flags, debug-* flags to stancjs

### DIFF
--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -564,7 +564,7 @@ let pp_typed_expression ppf e =
 let pretty_print_program ?(bare_functions = false) ?(line_length = 78)
     ?(inline_includes = false) p =
   let result =
-    strf "%a" (pp_program ~bare_functions ~line_length ~inline_includes) p in
+    str "%a" (pp_program ~bare_functions ~line_length ~inline_includes) p in
   check_correctness ~bare_functions p result ;
   result
 

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -290,7 +290,7 @@ let use_file filename =
       if !dump_opt_mir_pretty then Program.Typed.pp Format.std_formatter opt ;
       opt in
     if !output_file = "" then output_file := remove_dotstan !model_file ^ ".hpp" ;
-    let cpp = Fmt.strf "%a" Stan_math_code_gen.pp_prog opt_mir in
+    let cpp = Fmt.str "%a" Stan_math_code_gen.pp_prog opt_mir in
     Out_channel.write_all !output_file ~data:cpp ;
     if !print_model_cpp then print_endline cpp )
 

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -169,4 +169,9 @@ let stan2cpp_wrapped name code (flags : Js.string_array Js.t Js.opt) =
       (warnings @ pedantic_mode_warnings) in
   wrap_result ?printed_filename result ~warnings
 
-let () = Js.export "stanc" stan2cpp_wrapped
+let dump_stan_math_signatures () =
+  Js.string @@ Fmt.str "%a" Stan_math_signatures.pretty_print_all_math_sigs ()
+
+let () =
+  Js.export "dump_stan_math_signatures" dump_stan_math_signatures ;
+  Js.export "stanc" stan2cpp_wrapped

--- a/test/stancjs/debug.js
+++ b/test/stancjs/debug.js
@@ -12,18 +12,29 @@ y~std_normal();
 
 let debug_mir_test = stanc.stanc("basic", basic_model, ["debug-mir"]);
 var ind = debug_mir_test.result.search("#include \\<stan/model/");
-if (ind > -1) {
-    console.log("ERROR: MIR printing is not valid.")
-}
+console.assert(ind < 0, "ERROR: MIR printing is not valid.")
 
-let debug_opt_mir_test = stanc.stanc("basic", basic_model, ["debug-optimized-mir"]);
+
+let debug_mir_pretty_test = stanc.stanc("basic", basic_model, ["debug-mir-pretty"]);
+var ind = debug_mir_pretty_test.result.search("#include \\<stan/model/");
+console.assert(ind < 0, "ERROR: MIR pretty printing is not valid.")
+
+
+let debug_opt_mir_test = stanc.stanc("basic", basic_model, ["01", "debug-optimized-mir"]);
 var ind = debug_opt_mir_test.result.search("#include \\<stan/model/");
-if (ind > -1) {
-    console.log("ERROR: Optimized MIR printing is not valid.")
-}
+console.assert(ind < 0, "ERROR: Optimized MIR printing is not valid.")
+
+
+let debug_opt_mir_pretty_test = stanc.stanc("basic", basic_model, ["01", "debug-optimized-mir-pretty"]);
+var ind = debug_opt_mir_pretty_test.result.search("#include \\<stan/model/");
+console.assert(ind < 0, "ERROR: Optimized MIR pretty printing is not valid.")
 
 let debug_tx_mir_test = stanc.stanc("basic", basic_model, ["debug-transformed-mir"]);
 var ind = debug_tx_mir_test.result.search("#include \\<stan/model/");
-if (ind > -1) {
-    console.log("ERROR: Transformed MIR printing is not valid.")
-}
+console.assert(ind < 0, "ERROR: Transformed MIR printing is not valid.")
+
+
+let debug_tx_mir_pretty_test = stanc.stanc("basic", basic_model, ["debug-transformed-mir-pretty"]);
+var ind = debug_tx_mir_pretty_test.result.search("#include \\<stan/model/");
+console.assert(ind < 0, "ERROR: Transformed MIR pretty printing is not valid.")
+

--- a/test/stancjs/debug.js
+++ b/test/stancjs/debug.js
@@ -1,0 +1,29 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+let basic_model = `
+parameters {
+real y;
+}
+model {
+y~std_normal();
+}
+`
+
+let debug_mir_test = stanc.stanc("basic", basic_model, ["debug-mir"]);
+var ind = debug_mir_test.result.search("#include \\<stan/model/");
+if (ind > -1) {
+    console.log("ERROR: MIR printing is not valid.")
+}
+
+let debug_opt_mir_test = stanc.stanc("basic", basic_model, ["debug-optimized-mir"]);
+var ind = debug_opt_mir_test.result.search("#include \\<stan/model/");
+if (ind > -1) {
+    console.log("ERROR: Optimized MIR printing is not valid.")
+}
+
+let debug_tx_mir_test = stanc.stanc("basic", basic_model, ["debug-transformed-mir"]);
+var ind = debug_tx_mir_test.result.search("#include \\<stan/model/");
+if (ind > -1) {
+    console.log("ERROR: Transformed MIR printing is not valid.")
+}

--- a/test/stancjs/math_sigs.js
+++ b/test/stancjs/math_sigs.js
@@ -1,6 +1,6 @@
 var stanc = require('../../src/stancjs/stancjs.bc.js');
 var utils = require("./utils/utils.js");
 
-let stan_math_sigs = stanc.stanc("sigs", "", ["dump-stan-math-signatures"]);
-console.log(stan_math_sigs.result)
-
+let stan_math_sigs = stanc.dump_stan_math_signatures();
+console.assert(stan_math_sigs.includes("bernoulli_cdf(int, real) => real"), "Failed to find bernoulli signature!")
+console.assert(stan_math_sigs.includes("zeros_array(int) => array[] real"), "Failed to find zeros_array signature!")

--- a/test/stancjs/math_sigs.js
+++ b/test/stancjs/math_sigs.js
@@ -1,0 +1,6 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+let stan_math_sigs = stanc.stanc("sigs", "", ["dump-stan-math-signatures"]);
+console.log(stan_math_sigs.result)
+

--- a/test/stancjs/optimization.js
+++ b/test/stancjs/optimization.js
@@ -21,6 +21,31 @@ if (ind > -1) {
     console.log("ERROR: No optimization without the O flag!")
 }
 
+var ad_model = `
+data {
+    matrix[10, 10] X_d;
+}
+parameters {
+    matrix[10, 10] X_p;
+}
+
+transformed parameters {
+    matrix[10, 10] X_tp1 = X_d;
+}
+`
+
+var opt_test = stanc.stanc("optimization", ad_model, ["O1"]);
+var ind = opt_test.result.search("\\<double, -1, -1\\> X_tp1");
+if (ind == -1) {
+    console.log("ERROR: No AD optimization with the O1 flag!")
+}
+
+var opt_test = stanc.stanc("optimization", ad_model, ["O0"]);
+var ind = opt_test.result.search("\\<local_scalar_t__, -1, -1\\> X_tp1");
+if (ind == -1) {
+    console.log("ERROR: AD optimization without the O1 flag!")
+}
+
 var glm_model = `
 data {
     int<lower=1> k;

--- a/test/stancjs/optimization.js
+++ b/test/stancjs/optimization.js
@@ -11,15 +11,11 @@ transformed data {
 `
 var opt_test = stanc.stanc("optimization", opt_model, []);
 var ind = opt_test.result.search("int t = 1; t <= 5; \\+\\+t");
-if (ind == -1) {
-    console.log("ERROR: Optimization without the O flag!")
-}
+console.assert(ind > -1, "ERROR: Optimization without the O flag!")
 
 var opt_test = stanc.stanc("optimization", opt_model, ["O"]);
 var ind = opt_test.result.search("int t = 1; t <= 5; \\+\\+t");
-if (ind > -1) {
-    console.log("ERROR: No optimization without the O flag!")
-}
+console.assert(ind < 0, "ERROR: No optimization without the O flag!")
 
 var ad_model = `
 data {
@@ -36,15 +32,11 @@ transformed parameters {
 
 var opt_test = stanc.stanc("optimization", ad_model, ["O1"]);
 var ind = opt_test.result.search("\\<double, -1, -1\\> X_tp1");
-if (ind == -1) {
-    console.log("ERROR: No AD optimization with the O1 flag!")
-}
+console.assert(ind > -1, "ERROR: No AD optimization with the O1 flag!")
 
 var opt_test = stanc.stanc("optimization", ad_model, ["O0"]);
 var ind = opt_test.result.search("\\<local_scalar_t__, -1, -1\\> X_tp1");
-if (ind == -1) {
-    console.log("ERROR: AD optimization without the O1 flag!")
-}
+console.assert(ind > -1, "ERROR: AD optimization without the O1 flag!")
 
 var glm_model = `
 data {
@@ -67,16 +59,14 @@ data {
 var no_opencl_test = stanc.stanc("no_opencl", glm_model);
 utils.print_error(no_opencl_test)
 var ind = no_opencl_test.result.search("matrix_cl<int> y_opencl__");
-if (ind > -1) {
-    console.log("ERROR: OpenCL code found without the use-opencl flag!")
-}
+console.assert(ind < 0, "ERROR: OpenCL code found without the use-opencl flag!")
+
 
 var opencl_test = stanc.stanc("opencl", glm_model, ["use-opencl"]);
 utils.print_error(opencl_test)
 var ind = opencl_test.result.search("matrix_cl<int> y_opencl__");
-if (ind == -1) {
-    console.log("ERROR: No OpenCL code found with the use-opencl flag!")
-}
+console.assert(ind > -1, "ERROR: No OpenCL code found with the use-opencl flag!")
+
 
 // multiple flags
 
@@ -111,6 +101,5 @@ utils.print_error(opencl_test)
 var opencl_test = stanc.stanc("opencl", glm_model2, ["use-opencl", "allow-undefined"]);
 utils.print_error(opencl_test)
 var ind = opencl_test.result.search("matrix_cl<int> y_opencl__");
-if (ind == -1) {
-    console.log("ERROR: No OpenCL code found with the use-opencl flag!")
-}
+console.assert(ind > -1, "ERROR: No OpenCL code found with the use-opencl flag!")
+

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -67,6 +67,8 @@ dim(z) = (3, 4)
 dim(w) = (3)
 dim(p) = (4, 3)
 
+$ node debug.js
+
 $ node filename.js
 Semantic error in 'good_filename', line 6, column 4 to column 5: 
 Identifier 'z' not in scope.
@@ -178,6 +180,8 @@ $ node info.js
   "functions": [  ],
   "distributions": [  ],
   "included_files": [  ] }
+
+$ node math_sigs.js
 
 $ node optimization.js
 Semantic error in 'string', line 3, column 8 to column 11: 


### PR DESCRIPTION
This is not completely done yet as I am having two issues:
- I am not sure if/how we can return the "pretty" prints (`debug-mir-pretty`, `debug-transformed-mir-pretty`, etc.) I am not sure how to replace this call to make it return a string: `Program.Typed.pp Format.std_formatter tx_mir`
- The stan math signatures hashtbl seems to be empty when called with stancjs. See comment.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Add optimization level flags, debug-* and dump-math-signatures flags to stancjs.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
