### PR TITLE
Move assignment logic into promotion functionality

### DIFF
--- a/src/frontend/SignatureMismatch.mli
+++ b/src/frontend/SignatureMismatch.mli
@@ -41,12 +41,17 @@ type match_result =
   , signature_error list * bool )
   generic_match_result
 
+val check_of_same_type_mod_conv :
+  UnsizedType.t -> UnsizedType.t -> (promotions, type_mismatch) result
+
 val check_compatible_arguments_mod_conv :
      (UnsizedType.autodifftype * UnsizedType.t) list
   -> (UnsizedType.autodifftype * UnsizedType.t) list
   -> (promotions list, function_mismatch) result
 
-val promote :
+val promote : Ast.typed_expression -> promotions -> Ast.typed_expression
+
+val promote_list :
   Ast.typed_expression list -> promotions list -> Ast.typed_expression list
 (** Given a list of expressions (arguments) and a list of [promotions],
   return a list of expressions which include the

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -44,7 +44,7 @@ module Fixed = struct
       | EAnd (l, r) -> Fmt.pf ppf "%a && %a" pp_e l pp_e r
       | EOr (l, r) -> Fmt.pf ppf "%a || %a" pp_e l pp_e r
       | Promotion (from, ut, _) ->
-          Fmt.pf ppf "%a -> %a" pp_e from UnsizedType.pp ut
+          Fmt.pf ppf "promote(@[%a,@ %a@])" pp_e from UnsizedType.pp ut
 
     include Foldable.Make (struct
       type nonrec 'a t = 'a t

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -102,12 +102,6 @@ let check_of_same_type_mod_conv name t1 t2 =
         | Unequal_lengths -> false )
     | _ -> t1 = t2
 
-let rec check_of_same_type_mod_array_conv name t1 t2 =
-  match (t1, t2) with
-  | UArray t1elt, UArray t2elt ->
-      check_of_same_type_mod_array_conv name t1elt t2elt
-  | _ -> check_of_same_type_mod_conv name t1 t2
-
 let check_compatible_arguments_mod_conv name args1 args2 =
   match
     List.for_all2

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -457,8 +457,7 @@ and pp_user_defined_fun ppf (f, suffix, es) =
 and pp_compiler_internal_fn ad ut f ppf es =
   let pp_array_literal ut ppf es =
     pf ppf "std::vector<%a>{@,%a}" pp_unsizedtype_local (ad, ut)
-      (list ~sep:comma (pp_promoted ad ut))
-      es in
+      (list ~sep:comma pp_expr) es in
   match f with
   | Internal_fun.FnMakeArray ->
       let ut =
@@ -515,20 +514,6 @@ and pp_compiler_internal_fn ad ut f ppf es =
   | _ ->
       gen_fun_app FnPlain ppf (Internal_fun.to_string f) es Common.Helpers.AoS
         (Some UnsizedType.Void)
-
-and pp_promoted ad ut ppf e =
-  match e with
-  | Expr.{Fixed.meta= {Typed.Meta.type_; adlevel; _}; _}
-    when type_ = ut && adlevel = ad ->
-      pp_expr ppf e
-  | {pattern= FunApp (CompilerInternal Internal_fun.FnMakeArray, es); _} ->
-      pp_compiler_internal_fn ad ut Internal_fun.FnMakeArray ppf es
-  | _ -> (
-    match ut with
-    | UnsizedType.UComplex -> pf ppf "@[<hov>%a@]" pp_expr e
-    | _ ->
-        pf ppf "stan::math::promote_scalar<%s>(@[<hov>%a@])"
-          (local_scalar ut ad) pp_expr e )
 
 and pp_indexed ppf (vident, indices, pretty) =
   pf ppf "@[<hov 2>stan::model::rvalue(@,%s,@ %S,@ %a)@]" vident pretty

--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -318,6 +318,8 @@ let rec pp_statement (ppf : Format.formatter) Stmt.Fixed.{pattern; meta} =
       pf ppf "@[<hov 4>%s = %a;@]" vident pp_expr rhs
   | Assignment
       ((vident, _, []), ({meta= Expr.Typed.Meta.{type_= UInt; _}; _} as rhs))
+   |Assignment
+      ((vident, _, []), ({meta= Expr.Typed.Meta.{type_= UComplex; _}; _} as rhs))
    |Assignment ((vident, _, []), ({meta= {type_= UReal; _}; _} as rhs)) ->
       pf ppf "@[<hov 4>%s = %a;@]" vident pp_expr rhs
   | Assignment ((assignee, UInt, idcs), rhs)

--- a/test/integration/cli-args/warn-pedantic/stanc.expected
+++ b/test/integration/cli-args/warn-pedantic/stanc.expected
@@ -431,9 +431,6 @@ Warning in 'param-depend-control.stan', line 13, column 2: A control flow
 Warning in 'param-depend-control.stan', line 8, column 2: A control flow
     statement depends on parameter(s): a.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  unbounded-sigma.stan
-Warning in 'unbounded-sigma.stan', line 15, column 11: A normal distribution
-    is given value -1 as a scale parameter (argument 2), but a scale
-    parameter is not strictly positive.
 Warning in 'unbounded-sigma.stan', line 12, column 17: A normal distribution
     is given parameter sigma_c as a scale parameter (argument 2), but sigma_c
     was not constrained to be strictly positive.

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1598,8 +1598,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       
       
       current_statement__ = 346;
-      stan::model::assign(d_complex, context__.vals_c("d_complex")[(1 - 1)],
-        "assigning variable d_complex");
+      d_complex = context__.vals_c("d_complex")[(1 - 1)];
       current_statement__ = 347;
       context__.validate_dims("data initialization","d_complex_array",
           "double",
@@ -1693,45 +1692,36 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       
       
       current_statement__ = 354;
-      td_complex = td_i;
+      td_complex = stan::math::promote_scalar<std::complex<double>>(td_i);
       current_statement__ = 355;
-      td_complex = td_r;
+      td_complex = stan::math::promote_scalar<std::complex<double>>(td_r);
       current_statement__ = 356;
-      td_complex = d_i;
+      td_complex = stan::math::promote_scalar<std::complex<double>>(d_i);
       current_statement__ = 357;
-      td_complex = d_r;
+      td_complex = stan::math::promote_scalar<std::complex<double>>(d_r);
       current_statement__ = 358;
-      td_complex = 1;
+      td_complex = stan::math::promote_scalar<std::complex<double>>(1);
       current_statement__ = 359;
-      td_complex = 1.1;
+      td_complex = stan::math::promote_scalar<std::complex<double>>(1.1);
       current_statement__ = 360;
-      stan::model::assign(td_complex, d_complex,
-        "assigning variable td_complex");
+      td_complex = d_complex;
       current_statement__ = 361;
-      stan::model::assign(td_complex,
-        stan::model::rvalue(d_complex_array, "d_complex_array",
-          stan::model::index_uni(1)), "assigning variable td_complex");
+      td_complex = stan::model::rvalue(d_complex_array, "d_complex_array",
+                     stan::model::index_uni(1));
       current_statement__ = 362;
-      stan::model::assign(td_complex, stan::math::to_complex(),
-        "assigning variable td_complex");
+      td_complex = stan::math::to_complex();
       current_statement__ = 363;
-      stan::model::assign(td_complex, stan::math::to_complex(1),
-        "assigning variable td_complex");
+      td_complex = stan::math::to_complex(1);
       current_statement__ = 364;
-      stan::model::assign(td_complex, stan::math::to_complex(1.2),
-        "assigning variable td_complex");
+      td_complex = stan::math::to_complex(1.2);
       current_statement__ = 365;
-      stan::model::assign(td_complex, stan::math::to_complex(1, 2),
-        "assigning variable td_complex");
+      td_complex = stan::math::to_complex(1, 2);
       current_statement__ = 366;
-      stan::model::assign(td_complex, stan::math::to_complex(1.1, 2),
-        "assigning variable td_complex");
+      td_complex = stan::math::to_complex(1.1, 2);
       current_statement__ = 367;
-      stan::model::assign(td_complex, stan::math::to_complex(1, 2.2),
-        "assigning variable td_complex");
+      td_complex = stan::math::to_complex(1, 2.2);
       current_statement__ = 368;
-      stan::model::assign(td_complex, stan::math::to_complex(1.1, 2.2),
-        "assigning variable td_complex");
+      td_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 369;
       stan::model::assign(td_complex_array, d_complex_array,
         "assigning variable td_complex_array");
@@ -1757,7 +1747,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         "assigning variable td_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 375;
-      stan::model::assign(td_complex_array_2d, 1,
+      stan::model::assign(td_complex_array_2d,
+        stan::math::promote_scalar<std::complex<double>>(1),
         "assigning variable td_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 376;
@@ -1792,11 +1783,9 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             {
               std::complex<double> td_k;
               current_statement__ = 384;
-              stan::model::assign(td_k, td_j[(sym1__ - 1)],
-                "assigning variable td_k");
+              td_k = td_j[(sym1__ - 1)];
               current_statement__ = 385;
-              stan::model::assign(td_complex, td_k,
-                "assigning variable td_complex");
+              td_complex = td_k;
             }
           }
         }
@@ -1824,17 +1813,13 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                  "td_complex_array_2d",
                  stan::model::index_uni(1), stan::model::index_uni(1)));
       current_statement__ = 392;
-      stan::model::assign(td_complex, foo(pstream__),
-        "assigning variable td_complex");
+      td_complex = foo(pstream__);
       current_statement__ = 393;
       td_r = foo1(td_complex, pstream__);
       current_statement__ = 394;
-      stan::model::assign(td_complex, foo2(td_r, pstream__),
-        "assigning variable td_complex");
+      td_complex = foo2(td_r, pstream__);
       current_statement__ = 395;
-      stan::model::assign(td_complex,
-        foo3(stan::model::deep_copy(td_complex), pstream__),
-        "assigning variable td_complex");
+      td_complex = foo3(td_complex, pstream__);
       current_statement__ = 396;
       stan::model::assign(td_complex_array, foo4(pstream__),
         "assigning variable td_complex_array");
