### PR TITLE
Checkout develop for CmdStan/Stan/Math by default, not master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,11 +29,11 @@ pipeline {
     agent none
     parameters {
         booleanParam(name:"skip_end_to_end", defaultValue: false, description:"Skip end-to-end tests ")
-        string(defaultValue: '', name: 'cmdstan_pr',
+        string(defaultValue: 'develop', name: 'cmdstan_pr',
                description: "CmdStan PR to test against. Will check out this PR in the downstream Stan repo.")
-        string(defaultValue: '', name: 'stan_pr',
+        string(defaultValue: 'develop', name: 'stan_pr',
                description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
-        string(defaultValue: '', name: 'math_pr',
+        string(defaultValue: 'develop', name: 'math_pr',
                description: "Math PR to test against. Will check out this PR in the downstream Math repo.")        
     }
     options {parallelsAlwaysFailFast()}


### PR DESCRIPTION
Fixes the issue that caused stanc3 master to fail. If not otherwise specified, we checkout the master branches of CmdStan/Stan/Math, but we want to work with develop branches.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