@@ -1920,52 +1905,41 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
            std::vector<std::complex<local_scalar_t__>>(3, 
              std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
       current_statement__ = 9;
-      tp_complex = tp_r;
+      tp_complex = stan::math::promote_scalar<std::complex<local_scalar_t__>>(tp_r);
       current_statement__ = 10;
-      tp_complex = d_i;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(d_i);
       current_statement__ = 11;
-      tp_complex = d_r;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(d_r);
       current_statement__ = 12;
-      tp_complex = p_r;
+      tp_complex = stan::math::promote_scalar<std::complex<local_scalar_t__>>(p_r);
       current_statement__ = 13;
-      tp_complex = 1;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(1);
       current_statement__ = 14;
-      tp_complex = 1.1;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(1.1);
       current_statement__ = 15;
-      stan::model::assign(tp_complex, d_complex,
-        "assigning variable tp_complex");
+      tp_complex = d_complex;
       current_statement__ = 16;
-      stan::model::assign(tp_complex,
-        stan::model::rvalue(d_complex_array, "d_complex_array",
-          stan::model::index_uni(1)), "assigning variable tp_complex");
+      tp_complex = stan::model::rvalue(d_complex_array, "d_complex_array",
+                     stan::model::index_uni(1));
       current_statement__ = 17;
-      stan::model::assign(tp_complex, p_complex,
-        "assigning variable tp_complex");
+      tp_complex = p_complex;
       current_statement__ = 18;
-      stan::model::assign(tp_complex,
-        stan::model::rvalue(p_complex_array, "p_complex_array",
-          stan::model::index_uni(1)), "assigning variable tp_complex");
+      tp_complex = stan::model::rvalue(p_complex_array, "p_complex_array",
+                     stan::model::index_uni(1));
       current_statement__ = 19;
-      stan::model::assign(tp_complex, stan::math::to_complex(),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex();
       current_statement__ = 20;
-      stan::model::assign(tp_complex, stan::math::to_complex(1),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1);
       current_statement__ = 21;
-      stan::model::assign(tp_complex, stan::math::to_complex(1.2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1.2);
       current_statement__ = 22;
-      stan::model::assign(tp_complex, stan::math::to_complex(1, 2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1, 2);
       current_statement__ = 23;
-      stan::model::assign(tp_complex, stan::math::to_complex(1.1, 2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1.1, 2);
       current_statement__ = 24;
-      stan::model::assign(tp_complex, stan::math::to_complex(1, 2.2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1, 2.2);
       current_statement__ = 25;
-      stan::model::assign(tp_complex, stan::math::to_complex(1.1, 2.2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 26;
       stan::model::assign(tp_complex_array, d_complex_array,
         "assigning variable tp_complex_array");
@@ -1989,7 +1963,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       stan::model::assign(tp_complex_array_2d,
         std::vector<std::vector<std::complex<local_scalar_t__>>>{
         std::vector<std::complex<local_scalar_t__>>{1, tp_complex, 3},
-        std::vector<std::complex<local_scalar_t__>>{stan::math::to_complex(),
+        std::vector<std::complex<double>>{stan::math::to_complex(),
         stan::math::to_complex(1.1), stan::math::to_complex(1, 2.1)}},
         "assigning variable tp_complex_array_2d");
       current_statement__ = 33;
@@ -1997,7 +1971,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 34;
-      stan::model::assign(tp_complex_array_2d, 1,
+      stan::model::assign(tp_complex_array_2d,
+        stan::math::promote_scalar<std::complex<double>>(1),
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 35;
@@ -2032,11 +2007,9 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             {
               std::complex<local_scalar_t__> tp_k;
               current_statement__ = 43;
-              stan::model::assign(tp_k, tp_j[(sym1__ - 1)],
-                "assigning variable tp_k");
+              tp_k = tp_j[(sym1__ - 1)];
               current_statement__ = 44;
-              stan::model::assign(tp_complex, tp_k,
-                "assigning variable tp_complex");
+              tp_complex = tp_k;
             }
           }
         }
@@ -2064,17 +2037,13 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                  "tp_complex_array_2d",
                  stan::model::index_uni(1), stan::model::index_uni(1)));
       current_statement__ = 51;
-      stan::model::assign(tp_complex, foo(pstream__),
-        "assigning variable tp_complex");
+      tp_complex = foo(pstream__);
       current_statement__ = 52;
       tp_r = foo1(tp_complex, pstream__);
       current_statement__ = 53;
-      stan::model::assign(tp_complex, foo2(tp_r, pstream__),
-        "assigning variable tp_complex");
+      tp_complex = foo2(tp_r, pstream__);
       current_statement__ = 54;
-      stan::model::assign(tp_complex,
-        foo3(stan::model::deep_copy(tp_complex), pstream__),
-        "assigning variable tp_complex");
+      tp_complex = foo3(tp_complex, pstream__);
       current_statement__ = 55;
       stan::model::assign(tp_complex_array, foo4(pstream__),
         "assigning variable tp_complex_array");
@@ -2198,52 +2167,41 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 5;
       tp_r = 1.1;
       current_statement__ = 9;
-      tp_complex = tp_r;
+      tp_complex = stan::math::promote_scalar<std::complex<local_scalar_t__>>(tp_r);
       current_statement__ = 10;
-      tp_complex = d_i;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(d_i);
       current_statement__ = 11;
-      tp_complex = d_r;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(d_r);
       current_statement__ = 12;
-      tp_complex = p_r;
+      tp_complex = stan::math::promote_scalar<std::complex<local_scalar_t__>>(p_r);
       current_statement__ = 13;
-      tp_complex = 1;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(1);
       current_statement__ = 14;
-      tp_complex = 1.1;
+      tp_complex = stan::math::promote_scalar<std::complex<double>>(1.1);
       current_statement__ = 15;
-      stan::model::assign(tp_complex, d_complex,
-        "assigning variable tp_complex");
+      tp_complex = d_complex;
       current_statement__ = 16;
-      stan::model::assign(tp_complex,
-        stan::model::rvalue(d_complex_array, "d_complex_array",
-          stan::model::index_uni(1)), "assigning variable tp_complex");
+      tp_complex = stan::model::rvalue(d_complex_array, "d_complex_array",
+                     stan::model::index_uni(1));
       current_statement__ = 17;
-      stan::model::assign(tp_complex, p_complex,
-        "assigning variable tp_complex");
+      tp_complex = p_complex;
       current_statement__ = 18;
-      stan::model::assign(tp_complex,
-        stan::model::rvalue(p_complex_array, "p_complex_array",
-          stan::model::index_uni(1)), "assigning variable tp_complex");
+      tp_complex = stan::model::rvalue(p_complex_array, "p_complex_array",
+                     stan::model::index_uni(1));
       current_statement__ = 19;
-      stan::model::assign(tp_complex, stan::math::to_complex(),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex();
       current_statement__ = 20;
-      stan::model::assign(tp_complex, stan::math::to_complex(1),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1);
       current_statement__ = 21;
-      stan::model::assign(tp_complex, stan::math::to_complex(1.2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1.2);
       current_statement__ = 22;
-      stan::model::assign(tp_complex, stan::math::to_complex(1, 2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1, 2);
       current_statement__ = 23;
-      stan::model::assign(tp_complex, stan::math::to_complex(1.1, 2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1.1, 2);
       current_statement__ = 24;
-      stan::model::assign(tp_complex, stan::math::to_complex(1, 2.2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1, 2.2);
       current_statement__ = 25;
-      stan::model::assign(tp_complex, stan::math::to_complex(1.1, 2.2),
-        "assigning variable tp_complex");
+      tp_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 26;
       stan::model::assign(tp_complex_array, d_complex_array,
         "assigning variable tp_complex_array");
@@ -2267,7 +2225,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       stan::model::assign(tp_complex_array_2d,
         std::vector<std::vector<std::complex<local_scalar_t__>>>{
         std::vector<std::complex<local_scalar_t__>>{1, tp_complex, 3},
-        std::vector<std::complex<local_scalar_t__>>{stan::math::to_complex(),
+        std::vector<std::complex<double>>{stan::math::to_complex(),
         stan::math::to_complex(1.1), stan::math::to_complex(1, 2.1)}},
         "assigning variable tp_complex_array_2d");
       current_statement__ = 33;
@@ -2275,7 +2233,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 34;
-      stan::model::assign(tp_complex_array_2d, 1,
+      stan::model::assign(tp_complex_array_2d,
+        stan::math::promote_scalar<std::complex<double>>(1),
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 35;
@@ -2310,11 +2269,9 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             {
               std::complex<local_scalar_t__> tp_k;
               current_statement__ = 43;
-              stan::model::assign(tp_k, tp_j[(sym1__ - 1)],
-                "assigning variable tp_k");
+              tp_k = tp_j[(sym1__ - 1)];
               current_statement__ = 44;
-              stan::model::assign(tp_complex, tp_k,
-                "assigning variable tp_complex");
+              tp_complex = tp_k;
             }
           }
         }
@@ -2342,17 +2299,13 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                  "tp_complex_array_2d",
                  stan::model::index_uni(1), stan::model::index_uni(1)));
       current_statement__ = 51;
-      stan::model::assign(tp_complex, foo(pstream__),
-        "assigning variable tp_complex");
+      tp_complex = foo(pstream__);
       current_statement__ = 52;
       tp_r = foo1(tp_complex, pstream__);
       current_statement__ = 53;
-      stan::model::assign(tp_complex, foo2(tp_r, pstream__),
-        "assigning variable tp_complex");
+      tp_complex = foo2(tp_r, pstream__);
       current_statement__ = 54;
-      stan::model::assign(tp_complex,
-        foo3(stan::model::deep_copy(tp_complex), pstream__),
-        "assigning variable tp_complex");
+      tp_complex = foo3(tp_complex, pstream__);
       current_statement__ = 55;
       stan::model::assign(tp_complex_array, foo4(pstream__),
         "assigning variable tp_complex_array");
@@ -2408,54 +2361,43 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
              std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
                std::numeric_limits<double>::quiet_NaN())));
       current_statement__ = 67;
-      gq_complex = gq_i;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(gq_i);
       current_statement__ = 68;
-      gq_complex = gq_r;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(gq_r);
       current_statement__ = 69;
-      gq_complex = d_i;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(d_i);
       current_statement__ = 70;
-      gq_complex = d_r;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(d_r);
       current_statement__ = 71;
-      gq_complex = p_r;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(p_r);
       current_statement__ = 72;
-      gq_complex = 1;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(1);
       current_statement__ = 73;
-      gq_complex = 1.1;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(1.1);
       current_statement__ = 74;
-      stan::model::assign(gq_complex, d_complex,
-        "assigning variable gq_complex");
+      gq_complex = d_complex;
       current_statement__ = 75;
-      stan::model::assign(gq_complex,
-        stan::model::rvalue(d_complex_array, "d_complex_array",
-          stan::model::index_uni(1)), "assigning variable gq_complex");
+      gq_complex = stan::model::rvalue(d_complex_array, "d_complex_array",
+                     stan::model::index_uni(1));
       current_statement__ = 76;
-      stan::model::assign(gq_complex, p_complex,
-        "assigning variable gq_complex");
+      gq_complex = p_complex;
       current_statement__ = 77;
-      stan::model::assign(gq_complex,
-        stan::model::rvalue(p_complex_array, "p_complex_array",
-          stan::model::index_uni(1)), "assigning variable gq_complex");
+      gq_complex = stan::model::rvalue(p_complex_array, "p_complex_array",
+                     stan::model::index_uni(1));
       current_statement__ = 78;
-      stan::model::assign(gq_complex, stan::math::to_complex(),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex();
       current_statement__ = 79;
-      stan::model::assign(gq_complex, stan::math::to_complex(1),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(1);
       current_statement__ = 80;
-      stan::model::assign(gq_complex, stan::math::to_complex(1.2),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(1.2);
       current_statement__ = 81;
-      stan::model::assign(gq_complex, stan::math::to_complex(1, 2),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(1, 2);
       current_statement__ = 82;
-      stan::model::assign(gq_complex, stan::math::to_complex(1.1, 2),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(1.1, 2);
       current_statement__ = 83;
-      stan::model::assign(gq_complex, stan::math::to_complex(1, 2.2),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(1, 2.2);
       current_statement__ = 84;
-      stan::model::assign(gq_complex, stan::math::to_complex(1.1, 2.2),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 85;
       stan::model::assign(gq_complex_array, d_complex_array,
         "assigning variable gq_complex_array");
@@ -2487,7 +2429,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         "assigning variable gq_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 93;
-      stan::model::assign(gq_complex_array_2d, 1,
+      stan::model::assign(gq_complex_array_2d,
+        stan::math::promote_scalar<std::complex<double>>(1),
         "assigning variable gq_complex_array_2d", stan::model::index_uni(1),
                                                     stan::model::index_uni(1));
       current_statement__ = 94;
@@ -2522,11 +2465,9 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             {
               std::complex<double> gq_k;
               current_statement__ = 102;
-              stan::model::assign(gq_k, gq_j[(sym1__ - 1)],
-                "assigning variable gq_k");
+              gq_k = gq_j[(sym1__ - 1)];
               current_statement__ = 103;
-              stan::model::assign(gq_complex, gq_k,
-                "assigning variable gq_complex");
+              gq_complex = gq_k;
             }
           }
         }
@@ -2554,17 +2495,13 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                  "gq_complex_array_2d",
                  stan::model::index_uni(1), stan::model::index_uni(1)));
       current_statement__ = 110;
-      stan::model::assign(gq_complex, foo(pstream__),
-        "assigning variable gq_complex");
+      gq_complex = foo(pstream__);
       current_statement__ = 111;
       gq_r = foo1(gq_complex, pstream__);
       current_statement__ = 112;
-      stan::model::assign(gq_complex, foo2(gq_r, pstream__),
-        "assigning variable gq_complex");
+      gq_complex = foo2(gq_r, pstream__);
       current_statement__ = 113;
-      stan::model::assign(gq_complex,
-        foo3(stan::model::deep_copy(gq_complex), pstream__),
-        "assigning variable gq_complex");
+      gq_complex = foo3(gq_complex, pstream__);
       current_statement__ = 114;
       stan::model::assign(gq_complex_array, foo4(pstream__),
         "assigning variable gq_complex_array");
@@ -2590,223 +2527,156 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
            std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 121;
-      stan::model::assign(z, stan::math::to_complex(1, 2),
-        "assigning variable z");
+      z = stan::math::to_complex(1, 2);
       std::complex<double> y =
          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
            std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 122;
-      stan::model::assign(y, stan::math::to_complex(3, 4),
-        "assigning variable y");
+      y = stan::math::to_complex(3, 4);
       std::vector<int> i_arr =
          std::vector<int>(0, std::numeric_limits<int>::min());
       std::vector<int> i_arr_1 =
          std::vector<int>(1, std::numeric_limits<int>::min());
       current_statement__ = 125;
-      stan::model::assign(gq_complex, (z + y),
-        "assigning variable gq_complex");
+      gq_complex = (z + y);
       current_statement__ = 126;
-      stan::model::assign(gq_complex, (z + gq_r),
-        "assigning variable gq_complex");
+      gq_complex = (z + gq_r);
       current_statement__ = 127;
-      stan::model::assign(gq_complex, (gq_r + z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_r + z);
       current_statement__ = 128;
-      stan::model::assign(gq_complex, (z + gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (z + gq_i);
       current_statement__ = 129;
-      stan::model::assign(gq_complex, (gq_i + z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i + z);
       current_statement__ = 130;
-      stan::model::assign(gq_complex, (d_complex + p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex + p_complex);
       current_statement__ = 131;
-      stan::model::assign(gq_complex, (d_complex + d_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex + d_r);
       current_statement__ = 132;
-      stan::model::assign(gq_complex, (d_complex + p_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex + p_r);
       current_statement__ = 133;
-      stan::model::assign(gq_complex, (d_r + p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_r + p_complex);
       current_statement__ = 134;
-      stan::model::assign(gq_complex, (p_complex + p_r),
-        "assigning variable gq_complex");
+      gq_complex = (p_complex + p_r);
       current_statement__ = 135;
-      stan::model::assign(gq_complex, (d_complex + gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex + gq_i);
       current_statement__ = 136;
-      stan::model::assign(gq_complex, (gq_i + p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i + p_complex);
       current_statement__ = 137;
-      stan::model::assign(gq_complex, (z - y),
-        "assigning variable gq_complex");
+      gq_complex = (z - y);
       current_statement__ = 138;
-      stan::model::assign(gq_complex, (z - gq_r),
-        "assigning variable gq_complex");
+      gq_complex = (z - gq_r);
       current_statement__ = 139;
-      stan::model::assign(gq_complex, (gq_r - z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_r - z);
       current_statement__ = 140;
-      stan::model::assign(gq_complex, (z - gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (z - gq_i);
       current_statement__ = 141;
-      stan::model::assign(gq_complex, (gq_i - z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i - z);
       current_statement__ = 142;
-      stan::model::assign(gq_complex, (d_complex - p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex - p_complex);
       current_statement__ = 143;
-      stan::model::assign(gq_complex, (d_complex - d_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex - d_r);
       current_statement__ = 144;
-      stan::model::assign(gq_complex, (d_complex - p_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex - p_r);
       current_statement__ = 145;
-      stan::model::assign(gq_complex, (d_r - p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_r - p_complex);
       current_statement__ = 146;
-      stan::model::assign(gq_complex, (p_complex - p_r),
-        "assigning variable gq_complex");
+      gq_complex = (p_complex - p_r);
       current_statement__ = 147;
-      stan::model::assign(gq_complex, (d_complex - gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex - gq_i);
       current_statement__ = 148;
-      stan::model::assign(gq_complex, (gq_i - p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i - p_complex);
       current_statement__ = 149;
-      stan::model::assign(gq_complex, (z * y),
-        "assigning variable gq_complex");
+      gq_complex = (z * y);
       current_statement__ = 150;
-      stan::model::assign(gq_complex, (z * gq_r),
-        "assigning variable gq_complex");
+      gq_complex = (z * gq_r);
       current_statement__ = 151;
-      stan::model::assign(gq_complex, (gq_r * z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_r * z);
       current_statement__ = 152;
-      stan::model::assign(gq_complex, (z * gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (z * gq_i);
       current_statement__ = 153;
-      stan::model::assign(gq_complex, (gq_i * z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i * z);
       current_statement__ = 154;
-      stan::model::assign(gq_complex, (d_complex * p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex * p_complex);
       current_statement__ = 155;
-      stan::model::assign(gq_complex, (d_complex * d_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex * d_r);
       current_statement__ = 156;
-      stan::model::assign(gq_complex, (d_complex * p_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex * p_r);
       current_statement__ = 157;
-      stan::model::assign(gq_complex, (d_r * p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_r * p_complex);
       current_statement__ = 158;
-      stan::model::assign(gq_complex, (p_complex * p_r),
-        "assigning variable gq_complex");
+      gq_complex = (p_complex * p_r);
       current_statement__ = 159;
-      stan::model::assign(gq_complex, (d_complex * gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex * gq_i);
       current_statement__ = 160;
-      stan::model::assign(gq_complex, (gq_i * p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i * p_complex);
       current_statement__ = 161;
-      stan::model::assign(gq_complex, (z / y),
-        "assigning variable gq_complex");
+      gq_complex = (z / y);
       current_statement__ = 162;
-      stan::model::assign(gq_complex, (z / gq_r),
-        "assigning variable gq_complex");
+      gq_complex = (z / gq_r);
       current_statement__ = 163;
-      stan::model::assign(gq_complex, (gq_r / z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_r / z);
       current_statement__ = 164;
-      stan::model::assign(gq_complex, (z / gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (z / gq_i);
       current_statement__ = 165;
-      stan::model::assign(gq_complex, (gq_i / z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i / z);
       current_statement__ = 166;
-      stan::model::assign(gq_complex, (d_complex / p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex / p_complex);
       current_statement__ = 167;
-      stan::model::assign(gq_complex, (d_complex / d_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex / d_r);
       current_statement__ = 168;
-      stan::model::assign(gq_complex, (d_complex / p_r),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex / p_r);
       current_statement__ = 169;
-      stan::model::assign(gq_complex, (d_r / p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (d_r / p_complex);
       current_statement__ = 170;
-      stan::model::assign(gq_complex, (p_complex / p_r),
-        "assigning variable gq_complex");
+      gq_complex = (p_complex / p_r);
       current_statement__ = 171;
-      stan::model::assign(gq_complex, (d_complex / gq_i),
-        "assigning variable gq_complex");
+      gq_complex = (d_complex / gq_i);
       current_statement__ = 172;
-      stan::model::assign(gq_complex, (gq_i / p_complex),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i / p_complex);
       current_statement__ = 173;
-      stan::model::assign(gq_complex, stan::math::pow(z, y),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(z, y);
       current_statement__ = 174;
-      stan::model::assign(gq_complex, stan::math::pow(z, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(z, gq_r);
       current_statement__ = 175;
-      stan::model::assign(gq_complex, stan::math::pow(gq_r, z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(gq_r, z);
       current_statement__ = 176;
-      stan::model::assign(gq_complex, stan::math::pow(z, gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(z, gq_i);
       current_statement__ = 177;
-      stan::model::assign(gq_complex, stan::math::pow(gq_i, z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(gq_i, z);
       current_statement__ = 178;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, p_complex);
       current_statement__ = 179;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, d_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, d_r);
       current_statement__ = 180;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, p_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, p_r);
       current_statement__ = 181;
-      stan::model::assign(gq_complex, stan::math::pow(d_r, p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_r, p_complex);
       current_statement__ = 182;
-      stan::model::assign(gq_complex, stan::math::pow(p_complex, p_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(p_complex, p_r);
       current_statement__ = 183;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, gq_i);
       current_statement__ = 184;
-      stan::model::assign(gq_complex, stan::math::pow(gq_i, p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(gq_i, p_complex);
       current_statement__ = 185;
-      stan::model::assign(gq_complex, -z, "assigning variable gq_complex");
+      gq_complex = -z;
       current_statement__ = 186;
-      gq_complex = -gq_r;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(-gq_r);
       current_statement__ = 187;
-      gq_complex = -gq_i;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(-gq_i);
       current_statement__ = 188;
-      stan::model::assign(gq_complex, -d_complex,
-        "assigning variable gq_complex");
+      gq_complex = -d_complex;
       current_statement__ = 189;
-      gq_complex = -d_r;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(-d_r);
       current_statement__ = 190;
-      stan::model::assign(gq_complex, -p_complex,
-        "assigning variable gq_complex");
+      gq_complex = -p_complex;
       current_statement__ = 191;
-      gq_complex = -p_r;
+      gq_complex = stan::math::promote_scalar<std::complex<double>>(-p_r);
       current_statement__ = 192;
-      stan::model::assign(gq_complex, (gq_i ? z : y),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i ? z : y);
       current_statement__ = 193;
-      stan::model::assign(gq_complex, (gq_i ? p_complex : z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i ? p_complex : z);
       current_statement__ = 194;
-      stan::model::assign(gq_complex, (gq_i ? d_complex : z),
-        "assigning variable gq_complex");
+      gq_complex = (gq_i ? d_complex : z);
       current_statement__ = 195;
       gq_i = stan::math::logical_eq(z, z);
       current_statement__ = 196;
@@ -2854,86 +2724,59 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 217;
       gq_r = stan::math::abs(d_complex);
       current_statement__ = 218;
-      stan::model::assign(gq_complex, stan::math::acos(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::acos(z);
       current_statement__ = 219;
-      stan::model::assign(gq_complex, stan::math::acos(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::acos(p_complex);
       current_statement__ = 220;
-      stan::model::assign(gq_complex, stan::math::acos(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::acos(d_complex);
       current_statement__ = 221;
-      stan::model::assign(gq_complex, stan::math::acosh(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::acosh(z);
       current_statement__ = 222;
-      stan::model::assign(gq_complex, stan::math::acosh(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::acosh(p_complex);
       current_statement__ = 223;
-      stan::model::assign(gq_complex, stan::math::acosh(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::acosh(d_complex);
       current_statement__ = 224;
-      stan::model::assign(gq_complex, stan::math::asin(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::asin(z);
       current_statement__ = 225;
-      stan::model::assign(gq_complex, stan::math::asin(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::asin(p_complex);
       current_statement__ = 226;
-      stan::model::assign(gq_complex, stan::math::asin(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::asin(d_complex);
       current_statement__ = 227;
-      stan::model::assign(gq_complex, stan::math::asinh(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::asinh(z);
       current_statement__ = 228;
-      stan::model::assign(gq_complex, stan::math::asinh(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::asinh(p_complex);
       current_statement__ = 229;
-      stan::model::assign(gq_complex, stan::math::asinh(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::asinh(d_complex);
       current_statement__ = 230;
-      stan::model::assign(gq_complex, stan::math::atan(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::atan(z);
       current_statement__ = 231;
-      stan::model::assign(gq_complex, stan::math::atan(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::atan(p_complex);
       current_statement__ = 232;
-      stan::model::assign(gq_complex, stan::math::atan(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::atan(d_complex);
       current_statement__ = 233;
-      stan::model::assign(gq_complex, stan::math::atanh(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::atanh(z);
       current_statement__ = 234;
-      stan::model::assign(gq_complex, stan::math::atanh(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::atanh(p_complex);
       current_statement__ = 235;
-      stan::model::assign(gq_complex, stan::math::atanh(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::atanh(d_complex);
       current_statement__ = 236;
-      stan::model::assign(gq_complex, stan::math::conj(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::conj(z);
       current_statement__ = 237;
-      stan::model::assign(gq_complex, stan::math::conj(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::conj(p_complex);
       current_statement__ = 238;
-      stan::model::assign(gq_complex, stan::math::conj(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::conj(d_complex);
       current_statement__ = 239;
-      stan::model::assign(gq_complex, stan::math::cos(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::cos(z);
       current_statement__ = 240;
-      stan::model::assign(gq_complex, stan::math::cos(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::cos(p_complex);
       current_statement__ = 241;
-      stan::model::assign(gq_complex, stan::math::cos(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::cos(d_complex);
       current_statement__ = 242;
-      stan::model::assign(gq_complex, stan::math::cosh(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::cosh(z);
       current_statement__ = 243;
-      stan::model::assign(gq_complex, stan::math::cosh(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::cosh(p_complex);
       current_statement__ = 244;
-      stan::model::assign(gq_complex, stan::math::cosh(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::cosh(d_complex);
       current_statement__ = 245;
       stan::model::assign(i_arr, stan::math::dims(z),
         "assigning variable i_arr");
@@ -2953,14 +2796,11 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       stan::model::assign(i_arr_1, stan::math::dims(d_complex_array),
         "assigning variable i_arr_1");
       current_statement__ = 251;
-      stan::model::assign(gq_complex, stan::math::exp(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::exp(z);
       current_statement__ = 252;
-      stan::model::assign(gq_complex, stan::math::exp(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::exp(p_complex);
       current_statement__ = 253;
-      stan::model::assign(gq_complex, stan::math::exp(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::exp(d_complex);
       current_statement__ = 254;
       gq_r = stan::math::get_imag(z);
       current_statement__ = 255;
@@ -2986,23 +2826,17 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         stan::math::head(d_complex_array, 1),
         "assigning variable gq_complex_array");
       current_statement__ = 263;
-      stan::model::assign(gq_complex, stan::math::log(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::log(z);
       current_statement__ = 264;
-      stan::model::assign(gq_complex, stan::math::log(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::log(p_complex);
       current_statement__ = 265;
-      stan::model::assign(gq_complex, stan::math::log(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::log(d_complex);
       current_statement__ = 266;
-      stan::model::assign(gq_complex, stan::math::log10(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::log10(z);
       current_statement__ = 267;
-      stan::model::assign(gq_complex, stan::math::log10(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::log10(p_complex);
       current_statement__ = 268;
-      stan::model::assign(gq_complex, stan::math::log10(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::log10(d_complex);
       current_statement__ = 269;
       gq_r = stan::math::norm(z);
       current_statement__ = 270;
@@ -3016,80 +2850,55 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 274;
       gq_i = stan::math::num_elements(d_complex_array);
       current_statement__ = 275;
-      stan::model::assign(gq_complex, stan::math::polar(gq_r, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::polar(gq_r, gq_r);
       current_statement__ = 276;
-      stan::model::assign(gq_complex, stan::math::polar(gq_i, gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::polar(gq_i, gq_i);
       current_statement__ = 277;
-      stan::model::assign(gq_complex, stan::math::polar(gq_r, gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::polar(gq_r, gq_i);
       current_statement__ = 278;
-      stan::model::assign(gq_complex, stan::math::polar(gq_i, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::polar(gq_i, gq_r);
       current_statement__ = 279;
-      stan::model::assign(gq_complex, stan::math::polar(p_r, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::polar(p_r, gq_r);
       current_statement__ = 280;
-      stan::model::assign(gq_complex, stan::math::polar(d_r, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::polar(d_r, gq_r);
       current_statement__ = 281;
-      stan::model::assign(gq_complex, stan::math::polar(p_r, d_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::polar(p_r, d_r);
       current_statement__ = 282;
-      stan::model::assign(gq_complex, stan::math::pow(z, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(z, gq_r);
       current_statement__ = 283;
-      stan::model::assign(gq_complex, stan::math::pow(z, gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(z, gq_i);
       current_statement__ = 284;
-      stan::model::assign(gq_complex, stan::math::pow(z, z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(z, z);
       current_statement__ = 285;
-      stan::model::assign(gq_complex, stan::math::pow(p_complex, p_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(p_complex, p_r);
       current_statement__ = 286;
-      stan::model::assign(gq_complex, stan::math::pow(p_complex, d_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(p_complex, d_r);
       current_statement__ = 287;
-      stan::model::assign(gq_complex, stan::math::pow(p_complex, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(p_complex, gq_r);
       current_statement__ = 288;
-      stan::model::assign(gq_complex, stan::math::pow(p_complex, z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(p_complex, z);
       current_statement__ = 289;
-      stan::model::assign(gq_complex, stan::math::pow(p_complex, d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(p_complex, d_complex);
       current_statement__ = 290;
-      stan::model::assign(gq_complex, stan::math::pow(p_complex, p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(p_complex, p_complex);
       current_statement__ = 291;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, p_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, p_r);
       current_statement__ = 292;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, d_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, d_r);
       current_statement__ = 293;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, gq_r);
       current_statement__ = 294;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, z);
       current_statement__ = 295;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, d_complex);
       current_statement__ = 296;
-      stan::model::assign(gq_complex, stan::math::pow(d_complex, p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::pow(d_complex, p_complex);
       current_statement__ = 297;
-      stan::model::assign(gq_complex, stan::math::proj(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::proj(z);
       current_statement__ = 298;
-      stan::model::assign(gq_complex, stan::math::proj(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::proj(p_complex);
       current_statement__ = 299;
-      stan::model::assign(gq_complex, stan::math::proj(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::proj(d_complex);
       current_statement__ = 300;
       stan::model::assign(gq_complex_array,
         stan::math::reverse(stan::model::deep_copy(gq_complex_array)),
@@ -3103,23 +2912,17 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         stan::math::reverse(d_complex_array),
         "assigning variable gq_complex_array");
       current_statement__ = 303;
-      stan::model::assign(gq_complex, stan::math::sin(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sin(z);
       current_statement__ = 304;
-      stan::model::assign(gq_complex, stan::math::sin(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sin(p_complex);
       current_statement__ = 305;
-      stan::model::assign(gq_complex, stan::math::sin(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sin(d_complex);
       current_statement__ = 306;
-      stan::model::assign(gq_complex, stan::math::sinh(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sinh(z);
       current_statement__ = 307;
-      stan::model::assign(gq_complex, stan::math::sinh(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sinh(p_complex);
       current_statement__ = 308;
-      stan::model::assign(gq_complex, stan::math::sinh(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sinh(d_complex);
       current_statement__ = 309;
       gq_i = stan::math::size(gq_complex_array);
       current_statement__ = 310;
@@ -3127,14 +2930,11 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 311;
       gq_i = stan::math::size(d_complex_array);
       current_statement__ = 312;
-      stan::model::assign(gq_complex, stan::math::sqrt(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sqrt(z);
       current_statement__ = 313;
-      stan::model::assign(gq_complex, stan::math::sqrt(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sqrt(p_complex);
       current_statement__ = 314;
-      stan::model::assign(gq_complex, stan::math::sqrt(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::sqrt(d_complex);
       current_statement__ = 315;
       stan::model::assign(gq_complex_array,
         stan::math::tail(stan::model::deep_copy(gq_complex_array), 1),
@@ -3148,76 +2948,54 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         stan::math::tail(d_complex_array, 1),
         "assigning variable gq_complex_array");
       current_statement__ = 318;
-      stan::model::assign(gq_complex, stan::math::tan(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::tan(z);
       current_statement__ = 319;
-      stan::model::assign(gq_complex, stan::math::tan(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::tan(p_complex);
       current_statement__ = 320;
-      stan::model::assign(gq_complex, stan::math::tan(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::tan(d_complex);
       current_statement__ = 321;
-      stan::model::assign(gq_complex, stan::math::tanh(z),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::tanh(z);
       current_statement__ = 322;
-      stan::model::assign(gq_complex, stan::math::tanh(p_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::tanh(p_complex);
       current_statement__ = 323;
-      stan::model::assign(gq_complex, stan::math::tanh(d_complex),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::tanh(d_complex);
       current_statement__ = 324;
-      stan::model::assign(gq_complex, stan::math::to_complex(),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex();
       current_statement__ = 325;
-      stan::model::assign(gq_complex, stan::math::to_complex(gq_r, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(gq_r, gq_r);
       current_statement__ = 326;
-      stan::model::assign(gq_complex, stan::math::to_complex(gq_i, gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(gq_i, gq_i);
       current_statement__ = 327;
-      stan::model::assign(gq_complex, stan::math::to_complex(gq_r, gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(gq_r, gq_i);
       current_statement__ = 328;
-      stan::model::assign(gq_complex, stan::math::to_complex(gq_i, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(gq_i, gq_r);
       current_statement__ = 329;
-      stan::model::assign(gq_complex, stan::math::to_complex(gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(gq_r);
       current_statement__ = 330;
-      stan::model::assign(gq_complex, stan::math::to_complex(gq_i),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(gq_i);
       current_statement__ = 331;
-      stan::model::assign(gq_complex, stan::math::to_complex(p_r, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(p_r, gq_r);
       current_statement__ = 332;
-      stan::model::assign(gq_complex, stan::math::to_complex(p_r, d_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(p_r, d_r);
       current_statement__ = 333;
-      stan::model::assign(gq_complex, stan::math::to_complex(d_r, gq_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(d_r, gq_r);
       current_statement__ = 334;
-      stan::model::assign(gq_complex, stan::math::to_complex(p_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(p_r);
       current_statement__ = 335;
-      stan::model::assign(gq_complex, stan::math::to_complex(d_r),
-        "assigning variable gq_complex");
+      gq_complex = stan::math::to_complex(d_r);
       std::complex<double> zi =
          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
            std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 336;
-      stan::model::assign(zi, (1 + stan::math::to_complex(0, 3.14)),
-        "assigning variable zi");
+      zi = (1 + stan::math::to_complex(0, 3.14));
       current_statement__ = 337;
-      stan::model::assign(zi,
-        (stan::model::deep_copy(zi) * stan::math::to_complex(0, 0)),
-        "assigning variable zi");
+      zi = (zi * stan::math::to_complex(0, 0));
       std::complex<double> yi =
          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
            std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 338;
-      stan::model::assign(yi,
-        ((stan::math::to_complex(0, 1.1) + stan::math::to_complex(0.0, 2.2))
-          + stan::math::to_complex()), "assigning variable yi");
+      yi = ((stan::math::to_complex(0, 1.1) +
+              stan::math::to_complex(0.0, 2.2)) + stan::math::to_complex());
       double x = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 339;
       x = stan::math::get_real(
@@ -3265,8 +3043,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       out__.write(p_r);
       std::complex<local_scalar_t__> p_complex =
          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      stan::model::assign(p_complex, in__.read<local_scalar_t__>(),
-        "assigning variable p_complex");
+      p_complex = in__.read<local_scalar_t__>();
       out__.write(p_complex);
       std::vector<std::complex<local_scalar_t__>> p_complex_array =
          std::vector<std::complex<local_scalar_t__>>(2, 
@@ -5283,31 +5060,21 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
          std::vector<std::vector<local_scalar_t__>>(3, 
            std::vector<local_scalar_t__>(3, DUMMY_VAR__));
       current_statement__ = 2;
-      stan::model::assign(y, std::vector<std::vector<local_scalar_t__>>{
-        stan::math::promote_scalar<local_scalar_t__>(x), xx, xx},
-        "assigning variable y");
+      stan::model::assign(y, std::vector<std::vector<local_scalar_t__>>{x,
+        xx, xx}, "assigning variable y");
       std::vector<std::vector<local_scalar_t__>> w =
          std::vector<std::vector<local_scalar_t__>>(3, 
            std::vector<local_scalar_t__>(3, DUMMY_VAR__));
       current_statement__ = 3;
       stan::model::assign(w, std::vector<std::vector<local_scalar_t__>>{
-        std::vector<local_scalar_t__>{
-        stan::math::promote_scalar<local_scalar_t__>(1.0),
-        stan::math::promote_scalar<local_scalar_t__>(2),
-        stan::math::promote_scalar<local_scalar_t__>(3)}, xx, xx},
-        "assigning variable w");
+        std::vector<double>{1.0, 2, 3}, xx, xx}, "assigning variable w");
       std::vector<std::vector<local_scalar_t__>> td_arr33 =
          std::vector<std::vector<local_scalar_t__>>(3, 
            std::vector<local_scalar_t__>(3, DUMMY_VAR__));
       current_statement__ = 4;
       stan::model::assign(td_arr33, std::vector<std::vector<double>>{
-        std::vector<double>{stan::math::promote_scalar<double>(1),
-        stan::math::promote_scalar<double>(2),
-        stan::math::promote_scalar<double>(3)}, std::vector<double>{
-        stan::math::promote_scalar<double>(1), 2.,
-        stan::math::promote_scalar<double>(3)}, std::vector<double>{1., 2.,
-        stan::math::promote_scalar<double>(3)}},
-        "assigning variable td_arr33");
+        std::vector<int>{1, 2, 3}, std::vector<double>{1, 2., 3},
+        std::vector<double>{1., 2., 3}}, "assigning variable td_arr33");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5360,25 +5127,15 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
         return ;
       } 
       current_statement__ = 2;
-      stan::model::assign(y, std::vector<std::vector<local_scalar_t__>>{
-        stan::math::promote_scalar<local_scalar_t__>(x), xx, xx},
-        "assigning variable y");
+      stan::model::assign(y, std::vector<std::vector<local_scalar_t__>>{x,
+        xx, xx}, "assigning variable y");
       current_statement__ = 3;
       stan::model::assign(w, std::vector<std::vector<local_scalar_t__>>{
-        std::vector<local_scalar_t__>{
-        stan::math::promote_scalar<local_scalar_t__>(1.0),
-        stan::math::promote_scalar<local_scalar_t__>(2),
-        stan::math::promote_scalar<local_scalar_t__>(3)}, xx, xx},
-        "assigning variable w");
+        std::vector<double>{1.0, 2, 3}, xx, xx}, "assigning variable w");
       current_statement__ = 4;
       stan::model::assign(td_arr33, std::vector<std::vector<double>>{
-        std::vector<double>{stan::math::promote_scalar<double>(1),
-        stan::math::promote_scalar<double>(2),
-        stan::math::promote_scalar<double>(3)}, std::vector<double>{
-        stan::math::promote_scalar<double>(1), 2.,
-        stan::math::promote_scalar<double>(3)}, std::vector<double>{1., 2.,
-        stan::math::promote_scalar<double>(3)}},
-        "assigning variable td_arr33");
+        std::vector<int>{1, 2, 3}, std::vector<double>{1, 2., 3},
+        std::vector<double>{1., 2., 3}}, "assigning variable td_arr33");
       if (emit_transformed_parameters__) {
         for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
           for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
@@ -10203,7 +9960,8 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
       
       
       current_statement__ = 363;
-      stan::model::assign(x_mul_ind, std::vector<int>{1, 2},
+      stan::model::assign(x_mul_ind,
+        stan::math::promote_scalar<double>(std::vector<int>{1, 2}),
         "assigning variable x_mul_ind");
       current_statement__ = 364;
       transformed_data_real = std::numeric_limits<double>::quiet_NaN();
@@ -24251,9 +24009,8 @@ ident_functor__::operator()(const std::complex<T0__>& x,
          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
            std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 2;
-      stan::model::assign(zi,
-        ident(stan::math::promote_scalar<std::complex<double>>(z), pstream__),
-        "assigning variable zi");
+      zi = ident(
+             stan::math::promote_scalar<std::complex<double>>(z), pstream__);
       std::vector<int> zs =
          std::vector<int>(4, std::numeric_limits<int>::min());
       current_statement__ = 3;

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -632,19 +632,18 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       std::complex<local_scalar_t__> z =
          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
       current_statement__ = 7;
-      stan::model::assign(z,
-        (1 ? stan::math::to_complex(0, 3) :
-           stan::math::promote_scalar<std::complex<double>>(2)),
-        "assigning variable z");
+      z = (1 ? stan::math::to_complex(0, 3) :
+             stan::math::promote_scalar<std::complex<double>>(2));
       {
         std::complex<local_scalar_t__> z2 =
            std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
         current_statement__ = 8;
-        z2 = (1 ? r : 2);
+        z2 = stan::math::promote_scalar<std::complex<local_scalar_t__>>((
+            1 ? r : 2));
         current_statement__ = 9;
-        stan::model::assign(z2,
-          (1 ? stan::math::promote_scalar<std::complex<local_scalar_t__>>(0)
-             : zp), "assigning variable z2");
+        z2 = (1 ?
+                stan::math::promote_scalar<std::complex<local_scalar_t__>>(0)
+                : zp);
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -727,10 +726,8 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
            stan::math::eval(stan::math::multiply(2, a))),
         "assigning variable d");
       current_statement__ = 7;
-      stan::model::assign(z,
-        (1 ? stan::math::to_complex(0, 3) :
-           stan::math::promote_scalar<std::complex<double>>(2)),
-        "assigning variable z");
+      z = (1 ? stan::math::to_complex(0, 3) :
+             stan::math::promote_scalar<std::complex<double>>(2));
       if (emit_transformed_parameters__) {
         out__.write(c);
         out__.write(d);
@@ -778,8 +775,7 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       out__.write(r);
       std::complex<local_scalar_t__> zp =
          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      stan::model::assign(zp, in__.read<local_scalar_t__>(),
-        "assigning variable zp");
+      zp = in__.read<local_scalar_t__>();
       out__.write(zp);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -733,9 +733,15 @@
                                       (meta <opaque>))
                                      ((pattern
                                        (Assignment (z UReal ())
-                                        ((pattern (Lit Int 0))
+                                        ((pattern
+                                          (Promotion
+                                           ((pattern (Lit Int 0))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))
+                                           UReal DataOnly))
                                          (meta
-                                          ((type_ UInt) (loc <opaque>)
+                                          ((type_ UReal) (loc <opaque>)
                                            (adlevel DataOnly))))))
                                       (meta <opaque>))
                                      ((pattern Break) (meta <opaque>)))))
@@ -899,9 +905,15 @@
                               (meta <opaque>))
                              ((pattern
                                (Assignment (z UReal ())
-                                ((pattern (Lit Int 0))
+                                ((pattern
+                                  (Promotion
+                                   ((pattern (Lit Int 0))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly))))
+                                   UReal DataOnly))
                                  (meta
-                                  ((type_ UInt) (loc <opaque>)
+                                  ((type_ UReal) (loc <opaque>)
                                    (adlevel DataOnly))))))
                               (meta <opaque>))
                              ((pattern Break) (meta <opaque>)))))
@@ -1025,9 +1037,15 @@
                               (meta <opaque>))
                              ((pattern
                                (Assignment (z UReal ())
-                                ((pattern (Lit Int 0))
+                                ((pattern
+                                  (Promotion
+                                   ((pattern (Lit Int 0))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly))))
+                                   UReal DataOnly))
                                  (meta
-                                  ((type_ UInt) (loc <opaque>)
+                                  ((type_ UReal) (loc <opaque>)
                                    (adlevel DataOnly))))))
                               (meta <opaque>))
                              ((pattern Break) (meta <opaque>)))))
@@ -4544,9 +4562,14 @@
                     (meta <opaque>))
                    ((pattern
                      (Assignment (z UReal ())
-                      ((pattern (Lit Int 0))
+                      ((pattern
+                        (Promotion
+                         ((pattern (Lit Int 0))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         UReal DataOnly))
                        (meta
-                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
                     (meta <opaque>)))))
                 (meta <opaque>)))))
             (meta <opaque>)))))
@@ -4635,9 +4658,15 @@
                         (meta <opaque>))
                        ((pattern
                          (Assignment (z UReal ())
-                          ((pattern (Var i))
+                          ((pattern
+                            (Promotion
+                             ((pattern (Var i))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             UReal DataOnly))
                            (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
                 (meta <opaque>)))))
@@ -4736,14 +4765,18 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (Assignment (x_mul_ind (UArray UInt) ())
+     (Assignment (x_mul_ind (UArray UReal) ())
       ((pattern
-        (FunApp (CompilerInternal FnMakeArray)
-         (((pattern (Lit Int 1))
-           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-          ((pattern (Lit Int 2))
-           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+        (Promotion
+         ((pattern
+           (FunApp (CompilerInternal FnMakeArray)
+            (((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         UReal DataOnly))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
     (meta <opaque>))
    ((pattern
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_real)

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -751,9 +751,15 @@
                                       (meta <opaque>))
                                      ((pattern
                                        (Assignment (z UReal ())
-                                        ((pattern (Lit Int 0))
+                                        ((pattern
+                                          (Promotion
+                                           ((pattern (Lit Int 0))
+                                            (meta
+                                             ((type_ UInt) (loc <opaque>)
+                                              (adlevel DataOnly))))
+                                           UReal DataOnly))
                                          (meta
-                                          ((type_ UInt) (loc <opaque>)
+                                          ((type_ UReal) (loc <opaque>)
                                            (adlevel DataOnly))))))
                                       (meta <opaque>))
                                      ((pattern Break) (meta <opaque>)))))
@@ -917,9 +923,15 @@
                               (meta <opaque>))
                              ((pattern
                                (Assignment (z UReal ())
-                                ((pattern (Lit Int 0))
+                                ((pattern
+                                  (Promotion
+                                   ((pattern (Lit Int 0))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly))))
+                                   UReal DataOnly))
                                  (meta
-                                  ((type_ UInt) (loc <opaque>)
+                                  ((type_ UReal) (loc <opaque>)
                                    (adlevel DataOnly))))))
                               (meta <opaque>))
                              ((pattern Break) (meta <opaque>)))))
@@ -1043,9 +1055,15 @@
                               (meta <opaque>))
                              ((pattern
                                (Assignment (z UReal ())
-                                ((pattern (Lit Int 0))
+                                ((pattern
+                                  (Promotion
+                                   ((pattern (Lit Int 0))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly))))
+                                   UReal DataOnly))
                                  (meta
-                                  ((type_ UInt) (loc <opaque>)
+                                  ((type_ UReal) (loc <opaque>)
                                    (adlevel DataOnly))))))
                               (meta <opaque>))
                              ((pattern Break) (meta <opaque>)))))
@@ -7951,9 +7969,14 @@
                     (meta <opaque>))
                    ((pattern
                      (Assignment (z UReal ())
-                      ((pattern (Lit Int 0))
+                      ((pattern
+                        (Promotion
+                         ((pattern (Lit Int 0))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                         UReal DataOnly))
                        (meta
-                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
                     (meta <opaque>)))))
                 (meta <opaque>)))))
             (meta <opaque>)))))
@@ -8042,9 +8065,15 @@
                         (meta <opaque>))
                        ((pattern
                          (Assignment (z UReal ())
-                          ((pattern (Var i))
+                          ((pattern
+                            (Promotion
+                             ((pattern (Var i))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             UReal DataOnly))
                            (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
                 (meta <opaque>)))))
@@ -8143,14 +8172,18 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (Assignment (x_mul_ind (UArray UInt) ())
+     (Assignment (x_mul_ind (UArray UReal) ())
       ((pattern
-        (FunApp (CompilerInternal FnMakeArray)
-         (((pattern (Lit Int 1))
-           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-          ((pattern (Lit Int 2))
-           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-       (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))))
+        (Promotion
+         ((pattern
+           (FunApp (CompilerInternal FnMakeArray)
+            (((pattern (Lit Int 1))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             ((pattern (Lit Int 2))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UInt)) (loc <opaque>) (adlevel DataOnly))))
+         UReal DataOnly))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
     (meta <opaque>))
    ((pattern
      (Decl (decl_adtype DataOnly) (decl_id transformed_data_real)

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2092,6 +2092,8 @@ simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
 class ad_level_failing_model final : public model_base_crtp<ad_level_failing_model> {
 
  private:
+  double lcm_sym26__;
+  double lcm_sym25__;
   int N_t;
   std::vector<double> t;
   std::vector<double> y0;
@@ -2126,6 +2128,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
+      
+      
       int pos__;
       pos__ = 1;
       current_statement__ = 16;
@@ -2187,8 +2191,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       kappa = std::numeric_limits<double>::quiet_NaN();
       
       
-      current_statement__ = 25;
-      kappa = 1000000;
+      lcm_sym26__ = 1000000;
+      kappa = lcm_sym26__;
       current_statement__ = 26;
       x_r = std::vector<double>(0, std::numeric_limits<double>::quiet_NaN());
       
@@ -2198,7 +2202,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       
       
       current_statement__ = 25;
-      stan::math::check_greater_or_equal(function__, "kappa", 1000000, 0);
+      stan::math::check_greater_or_equal(function__, "kappa", lcm_sym26__, 0);
       current_statement__ = 28;
       stan::math::validate_non_negative_index("y", "N_t", N_t);
     } catch (const std::exception& e) {
@@ -2260,8 +2264,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<double> theta =
            std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
         stan::model::assign(lcm_sym24__, std::vector<local_scalar_t__>{beta,
-          stan::math::promote_scalar<local_scalar_t__>(1000000), gamma, xi,
-          delta}, "assigning variable lcm_sym24__");
+          1000000, gamma, xi, delta}, "assigning variable lcm_sym24__");
         stan::model::assign(lcm_sym19__,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, 0, t,
             lcm_sym24__, x_r, x_i, pstream__),
@@ -2389,9 +2392,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       {
         std::vector<double> theta =
            std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
-        stan::model::assign(lcm_sym9__, std::vector<double>{beta,
-          stan::math::promote_scalar<double>(1000000), gamma, xi, delta},
-          "assigning variable lcm_sym9__");
+        stan::model::assign(lcm_sym9__, std::vector<double>{beta, 1000000,
+          gamma, xi, delta}, "assigning variable lcm_sym9__");
         stan::model::assign(lcm_sym8__,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, 0, t,
             lcm_sym9__, x_r, x_i, pstream__), "assigning variable lcm_sym8__");
@@ -2516,11 +2518,11 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     param_names__.emplace_back(std::string() + "xi");
     param_names__.emplace_back(std::string() + "delta");
     if (emit_transformed_parameters__) {
-      for (int sym25__ = 1; sym25__ <= 4; ++sym25__) {
+      for (int sym27__ = 1; sym27__ <= 4; ++sym27__) {
         {
-          for (int sym26__ = 1; sym26__ <= N_t; ++sym26__) {
+          for (int sym28__ = 1; sym28__ <= N_t; ++sym28__) {
             {
-              param_names__.emplace_back(std::string() + "y" + '.' + std::to_string(sym26__) + '.' + std::to_string(sym25__));
+              param_names__.emplace_back(std::string() + "y" + '.' + std::to_string(sym28__) + '.' + std::to_string(sym27__));
             } 
           }
         } 
@@ -2544,11 +2546,11 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     param_names__.emplace_back(std::string() + "xi");
     param_names__.emplace_back(std::string() + "delta");
     if (emit_transformed_parameters__) {
-      for (int sym25__ = 1; sym25__ <= 4; ++sym25__) {
+      for (int sym27__ = 1; sym27__ <= 4; ++sym27__) {
         {
-          for (int sym26__ = 1; sym26__ <= N_t; ++sym26__) {
+          for (int sym28__ = 1; sym28__ <= N_t; ++sym28__) {
             {
-              param_names__.emplace_back(std::string() + "y" + '.' + std::to_string(sym26__) + '.' + std::to_string(sym25__));
+              param_names__.emplace_back(std::string() + "y" + '.' + std::to_string(sym28__) + '.' + std::to_string(sym27__));
             } 
           }
         } 
@@ -2706,8 +2708,8 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'copy_fail.stan', line 72, column 2 to column 52)",
  " (in 'copy_fail.stan', line 73, column 2 to column 50)",
  " (in 'copy_fail.stan', line 74, column 2 to column 50)",
- " (in 'copy_fail.stan', line 79, column 6 to column 20)",
  " (in 'copy_fail.stan', line 80, column 6 to column 18)",
+ " (in 'copy_fail.stan', line 79, column 6 to column 20)",
  " (in 'copy_fail.stan', line 78, column 34 to line 81, column 5)",
  " (in 'copy_fail.stan', line 83, column 6 to column 32)",
  " (in 'copy_fail.stan', line 84, column 6 to column 23)",
@@ -3047,6 +3049,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
  class copy_fail_model final : public model_base_crtp<copy_fail_model> {
 
  private:
+  int lcm_sym131__;
+  int lcm_sym130__;
   int lcm_sym129__;
   int lcm_sym128__;
   int lcm_sym127__;
@@ -3064,8 +3068,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   int lcm_sym115__;
   int lcm_sym114__;
   int lcm_sym113__;
-  int lcm_sym112__;
-  int lcm_sym111__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -3163,8 +3165,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         current_statement__ = 36;
         if (stan::math::logical_gte(n_occasions, 1)) {
           {
-            lcm_sym112__ = stan::math::logical_gte(nind, 1);
-            if (lcm_sym112__) {
+            lcm_sym114__ = stan::math::logical_gte(nind, 1);
+            if (lcm_sym114__) {
               current_statement__ = 36;
               stan::model::assign(y,
                 stan::model::rvalue(y_flat__, "y_flat__",
@@ -3184,7 +3186,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
             } 
             for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
               current_statement__ = 36;
-              if (lcm_sym112__) {
+              if (lcm_sym114__) {
                 current_statement__ = 36;
                 stan::model::assign(y, y_flat__[(pos__ - 1)],
                   "assigning variable y", stan::model::index_uni(1),
@@ -3203,7 +3205,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
             }
           }
         } else {
-          lcm_sym112__ = stan::math::logical_gte(nind, 1);
+          lcm_sym114__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 36;
@@ -3222,16 +3224,16 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::check_greater_or_equal(function__, "max_age", max_age, 1);
       current_statement__ = 38;
       stan::math::validate_non_negative_index("x", "nind", nind);
-      lcm_sym114__ = (n_occasions - 1);
+      lcm_sym116__ = (n_occasions - 1);
       stan::math::validate_non_negative_index("x", "n_occasions - 1",
-                                              lcm_sym114__);
+                                              lcm_sym116__);
       current_statement__ = 39;
       context__.validate_dims("data initialization","x","int",
            std::vector<size_t>{static_cast<size_t>(nind),
-            static_cast<size_t>(lcm_sym114__)});
+            static_cast<size_t>(lcm_sym116__)});
       x = 
         std::vector<std::vector<int>>(nind, 
-          std::vector<int>(lcm_sym114__, std::numeric_limits<int>::min()));
+          std::vector<int>(lcm_sym116__, std::numeric_limits<int>::min()));
       
       
       {
@@ -3241,9 +3243,9 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         current_statement__ = 39;
         pos__ = 1;
         current_statement__ = 39;
-        if (stan::math::logical_gte(lcm_sym114__, 1)) {
+        if (stan::math::logical_gte(lcm_sym116__, 1)) {
           current_statement__ = 39;
-          if (lcm_sym112__) {
+          if (lcm_sym114__) {
             current_statement__ = 39;
             stan::model::assign(x,
               stan::model::rvalue(x_flat__, "x_flat__",
@@ -3261,9 +3263,9 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
               pos__ = (pos__ + 1);
             }
           } 
-          for (int sym1__ = 2; sym1__ <= lcm_sym114__; ++sym1__) {
+          for (int sym1__ = 2; sym1__ <= lcm_sym116__; ++sym1__) {
             current_statement__ = 39;
-            if (lcm_sym112__) {
+            if (lcm_sym114__) {
               current_statement__ = 39;
               stan::model::assign(x, x_flat__[(pos__ - 1)],
                 "assigning variable x", stan::model::index_uni(1),
@@ -3291,7 +3293,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       
       
       current_statement__ = 40;
-      n_occ_minus_1 = lcm_sym114__;
+      n_occ_minus_1 = lcm_sym116__;
       current_statement__ = 41;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 42;
@@ -3305,15 +3307,15 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       
       
       current_statement__ = 49;
-      if (lcm_sym112__) {
+      if (lcm_sym114__) {
         int inline_sym17__;
         int inline_sym19__;
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym121__ = stan::math::size(
+          lcm_sym123__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym121__;
+          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym123__;
                ++inline_sym18__) {
             current_statement__ = 46;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
@@ -3337,10 +3339,10 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           int inline_sym19__;
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym120__ = stan::math::size(
+            lcm_sym122__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym120__;
+            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym122__;
                  ++inline_sym18__) {
               current_statement__ = 46;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
@@ -3362,25 +3364,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         }
       } 
       current_statement__ = 56;
-      if (lcm_sym112__) {
+      if (lcm_sym114__) {
         int inline_sym21__;
         int inline_sym24__;
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym121__ = stan::math::size(
+          lcm_sym123__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          lcm_sym118__ = (lcm_sym121__ - 1);
-          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym118__;
+          lcm_sym120__ = (lcm_sym123__ - 1);
+          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym120__;
                ++inline_sym23__) {
             int inline_sym22__ = std::numeric_limits<int>::min();
-            lcm_sym117__ = (lcm_sym121__ - inline_sym23__);
-            inline_sym22__ = lcm_sym117__;
+            lcm_sym119__ = (lcm_sym123__ - inline_sym23__);
+            inline_sym22__ = lcm_sym119__;
             current_statement__ = 52;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
-                (lcm_sym117__ - 1)]) {
+                (lcm_sym119__ - 1)]) {
               inline_sym24__ = 1;
-              inline_sym21__ = lcm_sym117__;
+              inline_sym21__ = lcm_sym119__;
               break;
             } 
           }
@@ -3398,20 +3400,20 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           int inline_sym24__;
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym120__ = stan::math::size(
+            lcm_sym122__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            lcm_sym116__ = (lcm_sym120__ - 1);
-            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym116__;
+            lcm_sym118__ = (lcm_sym122__ - 1);
+            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym118__;
                  ++inline_sym23__) {
               int inline_sym22__ = std::numeric_limits<int>::min();
-              lcm_sym115__ = (lcm_sym120__ - inline_sym23__);
-              inline_sym22__ = lcm_sym115__;
+              lcm_sym117__ = (lcm_sym122__ - inline_sym23__);
+              inline_sym22__ = lcm_sym117__;
               current_statement__ = 52;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
-                  (lcm_sym115__ - 1)]) {
+                  (lcm_sym117__ - 1)]) {
                 inline_sym24__ = 1;
-                inline_sym21__ = lcm_sym115__;
+                inline_sym21__ = lcm_sym117__;
                 break;
               } 
             }
@@ -3440,12 +3442,12 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 59;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-                                              lcm_sym114__);
+                                              lcm_sym116__);
       current_statement__ = 60;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 61;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-                                              lcm_sym114__);
+                                              lcm_sym116__);
       current_statement__ = 62;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 63;
@@ -3476,10 +3478,12 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym112__;
+      int lcm_sym111__;
       int lcm_sym110__;
       int lcm_sym109__;
       int lcm_sym108__;
-      int lcm_sym107__;
+      double lcm_sym107__;
       double lcm_sym106__;
       double lcm_sym105__;
       double lcm_sym104__;
@@ -3495,7 +3499,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       double lcm_sym94__;
       double lcm_sym93__;
       double lcm_sym92__;
-      double lcm_sym91__;
+      int lcm_sym91__;
       int lcm_sym90__;
       int lcm_sym89__;
       int lcm_sym88__;
@@ -3515,7 +3519,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       int lcm_sym74__;
       int lcm_sym73__;
       int lcm_sym72__;
-      int lcm_sym71__;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__, 
@@ -3534,46 +3537,46 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       Eigen::Matrix<local_scalar_t__, -1, -1> chi =
          Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(nind, n_occasions,
            DUMMY_VAR__);
-      lcm_sym71__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym71__) {
-        lcm_sym108__ = stan::model::rvalue(first, "first",
+      lcm_sym72__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym72__) {
+        lcm_sym109__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym84__ = (lcm_sym108__ - 1);
-        if (stan::math::logical_gte(lcm_sym84__, 1)) {
-          current_statement__ = 6;
-          stan::model::assign(phi, 0,
+        lcm_sym85__ = (lcm_sym109__ - 1);
+        if (stan::math::logical_gte(lcm_sym85__, 1)) {
+          lcm_sym112__ = 0;
+          stan::model::assign(phi, lcm_sym112__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 7;
-          stan::model::assign(p, 0,
+          current_statement__ = 6;
+          stan::model::assign(p, lcm_sym112__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym84__; ++t) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+          for (int t = 2; t <= lcm_sym85__; ++t) {
+            current_statement__ = 7;
+            stan::model::assign(phi, lcm_sym112__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym112__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
         } 
-        lcm_sym82__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym82__, lcm_sym108__)) {
+        lcm_sym83__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym83__, lcm_sym109__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(stan::model::rvalue(x, "x",
                                        stan::model::index_uni(1),
-                                         stan::model::index_uni(lcm_sym108__)))),
+                                         stan::model::index_uni(lcm_sym109__)))),
             "assigning variable phi", stan::model::index_uni(1),
-                                        stan::model::index_uni(lcm_sym108__));
-          lcm_sym90__ = (lcm_sym108__ + 1);
+                                        stan::model::index_uni(lcm_sym109__));
+          lcm_sym91__ = (lcm_sym109__ + 1);
           stan::model::assign(p, mean_p,
             "assigning variable p", stan::model::index_uni(1),
-                                      stan::model::index_uni(lcm_sym108__));
-          for (int t = lcm_sym90__; t <= lcm_sym82__; ++t) {
+                                      stan::model::index_uni(lcm_sym109__));
+          for (int t = lcm_sym91__; t <= lcm_sym83__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -3589,44 +3592,44 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           }
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym107__ = stan::model::rvalue(first, "first",
+          lcm_sym108__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym83__ = (lcm_sym107__ - 1);
-          if (stan::math::logical_gte(lcm_sym83__, 1)) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+          lcm_sym84__ = (lcm_sym108__ - 1);
+          if (stan::math::logical_gte(lcm_sym84__, 1)) {
+            lcm_sym112__ = 0;
+            stan::model::assign(phi, lcm_sym112__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym112__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym83__; ++t) {
-              current_statement__ = 6;
-              stan::model::assign(phi, 0,
+            for (int t = 2; t <= lcm_sym84__; ++t) {
+              current_statement__ = 7;
+              stan::model::assign(phi, lcm_sym112__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 7;
-              stan::model::assign(p, 0,
+              current_statement__ = 6;
+              stan::model::assign(p, lcm_sym112__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
           } 
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym82__, lcm_sym107__)) {
+          if (stan::math::logical_gte(lcm_sym83__, lcm_sym108__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(stan::model::rvalue(x, "x",
                                          stan::model::index_uni(i),
-                                           stan::model::index_uni(lcm_sym107__)))),
+                                           stan::model::index_uni(lcm_sym108__)))),
               "assigning variable phi", stan::model::index_uni(i),
-                                          stan::model::index_uni(lcm_sym107__));
-            lcm_sym89__ = (lcm_sym107__ + 1);
+                                          stan::model::index_uni(lcm_sym108__));
+            lcm_sym90__ = (lcm_sym108__ + 1);
             stan::model::assign(p, mean_p,
               "assigning variable p", stan::model::index_uni(i),
-                                        stan::model::index_uni(lcm_sym107__));
-            for (int t = lcm_sym89__; t <= lcm_sym82__; ++t) {
+                                        stan::model::index_uni(lcm_sym108__));
+            for (int t = lcm_sym90__; t <= lcm_sym83__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -3660,55 +3663,55 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           stan::model::assign(inline_sym10__, 1.0,
             "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
                                                    stan::model::index_uni(n_occasions));
-          lcm_sym82__ = (n_occasions - 1);
-          if (stan::math::logical_gte(lcm_sym82__, 1)) {
+          lcm_sym83__ = (n_occasions - 1);
+          if (stan::math::logical_gte(lcm_sym83__, 1)) {
             int inline_sym11__ = std::numeric_limits<int>::min();
             int inline_sym12__ = std::numeric_limits<int>::min();
-            lcm_sym86__ = (lcm_sym82__ + 1);
+            lcm_sym87__ = (lcm_sym83__ + 1);
             current_statement__ = 21;
             stan::model::assign(inline_sym10__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi",
                    stan::model::index_uni(inline_sym14__),
-                     stan::model::index_uni(lcm_sym82__)) *
+                     stan::model::index_uni(lcm_sym83__)) *
                   (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni((lcm_sym86__ - 1))))),
+                        stan::model::index_uni((lcm_sym87__ - 1))))),
                 stan::model::rvalue(inline_sym10__, "inline_sym10__",
                   stan::model::index_uni(inline_sym14__),
-                    stan::model::index_uni(lcm_sym86__)),
+                    stan::model::index_uni(lcm_sym87__)),
                 (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym82__)))),
+                      stan::model::index_uni(lcm_sym83__)))),
               "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                     stan::model::index_uni(lcm_sym82__));
-            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym82__;
+                                                     stan::model::index_uni(lcm_sym83__));
+            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym83__;
                  ++inline_sym13__) {
               int inline_sym11__ = std::numeric_limits<int>::min();
-              lcm_sym81__ = (n_occasions - inline_sym13__);
+              lcm_sym82__ = (n_occasions - inline_sym13__);
               int inline_sym12__ = std::numeric_limits<int>::min();
-              lcm_sym85__ = (lcm_sym81__ + 1);
+              lcm_sym86__ = (lcm_sym82__ + 1);
               current_statement__ = 21;
               stan::model::assign(inline_sym10__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_sym14__),
-                       stan::model::index_uni(lcm_sym81__)) *
+                       stan::model::index_uni(lcm_sym82__)) *
                     (1 -
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_sym14__),
-                          stan::model::index_uni((lcm_sym85__ - 1))))),
+                          stan::model::index_uni((lcm_sym86__ - 1))))),
                   stan::model::rvalue(inline_sym10__, "inline_sym10__",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym85__)),
+                      stan::model::index_uni(lcm_sym86__)),
                   (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni(lcm_sym81__)))),
+                        stan::model::index_uni(lcm_sym82__)))),
                 "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                       stan::model::index_uni(lcm_sym81__));
+                                                       stan::model::index_uni(lcm_sym82__));
             }
           } 
           if (inline_sym15__) {
@@ -3738,30 +3741,30 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::check_less_or_equal(function__, "chi", inline_sym9__, 1);
       {
         current_statement__ = 31;
-        if (lcm_sym71__) {
-          lcm_sym108__ = stan::model::rvalue(first, "first",
+        if (lcm_sym72__) {
+          lcm_sym109__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym108__, 0)) {
-            lcm_sym110__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym109__, 0)) {
+            lcm_sym111__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym90__ = (lcm_sym108__ + 1);
-            if (stan::math::logical_gte(lcm_sym110__, lcm_sym90__)) {
+            lcm_sym91__ = (lcm_sym109__ + 1);
+            if (stan::math::logical_gte(lcm_sym111__, lcm_sym91__)) {
               current_statement__ = 25;
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym90__ - 1)))));
-              lcm_sym88__ = (lcm_sym90__ + 1);
+                      stan::model::index_uni((lcm_sym91__ - 1)))));
+              lcm_sym89__ = (lcm_sym91__ + 1);
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(
                   stan::model::rvalue(y, "y",
                     stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym90__)),
+                      stan::model::index_uni(lcm_sym91__)),
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym90__ - 1)))));
-              for (int t = lcm_sym88__; t <= lcm_sym110__; ++t) {
+                      stan::model::index_uni((lcm_sym91__ - 1)))));
+              for (int t = lcm_sym89__; t <= lcm_sym111__; ++t) {
                 current_statement__ = 25;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
@@ -3783,32 +3786,32 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
               stan::math::bernoulli_lpmf<propto__>(1,
                 stan::model::rvalue(inline_sym9__, "inline_sym9__",
                   stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym110__))));
+                    stan::model::index_uni(lcm_sym111__))));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym107__ = stan::model::rvalue(first, "first",
+            lcm_sym108__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym107__, 0)) {
-              lcm_sym109__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym108__, 0)) {
+              lcm_sym110__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym89__ = (lcm_sym107__ + 1);
-              if (stan::math::logical_gte(lcm_sym109__, lcm_sym89__)) {
+              lcm_sym90__ = (lcm_sym108__ + 1);
+              if (stan::math::logical_gte(lcm_sym110__, lcm_sym90__)) {
                 current_statement__ = 25;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym89__ - 1)))));
-                lcm_sym87__ = (lcm_sym89__ + 1);
+                        stan::model::index_uni((lcm_sym90__ - 1)))));
+                lcm_sym88__ = (lcm_sym90__ + 1);
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(
                     stan::model::rvalue(y, "y",
                       stan::model::index_uni(i),
-                        stan::model::index_uni(lcm_sym89__)),
+                        stan::model::index_uni(lcm_sym90__)),
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym89__ - 1)))));
-                for (int t = lcm_sym87__; t <= lcm_sym109__; ++t) {
+                        stan::model::index_uni((lcm_sym90__ - 1)))));
+                for (int t = lcm_sym88__; t <= lcm_sym110__; ++t) {
                   current_statement__ = 25;
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(1,
@@ -3830,7 +3833,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(inline_sym9__, "inline_sym9__",
                     stan::model::index_uni(i),
-                      stan::model::index_uni(lcm_sym109__))));
+                      stan::model::index_uni(lcm_sym110__))));
             } 
           }
         } 
@@ -3867,6 +3870,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym71__;
       int lcm_sym70__;
       int lcm_sym69__;
       double lcm_sym68__;
@@ -3922,21 +3926,21 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                         stan::model::index_uni(1));
         lcm_sym56__ = (lcm_sym70__ - 1);
         if (stan::math::logical_gte(lcm_sym56__, 1)) {
-          current_statement__ = 6;
-          stan::model::assign(phi, 0,
+          lcm_sym71__ = 0;
+          stan::model::assign(phi, lcm_sym71__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 7;
-          stan::model::assign(p, 0,
+          current_statement__ = 6;
+          stan::model::assign(p, lcm_sym71__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
           for (int t = 2; t <= lcm_sym56__; ++t) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+            current_statement__ = 7;
+            stan::model::assign(phi, lcm_sym71__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym71__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
@@ -3975,21 +3979,21 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           stan::model::index_uni(i));
           lcm_sym55__ = (lcm_sym69__ - 1);
           if (stan::math::logical_gte(lcm_sym55__, 1)) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+            lcm_sym71__ = 0;
+            stan::model::assign(phi, lcm_sym71__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym71__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
             for (int t = 2; t <= lcm_sym55__; ++t) {
-              current_statement__ = 6;
-              stan::model::assign(phi, 0,
+              current_statement__ = 7;
+              stan::model::assign(phi, lcm_sym71__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 7;
-              stan::model::assign(p, 0,
+              current_statement__ = 6;
+              stan::model::assign(p, lcm_sym71__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
@@ -4193,35 +4197,35 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     final {
     
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym130__ = 1; sym130__ <= max_age; ++sym130__) {
+    for (int sym132__ = 1; sym132__ <= max_age; ++sym132__) {
       {
-        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym130__));
+        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym132__));
       } 
     }
     if (emit_transformed_parameters__) {
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occasions; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occasions; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
@@ -4241,35 +4245,35 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     final {
     
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym130__ = 1; sym130__ <= max_age; ++sym130__) {
+    for (int sym132__ = 1; sym132__ <= max_age; ++sym132__) {
       {
-        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym130__));
+        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym132__));
       } 
     }
     if (emit_transformed_parameters__) {
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occasions; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occasions; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
@@ -5937,6 +5941,7 @@ static constexpr std::array<const char*, 8> locations_array__ =
 class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_experiment2_model> {
 
  private:
+  double lcm_sym5__;
   double lcm_sym4__;
   int j;
   double z;
@@ -5966,6 +5971,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
+      
       
       int pos__;
       pos__ = 1;
@@ -9135,8 +9141,8 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 77, column 2 to column 50)",
  " (in 'expr-prop-fail5.stan', line 78, column 2 to column 50)",
  " (in 'expr-prop-fail5.stan', line 79, column 2 to column 10)",
- " (in 'expr-prop-fail5.stan', line 85, column 6 to column 20)",
  " (in 'expr-prop-fail5.stan', line 86, column 6 to column 18)",
+ " (in 'expr-prop-fail5.stan', line 85, column 6 to column 20)",
  " (in 'expr-prop-fail5.stan', line 84, column 34 to line 87, column 5)",
  " (in 'expr-prop-fail5.stan', line 89, column 6 to column 45)",
  " (in 'expr-prop-fail5.stan', line 90, column 6 to column 23)",
@@ -9476,6 +9482,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model> {
 
  private:
+  int lcm_sym128__;
+  int lcm_sym127__;
   int lcm_sym126__;
   int lcm_sym125__;
   int lcm_sym124__;
@@ -9490,8 +9498,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   int lcm_sym115__;
   int lcm_sym114__;
   int lcm_sym113__;
-  int lcm_sym112__;
-  int lcm_sym111__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -9584,8 +9590,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         current_statement__ = 41;
         if (stan::math::logical_gte(n_occasions, 1)) {
           {
-            lcm_sym112__ = stan::math::logical_gte(nind, 1);
-            if (lcm_sym112__) {
+            lcm_sym114__ = stan::math::logical_gte(nind, 1);
+            if (lcm_sym114__) {
               current_statement__ = 41;
               stan::model::assign(y,
                 stan::model::rvalue(y_flat__, "y_flat__",
@@ -9605,7 +9611,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             } 
             for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
               current_statement__ = 41;
-              if (lcm_sym112__) {
+              if (lcm_sym114__) {
                 current_statement__ = 41;
                 stan::model::assign(y, y_flat__[(pos__ - 1)],
                   "assigning variable y", stan::model::index_uni(1),
@@ -9624,7 +9630,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             }
           }
         } else {
-          lcm_sym112__ = stan::math::logical_gte(nind, 1);
+          lcm_sym114__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 41;
@@ -9635,8 +9641,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       n_occ_minus_1 = std::numeric_limits<int>::min();
       
       
-      lcm_sym113__ = (n_occasions - 1);
-      n_occ_minus_1 = lcm_sym113__;
+      lcm_sym115__ = (n_occasions - 1);
+      n_occ_minus_1 = lcm_sym115__;
       current_statement__ = 43;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 44;
@@ -9650,15 +9656,15 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       
       
       current_statement__ = 51;
-      if (lcm_sym112__) {
+      if (lcm_sym114__) {
         int inline_sym17__;
         int inline_sym19__;
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym120__ = stan::math::size(
+          lcm_sym122__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym120__;
+          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym122__;
                ++inline_sym18__) {
             current_statement__ = 48;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
@@ -9682,10 +9688,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           int inline_sym19__;
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym119__ = stan::math::size(
+            lcm_sym121__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym119__;
+            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym121__;
                  ++inline_sym18__) {
               current_statement__ = 48;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
@@ -9707,25 +9713,25 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         }
       } 
       current_statement__ = 58;
-      if (lcm_sym112__) {
+      if (lcm_sym114__) {
         int inline_sym21__;
         int inline_sym24__;
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym120__ = stan::math::size(
+          lcm_sym122__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          lcm_sym117__ = (lcm_sym120__ - 1);
-          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym117__;
+          lcm_sym119__ = (lcm_sym122__ - 1);
+          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym119__;
                ++inline_sym23__) {
             int inline_sym22__ = std::numeric_limits<int>::min();
-            lcm_sym116__ = (lcm_sym120__ - inline_sym23__);
-            inline_sym22__ = lcm_sym116__;
+            lcm_sym118__ = (lcm_sym122__ - inline_sym23__);
+            inline_sym22__ = lcm_sym118__;
             current_statement__ = 54;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
-                (lcm_sym116__ - 1)]) {
+                (lcm_sym118__ - 1)]) {
               inline_sym24__ = 1;
-              inline_sym21__ = lcm_sym116__;
+              inline_sym21__ = lcm_sym118__;
               break;
             } 
           }
@@ -9743,20 +9749,20 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           int inline_sym24__;
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym119__ = stan::math::size(
+            lcm_sym121__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            lcm_sym115__ = (lcm_sym119__ - 1);
-            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym115__;
+            lcm_sym117__ = (lcm_sym121__ - 1);
+            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym117__;
                  ++inline_sym23__) {
               int inline_sym22__ = std::numeric_limits<int>::min();
-              lcm_sym114__ = (lcm_sym119__ - inline_sym23__);
-              inline_sym22__ = lcm_sym114__;
+              lcm_sym116__ = (lcm_sym121__ - inline_sym23__);
+              inline_sym22__ = lcm_sym116__;
               current_statement__ = 54;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
-                  (lcm_sym114__ - 1)]) {
+                  (lcm_sym116__ - 1)]) {
                 inline_sym24__ = 1;
-                inline_sym21__ = lcm_sym114__;
+                inline_sym21__ = lcm_sym116__;
                 break;
               } 
             }
@@ -9785,12 +9791,12 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 61;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-                                              lcm_sym113__);
+                                              lcm_sym115__);
       current_statement__ = 62;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 63;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-                                              lcm_sym113__);
+                                              lcm_sym115__);
       current_statement__ = 64;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 65;
@@ -9821,14 +9827,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym112__;
+      int lcm_sym111__;
       int lcm_sym110__;
       int lcm_sym109__;
       int lcm_sym108__;
-      int lcm_sym107__;
-      double lcm_sym106__;
+      double lcm_sym107__;
+      local_scalar_t__ lcm_sym106__;
       local_scalar_t__ lcm_sym105__;
       local_scalar_t__ lcm_sym104__;
-      local_scalar_t__ lcm_sym103__;
+      double lcm_sym103__;
       double lcm_sym102__;
       double lcm_sym101__;
       double lcm_sym100__;
@@ -9840,7 +9848,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       double lcm_sym94__;
       double lcm_sym93__;
       double lcm_sym92__;
-      double lcm_sym91__;
+      int lcm_sym91__;
       int lcm_sym90__;
       int lcm_sym89__;
       int lcm_sym88__;
@@ -9860,7 +9868,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       int lcm_sym74__;
       int lcm_sym73__;
       int lcm_sym72__;
-      int lcm_sym71__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__, 
@@ -9887,49 +9894,49 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
          Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(nind, n_occasions,
            DUMMY_VAR__);
       local_scalar_t__ mu = DUMMY_VAR__;
-      lcm_sym105__ = stan::math::logit(mean_phi);
-      mu = lcm_sym105__;
-      lcm_sym71__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym71__) {
-        lcm_sym108__ = stan::model::rvalue(first, "first",
+      lcm_sym106__ = stan::math::logit(mean_phi);
+      mu = lcm_sym106__;
+      lcm_sym72__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym72__) {
+        lcm_sym109__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym84__ = (lcm_sym108__ - 1);
-        if (stan::math::logical_gte(lcm_sym84__, 1)) {
-          current_statement__ = 9;
-          stan::model::assign(phi, 0,
+        lcm_sym85__ = (lcm_sym109__ - 1);
+        if (stan::math::logical_gte(lcm_sym85__, 1)) {
+          lcm_sym112__ = 0;
+          stan::model::assign(phi, lcm_sym112__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 10;
-          stan::model::assign(p, 0,
+          current_statement__ = 9;
+          stan::model::assign(p, lcm_sym112__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym84__; ++t) {
-            current_statement__ = 9;
-            stan::model::assign(phi, 0,
+          for (int t = 2; t <= lcm_sym85__; ++t) {
+            current_statement__ = 10;
+            stan::model::assign(phi, lcm_sym112__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 10;
-            stan::model::assign(p, 0,
+            current_statement__ = 9;
+            stan::model::assign(p, lcm_sym112__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
         } 
-        lcm_sym82__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym82__, lcm_sym108__)) {
-          lcm_sym104__ = stan::math::inv_logit(
-                           (lcm_sym105__ +
+        lcm_sym83__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym83__, lcm_sym109__)) {
+          lcm_sym105__ = stan::math::inv_logit(
+                           (lcm_sym106__ +
                              stan::model::rvalue(epsilon, "epsilon",
                                stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym104__,
+          stan::model::assign(phi, lcm_sym105__,
             "assigning variable phi", stan::model::index_uni(1),
-                                        stan::model::index_uni(lcm_sym108__));
-          lcm_sym90__ = (lcm_sym108__ + 1);
+                                        stan::model::index_uni(lcm_sym109__));
+          lcm_sym91__ = (lcm_sym109__ + 1);
           stan::model::assign(p, mean_p,
             "assigning variable p", stan::model::index_uni(1),
-                                      stan::model::index_uni(lcm_sym108__));
-          for (int t = lcm_sym90__; t <= lcm_sym82__; ++t) {
+                                      stan::model::index_uni(lcm_sym109__));
+          for (int t = lcm_sym91__; t <= lcm_sym83__; ++t) {
             current_statement__ = 12;
-            stan::model::assign(phi, lcm_sym104__,
+            stan::model::assign(phi, lcm_sym105__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
             current_statement__ = 13;
@@ -9939,45 +9946,45 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym107__ = stan::model::rvalue(first, "first",
+          lcm_sym108__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym83__ = (lcm_sym107__ - 1);
-          if (stan::math::logical_gte(lcm_sym83__, 1)) {
-            current_statement__ = 9;
-            stan::model::assign(phi, 0,
+          lcm_sym84__ = (lcm_sym108__ - 1);
+          if (stan::math::logical_gte(lcm_sym84__, 1)) {
+            lcm_sym112__ = 0;
+            stan::model::assign(phi, lcm_sym112__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 10;
-            stan::model::assign(p, 0,
+            current_statement__ = 9;
+            stan::model::assign(p, lcm_sym112__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym83__; ++t) {
-              current_statement__ = 9;
-              stan::model::assign(phi, 0,
+            for (int t = 2; t <= lcm_sym84__; ++t) {
+              current_statement__ = 10;
+              stan::model::assign(phi, lcm_sym112__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 10;
-              stan::model::assign(p, 0,
+              current_statement__ = 9;
+              stan::model::assign(p, lcm_sym112__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
           } 
           current_statement__ = 15;
-          if (stan::math::logical_gte(lcm_sym82__, lcm_sym107__)) {
-            lcm_sym103__ = stan::math::inv_logit(
-                             (lcm_sym105__ +
+          if (stan::math::logical_gte(lcm_sym83__, lcm_sym108__)) {
+            lcm_sym104__ = stan::math::inv_logit(
+                             (lcm_sym106__ +
                                stan::model::rvalue(epsilon, "epsilon",
                                  stan::model::index_uni(i))));
-            stan::model::assign(phi, lcm_sym103__,
+            stan::model::assign(phi, lcm_sym104__,
               "assigning variable phi", stan::model::index_uni(i),
-                                          stan::model::index_uni(lcm_sym107__));
-            lcm_sym89__ = (lcm_sym107__ + 1);
+                                          stan::model::index_uni(lcm_sym108__));
+            lcm_sym90__ = (lcm_sym108__ + 1);
             stan::model::assign(p, mean_p,
               "assigning variable p", stan::model::index_uni(i),
-                                        stan::model::index_uni(lcm_sym107__));
-            for (int t = lcm_sym89__; t <= lcm_sym82__; ++t) {
+                                        stan::model::index_uni(lcm_sym108__));
+            for (int t = lcm_sym90__; t <= lcm_sym83__; ++t) {
               current_statement__ = 12;
-              stan::model::assign(phi, lcm_sym103__,
+              stan::model::assign(phi, lcm_sym104__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
               current_statement__ = 13;
@@ -10005,55 +10012,55 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           stan::model::assign(inline_sym10__, 1.0,
             "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
                                                    stan::model::index_uni(n_occasions));
-          lcm_sym82__ = (n_occasions - 1);
-          if (stan::math::logical_gte(lcm_sym82__, 1)) {
+          lcm_sym83__ = (n_occasions - 1);
+          if (stan::math::logical_gte(lcm_sym83__, 1)) {
             int inline_sym11__ = std::numeric_limits<int>::min();
             int inline_sym12__ = std::numeric_limits<int>::min();
-            lcm_sym86__ = (lcm_sym82__ + 1);
+            lcm_sym87__ = (lcm_sym83__ + 1);
             current_statement__ = 24;
             stan::model::assign(inline_sym10__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi",
                    stan::model::index_uni(inline_sym14__),
-                     stan::model::index_uni(lcm_sym82__)) *
+                     stan::model::index_uni(lcm_sym83__)) *
                   (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni((lcm_sym86__ - 1))))),
+                        stan::model::index_uni((lcm_sym87__ - 1))))),
                 stan::model::rvalue(inline_sym10__, "inline_sym10__",
                   stan::model::index_uni(inline_sym14__),
-                    stan::model::index_uni(lcm_sym86__)),
+                    stan::model::index_uni(lcm_sym87__)),
                 (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym82__)))),
+                      stan::model::index_uni(lcm_sym83__)))),
               "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                     stan::model::index_uni(lcm_sym82__));
-            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym82__;
+                                                     stan::model::index_uni(lcm_sym83__));
+            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym83__;
                  ++inline_sym13__) {
               int inline_sym11__ = std::numeric_limits<int>::min();
               int inline_sym12__ = std::numeric_limits<int>::min();
-              lcm_sym81__ = (n_occasions - inline_sym13__);
-              lcm_sym85__ = (lcm_sym81__ + 1);
+              lcm_sym82__ = (n_occasions - inline_sym13__);
+              lcm_sym86__ = (lcm_sym82__ + 1);
               current_statement__ = 24;
               stan::model::assign(inline_sym10__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_sym14__),
-                       stan::model::index_uni(lcm_sym81__)) *
+                       stan::model::index_uni(lcm_sym82__)) *
                     (1 -
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_sym14__),
-                          stan::model::index_uni((lcm_sym85__ - 1))))),
+                          stan::model::index_uni((lcm_sym86__ - 1))))),
                   stan::model::rvalue(inline_sym10__, "inline_sym10__",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym85__)),
+                      stan::model::index_uni(lcm_sym86__)),
                   (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni(lcm_sym81__)))),
+                        stan::model::index_uni(lcm_sym82__)))),
                 "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                       stan::model::index_uni(lcm_sym81__));
+                                                       stan::model::index_uni(lcm_sym82__));
             }
           } 
           if (inline_sym15__) {
@@ -10085,30 +10092,30 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         current_statement__ = 29;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
         current_statement__ = 36;
-        if (lcm_sym71__) {
-          lcm_sym108__ = stan::model::rvalue(first, "first",
+        if (lcm_sym72__) {
+          lcm_sym109__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym108__, 0)) {
-            lcm_sym110__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym109__, 0)) {
+            lcm_sym111__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym90__ = (lcm_sym108__ + 1);
-            if (stan::math::logical_gte(lcm_sym110__, lcm_sym90__)) {
+            lcm_sym91__ = (lcm_sym109__ + 1);
+            if (stan::math::logical_gte(lcm_sym111__, lcm_sym91__)) {
               current_statement__ = 30;
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym90__ - 1)))));
-              lcm_sym88__ = (lcm_sym90__ + 1);
+                      stan::model::index_uni((lcm_sym91__ - 1)))));
+              lcm_sym89__ = (lcm_sym91__ + 1);
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(
                   stan::model::rvalue(y, "y",
                     stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym90__)),
+                      stan::model::index_uni(lcm_sym91__)),
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym90__ - 1)))));
-              for (int t = lcm_sym88__; t <= lcm_sym110__; ++t) {
+                      stan::model::index_uni((lcm_sym91__ - 1)))));
+              for (int t = lcm_sym89__; t <= lcm_sym111__; ++t) {
                 current_statement__ = 30;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
@@ -10130,32 +10137,32 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::math::bernoulli_lpmf<propto__>(1,
                 stan::model::rvalue(inline_sym9__, "inline_sym9__",
                   stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym110__))));
+                    stan::model::index_uni(lcm_sym111__))));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym107__ = stan::model::rvalue(first, "first",
+            lcm_sym108__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym107__, 0)) {
-              lcm_sym109__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym108__, 0)) {
+              lcm_sym110__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym89__ = (lcm_sym107__ + 1);
-              if (stan::math::logical_gte(lcm_sym109__, lcm_sym89__)) {
+              lcm_sym90__ = (lcm_sym108__ + 1);
+              if (stan::math::logical_gte(lcm_sym110__, lcm_sym90__)) {
                 current_statement__ = 30;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym89__ - 1)))));
-                lcm_sym87__ = (lcm_sym89__ + 1);
+                        stan::model::index_uni((lcm_sym90__ - 1)))));
+                lcm_sym88__ = (lcm_sym90__ + 1);
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(
                     stan::model::rvalue(y, "y",
                       stan::model::index_uni(i),
-                        stan::model::index_uni(lcm_sym89__)),
+                        stan::model::index_uni(lcm_sym90__)),
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym89__ - 1)))));
-                for (int t = lcm_sym87__; t <= lcm_sym109__; ++t) {
+                        stan::model::index_uni((lcm_sym90__ - 1)))));
+                for (int t = lcm_sym88__; t <= lcm_sym110__; ++t) {
                   current_statement__ = 30;
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(1,
@@ -10177,7 +10184,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(inline_sym9__, "inline_sym9__",
                     stan::model::index_uni(i),
-                      stan::model::index_uni(lcm_sym109__))));
+                      stan::model::index_uni(lcm_sym110__))));
             } 
           }
         } 
@@ -10214,6 +10221,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym71__;
       int lcm_sym70__;
       int lcm_sym69__;
       double lcm_sym68__;
@@ -10281,21 +10289,21 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                         stan::model::index_uni(1));
         lcm_sym56__ = (lcm_sym70__ - 1);
         if (stan::math::logical_gte(lcm_sym56__, 1)) {
-          current_statement__ = 9;
-          stan::model::assign(phi, 0,
+          lcm_sym71__ = 0;
+          stan::model::assign(phi, lcm_sym71__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 10;
-          stan::model::assign(p, 0,
+          current_statement__ = 9;
+          stan::model::assign(p, lcm_sym71__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
           for (int t = 2; t <= lcm_sym56__; ++t) {
-            current_statement__ = 9;
-            stan::model::assign(phi, 0,
+            current_statement__ = 10;
+            stan::model::assign(phi, lcm_sym71__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 10;
-            stan::model::assign(p, 0,
+            current_statement__ = 9;
+            stan::model::assign(p, lcm_sym71__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
@@ -10329,21 +10337,21 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                           stan::model::index_uni(i));
           lcm_sym55__ = (lcm_sym69__ - 1);
           if (stan::math::logical_gte(lcm_sym55__, 1)) {
-            current_statement__ = 9;
-            stan::model::assign(phi, 0,
+            lcm_sym71__ = 0;
+            stan::model::assign(phi, lcm_sym71__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 10;
-            stan::model::assign(p, 0,
+            current_statement__ = 9;
+            stan::model::assign(p, lcm_sym71__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
             for (int t = 2; t <= lcm_sym55__; ++t) {
-              current_statement__ = 9;
-              stan::model::assign(phi, 0,
+              current_statement__ = 10;
+              stan::model::assign(phi, lcm_sym71__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 10;
-              stan::model::assign(p, 0,
+              current_statement__ = 9;
+              stan::model::assign(p, lcm_sym71__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
@@ -10558,36 +10566,36 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym127__ = 1; sym127__ <= nind; ++sym127__) {
+    for (int sym129__ = 1; sym129__ <= nind; ++sym129__) {
       {
-        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym127__));
+        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym129__));
       } 
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym127__ = 1; sym127__ <= n_occ_minus_1; ++sym127__) {
+      for (int sym129__ = 1; sym129__ <= n_occ_minus_1; ++sym129__) {
         {
-          for (int sym128__ = 1; sym128__ <= nind; ++sym128__) {
+          for (int sym130__ = 1; sym130__ <= nind; ++sym130__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym128__) + '.' + std::to_string(sym127__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym130__) + '.' + std::to_string(sym129__));
             } 
           }
         } 
       }
-      for (int sym127__ = 1; sym127__ <= n_occ_minus_1; ++sym127__) {
+      for (int sym129__ = 1; sym129__ <= n_occ_minus_1; ++sym129__) {
         {
-          for (int sym128__ = 1; sym128__ <= nind; ++sym128__) {
+          for (int sym130__ = 1; sym130__ <= nind; ++sym130__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym128__) + '.' + std::to_string(sym127__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym130__) + '.' + std::to_string(sym129__));
             } 
           }
         } 
       }
-      for (int sym127__ = 1; sym127__ <= n_occasions; ++sym127__) {
+      for (int sym129__ = 1; sym129__ <= n_occasions; ++sym129__) {
         {
-          for (int sym128__ = 1; sym128__ <= nind; ++sym128__) {
+          for (int sym130__ = 1; sym130__ <= nind; ++sym130__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym128__) + '.' + std::to_string(sym127__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym130__) + '.' + std::to_string(sym129__));
             } 
           }
         } 
@@ -10609,36 +10617,36 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym127__ = 1; sym127__ <= nind; ++sym127__) {
+    for (int sym129__ = 1; sym129__ <= nind; ++sym129__) {
       {
-        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym127__));
+        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym129__));
       } 
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym127__ = 1; sym127__ <= n_occ_minus_1; ++sym127__) {
+      for (int sym129__ = 1; sym129__ <= n_occ_minus_1; ++sym129__) {
         {
-          for (int sym128__ = 1; sym128__ <= nind; ++sym128__) {
+          for (int sym130__ = 1; sym130__ <= nind; ++sym130__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym128__) + '.' + std::to_string(sym127__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym130__) + '.' + std::to_string(sym129__));
             } 
           }
         } 
       }
-      for (int sym127__ = 1; sym127__ <= n_occ_minus_1; ++sym127__) {
+      for (int sym129__ = 1; sym129__ <= n_occ_minus_1; ++sym129__) {
         {
-          for (int sym128__ = 1; sym128__ <= nind; ++sym128__) {
+          for (int sym130__ = 1; sym130__ <= nind; ++sym130__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym128__) + '.' + std::to_string(sym127__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym130__) + '.' + std::to_string(sym129__));
             } 
           }
         } 
       }
-      for (int sym127__ = 1; sym127__ <= n_occasions; ++sym127__) {
+      for (int sym129__ = 1; sym129__ <= n_occasions; ++sym129__) {
         {
-          for (int sym128__ = 1; sym128__ <= nind; ++sym128__) {
+          for (int sym130__ = 1; sym130__ <= nind; ++sym130__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym128__) + '.' + std::to_string(sym127__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym130__) + '.' + std::to_string(sym129__));
             } 
           }
         } 
@@ -15728,8 +15736,8 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'fails-test.stan', line 72, column 2 to column 52)",
  " (in 'fails-test.stan', line 73, column 2 to column 50)",
  " (in 'fails-test.stan', line 74, column 2 to column 50)",
- " (in 'fails-test.stan', line 79, column 6 to column 20)",
  " (in 'fails-test.stan', line 80, column 6 to column 18)",
+ " (in 'fails-test.stan', line 79, column 6 to column 20)",
  " (in 'fails-test.stan', line 78, column 34 to line 81, column 5)",
  " (in 'fails-test.stan', line 83, column 6 to column 32)",
  " (in 'fails-test.stan', line 84, column 6 to column 23)",
@@ -16069,6 +16077,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
  class fails_test_model final : public model_base_crtp<fails_test_model> {
 
  private:
+  int lcm_sym131__;
+  int lcm_sym130__;
   int lcm_sym129__;
   int lcm_sym128__;
   int lcm_sym127__;
@@ -16086,8 +16096,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   int lcm_sym115__;
   int lcm_sym114__;
   int lcm_sym113__;
-  int lcm_sym112__;
-  int lcm_sym111__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -16185,8 +16193,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         current_statement__ = 36;
         if (stan::math::logical_gte(n_occasions, 1)) {
           {
-            lcm_sym112__ = stan::math::logical_gte(nind, 1);
-            if (lcm_sym112__) {
+            lcm_sym114__ = stan::math::logical_gte(nind, 1);
+            if (lcm_sym114__) {
               current_statement__ = 36;
               stan::model::assign(y,
                 stan::model::rvalue(y_flat__, "y_flat__",
@@ -16206,7 +16214,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
             } 
             for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
               current_statement__ = 36;
-              if (lcm_sym112__) {
+              if (lcm_sym114__) {
                 current_statement__ = 36;
                 stan::model::assign(y, y_flat__[(pos__ - 1)],
                   "assigning variable y", stan::model::index_uni(1),
@@ -16225,7 +16233,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
             }
           }
         } else {
-          lcm_sym112__ = stan::math::logical_gte(nind, 1);
+          lcm_sym114__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 36;
@@ -16244,16 +16252,16 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::check_greater_or_equal(function__, "max_age", max_age, 1);
       current_statement__ = 38;
       stan::math::validate_non_negative_index("x", "nind", nind);
-      lcm_sym114__ = (n_occasions - 1);
+      lcm_sym116__ = (n_occasions - 1);
       stan::math::validate_non_negative_index("x", "n_occasions - 1",
-                                              lcm_sym114__);
+                                              lcm_sym116__);
       current_statement__ = 39;
       context__.validate_dims("data initialization","x","int",
            std::vector<size_t>{static_cast<size_t>(nind),
-            static_cast<size_t>(lcm_sym114__)});
+            static_cast<size_t>(lcm_sym116__)});
       x = 
         std::vector<std::vector<int>>(nind, 
-          std::vector<int>(lcm_sym114__, std::numeric_limits<int>::min()));
+          std::vector<int>(lcm_sym116__, std::numeric_limits<int>::min()));
       
       
       {
@@ -16263,9 +16271,9 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         current_statement__ = 39;
         pos__ = 1;
         current_statement__ = 39;
-        if (stan::math::logical_gte(lcm_sym114__, 1)) {
+        if (stan::math::logical_gte(lcm_sym116__, 1)) {
           current_statement__ = 39;
-          if (lcm_sym112__) {
+          if (lcm_sym114__) {
             current_statement__ = 39;
             stan::model::assign(x,
               stan::model::rvalue(x_flat__, "x_flat__",
@@ -16283,9 +16291,9 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
               pos__ = (pos__ + 1);
             }
           } 
-          for (int sym1__ = 2; sym1__ <= lcm_sym114__; ++sym1__) {
+          for (int sym1__ = 2; sym1__ <= lcm_sym116__; ++sym1__) {
             current_statement__ = 39;
-            if (lcm_sym112__) {
+            if (lcm_sym114__) {
               current_statement__ = 39;
               stan::model::assign(x, x_flat__[(pos__ - 1)],
                 "assigning variable x", stan::model::index_uni(1),
@@ -16313,7 +16321,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       
       
       current_statement__ = 40;
-      n_occ_minus_1 = lcm_sym114__;
+      n_occ_minus_1 = lcm_sym116__;
       current_statement__ = 41;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 42;
@@ -16327,15 +16335,15 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       
       
       current_statement__ = 49;
-      if (lcm_sym112__) {
+      if (lcm_sym114__) {
         int inline_sym17__;
         int inline_sym19__;
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym121__ = stan::math::size(
+          lcm_sym123__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym121__;
+          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym123__;
                ++inline_sym18__) {
             current_statement__ = 46;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
@@ -16359,10 +16367,10 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           int inline_sym19__;
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym120__ = stan::math::size(
+            lcm_sym122__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym120__;
+            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym122__;
                  ++inline_sym18__) {
               current_statement__ = 46;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
@@ -16384,25 +16392,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         }
       } 
       current_statement__ = 56;
-      if (lcm_sym112__) {
+      if (lcm_sym114__) {
         int inline_sym21__;
         int inline_sym24__;
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym121__ = stan::math::size(
+          lcm_sym123__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          lcm_sym118__ = (lcm_sym121__ - 1);
-          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym118__;
+          lcm_sym120__ = (lcm_sym123__ - 1);
+          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym120__;
                ++inline_sym23__) {
             int inline_sym22__ = std::numeric_limits<int>::min();
-            lcm_sym117__ = (lcm_sym121__ - inline_sym23__);
-            inline_sym22__ = lcm_sym117__;
+            lcm_sym119__ = (lcm_sym123__ - inline_sym23__);
+            inline_sym22__ = lcm_sym119__;
             current_statement__ = 52;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
-                (lcm_sym117__ - 1)]) {
+                (lcm_sym119__ - 1)]) {
               inline_sym24__ = 1;
-              inline_sym21__ = lcm_sym117__;
+              inline_sym21__ = lcm_sym119__;
               break;
             } 
           }
@@ -16420,20 +16428,20 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           int inline_sym24__;
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym120__ = stan::math::size(
+            lcm_sym122__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            lcm_sym116__ = (lcm_sym120__ - 1);
-            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym116__;
+            lcm_sym118__ = (lcm_sym122__ - 1);
+            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym118__;
                  ++inline_sym23__) {
               int inline_sym22__ = std::numeric_limits<int>::min();
-              lcm_sym115__ = (lcm_sym120__ - inline_sym23__);
-              inline_sym22__ = lcm_sym115__;
+              lcm_sym117__ = (lcm_sym122__ - inline_sym23__);
+              inline_sym22__ = lcm_sym117__;
               current_statement__ = 52;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
-                  (lcm_sym115__ - 1)]) {
+                  (lcm_sym117__ - 1)]) {
                 inline_sym24__ = 1;
-                inline_sym21__ = lcm_sym115__;
+                inline_sym21__ = lcm_sym117__;
                 break;
               } 
             }
@@ -16462,12 +16470,12 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 59;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-                                              lcm_sym114__);
+                                              lcm_sym116__);
       current_statement__ = 60;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 61;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-                                              lcm_sym114__);
+                                              lcm_sym116__);
       current_statement__ = 62;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 63;
@@ -16498,10 +16506,12 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym112__;
+      int lcm_sym111__;
       int lcm_sym110__;
       int lcm_sym109__;
       int lcm_sym108__;
-      int lcm_sym107__;
+      double lcm_sym107__;
       double lcm_sym106__;
       double lcm_sym105__;
       double lcm_sym104__;
@@ -16517,7 +16527,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       double lcm_sym94__;
       double lcm_sym93__;
       double lcm_sym92__;
-      double lcm_sym91__;
+      int lcm_sym91__;
       int lcm_sym90__;
       int lcm_sym89__;
       int lcm_sym88__;
@@ -16537,7 +16547,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       int lcm_sym74__;
       int lcm_sym73__;
       int lcm_sym72__;
-      int lcm_sym71__;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__, 
@@ -16556,46 +16565,46 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       Eigen::Matrix<local_scalar_t__, -1, -1> chi =
          Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(nind, n_occasions,
            DUMMY_VAR__);
-      lcm_sym71__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym71__) {
-        lcm_sym108__ = stan::model::rvalue(first, "first",
+      lcm_sym72__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym72__) {
+        lcm_sym109__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym84__ = (lcm_sym108__ - 1);
-        if (stan::math::logical_gte(lcm_sym84__, 1)) {
-          current_statement__ = 6;
-          stan::model::assign(phi, 0,
+        lcm_sym85__ = (lcm_sym109__ - 1);
+        if (stan::math::logical_gte(lcm_sym85__, 1)) {
+          lcm_sym112__ = 0;
+          stan::model::assign(phi, lcm_sym112__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 7;
-          stan::model::assign(p, 0,
+          current_statement__ = 6;
+          stan::model::assign(p, lcm_sym112__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym84__; ++t) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+          for (int t = 2; t <= lcm_sym85__; ++t) {
+            current_statement__ = 7;
+            stan::model::assign(phi, lcm_sym112__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym112__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
         } 
-        lcm_sym82__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym82__, lcm_sym108__)) {
+        lcm_sym83__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym83__, lcm_sym109__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(stan::model::rvalue(x, "x",
                                        stan::model::index_uni(1),
-                                         stan::model::index_uni(lcm_sym108__)))),
+                                         stan::model::index_uni(lcm_sym109__)))),
             "assigning variable phi", stan::model::index_uni(1),
-                                        stan::model::index_uni(lcm_sym108__));
-          lcm_sym90__ = (lcm_sym108__ + 1);
+                                        stan::model::index_uni(lcm_sym109__));
+          lcm_sym91__ = (lcm_sym109__ + 1);
           stan::model::assign(p, mean_p,
             "assigning variable p", stan::model::index_uni(1),
-                                      stan::model::index_uni(lcm_sym108__));
-          for (int t = lcm_sym90__; t <= lcm_sym82__; ++t) {
+                                      stan::model::index_uni(lcm_sym109__));
+          for (int t = lcm_sym91__; t <= lcm_sym83__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -16611,44 +16620,44 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           }
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym107__ = stan::model::rvalue(first, "first",
+          lcm_sym108__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym83__ = (lcm_sym107__ - 1);
-          if (stan::math::logical_gte(lcm_sym83__, 1)) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+          lcm_sym84__ = (lcm_sym108__ - 1);
+          if (stan::math::logical_gte(lcm_sym84__, 1)) {
+            lcm_sym112__ = 0;
+            stan::model::assign(phi, lcm_sym112__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym112__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym83__; ++t) {
-              current_statement__ = 6;
-              stan::model::assign(phi, 0,
+            for (int t = 2; t <= lcm_sym84__; ++t) {
+              current_statement__ = 7;
+              stan::model::assign(phi, lcm_sym112__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 7;
-              stan::model::assign(p, 0,
+              current_statement__ = 6;
+              stan::model::assign(p, lcm_sym112__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
           } 
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym82__, lcm_sym107__)) {
+          if (stan::math::logical_gte(lcm_sym83__, lcm_sym108__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(stan::model::rvalue(x, "x",
                                          stan::model::index_uni(i),
-                                           stan::model::index_uni(lcm_sym107__)))),
+                                           stan::model::index_uni(lcm_sym108__)))),
               "assigning variable phi", stan::model::index_uni(i),
-                                          stan::model::index_uni(lcm_sym107__));
-            lcm_sym89__ = (lcm_sym107__ + 1);
+                                          stan::model::index_uni(lcm_sym108__));
+            lcm_sym90__ = (lcm_sym108__ + 1);
             stan::model::assign(p, mean_p,
               "assigning variable p", stan::model::index_uni(i),
-                                        stan::model::index_uni(lcm_sym107__));
-            for (int t = lcm_sym89__; t <= lcm_sym82__; ++t) {
+                                        stan::model::index_uni(lcm_sym108__));
+            for (int t = lcm_sym90__; t <= lcm_sym83__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -16682,55 +16691,55 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           stan::model::assign(inline_sym10__, 1.0,
             "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
                                                    stan::model::index_uni(n_occasions));
-          lcm_sym82__ = (n_occasions - 1);
-          if (stan::math::logical_gte(lcm_sym82__, 1)) {
+          lcm_sym83__ = (n_occasions - 1);
+          if (stan::math::logical_gte(lcm_sym83__, 1)) {
             int inline_sym11__ = std::numeric_limits<int>::min();
             int inline_sym12__ = std::numeric_limits<int>::min();
-            lcm_sym86__ = (lcm_sym82__ + 1);
+            lcm_sym87__ = (lcm_sym83__ + 1);
             current_statement__ = 21;
             stan::model::assign(inline_sym10__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi",
                    stan::model::index_uni(inline_sym14__),
-                     stan::model::index_uni(lcm_sym82__)) *
+                     stan::model::index_uni(lcm_sym83__)) *
                   (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni((lcm_sym86__ - 1))))),
+                        stan::model::index_uni((lcm_sym87__ - 1))))),
                 stan::model::rvalue(inline_sym10__, "inline_sym10__",
                   stan::model::index_uni(inline_sym14__),
-                    stan::model::index_uni(lcm_sym86__)),
+                    stan::model::index_uni(lcm_sym87__)),
                 (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym82__)))),
+                      stan::model::index_uni(lcm_sym83__)))),
               "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                     stan::model::index_uni(lcm_sym82__));
-            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym82__;
+                                                     stan::model::index_uni(lcm_sym83__));
+            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym83__;
                  ++inline_sym13__) {
               int inline_sym11__ = std::numeric_limits<int>::min();
-              lcm_sym81__ = (n_occasions - inline_sym13__);
+              lcm_sym82__ = (n_occasions - inline_sym13__);
               int inline_sym12__ = std::numeric_limits<int>::min();
-              lcm_sym85__ = (lcm_sym81__ + 1);
+              lcm_sym86__ = (lcm_sym82__ + 1);
               current_statement__ = 21;
               stan::model::assign(inline_sym10__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_sym14__),
-                       stan::model::index_uni(lcm_sym81__)) *
+                       stan::model::index_uni(lcm_sym82__)) *
                     (1 -
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_sym14__),
-                          stan::model::index_uni((lcm_sym85__ - 1))))),
+                          stan::model::index_uni((lcm_sym86__ - 1))))),
                   stan::model::rvalue(inline_sym10__, "inline_sym10__",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym85__)),
+                      stan::model::index_uni(lcm_sym86__)),
                   (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni(lcm_sym81__)))),
+                        stan::model::index_uni(lcm_sym82__)))),
                 "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                       stan::model::index_uni(lcm_sym81__));
+                                                       stan::model::index_uni(lcm_sym82__));
             }
           } 
           if (inline_sym15__) {
@@ -16760,30 +16769,30 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::check_less_or_equal(function__, "chi", inline_sym9__, 1);
       {
         current_statement__ = 31;
-        if (lcm_sym71__) {
-          lcm_sym108__ = stan::model::rvalue(first, "first",
+        if (lcm_sym72__) {
+          lcm_sym109__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym108__, 0)) {
-            lcm_sym110__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym109__, 0)) {
+            lcm_sym111__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym90__ = (lcm_sym108__ + 1);
-            if (stan::math::logical_gte(lcm_sym110__, lcm_sym90__)) {
+            lcm_sym91__ = (lcm_sym109__ + 1);
+            if (stan::math::logical_gte(lcm_sym111__, lcm_sym91__)) {
               current_statement__ = 25;
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym90__ - 1)))));
-              lcm_sym88__ = (lcm_sym90__ + 1);
+                      stan::model::index_uni((lcm_sym91__ - 1)))));
+              lcm_sym89__ = (lcm_sym91__ + 1);
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(
                   stan::model::rvalue(y, "y",
                     stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym90__)),
+                      stan::model::index_uni(lcm_sym91__)),
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym90__ - 1)))));
-              for (int t = lcm_sym88__; t <= lcm_sym110__; ++t) {
+                      stan::model::index_uni((lcm_sym91__ - 1)))));
+              for (int t = lcm_sym89__; t <= lcm_sym111__; ++t) {
                 current_statement__ = 25;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
@@ -16805,32 +16814,32 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
               stan::math::bernoulli_lpmf<propto__>(1,
                 stan::model::rvalue(inline_sym9__, "inline_sym9__",
                   stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym110__))));
+                    stan::model::index_uni(lcm_sym111__))));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym107__ = stan::model::rvalue(first, "first",
+            lcm_sym108__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym107__, 0)) {
-              lcm_sym109__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym108__, 0)) {
+              lcm_sym110__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym89__ = (lcm_sym107__ + 1);
-              if (stan::math::logical_gte(lcm_sym109__, lcm_sym89__)) {
+              lcm_sym90__ = (lcm_sym108__ + 1);
+              if (stan::math::logical_gte(lcm_sym110__, lcm_sym90__)) {
                 current_statement__ = 25;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym89__ - 1)))));
-                lcm_sym87__ = (lcm_sym89__ + 1);
+                        stan::model::index_uni((lcm_sym90__ - 1)))));
+                lcm_sym88__ = (lcm_sym90__ + 1);
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(
                     stan::model::rvalue(y, "y",
                       stan::model::index_uni(i),
-                        stan::model::index_uni(lcm_sym89__)),
+                        stan::model::index_uni(lcm_sym90__)),
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym89__ - 1)))));
-                for (int t = lcm_sym87__; t <= lcm_sym109__; ++t) {
+                        stan::model::index_uni((lcm_sym90__ - 1)))));
+                for (int t = lcm_sym88__; t <= lcm_sym110__; ++t) {
                   current_statement__ = 25;
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(1,
@@ -16852,7 +16861,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(inline_sym9__, "inline_sym9__",
                     stan::model::index_uni(i),
-                      stan::model::index_uni(lcm_sym109__))));
+                      stan::model::index_uni(lcm_sym110__))));
             } 
           }
         } 
@@ -16889,6 +16898,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym71__;
       int lcm_sym70__;
       int lcm_sym69__;
       double lcm_sym68__;
@@ -16944,21 +16954,21 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                         stan::model::index_uni(1));
         lcm_sym56__ = (lcm_sym70__ - 1);
         if (stan::math::logical_gte(lcm_sym56__, 1)) {
-          current_statement__ = 6;
-          stan::model::assign(phi, 0,
+          lcm_sym71__ = 0;
+          stan::model::assign(phi, lcm_sym71__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 7;
-          stan::model::assign(p, 0,
+          current_statement__ = 6;
+          stan::model::assign(p, lcm_sym71__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
           for (int t = 2; t <= lcm_sym56__; ++t) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+            current_statement__ = 7;
+            stan::model::assign(phi, lcm_sym71__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym71__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
@@ -16997,21 +17007,21 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           stan::model::index_uni(i));
           lcm_sym55__ = (lcm_sym69__ - 1);
           if (stan::math::logical_gte(lcm_sym55__, 1)) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+            lcm_sym71__ = 0;
+            stan::model::assign(phi, lcm_sym71__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym71__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
             for (int t = 2; t <= lcm_sym55__; ++t) {
-              current_statement__ = 6;
-              stan::model::assign(phi, 0,
+              current_statement__ = 7;
+              stan::model::assign(phi, lcm_sym71__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 7;
-              stan::model::assign(p, 0,
+              current_statement__ = 6;
+              stan::model::assign(p, lcm_sym71__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
@@ -17215,35 +17225,35 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     final {
     
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym130__ = 1; sym130__ <= max_age; ++sym130__) {
+    for (int sym132__ = 1; sym132__ <= max_age; ++sym132__) {
       {
-        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym130__));
+        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym132__));
       } 
     }
     if (emit_transformed_parameters__) {
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occasions; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occasions; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
@@ -17263,35 +17273,35 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     final {
     
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym130__ = 1; sym130__ <= max_age; ++sym130__) {
+    for (int sym132__ = 1; sym132__ <= max_age; ++sym132__) {
       {
-        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym130__));
+        param_names__.emplace_back(std::string() + "beta" + '.' + std::to_string(sym132__));
       } 
     }
     if (emit_transformed_parameters__) {
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occ_minus_1; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occ_minus_1; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
       }
-      for (int sym130__ = 1; sym130__ <= n_occasions; ++sym130__) {
+      for (int sym132__ = 1; sym132__ <= n_occasions; ++sym132__) {
         {
-          for (int sym131__ = 1; sym131__ <= nind; ++sym131__) {
+          for (int sym133__ = 1; sym133__ <= nind; ++sym133__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym131__) + '.' + std::to_string(sym130__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym133__) + '.' + std::to_string(sym132__));
             } 
           }
         } 
@@ -18418,6 +18428,7 @@ template <typename T0__>
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
+      double lcm_sym129__;
       int lcm_sym128__;
       Eigen::Matrix<double, -1, 1> lcm_sym127__;
       double lcm_sym126__;
@@ -18436,15 +18447,17 @@ template <typename T0__>
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(lcm_sym128__,
              DUMMY_VAR__);
         local_scalar_t__ log_residual_prob = DUMMY_VAR__;
+        lcm_sym129__ = 0;
         current_statement__ = 142;
         if (stan::math::logical_gte(lcm_sym128__, 1)) {
           current_statement__ = 47;
           stan::model::assign(log_cprob,
             (stan::math::log(
                stan::model::rvalue(gamma, "gamma", stan::model::index_uni(1)))
-              + 0), "assigning variable log_cprob", stan::model::index_uni(1));
+              + lcm_sym129__),
+            "assigning variable log_cprob", stan::model::index_uni(1));
           current_statement__ = 46;
-          log_residual_prob = (0 +
+          log_residual_prob = (lcm_sym129__ +
                                 stan::math::log1m(
                                   stan::model::rvalue(gamma, "gamma",
                                     stan::model::index_uni(1))));
@@ -18522,6 +18535,8 @@ prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
 class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> {
 
  private:
+  int lcm_sym279__;
+  int lcm_sym278__;
   int lcm_sym277__;
   int lcm_sym276__;
   int lcm_sym275__;
@@ -18536,8 +18551,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   int lcm_sym266__;
   int lcm_sym265__;
   int lcm_sym264__;
-  int lcm_sym263__;
-  int lcm_sym262__;
   int M;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -18631,8 +18644,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 106;
         if (stan::math::logical_gte(n_occasions, 1)) {
           {
-            lcm_sym262__ = stan::math::logical_gte(M, 1);
-            if (lcm_sym262__) {
+            lcm_sym264__ = stan::math::logical_gte(M, 1);
+            if (lcm_sym264__) {
               current_statement__ = 106;
               stan::model::assign(y,
                 stan::model::rvalue(y_flat__, "y_flat__",
@@ -18652,7 +18665,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             } 
             for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
               current_statement__ = 106;
-              if (lcm_sym262__) {
+              if (lcm_sym264__) {
                 current_statement__ = 106;
                 stan::model::assign(y, y_flat__[(pos__ - 1)],
                   "assigning variable y", stan::model::index_uni(1),
@@ -18671,7 +18684,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             }
           }
         } else {
-          lcm_sym262__ = stan::math::logical_gte(M, 1);
+          lcm_sym264__ = stan::math::logical_gte(M, 1);
         }
       }
       current_statement__ = 106;
@@ -18691,15 +18704,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       
       
       current_statement__ = 112;
-      if (lcm_sym262__) {
+      if (lcm_sym264__) {
         int inline_sym41__;
         int inline_sym43__;
         inline_sym43__ = 0;
         for (int inline_sym44__ = 1; inline_sym44__ <= 1; ++inline_sym44__) {
-          lcm_sym271__ = stan::math::size(
+          lcm_sym273__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          for (int inline_sym42__ = 1; inline_sym42__ <= lcm_sym271__;
+          for (int inline_sym42__ = 1; inline_sym42__ <= lcm_sym273__;
                ++inline_sym42__) {
             current_statement__ = 59;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
@@ -18723,10 +18736,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           int inline_sym43__;
           inline_sym43__ = 0;
           for (int inline_sym44__ = 1; inline_sym44__ <= 1; ++inline_sym44__) {
-            lcm_sym270__ = stan::math::size(
+            lcm_sym272__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            for (int inline_sym42__ = 1; inline_sym42__ <= lcm_sym270__;
+            for (int inline_sym42__ = 1; inline_sym42__ <= lcm_sym272__;
                  ++inline_sym42__) {
               current_statement__ = 59;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
@@ -18748,25 +18761,25 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         }
       } 
       current_statement__ = 119;
-      if (lcm_sym262__) {
+      if (lcm_sym264__) {
         int inline_sym45__;
         int inline_sym48__;
         inline_sym48__ = 0;
         for (int inline_sym49__ = 1; inline_sym49__ <= 1; ++inline_sym49__) {
-          lcm_sym271__ = stan::math::size(
+          lcm_sym273__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          lcm_sym268__ = (lcm_sym271__ - 1);
-          for (int inline_sym47__ = 0; inline_sym47__ <= lcm_sym268__;
+          lcm_sym270__ = (lcm_sym273__ - 1);
+          for (int inline_sym47__ = 0; inline_sym47__ <= lcm_sym270__;
                ++inline_sym47__) {
             int inline_sym46__ = std::numeric_limits<int>::min();
-            lcm_sym267__ = (lcm_sym271__ - inline_sym47__);
-            inline_sym46__ = lcm_sym267__;
+            lcm_sym269__ = (lcm_sym273__ - inline_sym47__);
+            inline_sym46__ = lcm_sym269__;
             current_statement__ = 115;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
-                (lcm_sym267__ - 1)]) {
+                (lcm_sym269__ - 1)]) {
               inline_sym48__ = 1;
-              inline_sym45__ = lcm_sym267__;
+              inline_sym45__ = lcm_sym269__;
               break;
             } 
           }
@@ -18784,20 +18797,20 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           int inline_sym48__;
           inline_sym48__ = 0;
           for (int inline_sym49__ = 1; inline_sym49__ <= 1; ++inline_sym49__) {
-            lcm_sym270__ = stan::math::size(
+            lcm_sym272__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            lcm_sym266__ = (lcm_sym270__ - 1);
-            for (int inline_sym47__ = 0; inline_sym47__ <= lcm_sym266__;
+            lcm_sym268__ = (lcm_sym272__ - 1);
+            for (int inline_sym47__ = 0; inline_sym47__ <= lcm_sym268__;
                  ++inline_sym47__) {
               int inline_sym46__ = std::numeric_limits<int>::min();
-              lcm_sym265__ = (lcm_sym270__ - inline_sym47__);
-              inline_sym46__ = lcm_sym265__;
+              lcm_sym267__ = (lcm_sym272__ - inline_sym47__);
+              inline_sym46__ = lcm_sym267__;
               current_statement__ = 115;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
-                  (lcm_sym265__ - 1)]) {
+                  (lcm_sym267__ - 1)]) {
                 inline_sym48__ = 1;
-                inline_sym45__ = lcm_sym265__;
+                inline_sym45__ = lcm_sym267__;
                 break;
               } 
             }
@@ -18827,11 +18840,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       epsilon_1dim__ = std::numeric_limits<int>::min();
       
       
-      lcm_sym264__ = (n_occasions - 1);
-      epsilon_1dim__ = lcm_sym264__;
+      lcm_sym266__ = (n_occasions - 1);
+      epsilon_1dim__ = lcm_sym266__;
       current_statement__ = 121;
       stan::math::validate_non_negative_index("epsilon", "n_occasions - 1",
-                                              lcm_sym264__);
+                                              lcm_sym266__);
       current_statement__ = 122;
       stan::math::validate_non_negative_index("phi", "M", M);
       current_statement__ = 123;
@@ -18839,10 +18852,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       
       
       current_statement__ = 123;
-      phi_2dim__ = lcm_sym264__;
+      phi_2dim__ = lcm_sym266__;
       current_statement__ = 123;
       stan::math::validate_non_negative_index("phi", "n_occasions - 1",
-                                              lcm_sym264__);
+                                              lcm_sym266__);
       current_statement__ = 124;
       stan::math::validate_non_negative_index("p", "M", M);
       current_statement__ = 125;
@@ -18887,21 +18900,23 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     (void) function__;  // suppress unused var warning
     
     try {
+      int lcm_sym263__;
+      int lcm_sym262__;
       int lcm_sym261__;
       int lcm_sym260__;
       int lcm_sym259__;
       int lcm_sym258__;
-      int lcm_sym257__;
       int lcm_sym256__;
-      int lcm_sym254__;
-      Eigen::Matrix<local_scalar_t__, -1, -1> lcm_sym253__;
-      double lcm_sym252__;
-      double lcm_sym251__;
-      local_scalar_t__ lcm_sym250__;
-      local_scalar_t__ lcm_sym249__;
-      double lcm_sym248__;
+      Eigen::Matrix<local_scalar_t__, -1, -1> lcm_sym255__;
+      double lcm_sym254__;
+      double lcm_sym253__;
+      local_scalar_t__ lcm_sym252__;
+      local_scalar_t__ lcm_sym251__;
+      double lcm_sym250__;
+      double lcm_sym249__;
+      int lcm_sym248__;
       double lcm_sym247__;
-      int lcm_sym246__;
+      double lcm_sym246__;
       double lcm_sym245__;
       double lcm_sym244__;
       double lcm_sym243__;
@@ -18913,11 +18928,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       double lcm_sym237__;
       double lcm_sym236__;
       double lcm_sym235__;
-      double lcm_sym234__;
-      double lcm_sym233__;
+      int lcm_sym234__;
+      int lcm_sym233__;
       int lcm_sym232__;
-      int lcm_sym231__;
-      int lcm_sym230__;
+      double lcm_sym231__;
+      double lcm_sym230__;
       double lcm_sym229__;
       double lcm_sym228__;
       double lcm_sym227__;
@@ -18930,18 +18945,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       double lcm_sym220__;
       double lcm_sym219__;
       double lcm_sym218__;
-      double lcm_sym217__;
-      double lcm_sym216__;
+      int lcm_sym217__;
+      int lcm_sym216__;
       int lcm_sym215__;
       int lcm_sym214__;
       int lcm_sym213__;
       int lcm_sym212__;
-      int lcm_sym211__;
-      int lcm_sym210__;
+      Eigen::Matrix<local_scalar_t__, -1, 1> lcm_sym211__;
+      Eigen::Matrix<local_scalar_t__, -1, 1> lcm_sym210__;
       Eigen::Matrix<local_scalar_t__, -1, 1> lcm_sym209__;
-      Eigen::Matrix<local_scalar_t__, -1, 1> lcm_sym208__;
-      Eigen::Matrix<local_scalar_t__, -1, 1> lcm_sym207__;
-      int lcm_sym255__;
+      int lcm_sym257__;
+      int lcm_sym207__;
+      int lcm_sym206__;
       int lcm_sym205__;
       int lcm_sym204__;
       int lcm_sym203__;
@@ -18951,8 +18966,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       int lcm_sym199__;
       int lcm_sym198__;
       int lcm_sym197__;
-      int lcm_sym196__;
-      int lcm_sym195__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__, 
@@ -18969,15 +18982,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<local_scalar_t__, -1, 1> epsilon =
          Eigen::Matrix<local_scalar_t__, -1, 1>::Constant((n_occasions - 1),
            DUMMY_VAR__);
-      lcm_sym255__ = (n_occasions - 1);
+      lcm_sym257__ = (n_occasions - 1);
       epsilon = in__.template read<Eigen::Matrix<local_scalar_t__, -1, 1>>(
-                  lcm_sym255__);
+                  lcm_sym257__);
       local_scalar_t__ sigma;
       current_statement__ = 5;
       sigma = in__.template read_constrain_lub<local_scalar_t__, jacobian__>(
                 0, 5, lp__);
       Eigen::Matrix<local_scalar_t__, -1, -1> phi =
-         Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(M, lcm_sym255__,
+         Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(M, lcm_sym257__,
            DUMMY_VAR__);
       Eigen::Matrix<local_scalar_t__, -1, -1> p =
          Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(M, n_occasions,
@@ -18986,117 +18999,117 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
          Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(M, n_occasions,
            DUMMY_VAR__);
       current_statement__ = 11;
-      if (stan::math::logical_gte(lcm_sym255__, 1)) {
-        lcm_sym197__ = stan::math::logical_gte(M, 1);
-        if (lcm_sym197__) {
-          lcm_sym250__ = stan::math::inv_logit(
+      if (stan::math::logical_gte(lcm_sym257__, 1)) {
+        lcm_sym199__ = stan::math::logical_gte(M, 1);
+        if (lcm_sym199__) {
+          lcm_sym252__ = stan::math::inv_logit(
                            (stan::math::logit(mean_phi) +
                              stan::model::rvalue(epsilon, "epsilon",
                                stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym250__,
+          stan::model::assign(phi, lcm_sym252__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
           for (int i = 2; i <= M; ++i) {
             current_statement__ = 9;
-            stan::model::assign(phi, lcm_sym250__,
+            stan::model::assign(phi, lcm_sym252__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
           }
         } 
-        for (int t = 2; t <= lcm_sym255__; ++t) {
+        for (int t = 2; t <= lcm_sym257__; ++t) {
           current_statement__ = 10;
-          if (lcm_sym197__) {
-            lcm_sym249__ = stan::math::inv_logit(
+          if (lcm_sym199__) {
+            lcm_sym251__ = stan::math::inv_logit(
                              (stan::math::logit(mean_phi) +
                                stan::model::rvalue(epsilon, "epsilon",
                                  stan::model::index_uni(t))));
-            stan::model::assign(phi, lcm_sym249__,
+            stan::model::assign(phi, lcm_sym251__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
             for (int i = 2; i <= M; ++i) {
               current_statement__ = 9;
-              stan::model::assign(phi, lcm_sym249__,
+              stan::model::assign(phi, lcm_sym251__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
             }
           } 
         }
       } 
-      stan::model::assign(lcm_sym253__,
+      stan::model::assign(lcm_sym255__,
         stan::math::rep_matrix(mean_p, M, n_occasions),
-        "assigning variable lcm_sym253__");
-      stan::model::assign(p, lcm_sym253__, "assigning variable p");
+        "assigning variable lcm_sym255__");
+      stan::model::assign(p, lcm_sym255__, "assigning variable p");
       Eigen::Matrix<local_scalar_t__, -1, -1> inline_sym22__;
       int inline_sym30__;
       inline_sym30__ = 0;
       for (int inline_sym31__ = 1; inline_sym31__ <= 1; ++inline_sym31__) {
         int inline_sym23__ = std::numeric_limits<int>::min();
-        lcm_sym254__ = stan::math::rows(lcm_sym253__);
+        lcm_sym256__ = stan::math::rows(lcm_sym255__);
         int inline_sym24__ = std::numeric_limits<int>::min();
-        lcm_sym246__ = stan::math::cols(lcm_sym253__);
+        lcm_sym248__ = stan::math::cols(lcm_sym255__);
         current_statement__ = 14;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym254__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym256__);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-                                                lcm_sym246__);
+                                                lcm_sym248__);
         Eigen::Matrix<local_scalar_t__, -1, -1> inline_sym25__ =
-           Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(lcm_sym254__,
-             lcm_sym246__, DUMMY_VAR__);
-        for (int inline_sym29__ = 1; inline_sym29__ <= lcm_sym254__;
+           Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(lcm_sym256__,
+             lcm_sym248__, DUMMY_VAR__);
+        for (int inline_sym29__ = 1; inline_sym29__ <= lcm_sym256__;
              ++inline_sym29__) {
           current_statement__ = 17;
           stan::model::assign(inline_sym25__, 1.0,
             "assigning variable inline_sym25__", stan::model::index_uni(inline_sym29__),
-                                                   stan::model::index_uni(lcm_sym246__));
-          lcm_sym211__ = (lcm_sym246__ - 1);
-          if (stan::math::logical_gte(lcm_sym211__, 1)) {
+                                                   stan::model::index_uni(lcm_sym248__));
+          lcm_sym213__ = (lcm_sym248__ - 1);
+          if (stan::math::logical_gte(lcm_sym213__, 1)) {
             int inline_sym26__ = std::numeric_limits<int>::min();
             int inline_sym27__ = std::numeric_limits<int>::min();
-            lcm_sym215__ = (lcm_sym211__ + 1);
+            lcm_sym217__ = (lcm_sym213__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_sym25__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi",
                    stan::model::index_uni(inline_sym29__),
-                     stan::model::index_uni(lcm_sym211__)) *
+                     stan::model::index_uni(lcm_sym213__)) *
                   (1 -
-                    stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                    stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                       stan::model::index_uni(inline_sym29__),
-                        stan::model::index_uni(lcm_sym215__)))),
+                        stan::model::index_uni(lcm_sym217__)))),
                 stan::model::rvalue(inline_sym25__, "inline_sym25__",
                   stan::model::index_uni(inline_sym29__),
-                    stan::model::index_uni(lcm_sym215__)),
+                    stan::model::index_uni(lcm_sym217__)),
                 (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_sym29__),
-                      stan::model::index_uni(lcm_sym211__)))),
+                      stan::model::index_uni(lcm_sym213__)))),
               "assigning variable inline_sym25__", stan::model::index_uni(inline_sym29__),
-                                                     stan::model::index_uni(lcm_sym211__));
-            for (int inline_sym28__ = 2; inline_sym28__ <= lcm_sym211__;
+                                                     stan::model::index_uni(lcm_sym213__));
+            for (int inline_sym28__ = 2; inline_sym28__ <= lcm_sym213__;
                  ++inline_sym28__) {
               int inline_sym26__ = std::numeric_limits<int>::min();
-              lcm_sym210__ = (lcm_sym246__ - inline_sym28__);
+              lcm_sym212__ = (lcm_sym248__ - inline_sym28__);
               int inline_sym27__ = std::numeric_limits<int>::min();
-              lcm_sym214__ = (lcm_sym210__ + 1);
+              lcm_sym216__ = (lcm_sym212__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_sym25__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_sym29__),
-                       stan::model::index_uni(lcm_sym210__)) *
+                       stan::model::index_uni(lcm_sym212__)) *
                     (1 -
-                      stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                      stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                         stan::model::index_uni(inline_sym29__),
-                          stan::model::index_uni(lcm_sym214__)))),
+                          stan::model::index_uni(lcm_sym216__)))),
                   stan::model::rvalue(inline_sym25__, "inline_sym25__",
                     stan::model::index_uni(inline_sym29__),
-                      stan::model::index_uni(lcm_sym214__)),
+                      stan::model::index_uni(lcm_sym216__)),
                   (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_sym29__),
-                        stan::model::index_uni(lcm_sym210__)))),
+                        stan::model::index_uni(lcm_sym212__)))),
                 "assigning variable inline_sym25__", stan::model::index_uni(inline_sym29__),
-                                                       stan::model::index_uni(lcm_sym210__));
+                                                       stan::model::index_uni(lcm_sym212__));
             }
           } 
           if (inline_sym30__) {
@@ -19117,9 +19130,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 6;
       stan::math::check_less_or_equal(function__, "phi", phi, 1);
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "p", lcm_sym253__, 0);
+      stan::math::check_greater_or_equal(function__, "p", lcm_sym255__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "p", lcm_sym253__, 1);
+      stan::math::check_less_or_equal(function__, "p", lcm_sym255__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "chi", inline_sym22__, 0);
       current_statement__ = 8;
@@ -19130,126 +19143,126 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         int inline_sym39__ = std::numeric_limits<int>::min();
         {
           int inline_sym32__ = std::numeric_limits<int>::min();
-          lcm_sym260__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym262__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(1));
           int inline_sym33__ = std::numeric_limits<int>::min();
-          lcm_sym261__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym263__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(2));
           current_statement__ = 77;
           stan::math::validate_non_negative_index("qgamma", "n_occasions",
-                                                  lcm_sym261__);
+                                                  lcm_sym263__);
           Eigen::Matrix<double, -1, 1> inline_sym34__ =
-             Eigen::Matrix<double, -1, 1>::Constant(lcm_sym261__,
+             Eigen::Matrix<double, -1, 1>::Constant(lcm_sym263__,
                std::numeric_limits<double>::quiet_NaN());
-          stan::model::assign(lcm_sym207__, stan::math::subtract(1.0, gamma),
-            "assigning variable lcm_sym207__");
-          lcm_sym204__ = stan::math::logical_gte(lcm_sym260__, 1);
-          if (lcm_sym204__) {
+          stan::model::assign(lcm_sym209__, stan::math::subtract(1.0, gamma),
+            "assigning variable lcm_sym209__");
+          lcm_sym206__ = stan::math::logical_gte(lcm_sym262__, 1);
+          if (lcm_sym206__) {
             current_statement__ = 79;
             stan::math::validate_non_negative_index("qp", "n_occasions",
-                                                    lcm_sym261__);
+                                                    lcm_sym263__);
             Eigen::Matrix<double, -1, 1> inline_sym35__ =
-               Eigen::Matrix<double, -1, 1>::Constant(lcm_sym261__,
+               Eigen::Matrix<double, -1, 1>::Constant(lcm_sym263__,
                  std::numeric_limits<double>::quiet_NaN());
-            stan::model::assign(lcm_sym209__,
+            stan::model::assign(lcm_sym211__,
               stan::math::subtract(1.0,
                 stan::math::transpose(
-                  stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                  stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                     stan::model::index_uni(1)))),
-              "assigning variable lcm_sym209__");
-            lcm_sym257__ = stan::model::rvalue(first, "first",
+              "assigning variable lcm_sym211__");
+            lcm_sym259__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(1));
-            if (lcm_sym257__) {
+            if (lcm_sym259__) {
               current_statement__ = 95;
-              if (stan::math::logical_eq(lcm_sym257__, 1)) {
+              if (stan::math::logical_eq(lcm_sym259__, 1)) {
                 current_statement__ = 93;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
                     (stan::model::rvalue(gamma, "gamma",
                        stan::model::index_uni(1)) *
-                      stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                      stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                         stan::model::index_uni(1), stan::model::index_uni(1)))));
               } else {
                 current_statement__ = 87;
                 stan::math::validate_non_negative_index("lp", "first[i]",
-                                                        lcm_sym257__);
+                                                        lcm_sym259__);
                 Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym36__ =
                    Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(
-                     lcm_sym257__, DUMMY_VAR__);
-                lcm_sym213__ = (lcm_sym257__ - 1);
+                     lcm_sym259__, DUMMY_VAR__);
+                lcm_sym215__ = (lcm_sym259__ - 1);
                 stan::model::assign(inline_sym36__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::model::rvalue(gamma, "gamma",
                          stan::model::index_uni(1))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
-                            stan::model::index_min_max(1, lcm_sym213__))))) +
+                          stan::model::rvalue(lcm_sym211__, "lcm_sym211__",
+                            stan::model::index_min_max(1, lcm_sym215__))))) +
                      stan::math::bernoulli_lpmf<false>(1,
                        stan::math::prod(
                          stan::model::rvalue(phi, "phi",
                            stan::model::index_uni(1),
-                             stan::model::index_min_max(1, lcm_sym213__)))))
+                             stan::model::index_min_max(1, lcm_sym215__)))))
                     +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                      stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                         stan::model::index_uni(1),
-                          stan::model::index_uni(lcm_sym257__)))),
+                          stan::model::index_uni(lcm_sym259__)))),
                   "assigning variable inline_sym36__", stan::model::index_uni(1));
-                if (stan::math::logical_gte(lcm_sym213__, 2)) {
+                if (stan::math::logical_gte(lcm_sym215__, 2)) {
                   current_statement__ = 89;
                   stan::model::assign(inline_sym36__,
                     ((((stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym207__, "lcm_sym207__",
+                            stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
                               stan::model::index_min_max(1, 1)))) +
                          stan::math::bernoulli_lpmf<false>(1,
                            stan::model::rvalue(gamma, "gamma",
                              stan::model::index_uni(2)))) +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
-                              stan::model::index_min_max(2, lcm_sym213__)))))
+                            stan::model::rvalue(lcm_sym211__, "lcm_sym211__",
+                              stan::model::index_min_max(2, lcm_sym215__)))))
                        +
                        stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
                            stan::model::rvalue(phi, "phi",
                              stan::model::index_uni(1),
-                               stan::model::index_min_max(2, lcm_sym213__)))))
+                               stan::model::index_min_max(2, lcm_sym215__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
-                        stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                        stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                           stan::model::index_uni(1),
-                            stan::model::index_uni(lcm_sym257__)))),
+                            stan::model::index_uni(lcm_sym259__)))),
                     "assigning variable inline_sym36__", stan::model::index_uni(2));
                   for (int inline_sym37__ = 3;
-                       inline_sym37__ <= lcm_sym213__; ++inline_sym37__) {
+                       inline_sym37__ <= lcm_sym215__; ++inline_sym37__) {
                     current_statement__ = 89;
                     stan::model::assign(inline_sym36__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym207__,
-                                "lcm_sym207__",
+                              stan::model::rvalue(lcm_sym209__,
+                                "lcm_sym209__",
                                 stan::model::index_min_max(1, (inline_sym37__
                                                                 - 1))))) +
                            stan::math::bernoulli_lpmf<false>(1,
                              gamma[(inline_sym37__ - 1)])) +
                           stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym209__,
-                                "lcm_sym209__",
-                                stan::model::index_min_max(inline_sym37__, lcm_sym213__)))))
+                              stan::model::rvalue(lcm_sym211__,
+                                "lcm_sym211__",
+                                stan::model::index_min_max(inline_sym37__, lcm_sym215__)))))
                          +
                          stan::math::bernoulli_lpmf<false>(1,
                            stan::math::prod(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(1),
-                                 stan::model::index_min_max(inline_sym37__, lcm_sym213__)))))
+                                 stan::model::index_min_max(inline_sym37__, lcm_sym215__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
-                          stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                          stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                             stan::model::index_uni(1),
-                              stan::model::index_uni(lcm_sym257__)))),
+                              stan::model::index_uni(lcm_sym259__)))),
                       "assigning variable inline_sym36__", stan::model::index_uni(inline_sym37__));
                   }
                 } 
@@ -19257,38 +19270,38 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 stan::model::assign(inline_sym36__,
                   ((stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym207__, "lcm_sym207__",
-                          stan::model::index_min_max(1, lcm_sym213__)))) +
+                        stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
+                          stan::model::index_min_max(1, lcm_sym215__)))) +
                      stan::math::bernoulli_lpmf<false>(1,
-                       gamma[(lcm_sym257__ - 1)])) +
+                       gamma[(lcm_sym259__ - 1)])) +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                      stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                         stan::model::index_uni(1),
-                          stan::model::index_uni(lcm_sym257__)))),
-                  "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym257__));
+                          stan::model::index_uni(lcm_sym259__)))),
+                  "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym259__));
                 current_statement__ = 91;
                 lp_accum__.add(stan::math::log_sum_exp(inline_sym36__));
               }
-              lcm_sym259__ = stan::model::rvalue(last, "last",
+              lcm_sym261__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(1));
-              if (stan::math::logical_gte(lcm_sym259__, (lcm_sym257__ + 1))) {
+              if (stan::math::logical_gte(lcm_sym261__, (lcm_sym259__ + 1))) {
                 current_statement__ = 96;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(1),
-                        stan::model::index_uni(((lcm_sym257__ + 1) - 1)))));
-                lcm_sym231__ = ((lcm_sym257__ + 1) + 1);
+                        stan::model::index_uni(((lcm_sym259__ + 1) - 1)))));
+                lcm_sym233__ = ((lcm_sym259__ + 1) + 1);
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(
                     stan::model::rvalue(y, "y",
                       stan::model::index_uni(1),
-                        stan::model::index_uni((lcm_sym257__ + 1))),
-                    stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                        stan::model::index_uni((lcm_sym259__ + 1))),
+                    stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                       stan::model::index_uni(1),
-                        stan::model::index_uni((lcm_sym257__ + 1)))));
-                for (int inline_sym37__ = lcm_sym231__;
-                     inline_sym37__ <= lcm_sym259__; ++inline_sym37__) {
+                        stan::model::index_uni((lcm_sym259__ + 1)))));
+                for (int inline_sym37__ = lcm_sym233__;
+                     inline_sym37__ <= lcm_sym261__; ++inline_sym37__) {
                   current_statement__ = 96;
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(1,
@@ -19301,7 +19314,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                       stan::model::rvalue(y, "y",
                         stan::model::index_uni(1),
                           stan::model::index_uni(inline_sym37__)),
-                      stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                      stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                         stan::model::index_uni(1),
                           stan::model::index_uni(inline_sym37__))));
                 }
@@ -19311,59 +19324,59 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(inline_sym22__, "inline_sym22__",
                     stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym259__))));
+                      stan::model::index_uni(lcm_sym261__))));
             } else {
-              lcm_sym232__ = (lcm_sym261__ + 1);
+              lcm_sym234__ = (lcm_sym263__ + 1);
               stan::math::validate_non_negative_index("lp",
                                                       "n_occasions + 1",
-                                                      lcm_sym232__);
+                                                      lcm_sym234__);
               Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym36__ =
                  Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(
-                   lcm_sym232__, DUMMY_VAR__);
+                   lcm_sym234__, DUMMY_VAR__);
               current_statement__ = 82;
               stan::model::assign(inline_sym36__,
                 ((stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(gamma, "gamma",
                       stan::model::index_uni(1))) +
                    stan::math::bernoulli_lpmf<false>(0,
-                     stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                     stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                        stan::model::index_uni(1), stan::model::index_uni(1))))
                   +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(inline_sym22__, "inline_sym22__",
                       stan::model::index_uni(1), stan::model::index_uni(1)))),
                 "assigning variable inline_sym36__", stan::model::index_uni(1));
-              if (stan::math::logical_gte(lcm_sym261__, 2)) {
+              if (stan::math::logical_gte(lcm_sym263__, 2)) {
                 current_statement__ = 83;
                 stan::model::assign(inline_sym36__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::math::prod(
-                         stan::model::rvalue(lcm_sym207__, "lcm_sym207__",
+                         stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
                            stan::model::index_min_max(1, 1)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(gamma, "gamma",
                           stan::model::index_uni(2)))) +
                      stan::math::bernoulli_lpmf<false>(0,
-                       stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                       stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                          stan::model::index_uni(1), stan::model::index_uni(2))))
                     +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(inline_sym22__, "inline_sym22__",
                         stan::model::index_uni(1), stan::model::index_uni(2)))),
                   "assigning variable inline_sym36__", stan::model::index_uni(2));
-                for (int inline_sym37__ = 3; inline_sym37__ <= lcm_sym261__;
+                for (int inline_sym37__ = 3; inline_sym37__ <= lcm_sym263__;
                      ++inline_sym37__) {
                   current_statement__ = 83;
                   stan::model::assign(inline_sym36__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
-                           stan::model::rvalue(lcm_sym207__, "lcm_sym207__",
+                           stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
                              stan::model::index_min_max(1, (inline_sym37__ -
                                                              1))))) +
                         stan::math::bernoulli_lpmf<false>(1,
                           gamma[(inline_sym37__ - 1)])) +
                        stan::math::bernoulli_lpmf<false>(0,
-                         stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                         stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                            stan::model::index_uni(1),
                              stan::model::index_uni(inline_sym37__)))) +
                       stan::math::bernoulli_lpmf<false>(1,
@@ -19376,121 +19389,121 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               current_statement__ = 84;
               stan::model::assign(inline_sym36__,
                 stan::math::bernoulli_lpmf<false>(1,
-                  stan::math::prod(lcm_sym207__)),
-                "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym232__));
+                  stan::math::prod(lcm_sym209__)),
+                "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym234__));
               current_statement__ = 85;
               lp_accum__.add(stan::math::log_sum_exp(inline_sym36__));
             }
-            for (int inline_sym38__ = 2; inline_sym38__ <= lcm_sym260__;
+            for (int inline_sym38__ = 2; inline_sym38__ <= lcm_sym262__;
                  ++inline_sym38__) {
               current_statement__ = 79;
               stan::math::validate_non_negative_index("qp", "n_occasions",
-                                                      lcm_sym261__);
+                                                      lcm_sym263__);
               Eigen::Matrix<double, -1, 1> inline_sym35__ =
-                 Eigen::Matrix<double, -1, 1>::Constant(lcm_sym261__,
+                 Eigen::Matrix<double, -1, 1>::Constant(lcm_sym263__,
                    std::numeric_limits<double>::quiet_NaN());
-              stan::model::assign(lcm_sym208__,
+              stan::model::assign(lcm_sym210__,
                 stan::math::subtract(1.0,
                   stan::math::transpose(
-                    stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                    stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                       stan::model::index_uni(inline_sym38__)))),
-                "assigning variable lcm_sym208__");
-              lcm_sym256__ = first[(inline_sym38__ - 1)];
-              if (lcm_sym256__) {
+                "assigning variable lcm_sym210__");
+              lcm_sym258__ = first[(inline_sym38__ - 1)];
+              if (lcm_sym258__) {
                 current_statement__ = 95;
-                if (stan::math::logical_eq(lcm_sym256__, 1)) {
+                if (stan::math::logical_eq(lcm_sym258__, 1)) {
                   current_statement__ = 93;
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(1,
                       (stan::model::rvalue(gamma, "gamma",
                          stan::model::index_uni(1)) *
-                        stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                        stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                           stan::model::index_uni(inline_sym38__),
                             stan::model::index_uni(1)))));
                 } else {
                   current_statement__ = 87;
                   stan::math::validate_non_negative_index("lp", "first[i]",
-                                                          lcm_sym256__);
+                                                          lcm_sym258__);
                   Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym36__ =
                      Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(
-                       lcm_sym256__, DUMMY_VAR__);
-                  lcm_sym212__ = (lcm_sym256__ - 1);
+                       lcm_sym258__, DUMMY_VAR__);
+                  lcm_sym214__ = (lcm_sym258__ - 1);
                   stan::model::assign(inline_sym36__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::model::rvalue(gamma, "gamma",
                            stan::model::index_uni(1))) +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym208__, "lcm_sym208__",
-                              stan::model::index_min_max(1, lcm_sym212__)))))
+                            stan::model::rvalue(lcm_sym210__, "lcm_sym210__",
+                              stan::model::index_min_max(1, lcm_sym214__)))))
                        +
                        stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
                            stan::model::rvalue(phi, "phi",
                              stan::model::index_uni(inline_sym38__),
-                               stan::model::index_min_max(1, lcm_sym212__)))))
+                               stan::model::index_min_max(1, lcm_sym214__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
-                        stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                        stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                           stan::model::index_uni(inline_sym38__),
-                            stan::model::index_uni(lcm_sym256__)))),
+                            stan::model::index_uni(lcm_sym258__)))),
                     "assigning variable inline_sym36__", stan::model::index_uni(1));
-                  if (stan::math::logical_gte(lcm_sym212__, 2)) {
+                  if (stan::math::logical_gte(lcm_sym214__, 2)) {
                     current_statement__ = 89;
                     stan::model::assign(inline_sym36__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym207__,
-                                "lcm_sym207__",
+                              stan::model::rvalue(lcm_sym209__,
+                                "lcm_sym209__",
                                 stan::model::index_min_max(1, 1)))) +
                            stan::math::bernoulli_lpmf<false>(1,
                              stan::model::rvalue(gamma, "gamma",
                                stan::model::index_uni(2)))) +
                           stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym208__,
-                                "lcm_sym208__",
-                                stan::model::index_min_max(2, lcm_sym212__)))))
+                              stan::model::rvalue(lcm_sym210__,
+                                "lcm_sym210__",
+                                stan::model::index_min_max(2, lcm_sym214__)))))
                          +
                          stan::math::bernoulli_lpmf<false>(1,
                            stan::math::prod(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(inline_sym38__),
-                                 stan::model::index_min_max(2, lcm_sym212__)))))
+                                 stan::model::index_min_max(2, lcm_sym214__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
-                          stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                          stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                             stan::model::index_uni(inline_sym38__),
-                              stan::model::index_uni(lcm_sym256__)))),
+                              stan::model::index_uni(lcm_sym258__)))),
                       "assigning variable inline_sym36__", stan::model::index_uni(2));
                     for (int inline_sym37__ = 3;
-                         inline_sym37__ <= lcm_sym212__; ++inline_sym37__) {
+                         inline_sym37__ <= lcm_sym214__; ++inline_sym37__) {
                       current_statement__ = 89;
                       stan::model::assign(inline_sym36__,
                         ((((stan::math::bernoulli_lpmf<false>(1,
                               stan::math::prod(
-                                stan::model::rvalue(lcm_sym207__,
-                                  "lcm_sym207__",
+                                stan::model::rvalue(lcm_sym209__,
+                                  "lcm_sym209__",
                                   stan::model::index_min_max(1, (inline_sym37__
                                                                   - 1))))) +
                              stan::math::bernoulli_lpmf<false>(1,
                                gamma[(inline_sym37__ - 1)])) +
                             stan::math::bernoulli_lpmf<false>(1,
                               stan::math::prod(
-                                stan::model::rvalue(lcm_sym208__,
-                                  "lcm_sym208__",
-                                  stan::model::index_min_max(inline_sym37__, lcm_sym212__)))))
+                                stan::model::rvalue(lcm_sym210__,
+                                  "lcm_sym210__",
+                                  stan::model::index_min_max(inline_sym37__, lcm_sym214__)))))
                            +
                            stan::math::bernoulli_lpmf<false>(1,
                              stan::math::prod(
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(inline_sym38__),
-                                   stan::model::index_min_max(inline_sym37__, lcm_sym212__)))))
+                                   stan::model::index_min_max(inline_sym37__, lcm_sym214__)))))
                           +
                           stan::math::bernoulli_lpmf<false>(1,
-                            stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                            stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                               stan::model::index_uni(inline_sym38__),
-                                stan::model::index_uni(lcm_sym256__)))),
+                                stan::model::index_uni(lcm_sym258__)))),
                         "assigning variable inline_sym36__", stan::model::index_uni(inline_sym37__));
                     }
                   } 
@@ -19498,37 +19511,37 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   stan::model::assign(inline_sym36__,
                     ((stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym207__, "lcm_sym207__",
-                            stan::model::index_min_max(1, lcm_sym212__)))) +
+                          stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
+                            stan::model::index_min_max(1, lcm_sym214__)))) +
                        stan::math::bernoulli_lpmf<false>(1,
-                         gamma[(lcm_sym256__ - 1)])) +
+                         gamma[(lcm_sym258__ - 1)])) +
                       stan::math::bernoulli_lpmf<false>(1,
-                        stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                        stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                           stan::model::index_uni(inline_sym38__),
-                            stan::model::index_uni(lcm_sym256__)))),
-                    "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym256__));
+                            stan::model::index_uni(lcm_sym258__)))),
+                    "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym258__));
                   current_statement__ = 91;
                   lp_accum__.add(stan::math::log_sum_exp(inline_sym36__));
                 }
-                lcm_sym258__ = last[(inline_sym38__ - 1)];
-                if (stan::math::logical_gte(lcm_sym258__, (lcm_sym256__ + 1))) {
+                lcm_sym260__ = last[(inline_sym38__ - 1)];
+                if (stan::math::logical_gte(lcm_sym260__, (lcm_sym258__ + 1))) {
                   current_statement__ = 96;
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(1,
                       stan::model::rvalue(phi, "phi",
                         stan::model::index_uni(inline_sym38__),
-                          stan::model::index_uni(((lcm_sym256__ + 1) - 1)))));
-                  lcm_sym230__ = ((lcm_sym256__ + 1) + 1);
+                          stan::model::index_uni(((lcm_sym258__ + 1) - 1)))));
+                  lcm_sym232__ = ((lcm_sym258__ + 1) + 1);
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(
                       stan::model::rvalue(y, "y",
                         stan::model::index_uni(inline_sym38__),
-                          stan::model::index_uni((lcm_sym256__ + 1))),
-                      stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                          stan::model::index_uni((lcm_sym258__ + 1))),
+                      stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                         stan::model::index_uni(inline_sym38__),
-                          stan::model::index_uni((lcm_sym256__ + 1)))));
-                  for (int inline_sym37__ = lcm_sym230__;
-                       inline_sym37__ <= lcm_sym258__; ++inline_sym37__) {
+                          stan::model::index_uni((lcm_sym258__ + 1)))));
+                  for (int inline_sym37__ = lcm_sym232__;
+                       inline_sym37__ <= lcm_sym260__; ++inline_sym37__) {
                     current_statement__ = 96;
                     lp_accum__.add(
                       stan::math::bernoulli_lpmf<propto__>(1,
@@ -19539,7 +19552,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     lp_accum__.add(
                       stan::math::bernoulli_lpmf<propto__>(
                         y[(inline_sym38__ - 1)][(inline_sym37__ - 1)],
-                        stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                        stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                           stan::model::index_uni(inline_sym38__),
                             stan::model::index_uni(inline_sym37__))));
                   }
@@ -19549,22 +19562,22 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   stan::math::bernoulli_lpmf<propto__>(1,
                     stan::model::rvalue(inline_sym22__, "inline_sym22__",
                       stan::model::index_uni(inline_sym38__),
-                        stan::model::index_uni(lcm_sym258__))));
+                        stan::model::index_uni(lcm_sym260__))));
               } else {
-                lcm_sym232__ = (lcm_sym261__ + 1);
+                lcm_sym234__ = (lcm_sym263__ + 1);
                 stan::math::validate_non_negative_index("lp",
                                                         "n_occasions + 1",
-                                                        lcm_sym232__);
+                                                        lcm_sym234__);
                 Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym36__ =
                    Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(
-                     lcm_sym232__, DUMMY_VAR__);
+                     lcm_sym234__, DUMMY_VAR__);
                 current_statement__ = 82;
                 stan::model::assign(inline_sym36__,
                   ((stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(gamma, "gamma",
                         stan::model::index_uni(1))) +
                      stan::math::bernoulli_lpmf<false>(0,
-                       stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                       stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                          stan::model::index_uni(inline_sym38__),
                            stan::model::index_uni(1)))) +
                     stan::math::bernoulli_lpmf<false>(1,
@@ -19572,18 +19585,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                         stan::model::index_uni(inline_sym38__),
                           stan::model::index_uni(1)))),
                   "assigning variable inline_sym36__", stan::model::index_uni(1));
-                if (stan::math::logical_gte(lcm_sym261__, 2)) {
+                if (stan::math::logical_gte(lcm_sym263__, 2)) {
                   current_statement__ = 83;
                   stan::model::assign(inline_sym36__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
-                           stan::model::rvalue(lcm_sym207__, "lcm_sym207__",
+                           stan::model::rvalue(lcm_sym209__, "lcm_sym209__",
                              stan::model::index_min_max(1, 1)))) +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::model::rvalue(gamma, "gamma",
                             stan::model::index_uni(2)))) +
                        stan::math::bernoulli_lpmf<false>(0,
-                         stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                         stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                            stan::model::index_uni(inline_sym38__),
                              stan::model::index_uni(2)))) +
                       stan::math::bernoulli_lpmf<false>(1,
@@ -19592,19 +19605,19 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                             stan::model::index_uni(2)))),
                     "assigning variable inline_sym36__", stan::model::index_uni(2));
                   for (int inline_sym37__ = 3;
-                       inline_sym37__ <= lcm_sym261__; ++inline_sym37__) {
+                       inline_sym37__ <= lcm_sym263__; ++inline_sym37__) {
                     current_statement__ = 83;
                     stan::model::assign(inline_sym36__,
                       (((stan::math::bernoulli_lpmf<false>(1,
                            stan::math::prod(
-                             stan::model::rvalue(lcm_sym207__,
-                               "lcm_sym207__",
+                             stan::model::rvalue(lcm_sym209__,
+                               "lcm_sym209__",
                                stan::model::index_min_max(1, (inline_sym37__
                                                                - 1))))) +
                           stan::math::bernoulli_lpmf<false>(1,
                             gamma[(inline_sym37__ - 1)])) +
                          stan::math::bernoulli_lpmf<false>(0,
-                           stan::model::rvalue(lcm_sym253__, "lcm_sym253__",
+                           stan::model::rvalue(lcm_sym255__, "lcm_sym255__",
                              stan::model::index_uni(inline_sym38__),
                                stan::model::index_uni(inline_sym37__)))) +
                         stan::math::bernoulli_lpmf<false>(1,
@@ -19618,8 +19631,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 current_statement__ = 84;
                 stan::model::assign(inline_sym36__,
                   stan::math::bernoulli_lpmf<false>(1,
-                    stan::math::prod(lcm_sym207__)),
-                  "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym232__));
+                    stan::math::prod(lcm_sym209__)),
+                  "assigning variable inline_sym36__", stan::model::index_uni(lcm_sym234__));
                 current_statement__ = 85;
                 lp_accum__.add(stan::math::log_sum_exp(inline_sym36__));
               }
@@ -19659,63 +19672,64 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym196__;
+      int lcm_sym195__;
       int lcm_sym194__;
       int lcm_sym193__;
       int lcm_sym192__;
       int lcm_sym191__;
       int lcm_sym190__;
-      int lcm_sym189__;
-      double lcm_sym162__;
+      double lcm_sym163__;
+      int lcm_sym188__;
       int lcm_sym187__;
       int lcm_sym186__;
       int lcm_sym185__;
       int lcm_sym184__;
       int lcm_sym183__;
-      int lcm_sym182__;
-      double lcm_sym181__;
-      int lcm_sym180__;
-      double lcm_sym179__;
+      double lcm_sym182__;
+      int lcm_sym181__;
+      double lcm_sym180__;
+      int lcm_sym179__;
       int lcm_sym178__;
       int lcm_sym177__;
       int lcm_sym176__;
-      int lcm_sym175__;
-      Eigen::Matrix<double, -1, -1> lcm_sym174__;
-      std::vector<std::vector<int>> lcm_sym173__;
+      Eigen::Matrix<double, -1, -1> lcm_sym175__;
+      std::vector<std::vector<int>> lcm_sym174__;
+      local_scalar_t__ lcm_sym173__;
       local_scalar_t__ lcm_sym172__;
-      local_scalar_t__ lcm_sym171__;
+      double lcm_sym171__;
       double lcm_sym170__;
       double lcm_sym169__;
       double lcm_sym168__;
       double lcm_sym167__;
       double lcm_sym166__;
-      double lcm_sym165__;
-      Eigen::Matrix<double, -1, 1> lcm_sym164__;
-      int lcm_sym163__;
+      Eigen::Matrix<double, -1, 1> lcm_sym165__;
+      int lcm_sym164__;
+      int lcm_sym158__;
       int lcm_sym157__;
       int lcm_sym156__;
       int lcm_sym155__;
-      int lcm_sym154__;
+      double lcm_sym154__;
       double lcm_sym153__;
       double lcm_sym152__;
       int lcm_sym151__;
       int lcm_sym150__;
       double lcm_sym149__;
-      double lcm_sym148__;
+      int lcm_sym148__;
       int lcm_sym147__;
       int lcm_sym146__;
       int lcm_sym145__;
       int lcm_sym144__;
       int lcm_sym143__;
-      int lcm_sym142__;
-      int lcm_sym188__;
+      int lcm_sym189__;
+      int lcm_sym141__;
       int lcm_sym140__;
       int lcm_sym139__;
       int lcm_sym138__;
       int lcm_sym137__;
       int lcm_sym136__;
       int lcm_sym135__;
-      int lcm_sym134__;
-      Eigen::Matrix<double, -1, 1> lcm_sym133__;
+      Eigen::Matrix<double, -1, 1> lcm_sym134__;
       double mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__, 
@@ -19732,15 +19746,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<double, -1, 1> epsilon =
          Eigen::Matrix<double, -1, 1>::Constant((n_occasions - 1),
            std::numeric_limits<double>::quiet_NaN());
-      lcm_sym188__ = (n_occasions - 1);
+      lcm_sym189__ = (n_occasions - 1);
       epsilon = in__.template read<Eigen::Matrix<local_scalar_t__, -1, 1>>(
-                  lcm_sym188__);
+                  lcm_sym189__);
       double sigma;
       current_statement__ = 5;
       sigma = in__.template read_constrain_lub<local_scalar_t__, jacobian__>(
                 0, 5, lp__);
       Eigen::Matrix<double, -1, -1> phi =
-         Eigen::Matrix<double, -1, -1>::Constant(M, lcm_sym188__,
+         Eigen::Matrix<double, -1, -1>::Constant(M, lcm_sym189__,
            std::numeric_limits<double>::quiet_NaN());
       Eigen::Matrix<double, -1, -1> p =
          Eigen::Matrix<double, -1, -1>::Constant(M, n_occasions,
@@ -19759,37 +19773,37 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         return ;
       } 
       current_statement__ = 11;
-      if (stan::math::logical_gte(lcm_sym188__, 1)) {
+      if (stan::math::logical_gte(lcm_sym189__, 1)) {
         {
-          lcm_sym134__ = stan::math::logical_gte(M, 1);
-          if (lcm_sym134__) {
-            lcm_sym172__ = stan::math::inv_logit(
+          lcm_sym135__ = stan::math::logical_gte(M, 1);
+          if (lcm_sym135__) {
+            lcm_sym173__ = stan::math::inv_logit(
                              (stan::math::logit(mean_phi) +
                                stan::model::rvalue(epsilon, "epsilon",
                                  stan::model::index_uni(1))));
-            stan::model::assign(phi, lcm_sym172__,
+            stan::model::assign(phi, lcm_sym173__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(1));
             for (int i = 2; i <= M; ++i) {
               current_statement__ = 9;
-              stan::model::assign(phi, lcm_sym172__,
+              stan::model::assign(phi, lcm_sym173__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(1));
             }
           } 
-          for (int t = 2; t <= lcm_sym188__; ++t) {
+          for (int t = 2; t <= lcm_sym189__; ++t) {
             current_statement__ = 10;
-            if (lcm_sym134__) {
-              lcm_sym171__ = stan::math::inv_logit(
+            if (lcm_sym135__) {
+              lcm_sym172__ = stan::math::inv_logit(
                                (stan::math::logit(mean_phi) +
                                  stan::model::rvalue(epsilon, "epsilon",
                                    stan::model::index_uni(t))));
-              stan::model::assign(phi, lcm_sym171__,
+              stan::model::assign(phi, lcm_sym172__,
                 "assigning variable phi", stan::model::index_uni(1),
                                             stan::model::index_uni(t));
               for (int i = 2; i <= M; ++i) {
                 current_statement__ = 9;
-                stan::model::assign(phi, lcm_sym171__,
+                stan::model::assign(phi, lcm_sym172__,
                   "assigning variable phi", stan::model::index_uni(i),
                                               stan::model::index_uni(t));
               }
@@ -19797,47 +19811,47 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
         }
       } else {
-        lcm_sym134__ = stan::math::logical_gte(M, 1);
+        lcm_sym135__ = stan::math::logical_gte(M, 1);
       }
-      stan::model::assign(lcm_sym174__,
+      stan::model::assign(lcm_sym175__,
         stan::math::rep_matrix(mean_p, M, n_occasions),
-        "assigning variable lcm_sym174__");
-      stan::model::assign(p, lcm_sym174__, "assigning variable p");
+        "assigning variable lcm_sym175__");
+      stan::model::assign(p, lcm_sym175__, "assigning variable p");
       Eigen::Matrix<double, -1, -1> inline_sym1__;
       int inline_sym9__;
       inline_sym9__ = 0;
       for (int inline_sym10__ = 1; inline_sym10__ <= 1; ++inline_sym10__) {
         int inline_sym2__ = std::numeric_limits<int>::min();
-        lcm_sym176__ = stan::math::rows(lcm_sym174__);
+        lcm_sym177__ = stan::math::rows(lcm_sym175__);
         int inline_sym3__ = std::numeric_limits<int>::min();
-        lcm_sym163__ = stan::math::cols(lcm_sym174__);
+        lcm_sym164__ = stan::math::cols(lcm_sym175__);
         current_statement__ = 14;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym176__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym177__);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-                                                lcm_sym163__);
+                                                lcm_sym164__);
         Eigen::Matrix<local_scalar_t__, -1, -1> inline_sym4__ =
-           Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(lcm_sym176__,
-             lcm_sym163__, DUMMY_VAR__);
-        for (int inline_sym8__ = 1; inline_sym8__ <= lcm_sym176__;
+           Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(lcm_sym177__,
+             lcm_sym164__, DUMMY_VAR__);
+        for (int inline_sym8__ = 1; inline_sym8__ <= lcm_sym177__;
              ++inline_sym8__) {
           current_statement__ = 17;
           stan::model::assign(inline_sym4__, 1.0,
             "assigning variable inline_sym4__", stan::model::index_uni(inline_sym8__),
-                                                  stan::model::index_uni(lcm_sym163__));
-          lcm_sym145__ = (lcm_sym163__ - 1);
-          if (stan::math::logical_gte(lcm_sym145__, 1)) {
+                                                  stan::model::index_uni(lcm_sym164__));
+          lcm_sym146__ = (lcm_sym164__ - 1);
+          if (stan::math::logical_gte(lcm_sym146__, 1)) {
             int inline_sym5__ = std::numeric_limits<int>::min();
             int inline_sym6__ = std::numeric_limits<int>::min();
-            lcm_sym151__ = (lcm_sym145__ + 1);
+            lcm_sym151__ = (lcm_sym146__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_sym4__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi",
                    stan::model::index_uni(inline_sym8__),
-                     stan::model::index_uni(lcm_sym145__)) *
+                     stan::model::index_uni(lcm_sym146__)) *
                   (1 -
-                    stan::model::rvalue(lcm_sym174__, "lcm_sym174__",
+                    stan::model::rvalue(lcm_sym175__, "lcm_sym175__",
                       stan::model::index_uni(inline_sym8__),
                         stan::model::index_uni(lcm_sym151__)))),
                 stan::model::rvalue(inline_sym4__, "inline_sym4__",
@@ -19846,23 +19860,23 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_sym8__),
-                      stan::model::index_uni(lcm_sym145__)))),
+                      stan::model::index_uni(lcm_sym146__)))),
               "assigning variable inline_sym4__", stan::model::index_uni(inline_sym8__),
-                                                    stan::model::index_uni(lcm_sym145__));
-            for (int inline_sym7__ = 2; inline_sym7__ <= lcm_sym145__;
+                                                    stan::model::index_uni(lcm_sym146__));
+            for (int inline_sym7__ = 2; inline_sym7__ <= lcm_sym146__;
                  ++inline_sym7__) {
               int inline_sym5__ = std::numeric_limits<int>::min();
-              lcm_sym144__ = (lcm_sym163__ - inline_sym7__);
+              lcm_sym145__ = (lcm_sym164__ - inline_sym7__);
               int inline_sym6__ = std::numeric_limits<int>::min();
-              lcm_sym150__ = (lcm_sym144__ + 1);
+              lcm_sym150__ = (lcm_sym145__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_sym4__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_sym8__),
-                       stan::model::index_uni(lcm_sym144__)) *
+                       stan::model::index_uni(lcm_sym145__)) *
                     (1 -
-                      stan::model::rvalue(lcm_sym174__, "lcm_sym174__",
+                      stan::model::rvalue(lcm_sym175__, "lcm_sym175__",
                         stan::model::index_uni(inline_sym8__),
                           stan::model::index_uni(lcm_sym150__)))),
                   stan::model::rvalue(inline_sym4__, "inline_sym4__",
@@ -19871,9 +19885,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_sym8__),
-                        stan::model::index_uni(lcm_sym144__)))),
+                        stan::model::index_uni(lcm_sym145__)))),
                 "assigning variable inline_sym4__", stan::model::index_uni(inline_sym8__),
-                                                      stan::model::index_uni(lcm_sym144__));
+                                                      stan::model::index_uni(lcm_sym145__));
             }
           } 
           if (inline_sym9__) {
@@ -19894,16 +19908,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 6;
       stan::math::check_less_or_equal(function__, "phi", phi, 1);
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "p", lcm_sym174__, 0);
+      stan::math::check_greater_or_equal(function__, "p", lcm_sym175__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "p", lcm_sym174__, 1);
+      stan::math::check_less_or_equal(function__, "p", lcm_sym175__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "chi", inline_sym1__, 0);
       current_statement__ = 8;
       stan::math::check_less_or_equal(function__, "chi", inline_sym1__, 1);
       if (emit_transformed_parameters__) {
         out__.write(phi);
-        out__.write(lcm_sym174__);
+        out__.write(lcm_sym175__);
         out__.write(inline_sym1__);
       } 
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -19923,31 +19937,31 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
          std::vector<std::vector<int>>(M, 
            std::vector<int>(n_occasions, std::numeric_limits<int>::min()));
       current_statement__ = 39;
-      if (lcm_sym134__) {
+      if (lcm_sym135__) {
         int q = std::numeric_limits<int>::min();
         double mu2 = std::numeric_limits<double>::quiet_NaN();
-        lcm_sym162__ = stan::model::rvalue(gamma, "gamma",
+        lcm_sym163__ = stan::model::rvalue(gamma, "gamma",
                          stan::model::index_uni(1));
         stan::model::assign(z,
-          stan::math::bernoulli_rng(lcm_sym162__, base_rng__),
+          stan::math::bernoulli_rng(lcm_sym163__, base_rng__),
           "assigning variable z", stan::model::index_uni(1),
                                     stan::model::index_uni(1));
-        lcm_sym136__ = stan::math::logical_gte(n_occasions, 2);
-        if (lcm_sym136__) {
-          lcm_sym192__ = stan::model::rvalue(z, "z",
+        lcm_sym137__ = stan::math::logical_gte(n_occasions, 2);
+        if (lcm_sym137__) {
+          lcm_sym193__ = stan::model::rvalue(z, "z",
                            stan::model::index_uni(1),
                              stan::model::index_uni(1));
-          lcm_sym157__ = (1 * (1 - lcm_sym192__));
-          q = lcm_sym157__;
-          lcm_sym169__ = stan::math::fma(
+          lcm_sym158__ = (1 * (1 - lcm_sym193__));
+          q = lcm_sym158__;
+          lcm_sym170__ = stan::math::fma(
                            stan::model::rvalue(phi, "phi",
                              stan::model::index_uni(1),
-                               stan::model::index_uni(1)), lcm_sym192__,
+                               stan::model::index_uni(1)), lcm_sym193__,
                            (stan::model::rvalue(gamma, "gamma",
-                              stan::model::index_uni(2)) * lcm_sym157__));
+                              stan::model::index_uni(2)) * lcm_sym158__));
           current_statement__ = 33;
           stan::model::assign(z,
-            stan::math::bernoulli_rng(lcm_sym169__, base_rng__),
+            stan::math::bernoulli_rng(lcm_sym170__, base_rng__),
             "assigning variable z", stan::model::index_uni(1),
                                       stan::model::index_uni(2));
           for (int t = 3; t <= n_occasions; ++t) {
@@ -19957,7 +19971,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     stan::model::rvalue(z, "z",
                       stan::model::index_uni(1),
                         stan::model::index_uni((t - 1)))));
-            lcm_sym170__ = stan::math::fma(
+            lcm_sym171__ = stan::math::fma(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(1),
                                  stan::model::index_uni((t - 1))),
@@ -19968,7 +19982,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                 stan::model::index_uni(t)) * q));
             current_statement__ = 33;
             stan::model::assign(z,
-              stan::math::bernoulli_rng(lcm_sym170__, base_rng__),
+              stan::math::bernoulli_rng(lcm_sym171__, base_rng__),
               "assigning variable z", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
@@ -19978,18 +19992,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           double mu2 = std::numeric_limits<double>::quiet_NaN();
           current_statement__ = 36;
           stan::model::assign(z,
-            stan::math::bernoulli_rng(lcm_sym162__, base_rng__),
+            stan::math::bernoulli_rng(lcm_sym163__, base_rng__),
             "assigning variable z", stan::model::index_uni(i),
                                       stan::model::index_uni(1));
           current_statement__ = 37;
-          if (lcm_sym136__) {
-            lcm_sym156__ = (1 *
+          if (lcm_sym137__) {
+            lcm_sym157__ = (1 *
                              (1 -
                                stan::model::rvalue(z, "z",
                                  stan::model::index_uni(i),
                                    stan::model::index_uni(1))));
-            q = lcm_sym156__;
-            lcm_sym167__ = stan::math::fma(
+            q = lcm_sym157__;
+            lcm_sym168__ = stan::math::fma(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(i),
                                  stan::model::index_uni(1)),
@@ -19997,10 +20011,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                stan::model::index_uni(i),
                                  stan::model::index_uni(1)),
                              (stan::model::rvalue(gamma, "gamma",
-                                stan::model::index_uni(2)) * lcm_sym156__));
+                                stan::model::index_uni(2)) * lcm_sym157__));
             current_statement__ = 33;
             stan::model::assign(z,
-              stan::math::bernoulli_rng(lcm_sym167__, base_rng__),
+              stan::math::bernoulli_rng(lcm_sym168__, base_rng__),
               "assigning variable z", stan::model::index_uni(i),
                                         stan::model::index_uni(2));
             for (int t = 3; t <= n_occasions; ++t) {
@@ -20010,7 +20024,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                       stan::model::rvalue(z, "z",
                         stan::model::index_uni(i),
                           stan::model::index_uni((t - 1)))));
-              lcm_sym168__ = stan::math::fma(
+              lcm_sym169__ = stan::math::fma(
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(i),
                                    stan::model::index_uni((t - 1))),
@@ -20021,7 +20035,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                   stan::model::index_uni(t)) * q));
               current_statement__ = 33;
               stan::model::assign(z,
-                stan::math::bernoulli_rng(lcm_sym168__, base_rng__),
+                stan::math::bernoulli_rng(lcm_sym169__, base_rng__),
                 "assigning variable z", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
@@ -20040,23 +20054,24 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         inline_sym16__ = 0;
         for (int inline_sym17__ = 1; inline_sym17__ <= 1; ++inline_sym17__) {
           int inline_sym12__ = std::numeric_limits<int>::min();
-          lcm_sym175__ = stan::math::rows(gamma);
+          lcm_sym176__ = stan::math::rows(gamma);
           current_statement__ = 43;
           stan::math::validate_non_negative_index("log_cprob", "N",
-                                                  lcm_sym175__);
+                                                  lcm_sym176__);
           Eigen::Matrix<local_scalar_t__, -1, 1> inline_sym13__ =
-             Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(lcm_sym175__,
+             Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(lcm_sym176__,
                DUMMY_VAR__);
           local_scalar_t__ inline_sym14__ = DUMMY_VAR__;
-          if (stan::math::logical_gte(lcm_sym175__, 1)) {
-            lcm_sym162__ = stan::model::rvalue(gamma, "gamma",
+          lcm_sym196__ = 0;
+          if (stan::math::logical_gte(lcm_sym176__, 1)) {
+            lcm_sym163__ = stan::model::rvalue(gamma, "gamma",
                              stan::model::index_uni(1));
             stan::model::assign(inline_sym13__,
-              (stan::math::log(lcm_sym162__) + 0),
+              (stan::math::log(lcm_sym163__) + lcm_sym196__),
               "assigning variable inline_sym13__", stan::model::index_uni(1));
             current_statement__ = 46;
-            inline_sym14__ = (0 + stan::math::log1m(lcm_sym162__));
-            for (int inline_sym15__ = 2; inline_sym15__ <= lcm_sym175__;
+            inline_sym14__ = (lcm_sym196__ + stan::math::log1m(lcm_sym163__));
+            for (int inline_sym15__ = 2; inline_sym15__ <= lcm_sym176__;
                  ++inline_sym15__) {
               current_statement__ = 47;
               stan::model::assign(inline_sym13__,
@@ -20096,25 +20111,25 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         stan::math::validate_non_negative_index("Nalive", "M", M);
         std::vector<int> Nalive =
            std::vector<int>(M, std::numeric_limits<int>::min());
-        lcm_sym179__ = stan::math::square(sigma);
-        sigma2 = lcm_sym179__;
-        lcm_sym181__ = stan::math::sum(inline_sym11__);
-        psi = lcm_sym181__;
-        stan::model::assign(lcm_sym133__,
-          stan::math::divide(inline_sym11__, lcm_sym181__),
-          "assigning variable lcm_sym133__");
-        stan::model::assign(b, lcm_sym133__, "assigning variable b");
+        lcm_sym180__ = stan::math::square(sigma);
+        sigma2 = lcm_sym180__;
+        lcm_sym182__ = stan::math::sum(inline_sym11__);
+        psi = lcm_sym182__;
+        stan::model::assign(lcm_sym134__,
+          stan::math::divide(inline_sym11__, lcm_sym182__),
+          "assigning variable lcm_sym134__");
+        stan::model::assign(b, lcm_sym134__, "assigning variable b");
         current_statement__ = 64;
-        if (lcm_sym134__) {
+        if (lcm_sym135__) {
           int f = std::numeric_limits<int>::min();
           int inline_sym18__;
           int inline_sym20__;
           inline_sym20__ = 0;
           for (int inline_sym21__ = 1; inline_sym21__ <= 1; ++inline_sym21__) {
-            lcm_sym178__ = stan::math::size(
+            lcm_sym179__ = stan::math::size(
                              stan::model::rvalue(z, "z",
                                stan::model::index_uni(1)));
-            for (int inline_sym19__ = 1; inline_sym19__ <= lcm_sym178__;
+            for (int inline_sym19__ = 1; inline_sym19__ <= lcm_sym179__;
                  ++inline_sym19__) {
               current_statement__ = 59;
               if (stan::model::rvalue(z, "z",
@@ -20146,10 +20161,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             inline_sym20__ = 0;
             for (int inline_sym21__ = 1; inline_sym21__ <= 1;
                  ++inline_sym21__) {
-              lcm_sym177__ = stan::math::size(
+              lcm_sym178__ = stan::math::size(
                                stan::model::rvalue(z, "z",
                                  stan::model::index_uni(i)));
-              for (int inline_sym19__ = 1; inline_sym19__ <= lcm_sym177__;
+              for (int inline_sym19__ = 1; inline_sym19__ <= lcm_sym178__;
                    ++inline_sym19__) {
                 current_statement__ = 59;
                 if (stan::model::rvalue(z, "z",
@@ -20176,8 +20191,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             } 
           }
         } 
-        lcm_sym135__ = stan::math::logical_gte(n_occasions, 1);
-        if (lcm_sym135__) {
+        lcm_sym136__ = stan::math::logical_gte(n_occasions, 1);
+        if (lcm_sym136__) {
           current_statement__ = 65;
           stan::model::assign(N,
             stan::math::sum(
@@ -20206,7 +20221,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
         } 
         current_statement__ = 71;
-        if (lcm_sym134__) {
+        if (lcm_sym135__) {
           current_statement__ = 68;
           stan::model::assign(Nind,
             stan::math::sum(
@@ -20236,14 +20251,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 72;
         Nsuper = stan::math::sum(Nalive);
       }
-      out__.write(lcm_sym179__);
-      out__.write(lcm_sym181__);
-      out__.write(lcm_sym133__);
+      out__.write(lcm_sym180__);
+      out__.write(lcm_sym182__);
+      out__.write(lcm_sym134__);
       out__.write(Nsuper);
       out__.write(N);
       out__.write(B);
-      if (lcm_sym135__) {
-        if (lcm_sym134__) {
+      if (lcm_sym136__) {
+        if (lcm_sym135__) {
           out__.write(
             stan::model::rvalue(z, "z",
               stan::model::index_uni(1), stan::model::index_uni(1)));
@@ -20254,7 +20269,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
         } 
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          if (lcm_sym134__) {
+          if (lcm_sym135__) {
             out__.write(
               stan::model::rvalue(z, "z",
                 stan::model::index_uni(1), stan::model::index_uni(sym1__)));
@@ -20282,9 +20297,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     
     try {
-      int lcm_sym132__;
+      int lcm_sym133__;
+      int lcm_sym131__;
       int lcm_sym130__;
-      int lcm_sym129__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ mean_phi;
@@ -20308,11 +20323,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<local_scalar_t__, -1, 1> epsilon =
          Eigen::Matrix<local_scalar_t__, -1, 1>::Constant((n_occasions - 1),
            DUMMY_VAR__);
-      lcm_sym132__ = (n_occasions - 1);
-      if (stan::math::logical_gte(lcm_sym132__, 1)) {
+      lcm_sym133__ = (n_occasions - 1);
+      if (stan::math::logical_gte(lcm_sym133__, 1)) {
         stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
           "assigning variable epsilon", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= lcm_sym132__; ++sym1__) {
+        for (int sym1__ = 2; sym1__ <= lcm_sym133__; ++sym1__) {
           stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
             "assigning variable epsilon", stan::model::index_uni(sym1__));
         }
@@ -20365,41 +20380,41 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+    for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
       {
-        param_names__.emplace_back(std::string() + "gamma" + '.' + std::to_string(sym278__));
+        param_names__.emplace_back(std::string() + "gamma" + '.' + std::to_string(sym280__));
       } 
     }
-    for (int sym278__ = 1; sym278__ <= epsilon_1dim__; ++sym278__) {
+    for (int sym280__ = 1; sym280__ <= epsilon_1dim__; ++sym280__) {
       {
-        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym278__));
+        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym280__));
       } 
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym278__ = 1; sym278__ <= phi_2dim__; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= phi_2dim__; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
@@ -20409,27 +20424,27 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "psi");
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          param_names__.emplace_back(std::string() + "b" + '.' + std::to_string(sym278__));
+          param_names__.emplace_back(std::string() + "b" + '.' + std::to_string(sym280__));
         } 
       }
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          param_names__.emplace_back(std::string() + "N" + '.' + std::to_string(sym278__));
+          param_names__.emplace_back(std::string() + "N" + '.' + std::to_string(sym280__));
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          param_names__.emplace_back(std::string() + "B" + '.' + std::to_string(sym278__));
+          param_names__.emplace_back(std::string() + "B" + '.' + std::to_string(sym280__));
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
@@ -20446,41 +20461,41 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+    for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
       {
-        param_names__.emplace_back(std::string() + "gamma" + '.' + std::to_string(sym278__));
+        param_names__.emplace_back(std::string() + "gamma" + '.' + std::to_string(sym280__));
       } 
     }
-    for (int sym278__ = 1; sym278__ <= epsilon_1dim__; ++sym278__) {
+    for (int sym280__ = 1; sym280__ <= epsilon_1dim__; ++sym280__) {
       {
-        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym278__));
+        param_names__.emplace_back(std::string() + "epsilon" + '.' + std::to_string(sym280__));
       } 
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym278__ = 1; sym278__ <= phi_2dim__; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= phi_2dim__; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
@@ -20490,27 +20505,27 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "psi");
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          param_names__.emplace_back(std::string() + "b" + '.' + std::to_string(sym278__));
+          param_names__.emplace_back(std::string() + "b" + '.' + std::to_string(sym280__));
         } 
       }
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          param_names__.emplace_back(std::string() + "N" + '.' + std::to_string(sym278__));
+          param_names__.emplace_back(std::string() + "N" + '.' + std::to_string(sym280__));
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          param_names__.emplace_back(std::string() + "B" + '.' + std::to_string(sym278__));
+          param_names__.emplace_back(std::string() + "B" + '.' + std::to_string(sym280__));
         } 
       }
-      for (int sym278__ = 1; sym278__ <= n_occasions; ++sym278__) {
+      for (int sym280__ = 1; sym280__ <= n_occasions; ++sym280__) {
         {
-          for (int sym279__ = 1; sym279__ <= M; ++sym279__) {
+          for (int sym281__ = 1; sym281__ <= M; ++sym281__) {
             {
-              param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym279__) + '.' + std::to_string(sym278__));
+              param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym281__) + '.' + std::to_string(sym280__));
             } 
           }
         } 
@@ -20675,6 +20690,7 @@ static constexpr std::array<const char*, 7> locations_array__ =
 class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> {
 
  private:
+  double lcm_sym4__;
   double lcm_sym3__;
   int j;
   double z;
@@ -20705,6 +20721,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
+      
       
       int pos__;
       pos__ = 1;
@@ -21728,8 +21745,8 @@ static constexpr std::array<const char*, 65> locations_array__ =
  " (in 'lcm-fails2.stan', line 70, column 2 to column 52)",
  " (in 'lcm-fails2.stan', line 71, column 2 to column 50)",
  " (in 'lcm-fails2.stan', line 72, column 2 to column 50)",
- " (in 'lcm-fails2.stan', line 77, column 6 to column 20)",
  " (in 'lcm-fails2.stan', line 78, column 6 to column 18)",
+ " (in 'lcm-fails2.stan', line 77, column 6 to column 20)",
  " (in 'lcm-fails2.stan', line 76, column 34 to line 79, column 5)",
  " (in 'lcm-fails2.stan', line 81, column 6 to column 27)",
  " (in 'lcm-fails2.stan', line 82, column 6 to column 23)",
@@ -22065,6 +22082,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
  class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
 
  private:
+  int lcm_sym119__;
+  int lcm_sym118__;
   int lcm_sym117__;
   int lcm_sym116__;
   int lcm_sym115__;
@@ -22079,8 +22098,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   int lcm_sym106__;
   int lcm_sym105__;
   int lcm_sym104__;
-  int lcm_sym103__;
-  int lcm_sym102__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -22173,8 +22190,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         current_statement__ = 36;
         if (stan::math::logical_gte(n_occasions, 1)) {
           {
-            lcm_sym103__ = stan::math::logical_gte(nind, 1);
-            if (lcm_sym103__) {
+            lcm_sym105__ = stan::math::logical_gte(nind, 1);
+            if (lcm_sym105__) {
               current_statement__ = 36;
               stan::model::assign(y,
                 stan::model::rvalue(y_flat__, "y_flat__",
@@ -22194,7 +22211,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
             } 
             for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
               current_statement__ = 36;
-              if (lcm_sym103__) {
+              if (lcm_sym105__) {
                 current_statement__ = 36;
                 stan::model::assign(y, y_flat__[(pos__ - 1)],
                   "assigning variable y", stan::model::index_uni(1),
@@ -22213,7 +22230,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
             }
           }
         } else {
-          lcm_sym103__ = stan::math::logical_gte(nind, 1);
+          lcm_sym105__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 36;
@@ -22224,8 +22241,8 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       n_occ_minus_1 = std::numeric_limits<int>::min();
       
       
-      lcm_sym104__ = (n_occasions - 1);
-      n_occ_minus_1 = lcm_sym104__;
+      lcm_sym106__ = (n_occasions - 1);
+      n_occ_minus_1 = lcm_sym106__;
       current_statement__ = 38;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 39;
@@ -22239,15 +22256,15 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       
       
       current_statement__ = 46;
-      if (lcm_sym103__) {
+      if (lcm_sym105__) {
         int inline_sym17__;
         int inline_sym19__;
         inline_sym19__ = 0;
         for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-          lcm_sym111__ = stan::math::size(
+          lcm_sym113__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym111__;
+          for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym113__;
                ++inline_sym18__) {
             current_statement__ = 43;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
@@ -22271,10 +22288,10 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           int inline_sym19__;
           inline_sym19__ = 0;
           for (int inline_sym20__ = 1; inline_sym20__ <= 1; ++inline_sym20__) {
-            lcm_sym110__ = stan::math::size(
+            lcm_sym112__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym110__;
+            for (int inline_sym18__ = 1; inline_sym18__ <= lcm_sym112__;
                  ++inline_sym18__) {
               current_statement__ = 43;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
@@ -22296,25 +22313,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
         }
       } 
       current_statement__ = 53;
-      if (lcm_sym103__) {
+      if (lcm_sym105__) {
         int inline_sym21__;
         int inline_sym24__;
         inline_sym24__ = 0;
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          lcm_sym111__ = stan::math::size(
+          lcm_sym113__ = stan::math::size(
                            stan::model::rvalue(y, "y",
                              stan::model::index_uni(1)));
-          lcm_sym108__ = (lcm_sym111__ - 1);
-          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym108__;
+          lcm_sym110__ = (lcm_sym113__ - 1);
+          for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym110__;
                ++inline_sym23__) {
             int inline_sym22__ = std::numeric_limits<int>::min();
-            lcm_sym107__ = (lcm_sym111__ - inline_sym23__);
-            inline_sym22__ = lcm_sym107__;
+            lcm_sym109__ = (lcm_sym113__ - inline_sym23__);
+            inline_sym22__ = lcm_sym109__;
             current_statement__ = 49;
             if (stan::model::rvalue(y, "y", stan::model::index_uni(1))[
-                (lcm_sym107__ - 1)]) {
+                (lcm_sym109__ - 1)]) {
               inline_sym24__ = 1;
-              inline_sym21__ = lcm_sym107__;
+              inline_sym21__ = lcm_sym109__;
               break;
             } 
           }
@@ -22332,20 +22349,20 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           int inline_sym24__;
           inline_sym24__ = 0;
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            lcm_sym110__ = stan::math::size(
+            lcm_sym112__ = stan::math::size(
                              stan::model::rvalue(y, "y",
                                stan::model::index_uni(i)));
-            lcm_sym106__ = (lcm_sym110__ - 1);
-            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym106__;
+            lcm_sym108__ = (lcm_sym112__ - 1);
+            for (int inline_sym23__ = 0; inline_sym23__ <= lcm_sym108__;
                  ++inline_sym23__) {
               int inline_sym22__ = std::numeric_limits<int>::min();
-              lcm_sym105__ = (lcm_sym110__ - inline_sym23__);
-              inline_sym22__ = lcm_sym105__;
+              lcm_sym107__ = (lcm_sym112__ - inline_sym23__);
+              inline_sym22__ = lcm_sym107__;
               current_statement__ = 49;
               if (stan::model::rvalue(y, "y", stan::model::index_uni(i))[
-                  (lcm_sym105__ - 1)]) {
+                  (lcm_sym107__ - 1)]) {
                 inline_sym24__ = 1;
-                inline_sym21__ = lcm_sym105__;
+                inline_sym21__ = lcm_sym107__;
                 break;
               } 
             }
@@ -22372,12 +22389,12 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 55;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-                                              lcm_sym104__);
+                                              lcm_sym106__);
       current_statement__ = 56;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 57;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-                                              lcm_sym104__);
+                                              lcm_sym106__);
       current_statement__ = 58;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 59;
@@ -22408,10 +22425,12 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym103__;
+      int lcm_sym102__;
       int lcm_sym101__;
       int lcm_sym100__;
       int lcm_sym99__;
-      int lcm_sym98__;
+      double lcm_sym98__;
       double lcm_sym97__;
       double lcm_sym96__;
       double lcm_sym95__;
@@ -22423,7 +22442,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       double lcm_sym89__;
       double lcm_sym88__;
       double lcm_sym87__;
-      double lcm_sym86__;
+      int lcm_sym86__;
       int lcm_sym85__;
       int lcm_sym84__;
       int lcm_sym83__;
@@ -22443,7 +22462,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       int lcm_sym69__;
       int lcm_sym68__;
       int lcm_sym67__;
-      int lcm_sym66__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__, 
@@ -22461,42 +22479,42 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       Eigen::Matrix<local_scalar_t__, -1, -1> chi =
          Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(nind, n_occasions,
            DUMMY_VAR__);
-      lcm_sym66__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym66__) {
-        lcm_sym99__ = stan::model::rvalue(first, "first",
-                        stan::model::index_uni(1));
-        lcm_sym79__ = (lcm_sym99__ - 1);
-        if (stan::math::logical_gte(lcm_sym79__, 1)) {
-          current_statement__ = 6;
-          stan::model::assign(phi, 0,
+      lcm_sym67__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym67__) {
+        lcm_sym100__ = stan::model::rvalue(first, "first",
+                         stan::model::index_uni(1));
+        lcm_sym80__ = (lcm_sym100__ - 1);
+        if (stan::math::logical_gte(lcm_sym80__, 1)) {
+          lcm_sym103__ = 0;
+          stan::model::assign(phi, lcm_sym103__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 7;
-          stan::model::assign(p, 0,
+          current_statement__ = 6;
+          stan::model::assign(p, lcm_sym103__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym79__; ++t) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+          for (int t = 2; t <= lcm_sym80__; ++t) {
+            current_statement__ = 7;
+            stan::model::assign(phi, lcm_sym103__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym103__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
         } 
-        lcm_sym77__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym77__, lcm_sym99__)) {
+        lcm_sym78__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym78__, lcm_sym100__)) {
           current_statement__ = 9;
           stan::model::assign(phi, mean_phi,
             "assigning variable phi", stan::model::index_uni(1),
-                                        stan::model::index_uni(lcm_sym99__));
-          lcm_sym85__ = (lcm_sym99__ + 1);
+                                        stan::model::index_uni(lcm_sym100__));
+          lcm_sym86__ = (lcm_sym100__ + 1);
           stan::model::assign(p, mean_p,
             "assigning variable p", stan::model::index_uni(1),
-                                      stan::model::index_uni(lcm_sym99__));
-          for (int t = lcm_sym85__; t <= lcm_sym77__; ++t) {
+                                      stan::model::index_uni(lcm_sym100__));
+          for (int t = lcm_sym86__; t <= lcm_sym78__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi, mean_phi,
               "assigning variable phi", stan::model::index_uni(1),
@@ -22508,40 +22526,40 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           }
         } 
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym98__ = stan::model::rvalue(first, "first",
+          lcm_sym99__ = stan::model::rvalue(first, "first",
                           stan::model::index_uni(i));
-          lcm_sym78__ = (lcm_sym98__ - 1);
-          if (stan::math::logical_gte(lcm_sym78__, 1)) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+          lcm_sym79__ = (lcm_sym99__ - 1);
+          if (stan::math::logical_gte(lcm_sym79__, 1)) {
+            lcm_sym103__ = 0;
+            stan::model::assign(phi, lcm_sym103__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym103__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym78__; ++t) {
-              current_statement__ = 6;
-              stan::model::assign(phi, 0,
+            for (int t = 2; t <= lcm_sym79__; ++t) {
+              current_statement__ = 7;
+              stan::model::assign(phi, lcm_sym103__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 7;
-              stan::model::assign(p, 0,
+              current_statement__ = 6;
+              stan::model::assign(p, lcm_sym103__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
           } 
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym77__, lcm_sym98__)) {
+          if (stan::math::logical_gte(lcm_sym78__, lcm_sym99__)) {
             current_statement__ = 9;
             stan::model::assign(phi, mean_phi,
               "assigning variable phi", stan::model::index_uni(i),
-                                          stan::model::index_uni(lcm_sym98__));
-            lcm_sym84__ = (lcm_sym98__ + 1);
+                                          stan::model::index_uni(lcm_sym99__));
+            lcm_sym85__ = (lcm_sym99__ + 1);
             stan::model::assign(p, mean_p,
               "assigning variable p", stan::model::index_uni(i),
-                                        stan::model::index_uni(lcm_sym98__));
-            for (int t = lcm_sym84__; t <= lcm_sym77__; ++t) {
+                                        stan::model::index_uni(lcm_sym99__));
+            for (int t = lcm_sym85__; t <= lcm_sym78__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi, mean_phi,
                 "assigning variable phi", stan::model::index_uni(i),
@@ -22571,55 +22589,55 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
           stan::model::assign(inline_sym10__, 1.0,
             "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
                                                    stan::model::index_uni(n_occasions));
-          lcm_sym77__ = (n_occasions - 1);
-          if (stan::math::logical_gte(lcm_sym77__, 1)) {
+          lcm_sym78__ = (n_occasions - 1);
+          if (stan::math::logical_gte(lcm_sym78__, 1)) {
             int inline_sym11__ = std::numeric_limits<int>::min();
             int inline_sym12__ = std::numeric_limits<int>::min();
-            lcm_sym81__ = (lcm_sym77__ + 1);
+            lcm_sym82__ = (lcm_sym78__ + 1);
             current_statement__ = 21;
             stan::model::assign(inline_sym10__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi",
                    stan::model::index_uni(inline_sym14__),
-                     stan::model::index_uni(lcm_sym77__)) *
+                     stan::model::index_uni(lcm_sym78__)) *
                   (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni((lcm_sym81__ - 1))))),
+                        stan::model::index_uni((lcm_sym82__ - 1))))),
                 stan::model::rvalue(inline_sym10__, "inline_sym10__",
                   stan::model::index_uni(inline_sym14__),
-                    stan::model::index_uni(lcm_sym81__)),
+                    stan::model::index_uni(lcm_sym82__)),
                 (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym77__)))),
+                      stan::model::index_uni(lcm_sym78__)))),
               "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                     stan::model::index_uni(lcm_sym77__));
-            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym77__;
+                                                     stan::model::index_uni(lcm_sym78__));
+            for (int inline_sym13__ = 2; inline_sym13__ <= lcm_sym78__;
                  ++inline_sym13__) {
               int inline_sym11__ = std::numeric_limits<int>::min();
-              lcm_sym76__ = (n_occasions - inline_sym13__);
+              lcm_sym77__ = (n_occasions - inline_sym13__);
               int inline_sym12__ = std::numeric_limits<int>::min();
-              lcm_sym80__ = (lcm_sym76__ + 1);
+              lcm_sym81__ = (lcm_sym77__ + 1);
               current_statement__ = 21;
               stan::model::assign(inline_sym10__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_sym14__),
-                       stan::model::index_uni(lcm_sym76__)) *
+                       stan::model::index_uni(lcm_sym77__)) *
                     (1 -
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_sym14__),
-                          stan::model::index_uni((lcm_sym80__ - 1))))),
+                          stan::model::index_uni((lcm_sym81__ - 1))))),
                   stan::model::rvalue(inline_sym10__, "inline_sym10__",
                     stan::model::index_uni(inline_sym14__),
-                      stan::model::index_uni(lcm_sym80__)),
+                      stan::model::index_uni(lcm_sym81__)),
                   (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_sym14__),
-                        stan::model::index_uni(lcm_sym76__)))),
+                        stan::model::index_uni(lcm_sym77__)))),
                 "assigning variable inline_sym10__", stan::model::index_uni(inline_sym14__),
-                                                       stan::model::index_uni(lcm_sym76__));
+                                                       stan::model::index_uni(lcm_sym77__));
             }
           } 
           if (inline_sym15__) {
@@ -22649,30 +22667,30 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       stan::math::check_less_or_equal(function__, "chi", inline_sym9__, 1);
       {
         current_statement__ = 31;
-        if (lcm_sym66__) {
-          lcm_sym99__ = stan::model::rvalue(first, "first",
-                          stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym99__, 0)) {
-            lcm_sym101__ = stan::model::rvalue(last, "last",
+        if (lcm_sym67__) {
+          lcm_sym100__ = stan::model::rvalue(first, "first",
+                           stan::model::index_uni(1));
+          if (stan::math::logical_gt(lcm_sym100__, 0)) {
+            lcm_sym102__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym85__ = (lcm_sym99__ + 1);
-            if (stan::math::logical_gte(lcm_sym101__, lcm_sym85__)) {
+            lcm_sym86__ = (lcm_sym100__ + 1);
+            if (stan::math::logical_gte(lcm_sym102__, lcm_sym86__)) {
               current_statement__ = 25;
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym85__ - 1)))));
-              lcm_sym83__ = (lcm_sym85__ + 1);
+                      stan::model::index_uni((lcm_sym86__ - 1)))));
+              lcm_sym84__ = (lcm_sym86__ + 1);
               lp_accum__.add(
                 stan::math::bernoulli_lpmf<propto__>(
                   stan::model::rvalue(y, "y",
                     stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym85__)),
+                      stan::model::index_uni(lcm_sym86__)),
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(1),
-                      stan::model::index_uni((lcm_sym85__ - 1)))));
-              for (int t = lcm_sym83__; t <= lcm_sym101__; ++t) {
+                      stan::model::index_uni((lcm_sym86__ - 1)))));
+              for (int t = lcm_sym84__; t <= lcm_sym102__; ++t) {
                 current_statement__ = 25;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
@@ -22694,32 +22712,32 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
               stan::math::bernoulli_lpmf<propto__>(1,
                 stan::model::rvalue(inline_sym9__, "inline_sym9__",
                   stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym101__))));
+                    stan::model::index_uni(lcm_sym102__))));
           } 
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym98__ = stan::model::rvalue(first, "first",
+            lcm_sym99__ = stan::model::rvalue(first, "first",
                             stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym98__, 0)) {
-              lcm_sym100__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym99__, 0)) {
+              lcm_sym101__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym84__ = (lcm_sym98__ + 1);
-              if (stan::math::logical_gte(lcm_sym100__, lcm_sym84__)) {
+              lcm_sym85__ = (lcm_sym99__ + 1);
+              if (stan::math::logical_gte(lcm_sym101__, lcm_sym85__)) {
                 current_statement__ = 25;
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(1,
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym84__ - 1)))));
-                lcm_sym82__ = (lcm_sym84__ + 1);
+                        stan::model::index_uni((lcm_sym85__ - 1)))));
+                lcm_sym83__ = (lcm_sym85__ + 1);
                 lp_accum__.add(
                   stan::math::bernoulli_lpmf<propto__>(
                     stan::model::rvalue(y, "y",
                       stan::model::index_uni(i),
-                        stan::model::index_uni(lcm_sym84__)),
+                        stan::model::index_uni(lcm_sym85__)),
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(i),
-                        stan::model::index_uni((lcm_sym84__ - 1)))));
-                for (int t = lcm_sym82__; t <= lcm_sym100__; ++t) {
+                        stan::model::index_uni((lcm_sym85__ - 1)))));
+                for (int t = lcm_sym83__; t <= lcm_sym101__; ++t) {
                   current_statement__ = 25;
                   lp_accum__.add(
                     stan::math::bernoulli_lpmf<propto__>(1,
@@ -22741,7 +22759,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                 stan::math::bernoulli_lpmf<propto__>(1,
                   stan::model::rvalue(inline_sym9__, "inline_sym9__",
                     stan::model::index_uni(i),
-                      stan::model::index_uni(lcm_sym100__))));
+                      stan::model::index_uni(lcm_sym101__))));
             } 
           }
         } 
@@ -22778,6 +22796,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym66__;
       int lcm_sym65__;
       int lcm_sym64__;
       double lcm_sym63__;
@@ -22828,21 +22847,21 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                         stan::model::index_uni(1));
         lcm_sym55__ = (lcm_sym65__ - 1);
         if (stan::math::logical_gte(lcm_sym55__, 1)) {
-          current_statement__ = 6;
-          stan::model::assign(phi, 0,
+          lcm_sym66__ = 0;
+          stan::model::assign(phi, lcm_sym66__,
             "assigning variable phi", stan::model::index_uni(1),
                                         stan::model::index_uni(1));
-          current_statement__ = 7;
-          stan::model::assign(p, 0,
+          current_statement__ = 6;
+          stan::model::assign(p, lcm_sym66__,
             "assigning variable p", stan::model::index_uni(1),
                                       stan::model::index_uni(1));
           for (int t = 2; t <= lcm_sym55__; ++t) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+            current_statement__ = 7;
+            stan::model::assign(phi, lcm_sym66__,
               "assigning variable phi", stan::model::index_uni(1),
                                           stan::model::index_uni(t));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym66__,
               "assigning variable p", stan::model::index_uni(1),
                                         stan::model::index_uni(t));
           }
@@ -22873,21 +22892,21 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           stan::model::index_uni(i));
           lcm_sym54__ = (lcm_sym64__ - 1);
           if (stan::math::logical_gte(lcm_sym54__, 1)) {
-            current_statement__ = 6;
-            stan::model::assign(phi, 0,
+            lcm_sym66__ = 0;
+            stan::model::assign(phi, lcm_sym66__,
               "assigning variable phi", stan::model::index_uni(i),
                                           stan::model::index_uni(1));
-            current_statement__ = 7;
-            stan::model::assign(p, 0,
+            current_statement__ = 6;
+            stan::model::assign(p, lcm_sym66__,
               "assigning variable p", stan::model::index_uni(i),
                                         stan::model::index_uni(1));
             for (int t = 2; t <= lcm_sym54__; ++t) {
-              current_statement__ = 6;
-              stan::model::assign(phi, 0,
+              current_statement__ = 7;
+              stan::model::assign(phi, lcm_sym66__,
                 "assigning variable phi", stan::model::index_uni(i),
                                             stan::model::index_uni(t));
-              current_statement__ = 7;
-              stan::model::assign(p, 0,
+              current_statement__ = 6;
+              stan::model::assign(p, lcm_sym66__,
                 "assigning variable p", stan::model::index_uni(i),
                                           stan::model::index_uni(t));
             }
@@ -23076,29 +23095,29 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
     if (emit_transformed_parameters__) {
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+      for (int sym120__ = 1; sym120__ <= n_occ_minus_1; ++sym120__) {
         {
-          for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+          for (int sym121__ = 1; sym121__ <= nind; ++sym121__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym119__) + '.' + std::to_string(sym118__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym121__) + '.' + std::to_string(sym120__));
             } 
           }
         } 
       }
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+      for (int sym120__ = 1; sym120__ <= n_occ_minus_1; ++sym120__) {
         {
-          for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+          for (int sym121__ = 1; sym121__ <= nind; ++sym121__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym119__) + '.' + std::to_string(sym118__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym121__) + '.' + std::to_string(sym120__));
             } 
           }
         } 
       }
-      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
+      for (int sym120__ = 1; sym120__ <= n_occasions; ++sym120__) {
         {
-          for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+          for (int sym121__ = 1; sym121__ <= nind; ++sym121__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym119__) + '.' + std::to_string(sym118__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym121__) + '.' + std::to_string(sym120__));
             } 
           }
         } 
@@ -23120,29 +23139,29 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
     if (emit_transformed_parameters__) {
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+      for (int sym120__ = 1; sym120__ <= n_occ_minus_1; ++sym120__) {
         {
-          for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+          for (int sym121__ = 1; sym121__ <= nind; ++sym121__) {
             {
-              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym119__) + '.' + std::to_string(sym118__));
+              param_names__.emplace_back(std::string() + "phi" + '.' + std::to_string(sym121__) + '.' + std::to_string(sym120__));
             } 
           }
         } 
       }
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+      for (int sym120__ = 1; sym120__ <= n_occ_minus_1; ++sym120__) {
         {
-          for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+          for (int sym121__ = 1; sym121__ <= nind; ++sym121__) {
             {
-              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym119__) + '.' + std::to_string(sym118__));
+              param_names__.emplace_back(std::string() + "p" + '.' + std::to_string(sym121__) + '.' + std::to_string(sym120__));
             } 
           }
         } 
       }
-      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
+      for (int sym120__ = 1; sym120__ <= n_occasions; ++sym120__) {
         {
-          for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+          for (int sym121__ = 1; sym121__ <= nind; ++sym121__) {
             {
-              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym119__) + '.' + std::to_string(sym118__));
+              param_names__.emplace_back(std::string() + "chi" + '.' + std::to_string(sym121__) + '.' + std::to_string(sym120__));
             } 
           }
         } 
@@ -23859,18 +23878,18 @@ static constexpr std::array<const char*, 52> locations_array__ =
 class off_dce_model final : public model_base_crtp<off_dce_model> {
 
  private:
+  int lcm_sym42__;
   int lcm_sym41__;
   int lcm_sym40__;
   int lcm_sym39__;
-  int lcm_sym38__;
+  double lcm_sym38__;
   double lcm_sym37__;
-  double lcm_sym36__;
+  int lcm_sym36__;
   int lcm_sym35__;
   int lcm_sym34__;
   int lcm_sym33__;
   int lcm_sym32__;
   int lcm_sym31__;
-  int lcm_sym30__;
   int R;
   int T;
   std::vector<std::vector<int>> y;
@@ -23958,8 +23977,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
         current_statement__ = 35;
         if (stan::math::logical_gte(T, 1)) {
           {
-            lcm_sym30__ = stan::math::logical_gte(R, 1);
-            if (lcm_sym30__) {
+            lcm_sym31__ = stan::math::logical_gte(R, 1);
+            if (lcm_sym31__) {
               current_statement__ = 35;
               stan::model::assign(y,
                 stan::model::rvalue(y_flat__, "y_flat__",
@@ -23979,7 +23998,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             } 
             for (int sym1__ = 2; sym1__ <= T; ++sym1__) {
               current_statement__ = 35;
-              if (lcm_sym30__) {
+              if (lcm_sym31__) {
                 current_statement__ = 35;
                 stan::model::assign(y, y_flat__[(pos__ - 1)],
                   "assigning variable y", stan::model::index_uni(1),
@@ -23998,7 +24017,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             }
           }
         } else {
-          lcm_sym30__ = stan::math::logical_gte(R, 1);
+          lcm_sym31__ = stan::math::logical_gte(R, 1);
         }
       }
       current_statement__ = 35;
@@ -24022,7 +24041,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
         current_statement__ = 37;
         pos__ = 1;
         current_statement__ = 37;
-        if (lcm_sym30__) {
+        if (lcm_sym31__) {
           current_statement__ = 37;
           stan::model::assign(X,
             stan::model::rvalue(X_flat__, "X_flat__",
@@ -24052,7 +24071,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       current_statement__ = 41;
       occ_obs = 0;
       current_statement__ = 46;
-      if (lcm_sym30__) {
+      if (lcm_sym31__) {
         current_statement__ = 42;
         stan::model::assign(sum_y,
           stan::math::sum(
@@ -24119,17 +24138,17 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     (void) function__;  // suppress unused var warning
     
     try {
+      int lcm_sym30__;
       int lcm_sym29__;
-      int lcm_sym28__;
-      Eigen::Matrix<local_scalar_t__, -1, -1> lcm_sym27__;
+      Eigen::Matrix<local_scalar_t__, -1, -1> lcm_sym28__;
+      double lcm_sym27__;
       double lcm_sym26__;
-      double lcm_sym25__;
-      Eigen::Matrix<local_scalar_t__, -1, 1> lcm_sym24__;
+      Eigen::Matrix<local_scalar_t__, -1, 1> lcm_sym25__;
+      double lcm_sym24__;
       double lcm_sym23__;
       double lcm_sym22__;
       double lcm_sym21__;
-      double lcm_sym20__;
-      int lcm_sym19__;
+      int lcm_sym20__;
       local_scalar_t__ alpha_occ;
       current_statement__ = 1;
       alpha_occ = in__.template read<local_scalar_t__>();
@@ -24146,15 +24165,15 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
          Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(R, DUMMY_VAR__);
       Eigen::Matrix<local_scalar_t__, -1, -1> logit_p =
          Eigen::Matrix<local_scalar_t__, -1, -1>::Constant(R, T, DUMMY_VAR__);
-      stan::model::assign(lcm_sym24__,
+      stan::model::assign(lcm_sym25__,
         stan::math::fma(beta_occ, X, alpha_occ),
-        "assigning variable lcm_sym24__");
-      stan::model::assign(logit_psi, lcm_sym24__,
+        "assigning variable lcm_sym25__");
+      stan::model::assign(logit_psi, lcm_sym25__,
         "assigning variable logit_psi");
-      stan::model::assign(lcm_sym27__,
+      stan::model::assign(lcm_sym28__,
         stan::math::rep_matrix(stan::math::fma(beta_p, X, alpha_p), T),
-        "assigning variable lcm_sym27__");
-      stan::model::assign(logit_p, lcm_sym27__, "assigning variable logit_p");
+        "assigning variable lcm_sym28__");
+      stan::model::assign(logit_p, lcm_sym28__, "assigning variable logit_p");
       {
         current_statement__ = 30;
         if (stan::math::logical_gte(R, 1)) {
@@ -24163,26 +24182,26 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             current_statement__ = 25;
             lp_accum__.add(
               stan::math::bernoulli_logit_lpmf<propto__>(1,
-                stan::model::rvalue(lcm_sym24__, "lcm_sym24__",
+                stan::model::rvalue(lcm_sym25__, "lcm_sym25__",
                   stan::model::index_uni(1))));
             current_statement__ = 26;
             lp_accum__.add(
               stan::math::bernoulli_logit_lpmf<propto__>(
                 stan::model::rvalue(y, "y", stan::model::index_uni(1)),
-                stan::model::rvalue(lcm_sym27__, "lcm_sym27__",
+                stan::model::rvalue(lcm_sym28__, "lcm_sym28__",
                   stan::model::index_uni(1))));
           } else {
             current_statement__ = 23;
             lp_accum__.add(
               stan::math::log_sum_exp(
                 (stan::math::bernoulli_logit_lpmf<false>(1,
-                   stan::model::rvalue(lcm_sym24__, "lcm_sym24__",
+                   stan::model::rvalue(lcm_sym25__, "lcm_sym25__",
                      stan::model::index_uni(1))) +
                   stan::math::bernoulli_logit_lpmf<false>(0,
-                    stan::model::rvalue(lcm_sym27__, "lcm_sym27__",
+                    stan::model::rvalue(lcm_sym28__, "lcm_sym28__",
                       stan::model::index_uni(1)))),
                 stan::math::bernoulli_logit_lpmf<false>(0,
-                  stan::model::rvalue(lcm_sym24__, "lcm_sym24__",
+                  stan::model::rvalue(lcm_sym25__, "lcm_sym25__",
                     stan::model::index_uni(1)))));
           }
           for (int i = 2; i <= R; ++i) {
@@ -24192,26 +24211,26 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
               current_statement__ = 25;
               lp_accum__.add(
                 stan::math::bernoulli_logit_lpmf<propto__>(1,
-                  stan::model::rvalue(lcm_sym24__, "lcm_sym24__",
+                  stan::model::rvalue(lcm_sym25__, "lcm_sym25__",
                     stan::model::index_uni(i))));
               current_statement__ = 26;
               lp_accum__.add(
                 stan::math::bernoulli_logit_lpmf<propto__>(
                   stan::model::rvalue(y, "y", stan::model::index_uni(i)),
-                  stan::model::rvalue(lcm_sym27__, "lcm_sym27__",
+                  stan::model::rvalue(lcm_sym28__, "lcm_sym28__",
                     stan::model::index_uni(i))));
             } else {
               current_statement__ = 23;
               lp_accum__.add(
                 stan::math::log_sum_exp(
                   (stan::math::bernoulli_logit_lpmf<false>(1,
-                     stan::model::rvalue(lcm_sym24__, "lcm_sym24__",
+                     stan::model::rvalue(lcm_sym25__, "lcm_sym25__",
                        stan::model::index_uni(i))) +
                     stan::math::bernoulli_logit_lpmf<false>(0,
-                      stan::model::rvalue(lcm_sym27__, "lcm_sym27__",
+                      stan::model::rvalue(lcm_sym28__, "lcm_sym28__",
                         stan::model::index_uni(i)))),
                   stan::math::bernoulli_logit_lpmf<false>(0,
-                    stan::model::rvalue(lcm_sym24__, "lcm_sym24__",
+                    stan::model::rvalue(lcm_sym25__, "lcm_sym25__",
                       stan::model::index_uni(i)))));
             }
           }
@@ -24249,6 +24268,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym19__;
       double lcm_sym11__;
       double lcm_sym10__;
       int lcm_sym18__;
@@ -24473,16 +24493,16 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     param_names__.emplace_back(std::string() + "alpha_p");
     param_names__.emplace_back(std::string() + "beta_p");
     if (emit_transformed_parameters__) {
-      for (int sym42__ = 1; sym42__ <= R; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
         {
-          param_names__.emplace_back(std::string() + "logit_psi" + '.' + std::to_string(sym42__));
+          param_names__.emplace_back(std::string() + "logit_psi" + '.' + std::to_string(sym43__));
         } 
       }
-      for (int sym42__ = 1; sym42__ <= T; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= T; ++sym43__) {
         {
-          for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
+          for (int sym44__ = 1; sym44__ <= R; ++sym44__) {
             {
-              param_names__.emplace_back(std::string() + "logit_p" + '.' + std::to_string(sym43__) + '.' + std::to_string(sym42__));
+              param_names__.emplace_back(std::string() + "logit_p" + '.' + std::to_string(sym44__) + '.' + std::to_string(sym43__));
             } 
           }
         } 
@@ -24491,14 +24511,14 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "occ_fs");
-      for (int sym42__ = 1; sym42__ <= R; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
         {
-          param_names__.emplace_back(std::string() + "psi_con" + '.' + std::to_string(sym42__));
+          param_names__.emplace_back(std::string() + "psi_con" + '.' + std::to_string(sym43__));
         } 
       }
-      for (int sym42__ = 1; sym42__ <= R; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
         {
-          param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym42__));
+          param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym43__));
         } 
       }
     }
@@ -24516,16 +24536,16 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     param_names__.emplace_back(std::string() + "alpha_p");
     param_names__.emplace_back(std::string() + "beta_p");
     if (emit_transformed_parameters__) {
-      for (int sym42__ = 1; sym42__ <= R; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
         {
-          param_names__.emplace_back(std::string() + "logit_psi" + '.' + std::to_string(sym42__));
+          param_names__.emplace_back(std::string() + "logit_psi" + '.' + std::to_string(sym43__));
         } 
       }
-      for (int sym42__ = 1; sym42__ <= T; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= T; ++sym43__) {
         {
-          for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
+          for (int sym44__ = 1; sym44__ <= R; ++sym44__) {
             {
-              param_names__.emplace_back(std::string() + "logit_p" + '.' + std::to_string(sym43__) + '.' + std::to_string(sym42__));
+              param_names__.emplace_back(std::string() + "logit_p" + '.' + std::to_string(sym44__) + '.' + std::to_string(sym43__));
             } 
           }
         } 
@@ -24534,14 +24554,14 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "occ_fs");
-      for (int sym42__ = 1; sym42__ <= R; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
         {
-          param_names__.emplace_back(std::string() + "psi_con" + '.' + std::to_string(sym42__));
+          param_names__.emplace_back(std::string() + "psi_con" + '.' + std::to_string(sym43__));
         } 
       }
-      for (int sym42__ = 1; sym42__ <= R; ++sym42__) {
+      for (int sym43__ = 1; sym43__ <= R; ++sym43__) {
         {
-          param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym42__));
+          param_names__.emplace_back(std::string() + "z" + '.' + std::to_string(sym43__));
         } 
       }
     }
@@ -25517,7 +25537,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 93> locations_array__ = 
+static constexpr std::array<const char*, 91> locations_array__ = 
 {" (found before start of program)",
  " (in 'optimizations.stan', line 20, column 4 to column 15)",
  " (in 'optimizations.stan', line 21, column 4 to column 13)",
@@ -25554,13 +25574,11 @@ static constexpr std::array<const char*, 93> locations_array__ =
  " (in 'optimizations.stan', line 55, column 8 to column 20)",
  " (in 'optimizations.stan', line 52, column 21 to line 56, column 5)",
  " (in 'optimizations.stan', line 52, column 4 to line 56, column 5)",
- " (in 'optimizations.stan', line 57, column 4 to column 10)",
  " (in 'optimizations.stan', line 58, column 4 to column 16)",
  " (in 'optimizations.stan', line 60, column 6 to column 12)",
  " (in 'optimizations.stan', line 59, column 4 to line 60, column 12)",
  " (in 'optimizations.stan', line 61, column 4 to column 16)",
  " (in 'optimizations.stan', line 64, column 4 to column 16)",
- " (in 'optimizations.stan', line 65, column 4 to column 16)",
  " (in 'optimizations.stan', line 66, column 4 to column 16)",
  " (in 'optimizations.stan', line 68, column 6 to column 19)",
  " (in 'optimizations.stan', line 69, column 4 to column 16)",
@@ -25664,10 +25682,10 @@ int rfun(const int& y, std::ostream* pstream__) {
       {
         current_statement__ = 11;
         if (stan::math::logical_gt(y, 2)) {
-          current_statement__ = 90;
+          current_statement__ = 88;
           return (y + 24);
         } 
-        current_statement__ = 91;
+        current_statement__ = 89;
         return (y + 2);
       }
     } catch (const std::exception& e) {
@@ -25682,9 +25700,9 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
       {
-        current_statement__ = 61;
+        current_statement__ = 59;
         lp_accum__.add(2);
-        current_statement__ = 92;
+        current_statement__ = 90;
         return 24;
       }
     } catch (const std::exception& e) {
@@ -25772,6 +25790,16 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym66__;
+      double lcm_sym65__;
+      double lcm_sym64__;
+      double lcm_sym63__;
+      double lcm_sym62__;
+      double lcm_sym61__;
+      double lcm_sym60__;
+      double lcm_sym59__;
+      double lcm_sym58__;
+      double lcm_sym57__;
       double lcm_sym56__;
       int lcm_sym55__;
       int lcm_sym54__;
@@ -25815,10 +25843,11 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                 2);
       {
         double x = std::numeric_limits<double>::quiet_NaN();
+        lcm_sym63__ = 4;
         int inline_sym1__ = std::numeric_limits<int>::min();
         for (int inline_sym2__ = 1; inline_sym2__ <= 1; ++inline_sym2__) {
           current_statement__ = 8;
-          if (stan::math::logical_gt(4, 342)) {
+          if (stan::math::logical_gt(lcm_sym63__, 342)) {
             break;
           } 
           current_statement__ = 9;
@@ -26146,73 +26175,76 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 33;
           lp_accum__.add(2);
         }
+        lcm_sym62__ = 3;
+        x = lcm_sym62__;
         current_statement__ = 36;
-        x = 3;
-        current_statement__ = 37;
-        lp_accum__.add(3);
-        current_statement__ = 39;
+        lp_accum__.add(lcm_sym62__);
+        current_statement__ = 38;
         if (stan::math::logical_gt(theta, 2)) {
-          current_statement__ = 38;
+          current_statement__ = 37;
           x = 2;
         } 
-        current_statement__ = 40;
+        current_statement__ = 39;
         lp_accum__.add(x);
+        lcm_sym61__ = 247;
+        current_statement__ = 40;
+        lp_accum__.add(lcm_sym61__);
+        lcm_sym64__ = 576;
+        x = lcm_sym64__;
         current_statement__ = 41;
-        lp_accum__.add(247);
-        current_statement__ = 42;
-        x = 576;
-        current_statement__ = 43;
-        lp_accum__.add(576);
+        lp_accum__.add(lcm_sym64__);
         lcm_sym47__ = stan::math::logical_gt(theta, 46);
         if (lcm_sym47__) {
-          current_statement__ = 44;
+          current_statement__ = 42;
           x = 5880;
         } 
-        current_statement__ = 45;
+        current_statement__ = 43;
         lp_accum__.add(x);
         double z;
-        current_statement__ = 47;
+        current_statement__ = 45;
         z = x;
-        current_statement__ = 48;
+        current_statement__ = 46;
         lp_accum__.add(x);
-        current_statement__ = 50;
+        current_statement__ = 48;
         if (lcm_sym47__) {
-          current_statement__ = 49;
+          current_statement__ = 47;
           z = x;
         } 
-        current_statement__ = 51;
+        current_statement__ = 49;
         lp_accum__.add(z);
-        current_statement__ = 52;
+        current_statement__ = 50;
         lp_accum__.add(2);
         {
           double y = std::numeric_limits<double>::quiet_NaN();
-          current_statement__ = 54;
-          lp_accum__.add(24);
+          lcm_sym59__ = 24;
+          current_statement__ = 52;
+          lp_accum__.add(lcm_sym59__);
         }
         {
           double y = std::numeric_limits<double>::quiet_NaN();
-          current_statement__ = 57;
-          lp_accum__.add(245);
+          lcm_sym60__ = 245;
+          current_statement__ = 55;
+          lp_accum__.add(lcm_sym60__);
         }
         {
-          current_statement__ = 59;
+          current_statement__ = 57;
           lp_accum__.add(2);
         }
         int inline_sym20__;
         int inline_sym21__ = std::numeric_limits<int>::min();
         for (int inline_sym22__ = 1; inline_sym22__ <= 1; ++inline_sym22__) {
-          current_statement__ = 61;
+          current_statement__ = 59;
           lp_accum__.add(2);
           break;
         }
-        current_statement__ = 63;
+        current_statement__ = 61;
         while (576) {
           break;
         }
         int inline_sym23__;
         int inline_sym24__ = std::numeric_limits<int>::min();
         for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-          current_statement__ = 61;
+          current_statement__ = 59;
           lp_accum__.add(2);
           inline_sym23__ = 24;
           break;
@@ -26223,20 +26255,20 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           }
           int inline_sym24__ = std::numeric_limits<int>::min();
           for (int inline_sym25__ = 1; inline_sym25__ <= 1; ++inline_sym25__) {
-            current_statement__ = 61;
+            current_statement__ = 59;
             lp_accum__.add(2);
             inline_sym23__ = 24;
             break;
           }
         }
-        current_statement__ = 66;
+        current_statement__ = 64;
         for (int i = 31; i <= 225; ++i) { continue;}
-        current_statement__ = 68;
+        current_statement__ = 66;
         for (int i = 31; i <= 225; ++i) { break;}
         int inline_sym26__;
         int inline_sym27__ = std::numeric_limits<int>::min();
         for (int inline_sym28__ = 1; inline_sym28__ <= 1; ++inline_sym28__) {
-          current_statement__ = 61;
+          current_statement__ = 59;
           lp_accum__.add(2);
           inline_sym26__ = 24;
           break;
@@ -26245,7 +26277,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         int inline_sym29__;
         int inline_sym30__ = std::numeric_limits<int>::min();
         for (int inline_sym31__ = 1; inline_sym31__ <= 1; ++inline_sym31__) {
-          current_statement__ = 61;
+          current_statement__ = 59;
           lp_accum__.add(2);
           inline_sym29__ = 24;
           break;
@@ -26254,25 +26286,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         int inline_sym32__;
         int inline_sym33__ = std::numeric_limits<int>::min();
         for (int inline_sym34__ = 1; inline_sym34__ <= 1; ++inline_sym34__) {
-          current_statement__ = 61;
+          current_statement__ = 59;
           lp_accum__.add(2);
           break;
         }
         {
-          current_statement__ = 71;
+          current_statement__ = 69;
           lp_accum__.add(1);
-          current_statement__ = 72;
+          current_statement__ = 70;
           lp_accum__.add(24);
         }
         {
           {
-            current_statement__ = 74;
+            current_statement__ = 72;
             lp_accum__.add(1);
           }
         }
         double temp = std::numeric_limits<double>::quiet_NaN();
         {
-          current_statement__ = 78;
+          current_statement__ = 76;
           if (pstream__) {
             stan::math::stan_print(pstream__, "hello");
             stan::math::stan_print(pstream__, "\n");
@@ -26280,28 +26312,29 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         double temp2 = std::numeric_limits<double>::quiet_NaN();
         {
-          current_statement__ = 81;
-          lp_accum__.add(4);
-          current_statement__ = 82;
-          lp_accum__.add(6);
+          lcm_sym66__ = 6;
+          current_statement__ = 79;
+          lp_accum__.add(lcm_sym63__);
+          current_statement__ = 80;
+          lp_accum__.add(lcm_sym66__);
           {
-            current_statement__ = 81;
-            lp_accum__.add(4);
-            current_statement__ = 82;
-            lp_accum__.add(6);
+            current_statement__ = 79;
+            lp_accum__.add(lcm_sym63__);
+            current_statement__ = 80;
+            lp_accum__.add(lcm_sym66__);
           }
         }
         double dataonlyvar;
-        current_statement__ = 84;
-        dataonlyvar = 3;
-        current_statement__ = 85;
+        current_statement__ = 82;
+        dataonlyvar = lcm_sym62__;
+        current_statement__ = 83;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
         {
-          current_statement__ = 87;
+          current_statement__ = 85;
           paramvar = (theta * 34);
         }
-        current_statement__ = 89;
+        current_statement__ = 87;
         lp_accum__.add(paramvar);
       }
     } catch (const std::exception& e) {
@@ -26500,25 +26533,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     param_names__.emplace_back(std::string() + "theta");
     param_names__.emplace_back(std::string() + "phi");
-    for (int sym57__ = 1; sym57__ <= 2; ++sym57__) {
+    for (int sym67__ = 1; sym67__ <= 2; ++sym67__) {
       {
-        for (int sym58__ = 1; sym58__ <= 3; ++sym58__) {
+        for (int sym68__ = 1; sym68__ <= 3; ++sym68__) {
           {
-            param_names__.emplace_back(std::string() + "x_matrix" + '.' + std::to_string(sym58__) + '.' + std::to_string(sym57__));
+            param_names__.emplace_back(std::string() + "x_matrix" + '.' + std::to_string(sym68__) + '.' + std::to_string(sym67__));
           } 
         }
       } 
     }
-    for (int sym57__ = 1; sym57__ <= 2; ++sym57__) {
+    for (int sym67__ = 1; sym67__ <= 2; ++sym67__) {
       {
-        param_names__.emplace_back(std::string() + "x_vector" + '.' + std::to_string(sym57__));
+        param_names__.emplace_back(std::string() + "x_vector" + '.' + std::to_string(sym67__));
       } 
     }
-    for (int sym57__ = 1; sym57__ <= 2; ++sym57__) {
+    for (int sym67__ = 1; sym67__ <= 2; ++sym67__) {
       {
-        for (int sym58__ = 1; sym58__ <= 2; ++sym58__) {
+        for (int sym68__ = 1; sym68__ <= 2; ++sym68__) {
           {
-            param_names__.emplace_back(std::string() + "x_cov" + '.' + std::to_string(sym58__) + '.' + std::to_string(sym57__));
+            param_names__.emplace_back(std::string() + "x_cov" + '.' + std::to_string(sym68__) + '.' + std::to_string(sym67__));
           } 
         }
       } 
@@ -26541,23 +26574,23 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     param_names__.emplace_back(std::string() + "theta");
     param_names__.emplace_back(std::string() + "phi");
-    for (int sym57__ = 1; sym57__ <= 2; ++sym57__) {
+    for (int sym67__ = 1; sym67__ <= 2; ++sym67__) {
       {
-        for (int sym58__ = 1; sym58__ <= 3; ++sym58__) {
+        for (int sym68__ = 1; sym68__ <= 3; ++sym68__) {
           {
-            param_names__.emplace_back(std::string() + "x_matrix" + '.' + std::to_string(sym58__) + '.' + std::to_string(sym57__));
+            param_names__.emplace_back(std::string() + "x_matrix" + '.' + std::to_string(sym68__) + '.' + std::to_string(sym67__));
           } 
         }
       } 
     }
-    for (int sym57__ = 1; sym57__ <= 2; ++sym57__) {
+    for (int sym67__ = 1; sym67__ <= 2; ++sym67__) {
       {
-        param_names__.emplace_back(std::string() + "x_vector" + '.' + std::to_string(sym57__));
+        param_names__.emplace_back(std::string() + "x_vector" + '.' + std::to_string(sym67__));
       } 
     }
-    for (int sym57__ = 1; sym57__ <= 3; ++sym57__) {
+    for (int sym67__ = 1; sym67__ <= 3; ++sym67__) {
       {
-        param_names__.emplace_back(std::string() + "x_cov" + '.' + std::to_string(sym57__));
+        param_names__.emplace_back(std::string() + "x_cov" + '.' + std::to_string(sym67__));
       } 
     }
     if (emit_transformed_parameters__) {
@@ -28727,8 +28760,9 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym8__;
+      double lcm_sym7__;
       double lcm_sym6__;
-      double lcm_sym5__;
       local_scalar_t__ y;
       current_statement__ = 1;
       y = in__.template read<local_scalar_t__>();
@@ -28749,43 +28783,43 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       }
       double for_loop_var = std::numeric_limits<double>::quiet_NaN();
       {
-        current_statement__ = 10;
-        for_loop_var = 1;
+        lcm_sym8__ = 1;
+        for_loop_var = lcm_sym8__;
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym8__;
         }
       }
     } catch (const std::exception& e) {
@@ -28820,6 +28854,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     (void) function__;  // suppress unused var warning
     
     try {
+      double lcm_sym5__;
       double lcm_sym4__;
       double lcm_sym3__;
       int lcm_sym2__;
@@ -28850,43 +28885,43 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
         no_init_if = 1.0;
       }
       {
-        current_statement__ = 10;
-        for_loop_var = 1;
+        lcm_sym5__ = 1;
+        for_loop_var = lcm_sym5__;
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = lcm_sym5__;
         }
       }
       if (emit_transformed_parameters__) {

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -908,9 +908,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<local_scalar_t__> theta =
            std::vector<local_scalar_t__>(5, DUMMY_VAR__);
         current_statement__ = 6;
-        stan::model::assign(theta, std::vector<local_scalar_t__>{beta,
-          stan::math::promote_scalar<local_scalar_t__>(kappa), gamma, xi,
-          delta}, "assigning variable theta");
+        stan::model::assign(theta, std::vector<local_scalar_t__>{beta, kappa,
+          gamma, xi, delta}, "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, t0, t,
@@ -1018,9 +1017,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<double> theta =
            std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
         current_statement__ = 6;
-        stan::model::assign(theta, std::vector<local_scalar_t__>{beta,
-          stan::math::promote_scalar<local_scalar_t__>(kappa), gamma, xi,
-          delta}, "assigning variable theta");
+        stan::model::assign(theta, std::vector<local_scalar_t__>{beta, kappa,
+          gamma, xi, delta}, "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, t0, t,

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -848,7 +848,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       
       
       current_statement__ = 26;
-      stan::math::check_greater_or_equal(function__, "kappa", 1000000, 0);
+      stan::math::check_greater_or_equal(function__, "kappa", kappa, 0);
       current_statement__ = 29;
       stan::math::validate_non_negative_index("y", "N_t", N_t);
     } catch (const std::exception& e) {
@@ -898,12 +898,11 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       {
         std::vector<local_scalar_t__> theta;
         current_statement__ = 6;
-        stan::model::assign(theta, std::vector<local_scalar_t__>{beta,
-          stan::math::promote_scalar<local_scalar_t__>(1000000), gamma, xi,
-          delta}, "assigning variable theta");
+        stan::model::assign(theta, std::vector<local_scalar_t__>{beta, kappa,
+          gamma, xi, delta}, "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
-          stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, 0, t,
+          stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, t0, t,
             theta, x_r, x_i, pstream__), "assigning variable y");
       }
       current_statement__ = 5;
@@ -1007,12 +1006,11 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       {
         std::vector<double> theta;
         current_statement__ = 6;
-        stan::model::assign(theta, std::vector<double>{beta,
-          stan::math::promote_scalar<double>(1000000), gamma, xi, delta},
-          "assigning variable theta");
+        stan::model::assign(theta, std::vector<double>{beta, kappa, gamma,
+          xi, delta}, "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
-          stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, 0, t,
+          stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, t0, t,
             theta, x_r, x_i, pstream__), "assigning variable y");
       }
       current_statement__ = 5;
@@ -16599,7 +16597,7 @@ using namespace stan::math;
 
 
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 109> locations_array__ = 
+static constexpr std::array<const char*, 114> locations_array__ = 
 {" (found before start of program)",
  " (in 'optimizations.stan', line 20, column 4 to column 15)",
  " (in 'optimizations.stan', line 21, column 4 to column 13)",
@@ -16642,6 +16640,7 @@ static constexpr std::array<const char*, 109> locations_array__ =
  " (in 'optimizations.stan', line 60, column 6 to column 12)",
  " (in 'optimizations.stan', line 59, column 4 to line 60, column 12)",
  " (in 'optimizations.stan', line 61, column 4 to column 16)",
+ " (in 'optimizations.stan', line 63, column 4 to column 12)",
  " (in 'optimizations.stan', line 64, column 4 to column 16)",
  " (in 'optimizations.stan', line 65, column 4 to column 16)",
  " (in 'optimizations.stan', line 66, column 4 to column 16)",
@@ -16656,9 +16655,11 @@ static constexpr std::array<const char*, 109> locations_array__ =
  " (in 'optimizations.stan', line 75, column 4 to column 16)",
  " (in 'optimizations.stan', line 78, column 4 to column 16)",
  " (in 'optimizations.stan', line 80, column 8 to column 19)",
+ " (in 'optimizations.stan', line 81, column 8 to column 15)",
  " (in 'optimizations.stan', line 82, column 8 to column 20)",
  " (in 'optimizations.stan', line 79, column 4 to line 83, column 5)",
  " (in 'optimizations.stan', line 85, column 8 to column 20)",
+ " (in 'optimizations.stan', line 86, column 8 to column 16)",
  " (in 'optimizations.stan', line 87, column 8 to column 20)",
  " (in 'optimizations.stan', line 84, column 4 to line 88, column 5)",
  " (in 'optimizations.stan', line 90, column 11 to column 23)",
@@ -16687,7 +16688,9 @@ static constexpr std::array<const char*, 109> locations_array__ =
  " (in 'optimizations.stan', line 128, column 4 to column 14)",
  " (in 'optimizations.stan', line 132, column 6 to column 21)",
  " (in 'optimizations.stan', line 129, column 4 to line 132, column 21)",
+ " (in 'optimizations.stan', line 133, column 4 to column 17)",
  " (in 'optimizations.stan', line 134, column 4 to column 15)",
+ " (in 'optimizations.stan', line 136, column 8 to column 22)",
  " (in 'optimizations.stan', line 137, column 8 to column 23)",
  " (in 'optimizations.stan', line 138, column 8 to column 24)",
  " (in 'optimizations.stan', line 135, column 21 to line 139, column 5)",
@@ -16734,12 +16737,12 @@ template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
-      current_statement__ = 99;
+      current_statement__ = 104;
       if (stan::math::logical_gt(x, 342)) {
-        current_statement__ = 98;
+        current_statement__ = 103;
         return ;
       } 
-      current_statement__ = 100;
+      current_statement__ = 105;
       lp_accum__.add(y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16753,12 +16756,12 @@ int rfun(const int& y, std::ostream* pstream__) {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
-      current_statement__ = 103;
+      current_statement__ = 108;
       if (stan::math::logical_gt(y, 2)) {
-        current_statement__ = 102;
+        current_statement__ = 107;
         return (y + 24);
       } 
-      current_statement__ = 104;
+      current_statement__ = 109;
       return (y + 2);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16771,9 +16774,9 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
     try {
-      current_statement__ = 106;
+      current_statement__ = 111;
       lp_accum__.add(2);
-      current_statement__ = 107;
+      current_statement__ = 112;
       return 24;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16955,7 +16958,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 37;
         x = 3;
         current_statement__ = 38;
-        lp_accum__.add(3);
+        lp_accum__.add(x);
         current_statement__ = 40;
         if (stan::math::logical_gt(theta, 2)) {
           current_statement__ = 39;
@@ -16964,114 +16967,124 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 41;
         lp_accum__.add(x);
         current_statement__ = 42;
-        lp_accum__.add(247);
+        x = 247;
         current_statement__ = 43;
-        x = 576;
+        lp_accum__.add(x);
         current_statement__ = 44;
-        lp_accum__.add(576);
-        current_statement__ = 46;
+        x = 576;
+        current_statement__ = 45;
+        lp_accum__.add(x);
+        current_statement__ = 47;
         if (stan::math::logical_gt(theta, 46)) {
-          current_statement__ = 45;
+          current_statement__ = 46;
           x = 5880;
         } 
-        current_statement__ = 47;
+        current_statement__ = 48;
         lp_accum__.add(x);
         double z;
-        current_statement__ = 49;
-        z = x;
         current_statement__ = 50;
+        z = x;
+        current_statement__ = 51;
         lp_accum__.add(x);
-        current_statement__ = 52;
+        current_statement__ = 53;
         if (stan::math::logical_gt(theta, 46)) {
-          current_statement__ = 51;
+          current_statement__ = 52;
           z = x;
         } 
-        current_statement__ = 53;
-        lp_accum__.add(z);
         current_statement__ = 54;
+        lp_accum__.add(z);
+        current_statement__ = 55;
         lp_accum__.add(2);
         {
-          double y = std::numeric_limits<double>::quiet_NaN();
-          current_statement__ = 56;
-          lp_accum__.add(24);
+          double y;
+          current_statement__ = 57;
+          y = 24;
+          current_statement__ = 58;
+          lp_accum__.add(y);
         }
         {
-          double y = std::numeric_limits<double>::quiet_NaN();
-          current_statement__ = 59;
-          lp_accum__.add(245);
-        }
-        {
+          double y;
           current_statement__ = 61;
+          y = 245;
+          current_statement__ = 62;
+          lp_accum__.add(y);
+        }
+        {
+          current_statement__ = 64;
           lp_accum__.add(2);
         }
-        current_statement__ = 65;
+        current_statement__ = 68;
         if (rfun_lp<propto__>(lp__, lp_accum__, pstream__)) {
           ;
         } else ;
-        current_statement__ = 66;
+        current_statement__ = 69;
         while (576) {
           break;
         }
-        current_statement__ = 67;
+        current_statement__ = 70;
         while (rfun_lp<propto__>(lp__, lp_accum__, pstream__)) {
           break;
         }
-        current_statement__ = 69;
+        current_statement__ = 72;
         for (int i = 31; i <= 225; ++i) { continue;}
-        current_statement__ = 71;
+        current_statement__ = 74;
         for (int i = 31; i <= 225; ++i) { break;}
-        current_statement__ = 73;
+        current_statement__ = 76;
         for (int i = rfun_lp<propto__>(lp__, lp_accum__, pstream__);
              i <= 225; ++i) {
           continue;
         }
-        current_statement__ = 75;
+        current_statement__ = 78;
         for (int i = rfun_lp<propto__>(lp__, lp_accum__, pstream__);
              i <= 225; ++i) {
           break;
         }
-        current_statement__ = 77;
+        current_statement__ = 80;
         for (int i = rfun_lp<propto__>(lp__, lp_accum__, pstream__);
              i <= 225; ++i) ;
         {
-          current_statement__ = 78;
+          current_statement__ = 81;
           lp_accum__.add(1);
-          current_statement__ = 79;
+          current_statement__ = 82;
           lp_accum__.add(24);
         }
         {
           {
-            current_statement__ = 81;
+            current_statement__ = 84;
             lp_accum__.add(1);
           }
         }
         double temp = std::numeric_limits<double>::quiet_NaN();
         {
-          current_statement__ = 85;
+          current_statement__ = 88;
           if (pstream__) {
             stan::math::stan_print(pstream__, "hello");
             stan::math::stan_print(pstream__, "\n");
           }
         }
+        current_statement__ = 90;
+        temp = 4;
         double temp2 = std::numeric_limits<double>::quiet_NaN();
-        current_statement__ = 91;
+        current_statement__ = 96;
         for (int i = 2; i <= 3; ++i) {
-          current_statement__ = 88;
-          lp_accum__.add(4);
-          current_statement__ = 89;
-          lp_accum__.add(6);
+          current_statement__ = 92;
+          temp2 = 6;
+          current_statement__ = 93;
+          lp_accum__.add(temp);
+          current_statement__ = 94;
+          lp_accum__.add(temp2);
         }
         double dataonlyvar;
-        current_statement__ = 92;
+        current_statement__ = 97;
         dataonlyvar = 3;
-        current_statement__ = 93;
+        current_statement__ = 98;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
         {
-          current_statement__ = 95;
+          current_statement__ = 100;
           paramvar = (theta * 34);
         }
-        current_statement__ = 97;
+        current_statement__ = 102;
         lp_accum__.add(paramvar);
       }
     } catch (const std::exception& e) {

--- a/test/integration/good/promotion/array_promotion.stan
+++ b/test/integration/good/promotion/array_promotion.stan
@@ -18,6 +18,9 @@ data {
 
 transformed parameters {
    array[2,2] real zs = {{2,3},{7,0.5}};
+   array[2] complex z1 = {1,3};
+   array[2] complex z2 = {1,3.5};
+   array[2] complex z3 = {1,3.5i};
 }
 
 model {

--- a/test/integration/good/promotion/pretty.expected
+++ b/test/integration/good/promotion/pretty.expected
@@ -32,6 +32,9 @@ data {
 }
 transformed parameters {
   array[2, 2] real zs = {{2, 3}, {7, 0.5}};
+  array[2] complex z1 = {1, 3};
+  array[2] complex z2 = {1, 3.5};
+  array[2] complex z3 = {1, 3.5i};
 }
 model {
   array[3] int d = {1, 2, 3};

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -2980,26 +2980,26 @@ let%expect_test "lazy code motion, 13" =
   [%expect
     {|
       log_prob {
-        data int lcm_sym7__;
-        data int lcm_sym6__;
+        data real lcm_sym7__;
+        data real lcm_sym6__;
         data int lcm_sym5__;
         data int lcm_sym4__;
         data int lcm_sym3__;
         {
           real temp;
           if((2 > 3)) {
-            lcm_sym6__ = (2 * 2);
+            lcm_sym6__ = promote((2 * 2), real);
             temp = lcm_sym6__;
             ;
           } else {
             FnPrint__("hello");
-            lcm_sym6__ = (2 * 2);
+            lcm_sym6__ = promote((2 * 2), real);
             ;
           }
           temp = lcm_sym6__;
           real temp2;
           if((3 >= 2)) {
-            lcm_sym7__ = (2 * 3);
+            lcm_sym7__ = promote((2 * 3), real);
             temp2 = lcm_sym7__;
             target += temp;
             lcm_sym5__ = (2 + 1);
@@ -3227,7 +3227,7 @@ let%expect_test "adlevel_optimization" =
           data real z_data;
           if((1 > 2)) y = (y + x); else y = (y + w);
           if((2 > 1)) z = y;
-          if((3 > 1)) z_data = x;
+          if((3 > 1)) z_data = promote(x, real);
           FnPrint__(z);
           FnPrint__(z_data);
         }
@@ -3243,7 +3243,7 @@ let%expect_test "adlevel_optimization" =
           data real z_data;
           if((1 > 2)) y = (y + x); else y = (y + w);
           if((2 > 1)) z = y;
-          if((3 > 1)) z_data = x;
+          if((3 > 1)) z_data = promote(x, real);
           FnPrint__(z);
           FnPrint__(z_data);
         }
@@ -3365,8 +3365,12 @@ let%expect_test "adlevel_optimization expressions" =
                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
                 (Assignment (z_data UReal ())
-                 ((pattern (Var x))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                 ((pattern
+                   (Promotion
+                    ((pattern (Var x))
+                     (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                    UReal DataOnly))
+                  (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
                (meta <opaque>))
               ()))
             (meta <opaque>))
@@ -3417,7 +3421,7 @@ let%expect_test "adlevel_optimization 2" =
       log_prob {
         real w;
         data real w_trans;
-        w_trans = 1;
+        w_trans = promote(1, real);
         {
           data int x;
           array[real, 2] y;
@@ -3425,7 +3429,7 @@ let%expect_test "adlevel_optimization 2" =
           data real z_data;
           if((1 > 2)) y[1] = (y[1] + x); else y[2] = (y[2] + w);
           if((2 > 1)) z = y[1];
-          if((3 > 1)) z_data = x;
+          if((3 > 1)) z_data = promote(x, real);
           FnPrint__(z);
           FnPrint__(z_data);
         }
@@ -3435,7 +3439,7 @@ let%expect_test "adlevel_optimization 2" =
         data real w;
         data real w_trans;
         if(PNot__(emit_transformed_parameters__ || emit_generated_quantities__)) return;
-        w_trans = 1;
+        w_trans = promote(1, real);
         {
           data int x;
           data array[real, 2] y;
@@ -3443,7 +3447,7 @@ let%expect_test "adlevel_optimization 2" =
           data real z_data;
           if((1 > 2)) y[1] = (y[1] + x); else y[2] = (y[2] + w);
           if((2 > 1)) z = y[1];
-          if((3 > 1)) z_data = x;
+          if((3 > 1)) z_data = promote(x, real);
           FnPrint__(z);
           FnPrint__(z_data);
         }


### PR DESCRIPTION
Follow on to #1004. This tries to incorporate one of @nhuurre's suggestions there to handle array assignment and literals using the `Promote` expression. I'm thinking Tuples will need something like this as well, if we want to assign (int,int) to (real, int) for example.

I'm not 100% confident this will work as-is (mainly due to my lack of familiarity with the C++ at hand), so I am making this draft to run the tests.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Refactor how arrays have their types promoted internally.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
