### PR TITLE
[WIP] Generalize overloading templates

### DIFF
--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -94,12 +94,15 @@ let rec pp_unsizedtype_custom_scalar ppf (scalar, ut) =
 
 let pp_unsizedtype_custom_scalar_eigen_exprs ppf (scalar, ut) =
   match ut with
-  | UnsizedType.UInt | UReal | UMatrix | URowVector | UVector ->
+  | UnsizedType.UInt | UReal | UMatrix | URowVector | UVector | UComplex
+   |UArray _ ->
       string ppf scalar
-  | UComplex -> pf ppf "std::complex<%s>" scalar
+      (*
+  | UComplex -> pf ppf "%s" scalar
   | UArray t ->
       (* Expressions are not accepted for arrays of Eigen::Matrix *)
       pf ppf "std::vector<%a>" pp_unsizedtype_custom_scalar (scalar, t)
+      *)
   | UMathLibraryFunction | UFun _ ->
       Common.FatalError.fatal_error_msg
         [%message "Function types not implemented"]

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -94,14 +94,12 @@ let rec pp_unsizedtype_custom_scalar ppf (scalar, ut) =
 
 let pp_unsizedtype_custom_scalar_eigen_exprs ppf (scalar, ut) =
   match ut with
-  | UnsizedType.UInt | UReal | UMatrix | URowVector | UVector | UComplex
-   |UArray _ ->
-      string ppf scalar
-      (*
-  | UComplex -> pf ppf "%s" scalar
-  | UArray t ->
+  | UnsizedType.UArray t when scalar = "int" ->
       (* Expressions are not accepted for arrays of Eigen::Matrix *)
       pf ppf "std::vector<%a>" pp_unsizedtype_custom_scalar (scalar, t)
+  | UInt | UReal | UMatrix | URowVector | UVector | UComplex | UArray _ ->
+      string ppf scalar (*
+  | UComplex -> pf ppf "%s" scalar
       *)
   | UMathLibraryFunction | UFun _ ->
       Common.FatalError.fatal_error_msg

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -224,12 +224,8 @@ let pp_arg ppf (custom_scalar_opt, (_, name, ut)) =
     | Some scalar -> scalar
     | None -> stantype_prim_str ut in
   (* we add the _arg suffix for any Eigen types *)
-  if UnsizedType.is_eigen_type ut then
-    pf ppf "const %a& %s_arg__" pp_unsizedtype_custom_scalar_eigen_exprs
-      (scalar, ut) name
-  else
-    pf ppf "const %a& %s" pp_unsizedtype_custom_scalar_eigen_exprs (scalar, ut)
-      name
+  pf ppf "const %a& %s" pp_unsizedtype_custom_scalar_eigen_exprs (scalar, ut)
+    name
 
 let pp_arg_eigen_suffix ppf (custom_scalar_opt, (_, name, ut)) =
   let scalar =
@@ -237,11 +233,8 @@ let pp_arg_eigen_suffix ppf (custom_scalar_opt, (_, name, ut)) =
     | Some scalar -> scalar
     | None -> stantype_prim_str ut in
   (* we add the _arg suffix for any Eigen types *)
-  (*
   let opt_arg_suffix =
     if UnsizedType.is_eigen_type ut then name ^ "_arg__" else name in
-    *)
-  let opt_arg_suffix = name in
   pf ppf "const %a& %s" pp_unsizedtype_custom_scalar_eigen_exprs (scalar, ut)
     opt_arg_suffix
 

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -304,7 +304,7 @@ let pp_fun_def ppf
     pf ppf "%s(@[<hov>%a@]) " name (list ~sep:comma string) arg_strs ;
     Format.close_box () in
   let templates, templated_args = get_templates true `None in
-  pp_templates ~defaults:true ppf templates ;
+  pp_templates ~defaults:(Option.is_some fdbody) ppf templates ;
   pp_sig ppf (fdname, templated_args, `None) ;
   match fdbody with
   | None -> pf ppf ";@ "

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -48,7 +48,7 @@ let pp_template ppf template =
           | _ ->
               let next_bool_expr =
                 acc ^ require ^ "<"
-                ^ repper "value_type_t<" depth
+                ^ repper "stan::value_type_t<" depth
                 ^ name ^ repper ">" depth ^ ">" in
               if full_require_length = depth then next_bool_expr
               else next_bool_expr ^ ", " in

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -80,9 +80,14 @@ let pp_templates ~defaults ppf templates =
   match templates' with
   | [] -> ()
   | _ ->
-      pf ppf "template <@[%a, %a@]>@ "
-        (list ~sep:comma template_printer)
-        templates' template_require_printer require_templates
+      if List.length require_templates > 0 then
+        pf ppf "template <@[%a, %a@]>@ "
+          (list ~sep:comma template_printer)
+          templates' template_require_printer require_templates
+      else
+        pf ppf "template <@[%a@]>@ "
+          (list ~sep:comma template_printer)
+          templates'
 
 type found_functor =
   { struct_template: template option
@@ -161,7 +166,7 @@ let%expect_test "arg types templated correctly" =
   [(AutoDiffable, "xreal", UReal); (DataOnly, "yint", UInt)]
   |> maybe_templated_arg_types |> List.filter_opt |> String.concat ~sep:","
   |> print_endline ;
-  [%expect {| Txreal__,Tyint__ |}]
+  [%expect {| Txreal__ |}]
 
 (** Print the code for promoting stan real types
  @param ppf A pretty printer

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -128,7 +128,8 @@ let maybe_require_templates (names : string option list)
       | UArray ut_arr ->
           List.concat [["stan::is_std_vector"]; get_requires ut_arr]
       (* NB: Not unwinding array types due to the way arrays of eigens are printed *)
-      | UReal | UInt -> ["stan::is_stan_scalar_t"]
+      | UReal -> ["stan::is_stan_scalar"]
+      | UInt -> ["std::is_integral"]
       | _ -> [] in
     get_requires (trd3 arg) in
   List.map2_exn names args ~f:(fun name a ->

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -1036,7 +1036,9 @@ let pp_prog ppf (p : Program.Typed.t) =
   let pp_functor_decls ppf tbl =
     Hashtbl.iteri tbl ~f:(fun ~key ~data ->
         pf ppf "@[<v 2>%astruct %s {@,%aconst;@]@,};@."
-          (Fmt.option (Fmt.option pp_template_defaults))
+          (option
+             (option (fun ppf t ->
+                  pf ppf "template <%a>@ " pp_template_defaults t ) ) )
           (Option.map ~f:(fun x -> x.struct_template) (List.hd data))
           key
           (list ~sep:(any "const;@,") (fun ppf (ts, sign) ->
@@ -1048,7 +1050,9 @@ let pp_prog ppf (p : Program.Typed.t) =
   let pp_functors ppf tbl =
     Hashtbl.iter tbl ~f:(fun data ->
         List.iter data ~f:(fun {struct_template; defn; arg_templates; _} ->
-            pf ppf "%a%a%s@." (Fmt.option pp_template) struct_template
+            pf ppf "%a%a%s@."
+              (option (fun ppf t -> pf ppf "template <%a>@ " pp_template t))
+              struct_template
               (pp_templates ~defaults:false)
               arg_templates defn ) ) in
   pf ppf "@[<v>@ %s@ %s@ namespace %s {@ %s@ %a@ %a@ %s@ %a@ %a@ }@ @]" version

--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -224,8 +224,12 @@ let pp_arg ppf (custom_scalar_opt, (_, name, ut)) =
     | Some scalar -> scalar
     | None -> stantype_prim_str ut in
   (* we add the _arg suffix for any Eigen types *)
-  pf ppf "const %a& %s" pp_unsizedtype_custom_scalar_eigen_exprs (scalar, ut)
-    name
+  if UnsizedType.is_eigen_type ut then
+    pf ppf "const %a& %s_arg__" pp_unsizedtype_custom_scalar_eigen_exprs
+      (scalar, ut) name
+  else
+    pf ppf "const %a& %s" pp_unsizedtype_custom_scalar_eigen_exprs (scalar, ut)
+      name
 
 let pp_arg_eigen_suffix ppf (custom_scalar_opt, (_, name, ut)) =
   let scalar =

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1218,12 +1218,14 @@ static constexpr std::array<const char*, 427> locations_array__ =
  " (in 'complex_scalar.stan', line 33, column 45 to line 35, column 3)"};
 
 struct foo8_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
              std::ostream* pstream__) const;
 };
 struct foo1_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::complex<T0__>& z, std::ostream* pstream__) const;
 };
 struct foo4_functor__ {
@@ -1231,36 +1233,39 @@ struct foo4_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct foo6_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   operator()(const T0__& r, std::ostream* pstream__) const;
 };
 struct foo10_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
              std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::complex<stan::promote_args_t<T0__>>
   operator()(const T0__& r, std::ostream* pstream__) const;
 };
 struct foo9_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   operator()(const T0__& r, std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::complex<stan::promote_args_t<T0__>>
   operator()(const std::complex<T0__>& z, std::ostream* pstream__) const;
 };
 struct foo7_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   operator()(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) const;
 };
 struct foo5_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) const;
 };
 struct foo_functor__ {
@@ -1282,7 +1287,8 @@ std::complex<double> foo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo1(const std::complex<T0__>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -1297,7 +1303,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::complex<stan::promote_args_t<T0__>>
   foo2(const T0__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -1312,7 +1319,8 @@ template <typename T0__> std::complex<stan::promote_args_t<T0__>>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::complex<stan::promote_args_t<T0__>>
   foo3(const std::complex<T0__>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -1342,7 +1350,8 @@ std::vector<std::complex<double>> foo4(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo5(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -1357,7 +1366,7 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   foo6(const T0__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -1374,7 +1383,7 @@ template <typename T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   foo7(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -1390,7 +1399,8 @@ template <typename T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo8(const std::vector<std::vector<std::complex<T0__>>>& z,
        std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -1406,7 +1416,7 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   foo9(const T0__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -1428,7 +1438,7 @@ template <typename T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   foo10(const std::vector<std::vector<std::complex<T0__>>>& z,
         std::ostream* pstream__) {
@@ -1446,7 +1456,8 @@ template <typename T0__>
     }
     }
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo8_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
                            std::ostream* pstream__)  const
 {
@@ -1454,7 +1465,8 @@ foo8_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo1_functor__::operator()(const std::complex<T0__>& z,
                            std::ostream* pstream__)  const
 {
@@ -1469,7 +1481,7 @@ foo4_functor__::operator()(std::ostream* pstream__)  const
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
 std::vector<std::complex<stan::promote_args_t<T0__>>>
 foo6_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
@@ -1477,7 +1489,7 @@ foo6_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
 std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
 foo10_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
                             std::ostream* pstream__)  const
@@ -1486,14 +1498,15 @@ foo10_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& 
 }
 
 
-template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+std::complex<stan::promote_args_t<T0__>>
 foo2_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
   return foo2(r, pstream__);
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
 std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
 foo9_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
@@ -1501,7 +1514,8 @@ foo9_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 }
 
 
-template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+std::complex<stan::promote_args_t<T0__>>
 foo3_functor__::operator()(const std::complex<T0__>& z,
                            std::ostream* pstream__)  const
 {
@@ -1509,7 +1523,7 @@ foo3_functor__::operator()(const std::complex<T0__>& z,
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
 std::vector<std::complex<stan::promote_args_t<T0__>>>
 foo7_functor__::operator()(const std::vector<std::complex<T0__>>& z,
                            std::ostream* pstream__)  const
@@ -1518,7 +1532,8 @@ foo7_functor__::operator()(const std::vector<std::complex<T0__>>& z,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo5_functor__::operator()(const std::vector<std::complex<T0__>>& z,
                            std::ostream* pstream__)  const
 {
@@ -3730,7 +3745,7 @@ static constexpr std::array<const char*, 75> locations_array__ =
  " (in 'cpp-reserved-words.stan', line 14, column 17 to column 19)"};
 
 struct _stan_asm_functor__ {
-  template <typename T0__> void
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr> void
   operator()(const T0__& _stan_class, std::ostream* pstream__) const;
 };
 struct _stan_char16_t_functor__ {
@@ -3758,7 +3773,7 @@ struct _stan_alignof_functor__ {
   operator()(const int& _stan_char, std::ostream* pstream__) const;
 };
 struct _stan_and_eq_functor__ {
-  template <typename T0__> void
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
   operator()(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) const;
 };
 struct _stan_and_functor__ {
@@ -3821,7 +3836,7 @@ void _stan_and(const int& _stan_STAN_MAJOR, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> void
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
   _stan_and_eq(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -3835,7 +3850,7 @@ template <typename T0__> void
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> void
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr> void
   _stan_asm(const T0__& _stan_class_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
     int current_statement__ = 0; 
@@ -3955,7 +3970,7 @@ void _stan_char32_t(std::ostream* pstream__) {
     }
     }
 
-template <typename T0__> void
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr> void
 _stan_asm_functor__::operator()(const T0__& _stan_class,
                                 std::ostream* pstream__)  const
 {
@@ -4005,7 +4020,7 @@ _stan_alignof_functor__::operator()(const int& _stan_char,
 }
 
 
-template <typename T0__> void
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
 _stan_and_eq_functor__::operator()(const T0__& _stan_STAN_MINOR,
                                    std::ostream* pstream__)  const
 {
@@ -6467,14 +6482,14 @@ static constexpr std::array<const char*, 787> locations_array__ =
  " (in 'mother.stan', line 345, column 41 to line 349, column 3)"};
 
 struct foo_five_args_lp_functor__ {
-  template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
   operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
              const T4__& x5, const T5__& x6, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct f5_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>>
@@ -6490,11 +6505,12 @@ struct f5_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lcdf_functor__ {
-  template <typename T1__> stan::promote_args_t<T1__>
+  template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct covsqrt2corsqrt_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& mat, const int& invert, std::ostream* pstream__) const;
 };
@@ -6503,7 +6519,7 @@ struct foo_1_functor__ {
   operator()(const int& a, std::ostream* pstream__) const;
 };
 struct unit_normal_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -6517,7 +6533,7 @@ struct vecfoo_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>>>
@@ -6533,7 +6549,7 @@ struct f6_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_five_args_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
   operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
              const T4__& x5, std::ostream* pstream__) const;
@@ -6543,7 +6559,7 @@ struct foo_2_functor__ {
   operator()(const int& a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<int>>
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6557,11 +6573,11 @@ struct f3_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
-  template <typename T0__> void
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>
@@ -6577,7 +6593,7 @@ struct f7_functor__ {
              std::ostream* pstream__) const;
 };
 struct f11_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>>
@@ -6593,7 +6609,7 @@ struct f11_functor__ {
              std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>>>
@@ -6609,14 +6625,15 @@ struct f12_functor__ {
              std::ostream* pstream__) const;
 };
 struct sho_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<double>& x,
              const std::vector<int>& x_int, std::ostream* pstream__) const;
 };
 struct foo_bar2_functor__ {
-  template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
+  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
 };
 struct matfoo_functor__ {
@@ -6624,29 +6641,30 @@ struct matfoo_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
              const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
-  template <typename T0__, typename T1__, typename RNG>
+  template <typename T0__, typename T1__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& mu, const T1__& sigma, RNG& base_rng__,
              std::ostream* pstream__) const;
 };
 struct relative_diff_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   operator()(const T0__& x, const T1__& y, const T2__& max_, const T3__& min_,
              std::ostream* pstream__) const;
 };
 struct vecmubar_functor__ {
-  template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   operator()(const T0__& mu, std::ostream* pstream__) const;
 };
 struct f0_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   void
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6660,18 +6678,19 @@ struct f0_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lpmf_functor__ {
-  template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct foo_5_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<double>& data_r, const std::vector<int>& data_i,
              std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>
@@ -6687,7 +6706,7 @@ struct f4_functor__ {
              std::ostream* pstream__) const;
 };
 struct f10_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>
@@ -6703,7 +6722,7 @@ struct f10_functor__ {
              std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<int>
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6717,7 +6736,7 @@ struct f2_functor__ {
              std::ostream* pstream__) const;
 };
 struct f9_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>>>
@@ -6733,7 +6752,7 @@ struct f9_functor__ {
              std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>>
@@ -6749,21 +6768,24 @@ struct f8_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lccdf_functor__ {
-  template <typename T1__> stan::promote_args_t<T1__>
+  template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct vecmufoo_functor__ {
-  template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   operator()(const T0__& mu, std::ostream* pstream__) const;
 };
 struct foo_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo_3_functor__ {
-  template <typename T0__> std::vector<stan::promote_args_t<T0__>>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::vector<stan::promote_args_t<T0__>>
   operator()(const T0__& t, const int& n, std::ostream* pstream__) const;
 };
 struct foo_6_functor__ {
@@ -6771,18 +6793,19 @@ struct foo_6_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct binomialf_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& phi, const T1__& theta,
              const std::vector<double>& x_r, const std::vector<int>& x_i,
              std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   int
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6820,12 +6843,12 @@ int foo(const int& n, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<double>& x,
       const std::vector<int>& x_int, std::ostream* pstream__) ; 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<double>& x,
@@ -6869,7 +6892,8 @@ double foo_bar0(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo_bar1(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -6884,7 +6908,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T0__, T1__>
   foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
     int current_statement__ = 0; 
@@ -6899,7 +6924,8 @@ template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   foo_lpmf(const int& y, const T1__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
     int current_statement__ = 0; 
@@ -6912,7 +6938,8 @@ template <bool propto__, typename T1__> stan::promote_args_t<T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T1__> stan::promote_args_t<T1__>
+template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
     int current_statement__ = 0; 
@@ -6927,7 +6954,8 @@ template <typename T1__> stan::promote_args_t<T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T1__> stan::promote_args_t<T1__>
+template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
     int current_statement__ = 0; 
@@ -6942,7 +6970,7 @@ template <typename T1__> stan::promote_args_t<T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename RNG>
+template <typename T0__, typename T1__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_rng(const T0__& mu, const T1__& sigma, RNG& base_rng__,
           std::ostream* pstream__) {
@@ -6959,7 +6987,7 @@ template <typename T0__, typename T1__, typename RNG>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
@@ -7227,7 +7255,8 @@ int foo_2(const int& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> std::vector<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::vector<stan::promote_args_t<T0__>>
   foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -7242,7 +7271,7 @@ template <typename T0__> std::vector<stan::promote_args_t<T0__>>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
@@ -7257,7 +7286,8 @@ template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> void foo_4(const T0__& x, std::ostream* pstream__) {
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
+  foo_4(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -7274,7 +7304,7 @@ template <typename T0__> void foo_4(const T0__& x, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   relative_diff(const T0__& x, const T1__& y, const T2__& max_,
                 const T3__& min_, std::ostream* pstream__) {
@@ -7321,7 +7351,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   foo_5(const T0__& shared_params_arg__, const T1__& job_params_arg__,
         const std::vector<double>& data_r, const std::vector<int>& data_i,
@@ -7343,7 +7373,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
   foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3,
                 const T3__& x4, const T4__& x5, std::ostream* pstream__) {
@@ -7361,7 +7391,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
   foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
                    const T3__& x4, const T4__& x5, const T5__& x6,
@@ -7380,7 +7410,7 @@ template <bool propto__, typename T0__, typename T1__, typename T2__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   covsqrt2corsqrt(const T0__& mat_arg__, const int& invert,
                   std::ostream* pstream__) {
@@ -7419,7 +7449,7 @@ template <typename T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   void
   f0(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -7453,7 +7483,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   int
   f1(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -7484,7 +7514,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<int>
   f2(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -7515,7 +7545,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<int>>
   f3(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -7546,7 +7576,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>
@@ -7579,7 +7609,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>
@@ -7612,7 +7642,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>>
@@ -7645,7 +7675,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>
@@ -7678,7 +7708,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>
@@ -7711,7 +7741,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>>
@@ -7744,7 +7774,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>
@@ -7778,7 +7808,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>
@@ -7812,7 +7842,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>>
@@ -7908,7 +7938,8 @@ Eigen::Matrix<double, -1, 1> vecfoo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   vecmufoo(const T0__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -7928,7 +7959,8 @@ template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   vecmubar(const T0__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -7950,7 +7982,7 @@ template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   algebra_system(const T0__& x_arg__, const T1__& y_arg__,
                  const std::vector<T2__>& dat,
@@ -7984,7 +8016,7 @@ template <typename T0__, typename T1__, typename T2__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   binomialf(const T0__& phi_arg__, const T1__& theta_arg__,
             const std::vector<double>& x_r, const std::vector<int>& x_i,
@@ -8012,7 +8044,7 @@ template <typename T0__, typename T1__>
     }
     }
 
-template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr>
 stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
 foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
                                        const T2__& x3, const T3__& x4,
@@ -8026,7 +8058,7 @@ foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>
@@ -8046,7 +8078,8 @@ f5_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T1__> stan::promote_args_t<T1__>
+template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T1__>
 foo_lcdf_functor__::operator()(const int& y, const T1__& lambda,
                                std::ostream* pstream__)  const
 {
@@ -8054,7 +8087,7 @@ foo_lcdf_functor__::operator()(const int& y, const T1__& lambda,
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 covsqrt2corsqrt_functor__::operator()(const T0__& mat, const int& invert,
                                       std::ostream* pstream__)  const
@@ -8069,7 +8102,7 @@ int foo_1_functor__::operator()(const int& a, std::ostream* pstream__)  const
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 void
 unit_normal_lp_functor__::operator()(const T0__& u, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -8092,7 +8125,7 @@ vecfoo_functor__::operator()(std::ostream* pstream__)  const
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>>
@@ -8112,7 +8145,7 @@ f6_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr>
 stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
 foo_five_args_functor__::operator()(const T0__& x1, const T1__& x2,
                                     const T2__& x3, const T3__& x4,
@@ -8129,7 +8162,7 @@ int foo_2_functor__::operator()(const int& a, std::ostream* pstream__)  const
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<std::vector<int>>
 f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -8147,14 +8180,14 @@ f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T0__> void
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
 foo_4_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return foo_4(x, pstream__);
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>
@@ -8174,7 +8207,7 @@ f7_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>
@@ -8194,7 +8227,7 @@ f11_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>>
@@ -8214,7 +8247,7 @@ f12_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 std::vector<stan::promote_args_t<T0__, T1__, T2__>>
 sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                           const std::vector<T2__>& theta,
@@ -8226,7 +8259,8 @@ sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
 }
 
 
-template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T0__, T1__>
 foo_bar2_functor__::operator()(const T0__& x, const T1__& y,
                                std::ostream* pstream__)  const
 {
@@ -8241,7 +8275,7 @@ matfoo_functor__::operator()(std::ostream* pstream__)  const
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 algebra_system_functor__::operator()(const T0__& x, const T1__& y,
                                      const std::vector<T2__>& dat,
@@ -8252,7 +8286,7 @@ algebra_system_functor__::operator()(const T0__& x, const T1__& y,
 }
 
 
-template <typename T0__, typename T1__, typename RNG>
+template <typename T0__, typename T1__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
 stan::promote_args_t<T0__, T1__>
 foo_rng_functor__::operator()(const T0__& mu, const T1__& sigma,
                               RNG& base_rng__, std::ostream* pstream__) 
@@ -8262,7 +8296,7 @@ const
 }
 
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, T1__, T2__, T3__>
 relative_diff_functor__::operator()(const T0__& x, const T1__& y,
                                     const T2__& max_, const T3__& min_,
@@ -8272,7 +8306,8 @@ relative_diff_functor__::operator()(const T0__& x, const T1__& y,
 }
 
 
-template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmubar_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
 const
 {
@@ -8280,7 +8315,7 @@ const
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 void
 f0_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -8298,7 +8333,8 @@ f0_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T1__>
 foo_lpmf_functor__::operator()(const int& y, const T1__& lambda,
                                std::ostream* pstream__)  const
 {
@@ -8306,7 +8342,7 @@ foo_lpmf_functor__::operator()(const int& y, const T1__& lambda,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
 foo_5_functor__::operator()(const T0__& shared_params,
                             const T1__& job_params,
@@ -8318,7 +8354,7 @@ foo_5_functor__::operator()(const T0__& shared_params,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>
@@ -8338,7 +8374,7 @@ f4_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>
@@ -8358,7 +8394,7 @@ f10_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<int>
 f2_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -8376,7 +8412,7 @@ f2_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>>
@@ -8396,7 +8432,7 @@ f9_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>
@@ -8416,7 +8452,8 @@ f8_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 
-template <typename T1__> stan::promote_args_t<T1__>
+template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T1__>
 foo_lccdf_functor__::operator()(const int& y, const T1__& lambda,
                                 std::ostream* pstream__)  const
 {
@@ -8424,7 +8461,8 @@ foo_lccdf_functor__::operator()(const int& y, const T1__& lambda,
 }
 
 
-template <typename T0__> Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmufoo_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
 const
 {
@@ -8432,7 +8470,7 @@ const
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 stan::promote_args_t<T0__>
 foo_lp_functor__::operator()(const T0__& x, T_lp__& lp__,
                              T_lp_accum__& lp_accum__,
@@ -8442,7 +8480,8 @@ foo_lp_functor__::operator()(const T0__& x, T_lp__& lp__,
 }
 
 
-template <typename T0__> std::vector<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+std::vector<stan::promote_args_t<T0__>>
 foo_3_functor__::operator()(const T0__& t, const int& n,
                             std::ostream* pstream__)  const
 {
@@ -8456,7 +8495,7 @@ void foo_6_functor__::operator()(std::ostream* pstream__)  const
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
 binomialf_functor__::operator()(const T0__& phi, const T1__& theta,
                                 const std::vector<double>& x_r,
@@ -8467,14 +8506,15 @@ binomialf_functor__::operator()(const T0__& phi, const T1__& theta,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo_bar1_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return foo_bar1(x, pstream__);
 }
 
 
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__>
+template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
 int
 f1_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -14681,45 +14721,46 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'motherHOF.stan', line 25, column 45 to line 30, column 3)"};
 
 struct sho_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x,
              const std::vector<int>& x_int, std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
              const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   operator()(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
              const std::vector<T3__>& x_r, const std::vector<int>& x_i,
              std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<T2__>& data_r, const std::vector<int>& data_i,
              std::ostream* pstream__) const;
 };
 struct goo_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<T2__>& data_r, const std::vector<int>& data_i,
              std::ostream* pstream__) const;
 };
 struct map_rectfake_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<T3__>& x,
@@ -14749,7 +14790,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   integrand(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
             const std::vector<T3__>& x_r, const std::vector<int>& x_i,
@@ -14767,7 +14808,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   foo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
       const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -14789,7 +14830,7 @@ template <typename T0__, typename T1__, typename T2__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   goo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
       const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -14811,7 +14852,8 @@ template <typename T0__, typename T1__, typename T2__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   map_rectfake(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -14826,7 +14868,7 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   algebra_system(const T0__& x_arg__, const T1__& y_arg__,
                  const std::vector<T2__>& dat,
@@ -14861,7 +14903,7 @@ template <typename T0__, typename T1__, typename T2__>
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                           const std::vector<T2__>& theta,
@@ -14873,7 +14915,7 @@ sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 algebra_system_functor__::operator()(const T0__& x, const T1__& y,
                                      const std::vector<T2__>& dat,
@@ -14884,7 +14926,7 @@ algebra_system_functor__::operator()(const T0__& x, const T1__& y,
 }
 
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, T1__, T2__, T3__>
 integrand_functor__::operator()(const T0__& x, const T1__& xc,
                                 const std::vector<T2__>& theta,
@@ -14896,7 +14938,7 @@ integrand_functor__::operator()(const T0__& x, const T1__& xc,
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 foo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
                           const std::vector<T2__>& data_r,
@@ -14907,7 +14949,7 @@ foo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 goo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
                           const std::vector<T2__>& data_r,
@@ -14918,7 +14960,8 @@ goo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 map_rectfake_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
 {
@@ -17163,21 +17206,21 @@ static constexpr std::array<const char*, 630> locations_array__ =
  " (in 'new_integrate_interface.stan', line 2, column 47 to line 4, column 3)"};
 
 struct f_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                        stan::value_type_t<T3__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, const T2__& a, const T3__& b,
              std::ostream* pstream__) const;
 };
 struct f_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                        stan::value_type_t<T3__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& a, const T3__& b) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                      stan::value_type_t<T3__>>, -1, 1>
   f(const T0__& t, const T1__& z_arg__, const T2__& a, const T3__& b_arg__,
@@ -17200,7 +17243,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                      stan::value_type_t<T3__>>, -1, 1>
 f_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
@@ -17210,7 +17253,7 @@ f_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
 }
 
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                      stan::value_type_t<T3__>>, -1, 1>
 f_odefunctor__::operator()(const T0__& t, const T1__& z,
@@ -20996,14 +21039,14 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'old_integrate_interface.stan', line 7, column 38 to line 19, column 3)"};
 
 struct dz_dt_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& z,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   dz_dt(const T0__& t, const std::vector<T1__>& z,
         const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -21046,7 +21089,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 dz_dt_functor__::operator()(const T0__& t, const std::vector<T1__>& z,
                             const std::vector<T2__>& theta,
@@ -23308,6 +23351,723 @@ stan::math::profile_map& get_stan_profile_data() {
 
 
 
+  $ ../../../../../install/default/bin/stanc --print-cpp overloading_templating.stan
+
+// Code generated by %%NAME%% %%VERSION%%
+#include <stan/model/model_header.hpp>
+namespace overloading_templating_model_namespace {
+
+using stan::model::model_base_crtp;
+using namespace stan::math;
+
+
+stan::math::profile_map profiles__;
+static constexpr std::array<const char*, 35> locations_array__ = 
+{" (found before start of program)",
+ " (in 'overloading_templating.stan', line 42, column 4 to column 11)",
+ " (in 'overloading_templating.stan', line 43, column 4 to column 11)",
+ " (in 'overloading_templating.stan', line 46, column 4 to column 26)",
+ " (in 'overloading_templating.stan', line 47, column 4 to column 28)",
+ " (in 'overloading_templating.stan', line 48, column 4 to column 26)",
+ " (in 'overloading_templating.stan', line 49, column 4 to column 26)",
+ " (in 'overloading_templating.stan', line 50, column 4 to column 27)",
+ " (in 'overloading_templating.stan', line 51, column 4 to column 28)",
+ " (in 'overloading_templating.stan', line 52, column 4 to column 30)",
+ " (in 'overloading_templating.stan', line 53, column 4 to column 32)",
+ " (in 'overloading_templating.stan', line 54, column 4 to column 40)",
+ " (in 'overloading_templating.stan', line 39, column 3 to column 44)",
+ " (in 'overloading_templating.stan', line 3, column 4 to column 19)",
+ " (in 'overloading_templating.stan', line 2, column 17 to line 4, column 3)",
+ " (in 'overloading_templating.stan', line 7, column 4 to column 17)",
+ " (in 'overloading_templating.stan', line 6, column 20 to line 8, column 4)",
+ " (in 'overloading_templating.stan', line 10, column 4 to column 22)",
+ " (in 'overloading_templating.stan', line 9, column 26 to line 11, column 4)",
+ " (in 'overloading_templating.stan', line 13, column 4 to column 22)",
+ " (in 'overloading_templating.stan', line 12, column 22 to line 14, column 4)",
+ " (in 'overloading_templating.stan', line 16, column 4 to column 22)",
+ " (in 'overloading_templating.stan', line 15, column 22 to line 17, column 4)",
+ " (in 'overloading_templating.stan', line 19, column 4 to column 22)",
+ " (in 'overloading_templating.stan', line 18, column 28 to line 20, column 4)",
+ " (in 'overloading_templating.stan', line 23, column 4 to column 25)",
+ " (in 'overloading_templating.stan', line 22, column 33 to line 24, column 4)",
+ " (in 'overloading_templating.stan', line 26, column 4 to column 25)",
+ " (in 'overloading_templating.stan', line 25, column 30 to line 27, column 4)",
+ " (in 'overloading_templating.stan', line 29, column 4 to column 25)",
+ " (in 'overloading_templating.stan', line 28, column 30 to line 30, column 4)",
+ " (in 'overloading_templating.stan', line 32, column 4 to column 26)",
+ " (in 'overloading_templating.stan', line 31, column 29 to line 33, column 4)",
+ " (in 'overloading_templating.stan', line 35, column 4 to column 23)",
+ " (in 'overloading_templating.stan', line 34, column 25 to line 36, column 3)"};
+
+struct foo_functor__ {
+  double
+  operator()(const std::vector<int>& p, std::ostream* pstream__) const;
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  operator()(const std::vector<std::vector<T0__>>& p, std::ostream* pstream__) const;
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
+             std::ostream* pstream__) const;
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
+             std::ostream* pstream__) const;
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
+             std::ostream* pstream__) const;
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  operator()(const std::vector<T0__>& p, std::ostream* pstream__) const;
+  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+  stan::promote_args_t<stan::value_type_t<T0__>>
+  operator()(const T0__& p, std::ostream* pstream__) const;
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+  stan::promote_args_t<stan::value_type_t<T0__>>
+  operator()(const T0__& p, std::ostream* pstream__) const;
+  template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr>
+  stan::promote_args_t<stan::value_type_t<T0__>>
+  operator()(const T0__& p, std::ostream* pstream__) const;
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  operator()(const T0__& p, std::ostream* pstream__) const;
+  double
+  operator()(const int& p, std::ostream* pstream__) const;
+};
+
+double foo(const int& p, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 13;
+      return (p + 1.0);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__> foo(const T0__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 15;
+      return (p + 2);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr>
+  stan::promote_args_t<stan::value_type_t<T0__>>
+  foo(const T0__& p_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+    int current_statement__ = 0; 
+    const auto& p = stan::math::to_ref(p_arg__);
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 17;
+      return (stan::math::sum(p) + 3);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+  stan::promote_args_t<stan::value_type_t<T0__>>
+  foo(const T0__& p_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+    int current_statement__ = 0; 
+    const auto& p = stan::math::to_ref(p_arg__);
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 19;
+      return (stan::math::sum(p) + 4);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+  stan::promote_args_t<stan::value_type_t<T0__>>
+  foo(const T0__& p_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+    int current_statement__ = 0; 
+    const auto& p = stan::math::to_ref(p_arg__);
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 21;
+      return (stan::math::sum(p) + 5);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  foo(const std::vector<T0__>& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 23;
+      return (stan::math::sum(p) + 6);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  foo(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
+      std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 25;
+      return (stan::math::sum(
+                stan::model::rvalue(p, "p", stan::model::index_uni(1))) + 7);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  foo(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
+      std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 27;
+      return (stan::math::sum(
+                stan::model::rvalue(p, "p", stan::model::index_uni(1))) + 8);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  foo(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
+      std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 29;
+      return (stan::math::sum(
+                stan::model::rvalue(p, "p", stan::model::index_uni(1))) + 9);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
+  foo(const std::vector<std::vector<T0__>>& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 31;
+      return (stan::math::sum(
+                stan::model::rvalue(p, "p", stan::model::index_uni(1))) + 10);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+double foo(const std::vector<int>& p, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      current_statement__ = 33;
+      return (stan::math::sum(p) + 12);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+
+double
+foo_functor__::operator()(const std::vector<int>& p, std::ostream* pstream__) 
+const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
+foo_functor__::operator()(const std::vector<std::vector<T0__>>& p,
+                          std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
+foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
+                          std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
+foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
+                          std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
+foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
+                          std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
+foo_functor__::operator()(const std::vector<T0__>& p, std::ostream* pstream__) 
+const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+stan::promote_args_t<stan::value_type_t<T0__>>
+foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+stan::promote_args_t<stan::value_type_t<T0__>>
+foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr>
+stan::promote_args_t<stan::value_type_t<T0__>>
+foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
+foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+{
+  return foo(p, pstream__);
+}
+
+
+double foo_functor__::operator()(const int& p, std::ostream* pstream__) 
+const
+{
+  return foo(p, pstream__);
+}
+
+
+class overloading_templating_model final : public model_base_crtp<overloading_templating_model> {
+
+ private:
+  Eigen::Matrix<double, -1, 1> a__; 
+  Eigen::Map<Eigen::Matrix<double, -1, 1>> a{nullptr, 0};
+ 
+ public:
+  ~overloading_templating_model() { }
+  
+  inline std::string model_name() const final { return "overloading_templating_model"; }
+
+  inline std::vector<std::string> model_compile_info() const noexcept {
+    return std::vector<std::string>{"stanc_version = %%NAME%%3 %%VERSION%%", "stancflags = --print-cpp"};
+  }
+  
+  
+  overloading_templating_model(stan::io::var_context& context__,
+                               unsigned int random_seed__ = 0,
+                               std::ostream* pstream__ = nullptr) : model_base_crtp(0) {
+    int current_statement__ = 0;
+    using local_scalar_t__ = double ;
+    boost::ecuyer1988 base_rng__ = 
+        stan::services::util::create_rng(random_seed__, 0);
+    (void) base_rng__;  // suppress unused var warning
+    static constexpr const char* function__ = "overloading_templating_model_namespace::overloading_templating_model";
+    (void) function__;  // suppress unused var warning
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      current_statement__ = 12;
+      a__ = 
+        Eigen::Matrix<double, -1, 1>::Constant(5,
+          std::numeric_limits<double>::quiet_NaN());
+      new (&a) Eigen::Map<Eigen::Matrix<double, -1, 1>>(a__.data(), 5);
+      
+      current_statement__ = 12;
+      stan::model::assign(a, (Eigen::Matrix<double,-1,1>(5) << 0.1, 0.1, 0.1,
+        0.1, 0.1).finished(), "assigning variable a");
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    num_params_r__ = 1 + 1;
+    
+  }
+  
+  template <bool propto__, bool jacobian__ , typename VecR, typename VecI, 
+  stan::require_vector_like_t<VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  inline stan::scalar_type_t<VecR> log_prob_impl(VecR& params_r__,
+                                                 VecI& params_i__,
+                                                 std::ostream* pstream__ = nullptr) const {
+    using T__ = stan::scalar_type_t<VecR>;
+    using local_scalar_t__ = T__;
+    T__ lp__(0.0);
+    stan::math::accumulator<T__> lp_accum__;
+    stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    static constexpr const char* function__ = "overloading_templating_model_namespace::log_prob";
+    (void) function__;  // suppress unused var warning
+    
+    try {
+      local_scalar_t__ y = DUMMY_VAR__;
+      current_statement__ = 1;
+      y = in__.template read<local_scalar_t__>();
+      local_scalar_t__ z = DUMMY_VAR__;
+      current_statement__ = 2;
+      z = in__.template read<local_scalar_t__>();
+      {
+        current_statement__ = 3;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(y, foo(1, pstream__), 1));
+        current_statement__ = 4;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(y, foo(1.5, pstream__), 1));
+        current_statement__ = 5;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(a, foo(z, pstream__), 1));
+        current_statement__ = 6;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(y, foo(a, pstream__), 1));
+        current_statement__ = 7;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(y,
+            foo(stan::math::transpose(a), pstream__), 1));
+        current_statement__ = 8;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(y,
+            foo(std::vector<Eigen::Matrix<double, -1, 1>>{a}, pstream__), 1));
+        current_statement__ = 9;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(y,
+            foo(std::vector<int>{1, 2}, pstream__), 1));
+        current_statement__ = 10;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(y,
+            foo(std::vector<double>{stan::math::promote_scalar<double>(
+              1), 2.3}, pstream__), 1));
+        current_statement__ = 11;
+        lp_accum__.add(
+          stan::math::normal_lpdf<propto__>(std::vector<double>{5.5, 6.5},
+            foo(std::vector<local_scalar_t__>{z,
+              stan::math::promote_scalar<local_scalar_t__>(2.3)}, pstream__),
+            1));
+      }
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    lp_accum__.add(lp__);
+    return lp_accum__.sum();
+    } // log_prob_impl() 
+    
+  template <typename RNG, typename VecR, typename VecI, typename VecVar, 
+  stan::require_vector_like_vt<std::is_floating_point, VecR>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr, 
+  stan::require_std_vector_vt<std::is_floating_point, VecVar>* = nullptr> 
+  inline void write_array_impl(RNG& base_rng__, VecR& params_r__,
+                               VecI& params_i__, VecVar& vars__,
+                               const bool emit_transformed_parameters__ = true,
+                               const bool emit_generated_quantities__ = true,
+                               std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    double lp__ = 0.0;
+    (void) lp__;  // dummy to suppress unused var warning
+    int current_statement__ = 0; 
+    stan::math::accumulator<double> lp_accum__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    constexpr bool jacobian__ = false;
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    static constexpr const char* function__ = "overloading_templating_model_namespace::write_array";
+    (void) function__;  // suppress unused var warning
+    
+    try {
+      double y = std::numeric_limits<double>::quiet_NaN();
+      current_statement__ = 1;
+      y = in__.template read<local_scalar_t__>();
+      double z = std::numeric_limits<double>::quiet_NaN();
+      current_statement__ = 2;
+      z = in__.template read<local_scalar_t__>();
+      out__.write(y);
+      out__.write(z);
+      if (stan::math::logical_negation((stan::math::primitive_value(
+            emit_transformed_parameters__) || stan::math::primitive_value(
+            emit_generated_quantities__)))) {
+        return ;
+      } 
+      if (stan::math::logical_negation(emit_generated_quantities__)) {
+        return ;
+      } 
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    } // write_array_impl() 
+    
+  template <typename VecVar, typename VecI, 
+  stan::require_std_vector_t<VecVar>* = nullptr, 
+  stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr> 
+  inline void transform_inits_impl(VecVar& params_r__, VecI& params_i__,
+                                   VecVar& vars__,
+                                   std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ y = DUMMY_VAR__;
+      y = in__.read<local_scalar_t__>();
+      out__.write(y);
+      local_scalar_t__ z = DUMMY_VAR__;
+      z = in__.read<local_scalar_t__>();
+      out__.write(z);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    } // transform_inits_impl() 
+    
+  inline void get_param_names(std::vector<std::string>& names__) const {
+    
+    names__ = std::vector<std::string>{"y", "z"};
+    
+    } // get_param_names() 
+    
+  inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
+    
+    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
+      std::vector<size_t>{}};
+    
+    } // get_dims() 
+    
+  inline void constrained_param_names(
+                                      std::vector<std::string>& param_names__,
+                                      bool emit_transformed_parameters__ = true,
+                                      bool emit_generated_quantities__ = true) const
+    final {
+    
+    param_names__.emplace_back(std::string() + "y");
+    param_names__.emplace_back(std::string() + "z");
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // constrained_param_names() 
+    
+  inline void unconstrained_param_names(
+                                        std::vector<std::string>& param_names__,
+                                        bool emit_transformed_parameters__ = true,
+                                        bool emit_generated_quantities__ = true) const
+    final {
+    
+    param_names__.emplace_back(std::string() + "y");
+    param_names__.emplace_back(std::string() + "z");
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // unconstrained_param_names() 
+    
+  inline std::string get_constrained_sizedtypes() const {
+    
+    return std::string("[{\"name\":\"y\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"z\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"}]");
+    
+    } // get_constrained_sizedtypes() 
+    
+  inline std::string get_unconstrained_sizedtypes() const {
+    
+    return std::string("[{\"name\":\"y\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"},{\"name\":\"z\",\"type\":{\"name\":\"real\"},\"block\":\"parameters\"}]");
+    
+    } // get_unconstrained_sizedtypes() 
+    
+  
+    // Begin method overload boilerplate
+    template <typename RNG>
+    inline void write_array(RNG& base_rng,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& params_r,
+                            Eigen::Matrix<double,Eigen::Dynamic,1>& vars,
+                            const bool emit_transformed_parameters = true,
+                            const bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      const size_t num_params__ = 
+  (1 + 1);
+      const size_t num_transformed = 0;
+      const size_t num_gen_quantities = 0;
+      std::vector<double> vars_vec(num_params__
+       + (emit_transformed_parameters * num_transformed)
+       + (emit_generated_quantities * num_gen_quantities));
+      std::vector<int> params_i;
+      write_array_impl(base_rng, params_r, params_i, vars_vec,
+          emit_transformed_parameters, emit_generated_quantities, pstream);
+      vars = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,1>>(
+        vars_vec.data(), vars_vec.size());
+    }
+
+    template <typename RNG>
+    inline void write_array(RNG& base_rng, std::vector<double>& params_r,
+                            std::vector<int>& params_i,
+                            std::vector<double>& vars,
+                            bool emit_transformed_parameters = true,
+                            bool emit_generated_quantities = true,
+                            std::ostream* pstream = nullptr) const {
+      const size_t num_params__ = 
+  (1 + 1);
+      const size_t num_transformed = 0;
+      const size_t num_gen_quantities = 0;
+      vars.resize(num_params__
+        + (emit_transformed_parameters * num_transformed)
+        + (emit_generated_quantities * num_gen_quantities));
+      write_array_impl(base_rng, params_r, params_i, vars, emit_transformed_parameters, emit_generated_quantities, pstream);
+    }
+
+    template <bool propto__, bool jacobian__, typename T_>
+    inline T_ log_prob(Eigen::Matrix<T_,Eigen::Dynamic,1>& params_r,
+                       std::ostream* pstream = nullptr) const {
+      Eigen::Matrix<int, -1, 1> params_i;
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
+    }
+
+    template <bool propto__, bool jacobian__, typename T__>
+    inline T__ log_prob(std::vector<T__>& params_r,
+                        std::vector<int>& params_i,
+                        std::ostream* pstream = nullptr) const {
+      return log_prob_impl<propto__, jacobian__>(params_r, params_i, pstream);
+    }
+
+
+    inline void transform_inits(const stan::io::var_context& context,
+                         Eigen::Matrix<double, Eigen::Dynamic, 1>& params_r,
+                         std::ostream* pstream = nullptr) const final {
+      std::vector<double> params_r_vec(params_r.size());
+      std::vector<int> params_i;
+      transform_inits(context, params_i, params_r_vec, pstream);
+      params_r = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,1>>(
+        params_r_vec.data(), params_r_vec.size());
+    }
+
+  inline void transform_inits(const stan::io::var_context& context,
+                              std::vector<int>& params_i,
+                              std::vector<double>& vars,
+                              std::ostream* pstream__ = nullptr) const {
+     constexpr std::array<const char*, 2> names__{"y", "z"};
+      const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
+      const auto num_constrained_params__ = std::accumulate(
+        constrain_param_sizes__.begin(), constrain_param_sizes__.end(), 0);
+    
+     std::vector<double> params_r_flat__(num_constrained_params__);
+     Eigen::Index size_iter__ = 0;
+     Eigen::Index flat_iter__ = 0;
+     for (auto&& param_name__ : names__) {
+       const auto param_vec__ = context.vals_r(param_name__);
+       for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
+         params_r_flat__[flat_iter__] = param_vec__[i];
+         ++flat_iter__;
+       }
+       ++size_iter__;
+     }
+     vars.resize(num_params_r__);
+     transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    } // transform_inits() 
+     }; } 
+using stan_model = overloading_templating_model_namespace::overloading_templating_model;
+
+#ifndef USING_R
+
+// Boilerplate
+stan::model::model_base& new_model(
+        stan::io::var_context& data_context,
+        unsigned int seed,
+        std::ostream* msg_stream) {
+  stan_model* m = new stan_model(data_context, seed, msg_stream);
+  return *m;
+}
+
+stan::math::profile_map& get_stan_profile_data() {
+  return overloading_templating_model_namespace::profiles__;
+}
+
+#endif
+
+
+
   $ ../../../../../install/default/bin/stanc --print-cpp param-constraint.stan
 
 // Code generated by %%NAME%% %%VERSION%%
@@ -24093,15 +24853,18 @@ static constexpr std::array<const char*, 9> locations_array__ =
  " (in 'promotion.stan', line 6, column 28 to line 8, column 4)"};
 
 struct foo_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& zs, std::ostream* pstream__) const;
 };
 struct ident_functor__ {
-  template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::complex<stan::promote_args_t<T0__>>
   operator()(const std::complex<T0__>& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  std::complex<stan::promote_args_t<T0__>>
   ident(const std::complex<T0__>& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -24116,7 +24879,8 @@ template <typename T0__> std::complex<stan::promote_args_t<T0__>>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo(const std::vector<T0__>& zs, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -24132,7 +24896,8 @@ template <typename T0__> stan::promote_args_t<T0__>
     }
     }
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<T0__>& zs,
                           std::ostream* pstream__)  const
 {
@@ -24140,7 +24905,8 @@ foo_functor__::operator()(const std::vector<T0__>& zs,
 }
 
 
-template <typename T0__> std::complex<stan::promote_args_t<T0__>>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+std::complex<stan::promote_args_t<T0__>>
 ident_functor__::operator()(const std::complex<T0__>& x,
                             std::ostream* pstream__)  const
 {
@@ -24517,39 +25283,46 @@ static constexpr std::array<const char*, 26> locations_array__ =
  " (in 'reduce_sum_m1.stan', line 16, column 58 to line 18, column 3)"};
 
 template <bool propto__> struct foo_lpdf_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct h_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<T3__>& a) const;
 };
 struct g_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct h_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<T3__>& a,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g(const std::vector<T0__>& y_slice, const int& start, const int& end,
     std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -24571,7 +25344,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<T3__>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
@@ -24595,7 +25369,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo_lpdf(const std::vector<T0__>& y_slice, const int& start,
            const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -24610,7 +25385,8 @@ template <bool propto__, typename T0__> stan::promote_args_t<T0__>
     }
     }
 template <bool propto__> 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
                                            const int& start, const int& end,
                                            std::ostream* pstream__)  const
@@ -24619,7 +25395,8 @@ foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo_lpdf_functor__::operator()(const std::vector<T0__>& y_slice,
                                const int& start, const int& end,
                                std::ostream* pstream__)  const
@@ -24628,7 +25405,8 @@ foo_lpdf_functor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                         const int& end, std::ostream* pstream__)  const
 {
@@ -24636,7 +25414,8 @@ g_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__,
                           const std::vector<T3__>& a)  const
@@ -24645,7 +25424,8 @@ h_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__)  const
 {
@@ -24653,7 +25433,8 @@ g_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                         const int& end, const std::vector<T3__>& a,
                         std::ostream* pstream__)  const
@@ -25250,179 +26031,212 @@ static constexpr std::array<const char*, 180> locations_array__ =
  " (in 'reduce_sum_m2.stan', line 113, column 65 to line 121, column 3)"};
 
 struct g6_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h6_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
              std::ostream* pstream__) const;
 };
 struct h6_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) const;
 };
 struct h8_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
              std::ostream* pstream__) const;
 };
 struct h7_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
              std::ostream* pstream__) const;
 };
 struct h8_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) const;
 };
 struct h2_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
              std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h2_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) const;
 };
 struct g1_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h5_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__, const std::vector<std::vector<T3__>>& a) const;
 };
 struct g1_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct h1_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<T3__>& a, std::ostream* pstream__) const;
 };
 struct g7_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h4_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) const;
 };
 struct g4_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g7_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h5_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) const;
 };
 struct g8_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h3_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) const;
 };
 struct h7_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) const;
 };
 struct h1_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__, const std::vector<T3__>& a) const;
 };
 struct h3_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
              std::ostream* pstream__) const;
 };
 struct h4_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
      std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25438,7 +26252,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25465,7 +26280,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25492,7 +26308,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25520,7 +26337,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
      const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25555,7 +26373,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25591,7 +26410,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25627,7 +26447,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   g8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25663,7 +26484,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h1(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<T3__>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
@@ -25681,7 +26503,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h2(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
      std::ostream* pstream__) {
@@ -25709,7 +26532,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h3(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
      std::ostream* pstream__) {
@@ -25737,7 +26561,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h4(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
      std::ostream* pstream__) {
@@ -25766,7 +26591,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h5(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
@@ -25800,7 +26626,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h6(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
      std::ostream* pstream__) {
@@ -25836,7 +26663,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h7(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
      std::ostream* pstream__) {
@@ -25872,7 +26700,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   h8(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
      std::ostream* pstream__) {
@@ -25909,7 +26738,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
     }
     }
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -25918,7 +26748,8 @@ g6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h6_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
                          const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
@@ -25928,7 +26759,8 @@ h6_functor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h6_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) 
@@ -25938,7 +26770,8 @@ const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h8_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
                          const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
@@ -25948,7 +26781,8 @@ h8_functor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h7_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
                          const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
@@ -25958,7 +26792,8 @@ h7_functor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h8_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) 
@@ -25968,7 +26803,8 @@ const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h2_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
                          const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -25978,7 +26814,8 @@ h2_functor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -25987,7 +26824,8 @@ g8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h2_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) 
@@ -25997,7 +26835,8 @@ const
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, std::ostream* pstream__)  const
 {
@@ -26005,7 +26844,8 @@ g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -26014,7 +26854,8 @@ g2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26023,7 +26864,8 @@ g2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slic
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26032,7 +26874,8 @@ g3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slic
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h5_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<std::vector<T3__>>& a)  const
@@ -26041,7 +26884,8 @@ h5_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26050,7 +26894,8 @@ g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h1_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end, const std::vector<T3__>& a,
                          std::ostream* pstream__)  const
@@ -26059,7 +26904,8 @@ h1_functor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -26068,7 +26914,8 @@ g7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -26077,7 +26924,8 @@ g5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26086,7 +26934,8 @@ g5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26095,7 +26944,8 @@ g6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -26104,7 +26954,8 @@ g4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h4_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) 
@@ -26114,7 +26965,8 @@ const
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26123,7 +26975,8 @@ g4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_sli
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26132,7 +26985,8 @@ g7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, 
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h5_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
                          const std::vector<std::vector<T3__>>& a,
@@ -26142,7 +26996,8 @@ h5_functor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -26151,7 +27006,8 @@ g8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 g3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -26160,7 +27016,8 @@ g3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h3_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) 
@@ -26170,7 +27027,8 @@ const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h7_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) 
@@ -26180,7 +27038,8 @@ const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h1_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
                            const std::vector<T3__>& a)  const
@@ -26189,7 +27048,8 @@ h1_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h3_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
                          const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -26199,7 +27059,8 @@ h3_functor__::operator()(const std::vector<T0__>& y, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 h4_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
                          const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -27931,12 +28792,13 @@ static constexpr std::array<const char*, 342> locations_array__ =
  " (in 'reduce_sum_m3.stan', line 86, column 11 to line 149, column 3)"};
 
 struct f1a_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct s_rsfunctor__ {
-  template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__>
+  template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                        stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                        stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -27958,39 +28820,46 @@ struct s_rsfunctor__ {
              const std::vector<std::vector<std::vector<T19__>>>& q) const;
 };
 struct f4_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g12_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) const;
 };
 struct f5_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct f8_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
              std::ostream* pstream__) const;
 };
 struct f1a_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g10_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) const;
@@ -28000,96 +28869,110 @@ struct r_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct g1_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename T0__, typename T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
 };
 struct f6_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g12_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
              std::ostream* pstream__) const;
 };
 struct f2_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f3_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f12_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g9_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<std::vector<T3__>>& a) const;
 };
 struct g11_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
              std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f1_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g11_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) const;
 };
 struct g9_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<std::vector<T3__>>& a,
              std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename T0__, typename T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
-  template <typename T0__, typename T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
@@ -28100,12 +28983,13 @@ struct f11_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename T0__, typename T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
@@ -28116,13 +29000,15 @@ struct f11_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g6_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
              std::ostream* pstream__) const;
 };
 struct f7_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
@@ -28132,12 +29018,13 @@ struct f9_rsfunctor__ {
              std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename T0__, typename T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
@@ -28148,7 +29035,7 @@ struct f10_functor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct s_functor__ {
-  template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__>
+  template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                        stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                        stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -28171,12 +29058,13 @@ struct s_functor__ {
              std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename T0__, typename T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
@@ -28187,52 +29075,61 @@ struct f9_functor__ {
              std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g1_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
 };
 struct g7_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
              std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<T3__>& a,
              std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<T3__>& a) const;
 };
 struct f5_rsfunctor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) const;
 };
 struct g7_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) const;
 };
 struct g8_rsfunctor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) const;
@@ -28243,19 +29140,22 @@ struct f10_rsfunctor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g10_functor__ {
-  template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f1(const std::vector<T0__>& y_slice, const int& start, const int& end,
      std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28271,7 +29171,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f1a(const std::vector<T0__>& y_slice, const int& start, const int& end,
       std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28287,7 +29188,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28303,7 +29205,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28319,7 +29222,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28335,7 +29239,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
      const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28351,7 +29256,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28367,7 +29273,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28383,7 +29290,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28447,7 +29355,8 @@ double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   f12(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
       const int& start, const int& end, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -28463,7 +29372,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
@@ -28479,7 +29389,7 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   g2(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -28498,7 +29408,7 @@ template <typename T0__, typename T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   g3(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -28517,7 +29427,7 @@ template <typename T0__, typename T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   g4(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -28536,7 +29446,8 @@ template <typename T0__, typename T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g5(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<T3__>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
@@ -28552,7 +29463,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g6(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
      std::ostream* pstream__) {
@@ -28569,7 +29481,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g7(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
      std::ostream* pstream__) {
@@ -28586,7 +29499,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g8(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
      std::ostream* pstream__) {
@@ -28603,7 +29517,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g9(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
@@ -28619,7 +29534,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g10(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
       std::ostream* pstream__) {
@@ -28636,7 +29552,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g11(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
       std::ostream* pstream__) {
@@ -28653,7 +29570,8 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  stan::promote_args_t<T0__, T3__>
   g12(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
       std::ostream* pstream__) {
@@ -28670,7 +29588,7 @@ template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__>
+template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                      stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -29021,7 +29939,8 @@ double r(std::ostream* pstream__) {
     }
     }
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f1a_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
                             std::ostream* pstream__)  const
@@ -29030,7 +29949,7 @@ f1a_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__>
+template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
 stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                      stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -29059,7 +29978,8 @@ const
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29068,7 +29988,8 @@ f4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_sli
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g12_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
                             std::ostream* pstream__,
@@ -29079,7 +30000,8 @@ const
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -29088,7 +30010,8 @@ f5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29097,7 +30020,8 @@ f8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g8_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
                          const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -29107,7 +30031,8 @@ g8_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f1a_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__)  const
 {
@@ -29115,7 +30040,8 @@ f1a_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g10_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
                             std::ostream* pstream__,
@@ -29132,7 +30058,8 @@ double r_functor__::operator()(std::ostream* pstream__)  const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
                          std::ostream* pstream__)  const
@@ -29141,7 +30068,7 @@ g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g2_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -29151,7 +30078,8 @@ g2_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29160,7 +30088,8 @@ f6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g12_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
                           const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
@@ -29170,7 +30099,8 @@ g12_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29179,7 +30109,8 @@ f2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slic
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29188,7 +30119,8 @@ f3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slic
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -29197,7 +30129,8 @@ f6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f12_rsfunctor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
                             const int& start, const int& end,
                             std::ostream* pstream__)  const
@@ -29206,7 +30139,8 @@ f12_rsfunctor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g9_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__,
@@ -29216,7 +30150,8 @@ g9_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g11_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
                           const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
@@ -29226,7 +30161,8 @@ g11_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -29235,7 +30171,8 @@ f3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29244,7 +30181,8 @@ f1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -29253,7 +30191,8 @@ f7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g11_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
                             std::ostream* pstream__,
@@ -29264,7 +30203,8 @@ const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g9_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
                          const std::vector<std::vector<T3__>>& a,
@@ -29274,7 +30214,7 @@ g9_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g4_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -29284,7 +30224,7 @@ g4_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g4_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -29303,7 +30243,8 @@ f11_functor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_sl
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f12_functor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
                           const int& start, const int& end,
                           std::ostream* pstream__)  const
@@ -29312,7 +30253,7 @@ f12_functor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_s
 }
 
 
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g3_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -29331,7 +30272,8 @@ f11_rsfunctor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g6_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
                          const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -29341,7 +30283,8 @@ g6_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29358,7 +30301,8 @@ f9_rsfunctor__::operator()(const std::vector<int>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -29367,7 +30311,7 @@ f4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice
 }
 
 
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g2_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -29386,7 +30330,7 @@ f10_functor__::operator()(const std::vector<std::vector<int>>& y_slice,
 }
 
 
-template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__>
+template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
 stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                      stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -29414,7 +30358,8 @@ s_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -29423,7 +30368,7 @@ f2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
 }
 
 
-template <typename T0__, typename T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g3_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -29441,7 +30386,8 @@ f9_functor__::operator()(const std::vector<int>& y_slice, const int& start,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                          const int& start, const int& end,
                          std::ostream* pstream__)  const
@@ -29450,7 +30396,8 @@ f8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__, const T3__& a)  const
@@ -29459,7 +30406,8 @@ g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g7_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
                          const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -29469,7 +30417,8 @@ g7_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g5_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const std::vector<T3__>& a,
                          std::ostream* pstream__)  const
@@ -29478,7 +30427,8 @@ g5_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g5_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__,
@@ -29488,7 +30438,8 @@ g5_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__)  const
@@ -29497,7 +30448,8 @@ f5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g6_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__,
@@ -29508,7 +30460,8 @@ const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g7_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__,
@@ -29519,7 +30472,8 @@ const
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g8_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
                            std::ostream* pstream__,
@@ -29539,7 +30493,8 @@ f10_rsfunctor__::operator()(const std::vector<std::vector<int>>& y_slice,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 f1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, std::ostream* pstream__)  const
 {
@@ -29547,7 +30502,8 @@ f1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 }
 
 
-template <typename T0__, typename T3__> stan::promote_args_t<T0__, T3__>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+stan::promote_args_t<T0__, T3__>
 g10_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
                           const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
@@ -31570,19 +32526,19 @@ static constexpr std::array<const char*, 52> locations_array__ =
  " (in 'shadowing.stan', line 2, column 43 to line 6, column 3)"};
 
 struct rhs_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& alpha) const;
 };
 struct rhs_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& alpha,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   rhs(const T0__& t, const T1__& y_arg__, const T2__& alpha,
       std::ostream* pstream__) {
@@ -31607,7 +32563,7 @@ template <typename T0__, typename T1__, typename T2__>
     }
     }
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 rhs_odefunctor__::operator()(const T0__& t, const T1__& y,
                              std::ostream* pstream__, const T2__& alpha) 
@@ -31617,7 +32573,7 @@ const
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
                           std::ostream* pstream__)  const
@@ -32602,15 +33558,17 @@ struct foo1_lpmf_functor__ {
   operator()(const int& y, std::ostream* pstream__) const;
 };
 struct foo2_lpdf_functor__ {
-  template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& y, std::ostream* pstream__) const;
 };
 struct foo3_lpdf_functor__ {
-  template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& y, std::ostream* pstream__) const;
 };
 struct foo5_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -32656,7 +33614,8 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo2_lpdf(const T0__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -32669,7 +33628,8 @@ template <bool propto__, typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   foo3_lpdf(const T0__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -32682,7 +33642,7 @@ template <bool propto__, typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   foo5_lp(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -32721,7 +33681,8 @@ foo1_lpmf_functor__::operator()(const int& y, std::ostream* pstream__)  const
 }
 
 
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo2_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
 const
 {
@@ -32729,7 +33690,8 @@ const
 }
 
 
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 foo3_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
 const
 {
@@ -32737,7 +33699,7 @@ const
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 stan::promote_args_t<T0__>
 foo5_lp_functor__::operator()(const T0__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -36569,12 +37531,13 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'udf_tilde_stmt_conflict.stan', line 2, column 22 to line 4, column 3)"};
 
 struct normal_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& a, std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
-  normal(const T0__& a, std::ostream* pstream__) {
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__> normal(const T0__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -36589,7 +37552,8 @@ template <typename T0__> stan::promote_args_t<T0__>
     }
     }
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 normal_functor__::operator()(const T0__& a, std::ostream* pstream__)  const
 {
   return normal(a, pstream__);
@@ -36916,11 +37880,13 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'user_constrain.stan', line 2, column 36 to line 4, column 3)"};
 
 struct lb_constrain_functor__ {
-  template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
+  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T0__, T1__>
   lb_constrain(const T0__& x, const T1__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
     int current_statement__ = 0; 
@@ -36936,7 +37902,8 @@ template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
     }
     }
 
-template <typename T0__, typename T1__> stan::promote_args_t<T0__, T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T0__, T1__>
 lb_constrain_functor__::operator()(const T0__& x, const T1__& y,
                                    std::ostream* pstream__)  const
 {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1234,7 +1234,7 @@ struct foo4_functor__ {
 };
 struct foo6_functor__ {
   template <typename Tr__,
-            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tr__>>>
   operator()(const Tr__& r, std::ostream* pstream__) const;
 };
@@ -1246,13 +1246,13 @@ struct foo10_functor__ {
 };
 struct foo2_functor__ {
   template <typename Tr__,
-            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tr__>>
   operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo9_functor__ {
   template <typename Tr__,
-            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
   operator()(const Tr__& r, std::ostream* pstream__) const;
 };
@@ -1309,7 +1309,7 @@ template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
     }
     }
 template <typename Tr__,
-          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tr__>>
   foo2(const Tr__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tr__>;
@@ -1374,7 +1374,7 @@ template <typename Tz__,
     }
     }
 template <typename Tr__,
-          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tr__>>>
   foo6(const Tr__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tr__>;
@@ -1426,7 +1426,7 @@ template <typename Tz__,
     }
     }
 template <typename Tr__,
-          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
   foo9(const Tr__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tr__>;
@@ -1486,7 +1486,7 @@ foo4_functor__::operator()(std::ostream* pstream__)  const
   return foo4(pstream__);
 }
 
-template <typename Tr__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*>
+template <typename Tr__, stan::require_t<stan::is_stan_scalar<Tr__>>*>
 inline std::vector<std::complex<stan::return_type_t<Tr__>>>
 foo6_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
@@ -1501,14 +1501,14 @@ foo10_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
   return foo10(z, pstream__);
 }
 
-template <typename Tr__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*>
+template <typename Tr__, stan::require_t<stan::is_stan_scalar<Tr__>>*>
 inline std::complex<stan::return_type_t<Tr__>>
 foo2_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
   return foo2(r, pstream__);
 }
 
-template <typename Tr__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*>
+template <typename Tr__, stan::require_t<stan::is_stan_scalar<Tr__>>*>
 inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
 foo9_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
@@ -3757,7 +3757,7 @@ struct _stan_bitor_functor__ {
 };
 struct _stan_bitand_functor__ {
   template <typename T_stan_constexpr__,
-            stan::require_t<stan::is_stan_scalar_t<T_stan_constexpr__>>* = nullptr>
+            stan::require_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
   inline void
   operator()(const T_stan_constexpr__& _stan_constexpr, std::ostream* pstream__) const;
 };
@@ -3767,26 +3767,26 @@ struct _stan_catch_functor__ {
 };
 struct _stan_alignas_functor__ {
   template <typename T_stan_asm__,
-            stan::require_t<stan::is_stan_scalar_t<T_stan_asm__>>* = nullptr>
+            stan::require_t<std::is_integral<T_stan_asm__>>* = nullptr>
   inline void
   operator()(const T_stan_asm__& _stan_asm, std::ostream* pstream__) const;
 };
 struct _stan_alignof_functor__ {
   template <typename T_stan_char__,
-            stan::require_t<stan::is_stan_scalar_t<T_stan_char__>>* = nullptr>
+            stan::require_t<std::is_integral<T_stan_char__>>* = nullptr>
   inline void
   operator()(const T_stan_char__& _stan_char, std::ostream* pstream__) const;
 };
 struct _stan_and_eq_functor__ {
   template <typename T_stan_STAN_MINOR__,
-            stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MINOR__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>* = nullptr>
   inline void
   operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
              std::ostream* pstream__) const;
 };
 struct _stan_and_functor__ {
   template <typename T_stan_STAN_MAJOR__,
-            stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MAJOR__>>* = nullptr>
+            stan::require_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
   inline void
   operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
              std::ostream* pstream__) const;
@@ -3809,7 +3809,7 @@ struct _stan_case_functor__ {
 };
 
 template <typename T_stan_asm__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_asm__>>* = nullptr>
+          stan::require_t<std::is_integral<T_stan_asm__>>* = nullptr>
   inline void
   _stan_alignas(const T_stan_asm__& _stan_asm, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<T_stan_asm__>;
@@ -3825,7 +3825,7 @@ template <typename T_stan_asm__,
     }
     }
 template <typename T_stan_char__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_char__>>* = nullptr>
+          stan::require_t<std::is_integral<T_stan_char__>>* = nullptr>
   inline void
   _stan_alignof(const T_stan_char__& _stan_char, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<T_stan_char__>;
@@ -3841,7 +3841,7 @@ template <typename T_stan_char__,
     }
     }
 template <typename T_stan_STAN_MAJOR__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MAJOR__>>* = nullptr>
+          stan::require_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
   inline void
   _stan_and(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
             std::ostream* pstream__) {
@@ -3858,7 +3858,7 @@ template <typename T_stan_STAN_MAJOR__,
     }
     }
 template <typename T_stan_STAN_MINOR__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MINOR__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>* = nullptr>
   inline void
   _stan_and_eq(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
                std::ostream* pstream__) {
@@ -3892,7 +3892,7 @@ template <typename T_stan_class__,
     }
     }
 template <typename T_stan_constexpr__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_constexpr__>>* = nullptr>
+          stan::require_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
   inline void
   _stan_bitand(const T_stan_constexpr__& _stan_constexpr,
                std::ostream* pstream__) {
@@ -4020,7 +4020,7 @@ inline void _stan_bitor_functor__::operator()(std::ostream* pstream__)  const
 }
 
 template <typename T_stan_constexpr__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_constexpr__>>*>
+          stan::require_t<std::is_integral<T_stan_constexpr__>>*>
 inline void
 _stan_bitand_functor__::operator()(const T_stan_constexpr__& _stan_constexpr,
                                    std::ostream* pstream__)  const
@@ -4034,7 +4034,7 @@ inline void _stan_catch_functor__::operator()(std::ostream* pstream__)  const
 }
 
 template <typename T_stan_asm__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_asm__>>*>
+          stan::require_t<std::is_integral<T_stan_asm__>>*>
 inline void
 _stan_alignas_functor__::operator()(const T_stan_asm__& _stan_asm,
                                     std::ostream* pstream__)  const
@@ -4043,7 +4043,7 @@ _stan_alignas_functor__::operator()(const T_stan_asm__& _stan_asm,
 }
 
 template <typename T_stan_char__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_char__>>*>
+          stan::require_t<std::is_integral<T_stan_char__>>*>
 inline void
 _stan_alignof_functor__::operator()(const T_stan_char__& _stan_char,
                                     std::ostream* pstream__)  const
@@ -4052,7 +4052,7 @@ _stan_alignof_functor__::operator()(const T_stan_char__& _stan_char,
 }
 
 template <typename T_stan_STAN_MINOR__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MINOR__>>*>
+          stan::require_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>*>
 inline void
 _stan_and_eq_functor__::operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
                                    std::ostream* pstream__)  const
@@ -4061,7 +4061,7 @@ _stan_and_eq_functor__::operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
 }
 
 template <typename T_stan_STAN_MAJOR__,
-          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MAJOR__>>*>
+          stan::require_t<std::is_integral<T_stan_STAN_MAJOR__>>*>
 inline void
 _stan_and_functor__::operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
                                 std::ostream* pstream__)  const
@@ -6516,12 +6516,12 @@ struct foo_five_args_lp_functor__ {
   template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
             typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx6__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx6__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
                       stan::return_type_t<Tx6__>>
   operator()(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
@@ -6533,12 +6533,12 @@ struct f5_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6556,29 +6556,28 @@ struct f5_functor__ {
 };
 struct foo_lcdf_functor__ {
   template <typename Ty__, typename Tlambda__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+            stan::require_t<std::is_integral<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct covsqrt2corsqrt_functor__ {
   template <typename Tmat__, typename Tinvert__,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tinvert__>>* = nullptr>
+            stan::require_t<std::is_integral<Tinvert__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
   operator()(const Tmat__& mat, const Tinvert__& invert,
              std::ostream* pstream__) const;
 };
 struct foo_1_functor__ {
-  template <typename Ta__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
   inline int
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct unit_normal_lp_functor__ {
   template <bool propto__, typename Tu__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Tu__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tu__>>* = nullptr>
   inline void
   operator()(const Tu__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -6596,12 +6595,12 @@ struct f6_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6620,18 +6619,17 @@ struct f6_functor__ {
 struct foo_five_args_functor__ {
   template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
             typename Tx5__,
-            stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
   operator()(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
              const Tx4__& x4, const Tx5__& x5, std::ostream* pstream__) const;
 };
 struct foo_2_functor__ {
-  template <typename Ta__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
   inline int
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
@@ -6640,12 +6638,12 @@ struct f3_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6661,7 +6659,7 @@ struct f3_functor__ {
 };
 struct foo_4_functor__ {
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline void
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
@@ -6670,12 +6668,12 @@ struct f7_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6696,12 +6694,12 @@ struct f11_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6722,12 +6720,12 @@ struct f12_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6746,19 +6744,19 @@ struct f12_functor__ {
 struct sho_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
             typename Tx_int__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
 };
 struct foo_bar2_functor__ {
   template <typename Tx__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   operator()(const Tx__& x, const Ty__& y, std::ostream* pstream__) const;
 };
@@ -6771,33 +6769,33 @@ struct algebra_system_functor__ {
             typename Tdat_int__,
             stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
   template <typename Tmu__, typename Tsigma__, typename RNG,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tsigma__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tsigma__>>* = nullptr>
   inline stan::return_type_t<Tmu__, Tsigma__>
   operator()(const Tmu__& mu, const Tsigma__& sigma, RNG& base_rng__,
              std::ostream* pstream__) const;
 };
 struct relative_diff_functor__ {
   template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmax___>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmin___>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmax___>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmin___>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
   operator()(const Tx__& x, const Ty__& y, const Tmax___& max_,
              const Tmin___& min_, std::ostream* pstream__) const;
 };
 struct vecmubar_functor__ {
   template <typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   operator()(const Tmu__& mu, std::ostream* pstream__) const;
 };
@@ -6806,12 +6804,12 @@ struct f0_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6827,8 +6825,8 @@ struct f0_functor__ {
 };
 struct foo_lpmf_functor__ {
   template <bool propto__, typename Ty__, typename Tlambda__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+            stan::require_t<std::is_integral<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
@@ -6837,8 +6835,8 @@ struct foo_5_functor__ {
             typename Tdata_r__, typename Tdata_i__,
             stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -6849,12 +6847,12 @@ struct f4_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6875,12 +6873,12 @@ struct f10_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6901,12 +6899,12 @@ struct f2_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6925,12 +6923,12 @@ struct f9_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6951,12 +6949,12 @@ struct f8_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -6974,29 +6972,29 @@ struct f8_functor__ {
 };
 struct foo_lccdf_functor__ {
   template <typename Ty__, typename Tlambda__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+            stan::require_t<std::is_integral<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct vecmufoo_functor__ {
   template <typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   operator()(const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lp_functor__ {
   template <bool propto__, typename Tx__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo_3_functor__ {
   template <typename Tt__, typename Tn__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn__>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tn__>>
   operator()(const Tt__& t, const Tn__& n, std::ostream* pstream__) const;
 };
@@ -7009,15 +7007,15 @@ struct binomialf_functor__ {
             typename Tx_i__,
             stan::require_t<stan::is_col_vector<Tphi__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ttheta__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
   operator()(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
              const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
@@ -7026,12 +7024,12 @@ struct f1_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__,
-            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -7046,16 +7044,14 @@ struct f1_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  template <typename Tn__,
-            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+  template <typename Tn__, stan::require_t<std::is_integral<Tn__>>* = nullptr>
   inline int
   operator()(const Tn__& n, std::ostream* pstream__) const;
 };
 
-template <typename Tn__, stan::require_t<stan::is_stan_scalar_t<Tn__>>*>
-  inline int foo(const Tn__& n, std::ostream* pstream__) ; 
-template <typename Tn__,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+template <typename Tn__, stan::require_t<std::is_integral<Tn__>>*> inline int
+  foo(const Tn__& n, std::ostream* pstream__) ; 
+template <typename Tn__, stan::require_t<std::is_integral<Tn__>>* = nullptr>
   inline int foo(const Tn__& n, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__>;
     int current_statement__ = 0; 
@@ -7076,21 +7072,21 @@ template <typename Tn__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>*>
+          typename Tx_int__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) ; 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
           typename Tx_int__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) {
@@ -7135,7 +7131,7 @@ inline double foo_bar0(std::ostream* pstream__) {
     }
     }
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   foo_bar1(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -7152,8 +7148,8 @@ template <typename Tx__,
     }
     }
 template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   foo_bar2(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -7170,8 +7166,8 @@ template <typename Tx__, typename Ty__,
     }
     }
 template <bool propto__, typename Ty__, typename Tlambda__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+          stan::require_t<std::is_integral<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   foo_lpmf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
@@ -7186,8 +7182,8 @@ template <bool propto__, typename Ty__, typename Tlambda__,
     }
     }
 template <typename Ty__, typename Tlambda__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+          stan::require_t<std::is_integral<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   foo_lcdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
@@ -7204,8 +7200,8 @@ template <typename Ty__, typename Tlambda__,
     }
     }
 template <typename Ty__, typename Tlambda__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+          stan::require_t<std::is_integral<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   foo_lccdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
@@ -7222,8 +7218,8 @@ template <typename Ty__, typename Tlambda__,
     }
     }
 template <typename Tmu__, typename Tsigma__, typename RNG,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tsigma__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tsigma__>>* = nullptr>
   inline stan::return_type_t<Tmu__, Tsigma__>
   foo_rng(const Tmu__& mu, const Tsigma__& sigma, RNG& base_rng__,
           std::ostream* pstream__) {
@@ -7242,8 +7238,7 @@ template <typename Tmu__, typename Tsigma__, typename RNG,
     }
 template <bool propto__, typename Tu__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tu__>>* = nullptr>
-  inline void
+          stan::require_t<stan::is_stan_scalar<Tu__>>* = nullptr> inline void
   unit_normal_lp(const Tu__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tu__>;
@@ -7259,8 +7254,7 @@ template <bool propto__, typename Tu__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
   inline int foo_1(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
@@ -7485,8 +7479,7 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
   inline int foo_2(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
@@ -7515,8 +7508,8 @@ template <typename Ta__,
     }
     }
 template <typename Tt__, typename Tn__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn__>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tn__>>
   foo_3(const Tt__& t, const Tn__& n, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Tn__>;
@@ -7534,7 +7527,7 @@ template <typename Tt__, typename Tn__,
     }
 template <bool propto__, typename Tx__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   foo_lp(const Tx__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
@@ -7550,8 +7543,8 @@ template <bool propto__, typename Tx__, typename T_lp__,
     }
     }
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
-  inline void foo_4(const Tx__& x, std::ostream* pstream__) {
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr> inline void
+  foo_4(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -7569,10 +7562,10 @@ template <typename Tx__,
     }
     }
 template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmax___>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmin___>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmax___>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmin___>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
   relative_diff(const Tx__& x, const Ty__& y, const Tmax___& max_,
                 const Tmin___& min_, std::ostream* pstream__) {
@@ -7624,8 +7617,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__, typename Tdata_i__,
           stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   foo_5(const Tshared_params__& shared_params,
         const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -7649,11 +7642,11 @@ template <typename Tshared_params__, typename Tjob_params__,
     }
 template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
           typename Tx5__,
-          stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
   foo_five_args(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
                 const Tx4__& x4, const Tx5__& x5, std::ostream* pstream__) {
@@ -7674,12 +7667,12 @@ template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
 template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
           typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tx6__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tx6__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
                     stan::return_type_t<Tx6__>>
   foo_five_args_lp(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
@@ -7701,7 +7694,7 @@ template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
     }
 template <typename Tmat__, typename Tinvert__,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tinvert__>>* = nullptr>
+          stan::require_t<std::is_integral<Tinvert__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
   covsqrt2corsqrt(const Tmat__& mat, const Tinvert__& invert,
                   std::ostream* pstream__) {
@@ -7743,12 +7736,12 @@ template <typename Tmat__, typename Tinvert__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -7786,12 +7779,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -7826,12 +7819,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -7866,12 +7859,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -7906,12 +7899,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -7948,12 +7941,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -7990,12 +7983,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -8032,12 +8025,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -8074,12 +8067,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -8116,12 +8109,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -8158,12 +8151,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -8200,12 +8193,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -8242,12 +8235,12 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
@@ -8344,7 +8337,7 @@ inline Eigen::Matrix<double, -1, 1> vecfoo(std::ostream* pstream__) {
     }
     }
 template <typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   vecmufoo(const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tmu__>;
@@ -8366,7 +8359,7 @@ template <typename Tmu__,
     }
     }
 template <typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   vecmubar(const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tmu__>;
@@ -8392,8 +8385,8 @@ template <typename Tmu__,
 template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
           stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
@@ -8429,8 +8422,8 @@ template <typename Tphi__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__,
           stan::require_t<stan::is_col_vector<Tphi__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ttheta__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
   binomialf(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
             const Tx_i__& x_i, std::ostream* pstream__) {
@@ -8458,12 +8451,12 @@ template <typename Tphi__, typename Ttheta__, typename Tx_r__,
 template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
           typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx1__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx2__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx3__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx4__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx5__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx6__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx1__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx2__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx3__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx4__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx5__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx6__>>*>
 inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
                     stan::return_type_t<Tx6__>>
 foo_five_args_lp_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
@@ -8480,12 +8473,12 @@ foo_five_args_lp_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8505,8 +8498,8 @@ f5_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 }
 
 template <typename Ty__, typename Tlambda__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>*>
+          stan::require_t<std::is_integral<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar<Tlambda__>>*>
 inline stan::return_type_t<Ty__, Tlambda__>
 foo_lcdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
@@ -8516,7 +8509,7 @@ foo_lcdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
 
 template <typename Tmat__, typename Tinvert__,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tinvert__>>*>
+          stan::require_t<std::is_integral<Tinvert__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
 covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
                                       const Tinvert__& invert,
@@ -8525,7 +8518,7 @@ covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
   return covsqrt2corsqrt(mat, invert, pstream__);
 }
 
-template <typename Ta__, stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+template <typename Ta__, stan::require_t<std::is_integral<Ta__>>*>
 inline int
 foo_1_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
@@ -8533,8 +8526,7 @@ foo_1_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 }
 
 template <bool propto__, typename Tu__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tu__>>*>
+          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Tu__>>*>
 inline void
 unit_normal_lp_functor__::operator()(const Tu__& u, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -8557,12 +8549,12 @@ vecfoo_functor__::operator()(std::ostream* pstream__)  const
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8582,11 +8574,11 @@ f6_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 }
 
 template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
-          typename Tx5__, stan::require_t<stan::is_stan_scalar_t<Tx1__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx2__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx3__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx4__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tx5__>>*>
+          typename Tx5__, stan::require_t<stan::is_stan_scalar<Tx1__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx2__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx3__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx4__>>*,
+          stan::require_t<stan::is_stan_scalar<Tx5__>>*>
 inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
 foo_five_args_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
                                     const Tx3__& x3, const Tx4__& x4,
@@ -8596,7 +8588,7 @@ const
   return foo_five_args(x1, x2, x3, x4, x5, pstream__);
 }
 
-template <typename Ta__, stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+template <typename Ta__, stan::require_t<std::is_integral<Ta__>>*>
 inline int
 foo_2_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
@@ -8606,12 +8598,12 @@ foo_2_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8628,7 +8620,7 @@ f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline void
 foo_4_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -8638,12 +8630,12 @@ foo_4_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8665,12 +8657,12 @@ f7_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8692,12 +8684,12 @@ f11_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8717,11 +8709,11 @@ f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 }
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>*>
+          typename Tx_int__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
@@ -8732,8 +8724,8 @@ const
 }
 
 template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Tx__, Ty__>
 foo_bar2_functor__::operator()(const Tx__& x, const Ty__& y,
                                std::ostream* pstream__)  const
@@ -8750,8 +8742,8 @@ matfoo_functor__::operator()(std::ostream* pstream__)  const
 template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
           stan::require_t<stan::is_col_vector<Tx__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
@@ -8762,8 +8754,8 @@ algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
 }
 
 template <typename Tmu__, typename Tsigma__, typename RNG,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tsigma__>>*>
+          stan::require_t<stan::is_stan_scalar<Tmu__>>*,
+          stan::require_t<stan::is_stan_scalar<Tsigma__>>*>
 inline stan::return_type_t<Tmu__, Tsigma__>
 foo_rng_functor__::operator()(const Tmu__& mu, const Tsigma__& sigma,
                               RNG& base_rng__, std::ostream* pstream__) 
@@ -8773,10 +8765,10 @@ const
 }
 
 template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmax___>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmin___>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar<Tmax___>>*,
+          stan::require_t<stan::is_stan_scalar<Tmin___>>*>
 inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
 relative_diff_functor__::operator()(const Tx__& x, const Ty__& y,
                                     const Tmax___& max_, const Tmin___& min_,
@@ -8785,7 +8777,7 @@ relative_diff_functor__::operator()(const Tx__& x, const Ty__& y,
   return relative_diff(x, y, max_, min_, pstream__);
 }
 
-template <typename Tmu__, stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+template <typename Tmu__, stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
 vecmubar_functor__::operator()(const Tmu__& mu, std::ostream* pstream__) 
 const
@@ -8796,12 +8788,12 @@ const
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8819,8 +8811,8 @@ f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 }
 
 template <bool propto__, typename Ty__, typename Tlambda__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>*>
+          stan::require_t<std::is_integral<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar<Tlambda__>>*>
 inline stan::return_type_t<Ty__, Tlambda__>
 foo_lpmf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
@@ -8832,8 +8824,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__, typename Tdata_i__,
           stan::require_t<stan::is_col_vector<Tshared_params__>>*,
           stan::require_t<stan::is_col_vector<Tjob_params__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 foo_5_functor__::operator()(const Tshared_params__& shared_params,
                             const Tjob_params__& job_params,
@@ -8846,12 +8838,12 @@ foo_5_functor__::operator()(const Tshared_params__& shared_params,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8873,12 +8865,12 @@ f4_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8900,12 +8892,12 @@ f10_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8925,12 +8917,12 @@ f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8952,12 +8944,12 @@ f9_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -8977,8 +8969,8 @@ f8_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 }
 
 template <typename Ty__, typename Tlambda__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>*>
+          stan::require_t<std::is_integral<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar<Tlambda__>>*>
 inline stan::return_type_t<Ty__, Tlambda__>
 foo_lccdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                 std::ostream* pstream__)  const
@@ -8986,7 +8978,7 @@ foo_lccdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
   return foo_lccdf(y, lambda, pstream__);
 }
 
-template <typename Tmu__, stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+template <typename Tmu__, stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
 vecmufoo_functor__::operator()(const Tmu__& mu, std::ostream* pstream__) 
 const
@@ -8995,8 +8987,7 @@ const
 }
 
 template <bool propto__, typename Tx__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 foo_lp_functor__::operator()(const Tx__& x, T_lp__& lp__,
                              T_lp_accum__& lp_accum__,
@@ -9006,8 +8997,8 @@ foo_lp_functor__::operator()(const Tx__& x, T_lp__& lp__,
 }
 
 template <typename Tt__, typename Tn__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>*>
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_t<std::is_integral<Tn__>>*>
 inline std::vector<stan::return_type_t<Tt__, Tn__>>
 foo_3_functor__::operator()(const Tt__& t, const Tn__& n,
                             std::ostream* pstream__)  const
@@ -9023,8 +9014,8 @@ inline void foo_6_functor__::operator()(std::ostream* pstream__)  const
 template <typename Tphi__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_t<stan::is_col_vector<Tphi__>>*,
           stan::require_t<stan::is_col_vector<Ttheta__>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
 binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
                                 const Tx_r__& x_r, const Tx_i__& x_i,
@@ -9033,7 +9024,7 @@ binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
   return binomialf(phi, theta, x_r, x_i, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 foo_bar1_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -9043,12 +9034,12 @@ foo_bar1_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<std::is_integral<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
           stan::require_t<stan::is_col_vector<Ta7__>>*,
           stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
           stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
@@ -9065,7 +9056,7 @@ f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Tn__, stan::require_t<stan::is_stan_scalar_t<Tn__>>*>
+template <typename Tn__, stan::require_t<std::is_integral<Tn__>>*>
 inline int foo_functor__::operator()(const Tn__& n, std::ostream* pstream__) 
 const
 {
@@ -15258,11 +15249,11 @@ static constexpr std::array<const char*, 158> locations_array__ =
 struct sho_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
             typename Tx_int__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
@@ -15272,8 +15263,8 @@ struct algebra_system_functor__ {
             typename Tdat_int__,
             stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
@@ -15281,11 +15272,11 @@ struct algebra_system_functor__ {
 struct integrand_functor__ {
   template <typename Tx__, typename Txc__, typename Ttheta__,
             typename Tx_r__, typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Txc__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Txc__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
   operator()(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -15295,8 +15286,8 @@ struct foo_functor__ {
             typename Tdata_r__, typename Tdata_i__,
             stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -15307,8 +15298,8 @@ struct goo_functor__ {
             typename Tdata_r__, typename Tdata_i__,
             stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -15316,18 +15307,18 @@ struct goo_functor__ {
 };
 struct map_rectfake_functor__ {
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
           typename Tx_int__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) {
@@ -15359,11 +15350,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
     }
 template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Txc__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Txc__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
   integrand(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -15385,8 +15376,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__, typename Tdata_i__,
           stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   foo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
       const Tdata_r__& data_r, const Tdata_i__& data_i,
@@ -15412,8 +15403,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__, typename Tdata_i__,
           stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   goo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
       const Tdata_r__& data_r, const Tdata_i__& data_i,
@@ -15436,7 +15427,7 @@ template <typename Tshared_params__, typename Tjob_params__,
     }
     }
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   map_rectfake(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -15455,8 +15446,8 @@ template <typename Tx__,
 template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
           stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
@@ -15489,11 +15480,11 @@ template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>*>
+          typename Tx_int__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
@@ -15506,8 +15497,8 @@ const
 template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
           stan::require_t<stan::is_col_vector<Tx__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
@@ -15518,11 +15509,11 @@ algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
 }
 
 template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Txc__>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar<Txc__>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
 integrand_functor__::operator()(const Tx__& x, const Txc__& xc,
                                 const Ttheta__& theta, const Tx_r__& x_r,
@@ -15536,8 +15527,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__, typename Tdata_i__,
           stan::require_t<stan::is_col_vector<Tshared_params__>>*,
           stan::require_t<stan::is_col_vector<Tjob_params__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 foo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
@@ -15551,8 +15542,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__, typename Tdata_i__,
           stan::require_t<stan::is_col_vector<Tshared_params__>>*,
           stan::require_t<stan::is_col_vector<Tjob_params__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 goo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
@@ -15562,7 +15553,7 @@ goo_functor__::operator()(const Tshared_params__& shared_params,
   return goo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 map_rectfake_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -17809,9 +17800,9 @@ static constexpr std::array<const char*, 630> locations_array__ =
 
 struct f_functor__ {
   template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
@@ -17819,9 +17810,9 @@ struct f_functor__ {
 };
 struct f_odefunctor__ {
   template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
@@ -17829,9 +17820,9 @@ struct f_odefunctor__ {
 };
 
 template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
   f(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
@@ -17852,9 +17843,9 @@ template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
     }
     }
 template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar<Ta__>>*,
           stan::require_t<stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
 f_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
@@ -17864,9 +17855,9 @@ f_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
 }
 
 template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar<Ta__>>*,
           stan::require_t<stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
 f_odefunctor__::operator()(const Tt__& t, const Tz__& z,
@@ -21654,11 +21645,11 @@ static constexpr std::array<const char*, 35> locations_array__ =
 struct dz_dt_functor__ {
   template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar_t<value_type_t<Tz__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Tz__& z, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -21666,11 +21657,11 @@ struct dz_dt_functor__ {
 
 template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar_t<value_type_t<Tz__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
   dz_dt(const Tt__& t, const Tz__& z, const Ttheta__& theta,
         const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -21713,11 +21704,11 @@ template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar_t<value_type_t<Tz__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
 dz_dt_functor__::operator()(const Tt__& t, const Tz__& z,
                             const Ttheta__& theta, const Tx_r__& x_r,
@@ -24028,11 +24019,11 @@ static constexpr std::array<const char*, 35> locations_array__ =
 
 struct foo_functor__ {
   template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__,
@@ -24048,7 +24039,7 @@ struct foo_functor__ {
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__,
@@ -24064,17 +24055,15 @@ struct foo_functor__ {
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__,
-            stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+  template <typename Tp__, stan::require_t<std::is_integral<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
 };
 
-template <typename Tp__,
-          stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+template <typename Tp__, stan::require_t<std::is_integral<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24091,7 +24080,7 @@ template <typename Tp__,
     }
     }
 template <typename Tp__,
-          stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24162,7 +24151,7 @@ template <typename Tp__,
     }
     }
 template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24233,7 +24222,7 @@ template <typename Tp__,
     }
     }
 template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24251,7 +24240,7 @@ template <typename Tp__,
     }
     }
 template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24268,7 +24257,7 @@ template <typename Tp__,
     }
     }
 template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
@@ -24276,7 +24265,7 @@ foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 }
 
 template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tp__>>>>*>
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
@@ -24308,7 +24297,7 @@ foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 }
 
 template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
@@ -24337,14 +24326,14 @@ foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_t<stan::is_stan_scalar_t<Tp__>>*>
+template <typename Tp__, stan::require_t<stan::is_stan_scalar<Tp__>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_t<stan::is_stan_scalar_t<Tp__>>*>
+template <typename Tp__, stan::require_t<std::is_integral<Tp__>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
@@ -25496,7 +25485,7 @@ static constexpr std::array<const char*, 9> locations_array__ =
 
 struct foo_functor__ {
   template <typename Tzs__,
-            stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar_t<value_type_t<Tzs__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
   inline stan::return_type_t<Tzs__>
   operator()(const Tzs__& zs, std::ostream* pstream__) const;
 };
@@ -25523,7 +25512,7 @@ template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>* = nullptr>
     }
     }
 template <typename Tzs__,
-          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar_t<value_type_t<Tzs__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
   inline stan::return_type_t<Tzs__>
   foo(const Tzs__& zs, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tzs__>;
@@ -25540,7 +25529,7 @@ template <typename Tzs__,
     }
     }
 template <typename Tzs__,
-          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar_t<value_type_t<Tzs__>>>*>
+          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>*>
 inline stan::return_type_t<Tzs__>
 foo_functor__::operator()(const Tzs__& zs, std::ostream* pstream__)  const
 {
@@ -25926,9 +25915,9 @@ static constexpr std::array<const char*, 26> locations_array__ =
 template <bool propto__>
   struct foo_lpdf_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -25936,18 +25925,18 @@ template <bool propto__>
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Ty_slice__, typename Tstart__,
             typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -25955,19 +25944,19 @@ struct g_functor__ {
 struct h_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -25975,19 +25964,19 @@ struct g_rsfunctor__ {
 struct h_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
     std::ostream* pstream__) {
@@ -26013,10 +26002,10 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   h(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
     const Ta__& a, std::ostream* pstream__) {
@@ -26044,9 +26033,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <bool propto__, typename Ty_slice__, typename Tstart__,
           typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   foo_lpdf(const Ty_slice__& y_slice, const Tstart__& start,
            const Tend__& end, std::ostream* pstream__) {
@@ -26064,9 +26053,9 @@ template <bool propto__, typename Ty_slice__, typename Tstart__,
     }
 template <bool propto__>
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
                                            const Tstart__& start,
@@ -26078,9 +26067,9 @@ foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
 
 template <bool propto__, typename Ty_slice__, typename Tstart__,
           typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
                                const Tstart__& start, const Tend__& end,
@@ -26090,9 +26079,9 @@ foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                         const Tend__& end, std::ostream* pstream__)  const
@@ -26102,10 +26091,10 @@ g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__,
@@ -26115,9 +26104,9 @@ h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -26127,10 +26116,10 @@ g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 h_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                         const Tend__& end, const Ta__& a,
@@ -26730,17 +26719,17 @@ static constexpr std::array<const char*, 180> locations_array__ =
 struct g6_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h6_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26748,9 +26737,9 @@ struct h6_functor__ {
 };
 struct h6_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26758,9 +26747,9 @@ struct h6_rsfunctor__ {
 };
 struct h8_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26768,9 +26757,9 @@ struct h8_functor__ {
 };
 struct h7_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26778,9 +26767,9 @@ struct h7_functor__ {
 };
 struct h8_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26788,9 +26777,9 @@ struct h8_rsfunctor__ {
 };
 struct h2_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26799,17 +26788,17 @@ struct h2_functor__ {
 struct g8_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h2_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26817,9 +26806,9 @@ struct h2_rsfunctor__ {
 };
 struct g1_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -26827,8 +26816,8 @@ struct g1_functor__ {
 struct g2_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -26836,8 +26825,8 @@ struct g2_functor__ {
 struct g2_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -26845,37 +26834,37 @@ struct g2_rsfunctor__ {
 struct g3_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h5_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h1_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
@@ -26883,26 +26872,26 @@ struct h1_functor__ {
 struct g7_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -26910,8 +26899,8 @@ struct g5_rsfunctor__ {
 struct g6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -26919,17 +26908,17 @@ struct g6_rsfunctor__ {
 struct g4_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h4_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26938,8 +26927,8 @@ struct h4_rsfunctor__ {
 struct g4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -26947,18 +26936,18 @@ struct g4_rsfunctor__ {
 struct g7_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h5_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
@@ -26966,8 +26955,8 @@ struct h5_functor__ {
 struct g8_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -26975,17 +26964,17 @@ struct g8_rsfunctor__ {
 struct g3_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h3_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -26993,9 +26982,9 @@ struct h3_rsfunctor__ {
 };
 struct h7_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -27003,19 +26992,19 @@ struct h7_rsfunctor__ {
 };
 struct h1_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h3_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -27023,9 +27012,9 @@ struct h3_functor__ {
 };
 struct h4_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
@@ -27033,9 +27022,9 @@ struct h4_functor__ {
 };
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27055,8 +27044,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27087,8 +27076,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27119,8 +27108,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27151,9 +27140,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27192,8 +27181,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27233,8 +27222,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27274,8 +27263,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27314,10 +27303,10 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h1(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27338,9 +27327,9 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h2(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
@@ -27371,9 +27360,9 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h3(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
@@ -27404,9 +27393,9 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h4(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
@@ -27438,10 +27427,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h5(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27478,9 +27467,9 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h6(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
@@ -27519,9 +27508,9 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h7(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
@@ -27560,9 +27549,9 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h8(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
@@ -27602,8 +27591,8 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27612,9 +27601,9 @@ g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h6_functor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27625,9 +27614,9 @@ h6_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27638,9 +27627,9 @@ h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h8_functor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27651,9 +27640,9 @@ h8_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h7_functor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27664,9 +27653,9 @@ h7_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27677,9 +27666,9 @@ h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h2_functor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27691,8 +27680,8 @@ h2_functor__::operator()(const Ty__& y, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27701,9 +27690,9 @@ g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27714,9 +27703,9 @@ h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27726,8 +27715,8 @@ g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27737,8 +27726,8 @@ g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27748,8 +27737,8 @@ g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27758,10 +27747,10 @@ g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27771,9 +27760,9 @@ h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27782,10 +27771,10 @@ g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h1_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27796,8 +27785,8 @@ h1_functor__::operator()(const Ty__& y, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27806,9 +27795,9 @@ g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27817,9 +27806,9 @@ g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27829,8 +27818,8 @@ g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27840,8 +27829,8 @@ g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27850,9 +27839,9 @@ g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27864,8 +27853,8 @@ h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27875,8 +27864,8 @@ g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27885,10 +27874,10 @@ g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h5_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27899,8 +27888,8 @@ h5_functor__::operator()(const Ty__& y, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27910,8 +27899,8 @@ g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27920,9 +27909,9 @@ g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27933,9 +27922,9 @@ h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27946,10 +27935,10 @@ h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27959,9 +27948,9 @@ h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h3_functor__::operator()(const Ty__& y, const Tstart__& start,
@@ -27972,9 +27961,9 @@ h3_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h4_functor__::operator()(const Ty__& y, const Tstart__& start,
@@ -29708,9 +29697,9 @@ static constexpr std::array<const char*, 342> locations_array__ =
 
 struct f1a_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29722,26 +29711,26 @@ struct s_rsfunctor__ {
             typename Ti__, typename Tj__, typename Tk__, typename Tl__,
             typename Tm__, typename Tn__, typename To__, typename Tp__,
             typename Tq__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_t<std::is_integral<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
             stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                       stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                           stan::return_type_t<Th__, Ti__, Tj__,
@@ -29759,8 +29748,8 @@ struct s_rsfunctor__ {
 struct f4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29768,9 +29757,9 @@ struct f4_rsfunctor__ {
 struct g12_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29778,9 +29767,9 @@ struct g12_rsfunctor__ {
 };
 struct f5_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29788,8 +29777,8 @@ struct f5_functor__ {
 struct f8_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29797,9 +29786,9 @@ struct f8_rsfunctor__ {
 struct g8_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29807,9 +29796,9 @@ struct g8_functor__ {
 };
 struct f1a_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29817,9 +29806,9 @@ struct f1a_functor__ {
 struct g10_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29832,10 +29821,10 @@ struct r_functor__ {
 struct g1_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
@@ -29843,9 +29832,9 @@ struct g1_functor__ {
 struct g2_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29854,8 +29843,8 @@ struct g2_rsfunctor__ {
 struct f6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29863,9 +29852,9 @@ struct f6_rsfunctor__ {
 struct g12_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29874,8 +29863,8 @@ struct g12_functor__ {
 struct f2_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29883,8 +29872,8 @@ struct f2_rsfunctor__ {
 struct f3_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29892,17 +29881,17 @@ struct f3_rsfunctor__ {
 struct f6_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f12_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29910,10 +29899,10 @@ struct f12_rsfunctor__ {
 struct g9_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
@@ -29921,9 +29910,9 @@ struct g9_rsfunctor__ {
 struct g11_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29932,17 +29921,17 @@ struct g11_functor__ {
 struct f3_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f1_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29950,8 +29939,8 @@ struct f1_rsfunctor__ {
 struct f7_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29959,9 +29948,9 @@ struct f7_functor__ {
 struct g11_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29970,10 +29959,10 @@ struct g11_rsfunctor__ {
 struct g9_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
@@ -29981,9 +29970,9 @@ struct g9_functor__ {
 struct g4_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29992,9 +29981,9 @@ struct g4_functor__ {
 struct g4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30002,18 +29991,18 @@ struct g4_rsfunctor__ {
 };
 struct f11_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f12_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30021,9 +30010,9 @@ struct f12_functor__ {
 struct g3_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30031,9 +30020,9 @@ struct g3_functor__ {
 };
 struct f11_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30041,9 +30030,9 @@ struct f11_rsfunctor__ {
 struct g6_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30052,17 +30041,17 @@ struct g6_functor__ {
 struct f7_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f9_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30070,8 +30059,8 @@ struct f9_rsfunctor__ {
 struct f4_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30079,9 +30068,9 @@ struct f4_functor__ {
 struct g2_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30089,9 +30078,9 @@ struct g2_functor__ {
 };
 struct f10_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30103,26 +30092,26 @@ struct s_functor__ {
             typename Ti__, typename Tj__, typename Tk__, typename Tl__,
             typename Tm__, typename Tn__, typename To__, typename Tp__,
             typename Tq__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_t<std::is_integral<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
             stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                       stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                           stan::return_type_t<Th__, Ti__, Tj__,
@@ -30140,8 +30129,8 @@ struct s_functor__ {
 struct f2_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30149,9 +30138,9 @@ struct f2_functor__ {
 struct g3_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30159,9 +30148,9 @@ struct g3_rsfunctor__ {
 };
 struct f9_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30169,8 +30158,8 @@ struct f9_functor__ {
 struct f8_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30178,10 +30167,10 @@ struct f8_functor__ {
 struct g1_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
@@ -30189,9 +30178,9 @@ struct g1_rsfunctor__ {
 struct g7_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30200,10 +30189,10 @@ struct g7_functor__ {
 struct g5_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
@@ -30211,19 +30200,19 @@ struct g5_functor__ {
 struct g5_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30231,9 +30220,9 @@ struct f5_rsfunctor__ {
 struct g6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30242,9 +30231,9 @@ struct g6_rsfunctor__ {
 struct g7_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30253,9 +30242,9 @@ struct g7_rsfunctor__ {
 struct g8_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30263,18 +30252,18 @@ struct g8_rsfunctor__ {
 };
 struct f10_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30282,9 +30271,9 @@ struct f1_functor__ {
 struct g10_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
             typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+            stan::require_t<std::is_integral<Tend__>>* = nullptr,
             stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30292,9 +30281,9 @@ struct g10_functor__ {
 };
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30313,9 +30302,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f1a(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30335,8 +30324,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30356,8 +30345,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30377,8 +30366,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30397,9 +30386,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30419,8 +30408,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30440,8 +30429,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30461,8 +30450,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30481,9 +30470,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30502,9 +30491,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30523,9 +30512,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30544,9 +30533,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30566,10 +30555,10 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30589,9 +30578,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30613,9 +30602,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30637,9 +30626,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30661,10 +30650,10 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30684,9 +30673,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30707,9 +30696,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30730,9 +30719,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30753,10 +30742,10 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30776,9 +30765,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30799,9 +30788,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30822,9 +30811,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30849,26 +30838,26 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
           typename Tq__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
+          stan::require_t<std::is_integral<Tend__>>* = nullptr,
+          stan::require_t<std::is_integral<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
           stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
           stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -31213,9 +31202,9 @@ inline double r(std::ostream* pstream__) {
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1a_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31230,26 +31219,26 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
           typename Tq__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_t<std::is_integral<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tb__>>*,
           stan::require_t<stan::is_col_vector<Tc__>>*,
           stan::require_t<stan::is_row_vector<Td__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
-          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>*,
           stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>*,
           stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>*,
           stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>*,
           stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>*,
           stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>*,
           stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -31272,8 +31261,8 @@ s_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31283,9 +31272,9 @@ f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31296,9 +31285,9 @@ g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31308,8 +31297,8 @@ f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31319,9 +31308,9 @@ f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31332,9 +31321,9 @@ g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31344,9 +31333,9 @@ f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31363,10 +31352,10 @@ inline double r_functor__::operator()(std::ostream* pstream__)  const
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31377,9 +31366,9 @@ g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_t<stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31391,8 +31380,8 @@ g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31402,9 +31391,9 @@ f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31416,8 +31405,8 @@ g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31427,8 +31416,8 @@ f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31438,8 +31427,8 @@ f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31448,9 +31437,9 @@ f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31461,10 +31450,10 @@ const
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31475,9 +31464,9 @@ g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31489,8 +31478,8 @@ g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31499,9 +31488,9 @@ f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31511,8 +31500,8 @@ f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31522,9 +31511,9 @@ f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31536,10 +31525,10 @@ g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31550,9 +31539,9 @@ g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31564,9 +31553,9 @@ g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31577,9 +31566,9 @@ g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31588,9 +31577,9 @@ f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31600,9 +31589,9 @@ f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_t<stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31613,9 +31602,9 @@ g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31626,9 +31615,9 @@ const
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31640,8 +31629,8 @@ g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31650,9 +31639,9 @@ f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31662,8 +31651,8 @@ f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31673,9 +31662,9 @@ f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_t<stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31686,9 +31675,9 @@ g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31702,26 +31691,26 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
           typename Tq__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_t<std::is_integral<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tb__>>*,
           stan::require_t<stan::is_col_vector<Tc__>>*,
           stan::require_t<stan::is_row_vector<Td__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
-          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>*,
           stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>*,
           stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>*,
           stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>*,
           stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>*,
           stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>*,
           stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -31744,8 +31733,8 @@ s_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31755,9 +31744,9 @@ f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_t<stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31768,9 +31757,9 @@ g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31780,8 +31769,8 @@ f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31791,10 +31780,10 @@ f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31805,9 +31794,9 @@ g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31819,10 +31808,10 @@ g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31833,10 +31822,10 @@ g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31846,9 +31835,9 @@ g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31858,9 +31847,9 @@ f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31872,9 +31861,9 @@ g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31886,9 +31875,9 @@ g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31899,9 +31888,9 @@ g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31911,9 +31900,9 @@ const
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31923,9 +31912,9 @@ f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
+          stan::require_t<std::is_integral<Tstart__>>*,
+          stan::require_t<std::is_integral<Tend__>>*,
           stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -33950,27 +33939,27 @@ static constexpr std::array<const char*, 52> locations_array__ =
 
 struct rhs_odefunctor__ {
   template <typename Tt__, typename Ty__, typename Talpha__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Talpha__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
              const Talpha__& alpha) const;
 };
 struct rhs_functor__ {
   template <typename Tt__, typename Ty__, typename Talpha__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Talpha__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, const Talpha__& alpha,
              std::ostream* pstream__) const;
 };
 
 template <typename Tt__, typename Ty__, typename Talpha__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Talpha__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
   rhs(const Tt__& t, const Ty__& y, const Talpha__& alpha,
       std::ostream* pstream__) {
@@ -33994,9 +33983,9 @@ template <typename Tt__, typename Ty__, typename Talpha__,
     }
     }
 template <typename Tt__, typename Ty__, typename Talpha__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Talpha__>>*>
+          stan::require_t<stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
 rhs_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                              std::ostream* pstream__, const Talpha__& alpha) 
@@ -34006,9 +33995,9 @@ const
 }
 
 template <typename Tt__, typename Ty__, typename Talpha__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Talpha__>>*>
+          stan::require_t<stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
 rhs_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Talpha__& alpha, std::ostream* pstream__) 
@@ -34983,46 +34972,46 @@ static constexpr std::array<const char*, 13> locations_array__ =
 struct foo4_lp_functor__ {
   template <bool propto__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo0_lpmf_functor__ {
   template <bool propto__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo1_lpmf_functor__ {
   template <bool propto__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo2_lpdf_functor__ {
   template <bool propto__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo3_lpdf_functor__ {
   template <bool propto__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo5_lp_functor__ {
   template <bool propto__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo0_lpmf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35037,7 +35026,7 @@ template <bool propto__, typename Ty__,
     }
     }
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo1_lpmf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35053,7 +35042,7 @@ template <bool propto__, typename Ty__,
     }
 template <bool propto__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo4_lp(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -35069,7 +35058,7 @@ template <bool propto__, typename Ty__, typename T_lp__,
     }
     }
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo2_lpdf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35084,7 +35073,7 @@ template <bool propto__, typename Ty__,
     }
     }
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo3_lpdf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35100,7 +35089,7 @@ template <bool propto__, typename Ty__,
     }
 template <bool propto__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo5_lp(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -35116,8 +35105,7 @@ template <bool propto__, typename Ty__, typename T_lp__,
     }
     }
 template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          typename T_lp_accum__, stan::require_t<std::is_integral<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo4_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -35127,7 +35115,7 @@ foo4_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
 }
 
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<std::is_integral<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo0_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35136,7 +35124,7 @@ const
 }
 
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<std::is_integral<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo1_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35145,7 +35133,7 @@ const
 }
 
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo2_lpdf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35154,7 +35142,7 @@ const
 }
 
 template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo3_lpdf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35163,8 +35151,7 @@ const
 }
 
 template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo5_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -38997,13 +38984,13 @@ static constexpr std::array<const char*, 5> locations_array__ =
 
 struct normal_functor__ {
   template <typename Ta__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 
 template <typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   normal(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -39019,7 +39006,7 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+template <typename Ta__, stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ta__>
 normal_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
@@ -39348,15 +39335,15 @@ static constexpr std::array<const char*, 5> locations_array__ =
 
 struct lb_constrain_functor__ {
   template <typename Tx__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   operator()(const Tx__& x, const Ty__& y, std::ostream* pstream__) const;
 };
 
 template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   lb_constrain(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -39373,8 +39360,8 @@ template <typename Tx__, typename Ty__,
     }
     }
 template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Tx__, Ty__>
 lb_constrain_functor__::operator()(const Tx__& x, const Ty__& y,
                                    std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -6992,9 +6992,9 @@ int foo(const int& n, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<double>& x,

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -25778,7 +25778,8 @@ static constexpr std::array<const char*, 26> locations_array__ =
  " (in 'reduce_sum_m1.stan', line 17, column 4 to column 39)",
  " (in 'reduce_sum_m1.stan', line 16, column 58 to line 18, column 3)"};
 
-bool propto__struct foo_lpdf_rsfunctor__ {
+template <bool propto__>
+  struct foo_lpdf_rsfunctor__ {
   template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
@@ -25888,7 +25889,8 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-bool propto__template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <bool propto__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
                                            const int& start, const int& end,

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1218,13 +1218,12 @@ static constexpr std::array<const char*, 427> locations_array__ =
  " (in 'complex_scalar.stan', line 33, column 45 to line 35, column 3)"};
 
 struct foo8_functor__ {
-  template <typename Tz__,
-            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo1_functor__ {
-  template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_complex<Tz__>>* = nullptr>
   inline stan::return_type_t<Tz__>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
@@ -1233,43 +1232,37 @@ struct foo4_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct foo6_functor__ {
-  template <typename Tr__,
-            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
+  template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tr__>>>
   operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo10_functor__ {
-  template <typename Tz__,
-            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename Tr__,
-            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
+  template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tr__>>
   operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo9_functor__ {
-  template <typename Tr__,
-            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
+  template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
   operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_complex<Tz__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tz__>>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo7_functor__ {
-  template <typename Tz__,
-            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tz__>>>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo5_functor__ {
-  template <typename Tz__,
-            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
@@ -1292,7 +1285,7 @@ inline std::complex<double> foo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_complex<Tz__>>* = nullptr>
   inline stan::return_type_t<Tz__>
   foo1(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1308,8 +1301,7 @@ template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tr__,
-          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
+template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tr__>>
   foo2(const Tr__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tr__>;
@@ -1325,7 +1317,7 @@ template <typename Tr__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_complex<Tz__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tz__>>
   foo3(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1356,8 +1348,7 @@ inline std::vector<std::complex<double>> foo4(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   foo5(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1373,8 +1364,7 @@ template <typename Tz__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tr__,
-          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
+template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tr__>>>
   foo6(const Tr__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tr__>;
@@ -1391,8 +1381,7 @@ template <typename Tr__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tz__>>>
   foo7(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1408,8 +1397,7 @@ template <typename Tz__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   foo8(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1425,8 +1413,7 @@ template <typename Tz__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tr__,
-          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr>
+template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
   foo9(const Tr__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tr__>;
@@ -1448,8 +1435,7 @@ template <typename Tr__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
   foo10(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1465,15 +1451,14 @@ template <typename Tz__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
 inline stan::return_type_t<Tz__>
 foo8_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo8(z, pstream__);
 }
 
-template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>*>
+template <typename Tz__, stan::require_all_t<stan::is_complex<Tz__>>*>
 inline stan::return_type_t<Tz__>
 foo1_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
@@ -1486,52 +1471,49 @@ foo4_functor__::operator()(std::ostream* pstream__)  const
   return foo4(pstream__);
 }
 
-template <typename Tr__, stan::require_t<stan::is_stan_scalar<Tr__>>*>
+template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>*>
 inline std::vector<std::complex<stan::return_type_t<Tr__>>>
 foo6_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
   return foo6(r, pstream__);
 }
 
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
 inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
 foo10_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo10(z, pstream__);
 }
 
-template <typename Tr__, stan::require_t<stan::is_stan_scalar<Tr__>>*>
+template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>*>
 inline std::complex<stan::return_type_t<Tr__>>
 foo2_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
   return foo2(r, pstream__);
 }
 
-template <typename Tr__, stan::require_t<stan::is_stan_scalar<Tr__>>*>
+template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>*>
 inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
 foo9_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
   return foo9(r, pstream__);
 }
 
-template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>*>
+template <typename Tz__, stan::require_all_t<stan::is_complex<Tz__>>*>
 inline std::complex<stan::return_type_t<Tz__>>
 foo3_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo3(z, pstream__);
 }
 
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
 inline std::vector<std::complex<stan::return_type_t<Tz__>>>
 foo7_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo7(z, pstream__);
 }
 
-template <typename Tz__,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
 inline stan::return_type_t<Tz__>
 foo5_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
@@ -3742,8 +3724,7 @@ static constexpr std::array<const char*, 75> locations_array__ =
  " (in 'cpp-reserved-words.stan', line 14, column 17 to column 19)"};
 
 struct _stan_asm_functor__ {
-  template <typename T_stan_class__,
-            stan::require_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
+  template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
   inline void
   operator()(const T_stan_class__& _stan_class, std::ostream* pstream__) const;
 };
@@ -3756,8 +3737,7 @@ struct _stan_bitor_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_bitand_functor__ {
-  template <typename T_stan_constexpr__,
-            stan::require_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
+  template <typename T_stan_constexpr__, stan::require_all_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
   inline void
   operator()(const T_stan_constexpr__& _stan_constexpr, std::ostream* pstream__) const;
 };
@@ -3766,27 +3746,23 @@ struct _stan_catch_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_alignas_functor__ {
-  template <typename T_stan_asm__,
-            stan::require_t<std::is_integral<T_stan_asm__>>* = nullptr>
+  template <typename T_stan_asm__, stan::require_all_t<std::is_integral<T_stan_asm__>>* = nullptr>
   inline void
   operator()(const T_stan_asm__& _stan_asm, std::ostream* pstream__) const;
 };
 struct _stan_alignof_functor__ {
-  template <typename T_stan_char__,
-            stan::require_t<std::is_integral<T_stan_char__>>* = nullptr>
+  template <typename T_stan_char__, stan::require_all_t<std::is_integral<T_stan_char__>>* = nullptr>
   inline void
   operator()(const T_stan_char__& _stan_char, std::ostream* pstream__) const;
 };
 struct _stan_and_eq_functor__ {
-  template <typename T_stan_STAN_MINOR__,
-            stan::require_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>* = nullptr>
+  template <typename T_stan_STAN_MINOR__, stan::require_all_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>* = nullptr>
   inline void
   operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
              std::ostream* pstream__) const;
 };
 struct _stan_and_functor__ {
-  template <typename T_stan_STAN_MAJOR__,
-            stan::require_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
+  template <typename T_stan_STAN_MAJOR__, stan::require_all_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
   inline void
   operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
              std::ostream* pstream__) const;
@@ -3808,8 +3784,7 @@ struct _stan_case_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 
-template <typename T_stan_asm__,
-          stan::require_t<std::is_integral<T_stan_asm__>>* = nullptr>
+template <typename T_stan_asm__, stan::require_all_t<std::is_integral<T_stan_asm__>>* = nullptr>
   inline void
   _stan_alignas(const T_stan_asm__& _stan_asm, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<T_stan_asm__>;
@@ -3824,8 +3799,7 @@ template <typename T_stan_asm__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_char__,
-          stan::require_t<std::is_integral<T_stan_char__>>* = nullptr>
+template <typename T_stan_char__, stan::require_all_t<std::is_integral<T_stan_char__>>* = nullptr>
   inline void
   _stan_alignof(const T_stan_char__& _stan_char, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<T_stan_char__>;
@@ -3840,8 +3814,7 @@ template <typename T_stan_char__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_STAN_MAJOR__,
-          stan::require_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
+template <typename T_stan_STAN_MAJOR__, stan::require_all_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
   inline void
   _stan_and(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
             std::ostream* pstream__) {
@@ -3857,8 +3830,7 @@ template <typename T_stan_STAN_MAJOR__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_STAN_MINOR__,
-          stan::require_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>* = nullptr>
+template <typename T_stan_STAN_MINOR__, stan::require_all_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>* = nullptr>
   inline void
   _stan_and_eq(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
                std::ostream* pstream__) {
@@ -3874,8 +3846,7 @@ template <typename T_stan_STAN_MINOR__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_class__,
-          stan::require_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
+template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
   inline void
   _stan_asm(const T_stan_class__& _stan_class, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<T_stan_class__>;
@@ -3891,8 +3862,7 @@ template <typename T_stan_class__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_constexpr__,
-          stan::require_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
+template <typename T_stan_constexpr__, stan::require_all_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
   inline void
   _stan_bitand(const T_stan_constexpr__& _stan_constexpr,
                std::ostream* pstream__) {
@@ -3999,8 +3969,7 @@ inline void _stan_char32_t(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_class__,
-          stan::require_t<stan::is_col_vector<T_stan_class__>>*>
+template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>*>
 inline void
 _stan_asm_functor__::operator()(const T_stan_class__& _stan_class,
                                 std::ostream* pstream__)  const
@@ -4019,8 +3988,7 @@ inline void _stan_bitor_functor__::operator()(std::ostream* pstream__)  const
   return _stan_bitor(pstream__);
 }
 
-template <typename T_stan_constexpr__,
-          stan::require_t<std::is_integral<T_stan_constexpr__>>*>
+template <typename T_stan_constexpr__, stan::require_all_t<std::is_integral<T_stan_constexpr__>>*>
 inline void
 _stan_bitand_functor__::operator()(const T_stan_constexpr__& _stan_constexpr,
                                    std::ostream* pstream__)  const
@@ -4033,8 +4001,7 @@ inline void _stan_catch_functor__::operator()(std::ostream* pstream__)  const
   return _stan_catch(pstream__);
 }
 
-template <typename T_stan_asm__,
-          stan::require_t<std::is_integral<T_stan_asm__>>*>
+template <typename T_stan_asm__, stan::require_all_t<std::is_integral<T_stan_asm__>>*>
 inline void
 _stan_alignas_functor__::operator()(const T_stan_asm__& _stan_asm,
                                     std::ostream* pstream__)  const
@@ -4042,8 +4009,7 @@ _stan_alignas_functor__::operator()(const T_stan_asm__& _stan_asm,
   return _stan_alignas(_stan_asm, pstream__);
 }
 
-template <typename T_stan_char__,
-          stan::require_t<std::is_integral<T_stan_char__>>*>
+template <typename T_stan_char__, stan::require_all_t<std::is_integral<T_stan_char__>>*>
 inline void
 _stan_alignof_functor__::operator()(const T_stan_char__& _stan_char,
                                     std::ostream* pstream__)  const
@@ -4051,8 +4017,7 @@ _stan_alignof_functor__::operator()(const T_stan_char__& _stan_char,
   return _stan_alignof(_stan_char, pstream__);
 }
 
-template <typename T_stan_STAN_MINOR__,
-          stan::require_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>*>
+template <typename T_stan_STAN_MINOR__, stan::require_all_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>*>
 inline void
 _stan_and_eq_functor__::operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
                                    std::ostream* pstream__)  const
@@ -4060,8 +4025,7 @@ _stan_and_eq_functor__::operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
   return _stan_and_eq(_stan_STAN_MINOR, pstream__);
 }
 
-template <typename T_stan_STAN_MAJOR__,
-          stan::require_t<std::is_integral<T_stan_STAN_MAJOR__>>*>
+template <typename T_stan_STAN_MAJOR__, stan::require_all_t<std::is_integral<T_stan_STAN_MAJOR__>>*>
 inline void
 _stan_and_functor__::operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
                                 std::ostream* pstream__)  const
@@ -6515,13 +6479,10 @@ static constexpr std::array<const char*, 787> locations_array__ =
 struct foo_five_args_lp_functor__ {
   template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
             typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx6__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx1__>,
+            stan::is_stan_scalar<Tx2__>, stan::is_stan_scalar<Tx3__>,
+            stan::is_stan_scalar<Tx4__>, stan::is_stan_scalar<Tx5__>,
+            stan::is_stan_scalar<Tx6__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
                       stan::return_type_t<Tx6__>>
   operator()(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
@@ -6532,19 +6493,18 @@ struct f5_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>>
@@ -6555,29 +6515,28 @@ struct f5_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lcdf_functor__ {
-  template <typename Ty__, typename Tlambda__,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  template <typename Ty__,
+            typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+            stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct covsqrt2corsqrt_functor__ {
-  template <typename Tmat__, typename Tinvert__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr,
-            stan::require_t<std::is_integral<Tinvert__>>* = nullptr>
+  template <typename Tmat__,
+            typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
+            std::is_integral<Tinvert__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
   operator()(const Tmat__& mat, const Tinvert__& invert,
              std::ostream* pstream__) const;
 };
 struct foo_1_functor__ {
-  template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
   inline int
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct unit_normal_lp_functor__ {
   template <bool propto__, typename Tu__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Tu__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tu__>>* = nullptr>
   inline void
   operator()(const Tu__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -6594,19 +6553,18 @@ struct f6_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>>>
@@ -6618,18 +6576,16 @@ struct f6_functor__ {
 };
 struct foo_five_args_functor__ {
   template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
-            typename Tx5__,
-            stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr>
+            typename Tx5__, stan::require_all_t<stan::is_stan_scalar<Tx1__>,
+            stan::is_stan_scalar<Tx2__>, stan::is_stan_scalar<Tx3__>,
+            stan::is_stan_scalar<Tx4__>,
+            stan::is_stan_scalar<Tx5__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
   operator()(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
              const Tx4__& x4, const Tx5__& x5, std::ostream* pstream__) const;
 };
 struct foo_2_functor__ {
-  template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
   inline int
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
@@ -6637,19 +6593,18 @@ struct f3_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<int>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -6658,8 +6613,7 @@ struct f3_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline void
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
@@ -6667,19 +6621,18 @@ struct f7_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
@@ -6693,19 +6646,18 @@ struct f11_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
@@ -6719,19 +6671,18 @@ struct f12_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
@@ -6743,20 +6694,19 @@ struct f12_functor__ {
 };
 struct sho_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-            typename Tx_int__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+            typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
+            stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
 };
 struct foo_bar2_functor__ {
-  template <typename Tx__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+  template <typename Tx__,
+            typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   operator()(const Tx__& x, const Ty__& y, std::ostream* pstream__) const;
 };
@@ -6766,36 +6716,33 @@ struct matfoo_functor__ {
 };
 struct algebra_system_functor__ {
   template <typename Tx__, typename Ty__, typename Tdat__,
-            typename Tdat_int__,
-            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+            typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+            stan::is_col_vector<Ty__>,
+            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
+            stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
-  template <typename Tmu__, typename Tsigma__, typename RNG,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tsigma__>>* = nullptr>
+  template <typename Tmu__, typename Tsigma__,
+            typename RNG, stan::require_all_t<stan::is_stan_scalar<Tmu__>,
+            stan::is_stan_scalar<Tsigma__>>* = nullptr>
   inline stan::return_type_t<Tmu__, Tsigma__>
   operator()(const Tmu__& mu, const Tsigma__& sigma, RNG& base_rng__,
              std::ostream* pstream__) const;
 };
 struct relative_diff_functor__ {
-  template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmax___>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmin___>>* = nullptr>
+  template <typename Tx__, typename Ty__, typename Tmax___,
+            typename Tmin___, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            stan::is_stan_scalar<Ty__>, stan::is_stan_scalar<Tmax___>,
+            stan::is_stan_scalar<Tmin___>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
   operator()(const Tx__& x, const Ty__& y, const Tmax___& max_,
              const Tmin___& min_, std::ostream* pstream__) const;
 };
 struct vecmubar_functor__ {
-  template <typename Tmu__,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   operator()(const Tmu__& mu, std::ostream* pstream__) const;
 };
@@ -6803,19 +6750,18 @@ struct f0_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline void
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -6824,19 +6770,19 @@ struct f0_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lpmf_functor__ {
-  template <bool propto__, typename Ty__, typename Tlambda__,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  template <bool propto__, typename Ty__,
+            typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+            stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct foo_5_functor__ {
   template <typename Tshared_params__, typename Tjob_params__,
-            typename Tdata_r__, typename Tdata_i__,
-            stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+            typename Tdata_r__,
+            typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+            stan::is_col_vector<Tjob_params__>,
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+            stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -6846,19 +6792,18 @@ struct f4_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>
@@ -6872,19 +6817,18 @@ struct f10_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
@@ -6898,19 +6842,18 @@ struct f2_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<int>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -6922,19 +6865,18 @@ struct f9_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
@@ -6948,19 +6890,18 @@ struct f8_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
@@ -6971,30 +6912,28 @@ struct f8_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lccdf_functor__ {
-  template <typename Ty__, typename Tlambda__,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  template <typename Ty__,
+            typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+            stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct vecmufoo_functor__ {
-  template <typename Tmu__,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   operator()(const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lp_functor__ {
   template <bool propto__, typename Tx__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo_3_functor__ {
-  template <typename Tt__, typename Tn__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn__>>* = nullptr>
+  template <typename Tt__,
+            typename Tn__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            std::is_integral<Tn__>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tn__>>
   operator()(const Tt__& t, const Tn__& n, std::ostream* pstream__) const;
 };
@@ -7004,18 +6943,16 @@ struct foo_6_functor__ {
 };
 struct binomialf_functor__ {
   template <typename Tphi__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__,
-            stan::require_t<stan::is_col_vector<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ttheta__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
+            stan::is_col_vector<Ttheta__>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
   operator()(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
              const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
@@ -7023,19 +6960,18 @@ struct f1_functor__ {
   template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__,
-            stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_stan_scalar<Ta4__>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_col_vector<Ta7__>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_eigen_matrix_dynamic<Ta10__>,
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline int
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -7044,14 +6980,14 @@ struct f1_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  template <typename Tn__, stan::require_t<std::is_integral<Tn__>>* = nullptr>
+  template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>* = nullptr>
   inline int
   operator()(const Tn__& n, std::ostream* pstream__) const;
 };
 
-template <typename Tn__, stan::require_t<std::is_integral<Tn__>>*> inline int
-  foo(const Tn__& n, std::ostream* pstream__) ; 
-template <typename Tn__, stan::require_t<std::is_integral<Tn__>>* = nullptr>
+template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>*>
+  inline int foo(const Tn__& n, std::ostream* pstream__) ; 
+template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>* = nullptr>
   inline int foo(const Tn__& n, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__>;
     int current_statement__ = 0; 
@@ -7072,21 +7008,20 @@ template <typename Tn__, stan::require_t<std::is_integral<Tn__>>* = nullptr>
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
+          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) ; 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) {
@@ -7130,8 +7065,7 @@ inline double foo_bar0(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   foo_bar1(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -7147,9 +7081,9 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+template <typename Tx__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   foo_bar2(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -7165,9 +7099,9 @@ template <typename Tx__, typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tlambda__,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+template <bool propto__, typename Ty__,
+          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+          stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   foo_lpmf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
@@ -7181,9 +7115,9 @@ template <bool propto__, typename Ty__, typename Tlambda__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tlambda__,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+template <typename Ty__,
+          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+          stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   foo_lcdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
@@ -7199,9 +7133,9 @@ template <typename Ty__, typename Tlambda__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tlambda__,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+template <typename Ty__,
+          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+          stan::is_stan_scalar<Tlambda__>>* = nullptr>
   inline stan::return_type_t<Ty__, Tlambda__>
   foo_lccdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
@@ -7217,9 +7151,9 @@ template <typename Ty__, typename Tlambda__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tmu__, typename Tsigma__, typename RNG,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tsigma__>>* = nullptr>
+template <typename Tmu__, typename Tsigma__,
+          typename RNG, stan::require_all_t<stan::is_stan_scalar<Tmu__>,
+          stan::is_stan_scalar<Tsigma__>>* = nullptr>
   inline stan::return_type_t<Tmu__, Tsigma__>
   foo_rng(const Tmu__& mu, const Tsigma__& sigma, RNG& base_rng__,
           std::ostream* pstream__) {
@@ -7237,8 +7171,8 @@ template <typename Tmu__, typename Tsigma__, typename RNG,
     }
     }
 template <bool propto__, typename Tu__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tu__>>* = nullptr> inline void
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tu__>>* = nullptr>
+  inline void
   unit_normal_lp(const Tu__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tu__>;
@@ -7254,7 +7188,7 @@ template <bool propto__, typename Tu__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
+template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
   inline int foo_1(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
@@ -7479,7 +7413,7 @@ template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
+template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
   inline int foo_2(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
@@ -7507,9 +7441,9 @@ template <typename Ta__, stan::require_t<std::is_integral<Ta__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tn__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn__>>* = nullptr>
+template <typename Tt__,
+          typename Tn__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          std::is_integral<Tn__>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tn__>>
   foo_3(const Tt__& t, const Tn__& n, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Tn__>;
@@ -7526,8 +7460,7 @@ template <typename Tt__, typename Tn__,
     }
     }
 template <bool propto__, typename Tx__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   foo_lp(const Tx__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
@@ -7542,9 +7475,8 @@ template <bool propto__, typename Tx__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr> inline void
-  foo_4(const Tx__& x, std::ostream* pstream__) {
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  inline void foo_4(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -7561,11 +7493,10 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmax___>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmin___>>* = nullptr>
+template <typename Tx__, typename Ty__, typename Tmax___,
+          typename Tmin___, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Ty__>, stan::is_stan_scalar<Tmax___>,
+          stan::is_stan_scalar<Tmin___>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
   relative_diff(const Tx__& x, const Ty__& y, const Tmax___& max_,
                 const Tmin___& min_, std::ostream* pstream__) {
@@ -7614,11 +7545,11 @@ template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
     }
     }
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__, typename Tdata_i__,
-          stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+          typename Tdata_r__,
+          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          stan::is_col_vector<Tjob_params__>,
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   foo_5(const Tshared_params__& shared_params,
         const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -7641,12 +7572,10 @@ template <typename Tshared_params__, typename Tjob_params__,
     }
     }
 template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
-          typename Tx5__,
-          stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr>
+          typename Tx5__, stan::require_all_t<stan::is_stan_scalar<Tx1__>,
+          stan::is_stan_scalar<Tx2__>, stan::is_stan_scalar<Tx3__>,
+          stan::is_stan_scalar<Tx4__>,
+          stan::is_stan_scalar<Tx5__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
   foo_five_args(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
                 const Tx4__& x4, const Tx5__& x5, std::ostream* pstream__) {
@@ -7666,13 +7595,10 @@ template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
     }
 template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
           typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx1__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx2__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx3__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx4__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx5__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tx6__>>* = nullptr>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx1__>,
+          stan::is_stan_scalar<Tx2__>, stan::is_stan_scalar<Tx3__>,
+          stan::is_stan_scalar<Tx4__>, stan::is_stan_scalar<Tx5__>,
+          stan::is_stan_scalar<Tx6__>>* = nullptr>
   inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
                     stan::return_type_t<Tx6__>>
   foo_five_args_lp(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
@@ -7692,9 +7618,9 @@ template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tmat__, typename Tinvert__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr,
-          stan::require_t<std::is_integral<Tinvert__>>* = nullptr>
+template <typename Tmat__,
+          typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
+          std::is_integral<Tinvert__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
   covsqrt2corsqrt(const Tmat__& mat, const Tinvert__& invert,
                   std::ostream* pstream__) {
@@ -7735,19 +7661,19 @@ template <typename Tmat__, typename Tinvert__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline void
   f0(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7778,19 +7704,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline int
   f1(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7818,19 +7744,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<int>
   f2(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7858,19 +7784,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<int>>
   f3(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7898,19 +7824,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>
@@ -7940,19 +7866,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>
@@ -7982,19 +7908,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>>
@@ -8024,19 +7950,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
@@ -8066,19 +7992,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
@@ -8108,19 +8034,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
@@ -8150,19 +8076,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
@@ -8192,19 +8118,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
@@ -8234,19 +8160,19 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
     }
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
@@ -8336,8 +8262,7 @@ inline Eigen::Matrix<double, -1, 1> vecfoo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   vecmufoo(const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tmu__>;
@@ -8358,8 +8283,7 @@ template <typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
   vecmubar(const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tmu__>;
@@ -8382,11 +8306,11 @@ template <typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
-          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+template <typename Tx__, typename Ty__, typename Tdat__,
+          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+          stan::is_col_vector<Ty__>,
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
@@ -8419,11 +8343,10 @@ template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
     }
     }
 template <typename Tphi__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__,
-          stan::require_t<stan::is_col_vector<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ttheta__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
+          stan::is_col_vector<Ttheta__>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
   binomialf(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
             const Tx_i__& x_i, std::ostream* pstream__) {
@@ -8450,13 +8373,10 @@ template <typename Tphi__, typename Ttheta__, typename Tx_r__,
     }
 template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
           typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx1__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx2__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx3__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx4__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx5__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx6__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx1__>,
+          stan::is_stan_scalar<Tx2__>, stan::is_stan_scalar<Tx3__>,
+          stan::is_stan_scalar<Tx4__>, stan::is_stan_scalar<Tx5__>,
+          stan::is_stan_scalar<Tx6__>>*>
 inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
                     stan::return_type_t<Tx6__>>
 foo_five_args_lp_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
@@ -8472,19 +8392,19 @@ foo_five_args_lp_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>
@@ -8497,9 +8417,9 @@ f5_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ty__, typename Tlambda__,
-          stan::require_t<std::is_integral<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tlambda__>>*>
+template <typename Ty__,
+          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+          stan::is_stan_scalar<Tlambda__>>*>
 inline stan::return_type_t<Ty__, Tlambda__>
 foo_lcdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
@@ -8507,9 +8427,9 @@ foo_lcdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
   return foo_lcdf(y, lambda, pstream__);
 }
 
-template <typename Tmat__, typename Tinvert__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>*,
-          stan::require_t<std::is_integral<Tinvert__>>*>
+template <typename Tmat__,
+          typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
+          std::is_integral<Tinvert__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
 covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
                                       const Tinvert__& invert,
@@ -8518,7 +8438,7 @@ covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
   return covsqrt2corsqrt(mat, invert, pstream__);
 }
 
-template <typename Ta__, stan::require_t<std::is_integral<Ta__>>*>
+template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>*>
 inline int
 foo_1_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
@@ -8526,7 +8446,7 @@ foo_1_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 }
 
 template <bool propto__, typename Tu__, typename T_lp__,
-          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Tu__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tu__>>*>
 inline void
 unit_normal_lp_functor__::operator()(const Tu__& u, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -8548,19 +8468,19 @@ vecfoo_functor__::operator()(std::ostream* pstream__)  const
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>>
@@ -8574,11 +8494,9 @@ f6_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 }
 
 template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
-          typename Tx5__, stan::require_t<stan::is_stan_scalar<Tx1__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx2__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx3__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx4__>>*,
-          stan::require_t<stan::is_stan_scalar<Tx5__>>*>
+          typename Tx5__, stan::require_all_t<stan::is_stan_scalar<Tx1__>,
+          stan::is_stan_scalar<Tx2__>, stan::is_stan_scalar<Tx3__>,
+          stan::is_stan_scalar<Tx4__>, stan::is_stan_scalar<Tx5__>>*>
 inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
 foo_five_args_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
                                     const Tx3__& x3, const Tx4__& x4,
@@ -8588,7 +8506,7 @@ const
   return foo_five_args(x1, x2, x3, x4, x5, pstream__);
 }
 
-template <typename Ta__, stan::require_t<std::is_integral<Ta__>>*>
+template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>*>
 inline int
 foo_2_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
@@ -8597,19 +8515,19 @@ foo_2_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<int>>
 f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -8620,7 +8538,7 @@ f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline void
 foo_4_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -8629,19 +8547,19 @@ foo_4_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
@@ -8656,19 +8574,19 @@ f7_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
@@ -8683,19 +8601,19 @@ f11_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
@@ -8709,11 +8627,11 @@ f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 }
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
+          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
@@ -8723,9 +8641,9 @@ const
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar<Ty__>>*>
+template <typename Tx__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Tx__, Ty__>
 foo_bar2_functor__::operator()(const Tx__& x, const Ty__& y,
                                std::ostream* pstream__)  const
@@ -8739,11 +8657,11 @@ matfoo_functor__::operator()(std::ostream* pstream__)  const
   return matfoo(pstream__);
 }
 
-template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
-          stan::require_t<stan::is_col_vector<Tx__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
+template <typename Tx__, typename Ty__, typename Tdat__,
+          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+          stan::is_col_vector<Ty__>,
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
@@ -8753,9 +8671,9 @@ algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
   return algebra_system(x, y, dat, dat_int, pstream__);
 }
 
-template <typename Tmu__, typename Tsigma__, typename RNG,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>*,
-          stan::require_t<stan::is_stan_scalar<Tsigma__>>*>
+template <typename Tmu__, typename Tsigma__,
+          typename RNG, stan::require_all_t<stan::is_stan_scalar<Tmu__>,
+          stan::is_stan_scalar<Tsigma__>>*>
 inline stan::return_type_t<Tmu__, Tsigma__>
 foo_rng_functor__::operator()(const Tmu__& mu, const Tsigma__& sigma,
                               RNG& base_rng__, std::ostream* pstream__) 
@@ -8764,11 +8682,10 @@ const
   return foo_rng(mu, sigma, base_rng__, pstream__);
 }
 
-template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tmax___>>*,
-          stan::require_t<stan::is_stan_scalar<Tmin___>>*>
+template <typename Tx__, typename Ty__, typename Tmax___,
+          typename Tmin___, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Ty__>, stan::is_stan_scalar<Tmax___>,
+          stan::is_stan_scalar<Tmin___>>*>
 inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
 relative_diff_functor__::operator()(const Tx__& x, const Ty__& y,
                                     const Tmax___& max_, const Tmin___& min_,
@@ -8777,7 +8694,7 @@ relative_diff_functor__::operator()(const Tx__& x, const Ty__& y,
   return relative_diff(x, y, max_, min_, pstream__);
 }
 
-template <typename Tmu__, stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
 vecmubar_functor__::operator()(const Tmu__& mu, std::ostream* pstream__) 
 const
@@ -8787,19 +8704,19 @@ const
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline void
 f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -8810,9 +8727,9 @@ f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <bool propto__, typename Ty__, typename Tlambda__,
-          stan::require_t<std::is_integral<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tlambda__>>*>
+template <bool propto__, typename Ty__,
+          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+          stan::is_stan_scalar<Tlambda__>>*>
 inline stan::return_type_t<Ty__, Tlambda__>
 foo_lpmf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
@@ -8821,11 +8738,11 @@ foo_lpmf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
 }
 
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__, typename Tdata_i__,
-          stan::require_t<stan::is_col_vector<Tshared_params__>>*,
-          stan::require_t<stan::is_col_vector<Tjob_params__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
+          typename Tdata_r__,
+          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          stan::is_col_vector<Tjob_params__>,
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 foo_5_functor__::operator()(const Tshared_params__& shared_params,
                             const Tjob_params__& job_params,
@@ -8837,19 +8754,19 @@ foo_5_functor__::operator()(const Tshared_params__& shared_params,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>
@@ -8864,19 +8781,19 @@ f4_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
@@ -8891,19 +8808,19 @@ f10_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<int>
 f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -8916,19 +8833,19 @@ f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
@@ -8943,19 +8860,19 @@ f9_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
@@ -8968,9 +8885,9 @@ f8_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ty__, typename Tlambda__,
-          stan::require_t<std::is_integral<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tlambda__>>*>
+template <typename Ty__,
+          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
+          stan::is_stan_scalar<Tlambda__>>*>
 inline stan::return_type_t<Ty__, Tlambda__>
 foo_lccdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                 std::ostream* pstream__)  const
@@ -8978,7 +8895,7 @@ foo_lccdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
   return foo_lccdf(y, lambda, pstream__);
 }
 
-template <typename Tmu__, stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
 vecmufoo_functor__::operator()(const Tmu__& mu, std::ostream* pstream__) 
 const
@@ -8987,7 +8904,7 @@ const
 }
 
 template <bool propto__, typename Tx__, typename T_lp__,
-          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 foo_lp_functor__::operator()(const Tx__& x, T_lp__& lp__,
                              T_lp_accum__& lp_accum__,
@@ -8996,9 +8913,9 @@ foo_lp_functor__::operator()(const Tx__& x, T_lp__& lp__,
   return foo_lp<propto__>(x, lp__, lp_accum__, pstream__);
 }
 
-template <typename Tt__, typename Tn__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<std::is_integral<Tn__>>*>
+template <typename Tt__,
+          typename Tn__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          std::is_integral<Tn__>>*>
 inline std::vector<stan::return_type_t<Tt__, Tn__>>
 foo_3_functor__::operator()(const Tt__& t, const Tn__& n,
                             std::ostream* pstream__)  const
@@ -9012,10 +8929,10 @@ inline void foo_6_functor__::operator()(std::ostream* pstream__)  const
 }
 
 template <typename Tphi__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_col_vector<Tphi__>>*,
-          stan::require_t<stan::is_col_vector<Ttheta__>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
+          stan::is_col_vector<Ttheta__>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
 binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
                                 const Tx_r__& x_r, const Tx_i__& x_i,
@@ -9024,7 +8941,7 @@ binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
   return binomialf(phi, theta, x_r, x_i, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 foo_bar1_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -9033,19 +8950,19 @@ foo_bar1_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 
 template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
-          stan::require_t<std::is_integral<Ta1__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>>*,
-          stan::require_t<stan::is_stan_scalar<Ta4__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>>*,
-          stan::require_t<stan::is_col_vector<Ta7__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
+          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_stan_scalar<Ta4__>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_col_vector<Ta7__>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_eigen_matrix_dynamic<Ta10__>,
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
 inline int
 f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -9056,7 +8973,7 @@ f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Tn__, stan::require_t<std::is_integral<Tn__>>*>
+template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>*>
 inline int foo_functor__::operator()(const Tn__& n, std::ostream* pstream__) 
 const
 {
@@ -15248,46 +15165,44 @@ static constexpr std::array<const char*, 158> locations_array__ =
 
 struct sho_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-            typename Tx_int__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+            typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
+            stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
   template <typename Tx__, typename Ty__, typename Tdat__,
-            typename Tdat_int__,
-            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+            typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+            stan::is_col_vector<Ty__>,
+            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
+            stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
   template <typename Tx__, typename Txc__, typename Ttheta__,
-            typename Tx_r__, typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Txc__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            typename Tx_r__,
+            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            stan::is_stan_scalar<Txc__>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
   operator()(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct foo_functor__ {
   template <typename Tshared_params__, typename Tjob_params__,
-            typename Tdata_r__, typename Tdata_i__,
-            stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+            typename Tdata_r__,
+            typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+            stan::is_col_vector<Tjob_params__>,
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+            stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -15295,30 +15210,28 @@ struct foo_functor__ {
 };
 struct goo_functor__ {
   template <typename Tshared_params__, typename Tjob_params__,
-            typename Tdata_r__, typename Tdata_i__,
-            stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+            typename Tdata_r__,
+            typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+            stan::is_col_vector<Tjob_params__>,
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+            stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
              const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct map_rectfake_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) {
@@ -15349,12 +15262,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
     }
     }
 template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Txc__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Txc__>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
   integrand(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -15373,11 +15285,11 @@ template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__, typename Tdata_i__,
-          stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+          typename Tdata_r__,
+          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          stan::is_col_vector<Tjob_params__>,
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   foo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
       const Tdata_r__& data_r, const Tdata_i__& data_i,
@@ -15400,11 +15312,11 @@ template <typename Tshared_params__, typename Tjob_params__,
     }
     }
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__, typename Tdata_i__,
-          stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+          typename Tdata_r__,
+          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          stan::is_col_vector<Tjob_params__>,
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   goo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
       const Tdata_r__& data_r, const Tdata_i__& data_i,
@@ -15426,8 +15338,7 @@ template <typename Tshared_params__, typename Tjob_params__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   map_rectfake(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -15443,11 +15354,11 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
-          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+template <typename Tx__, typename Ty__, typename Tdat__,
+          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+          stan::is_col_vector<Ty__>,
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
@@ -15480,11 +15391,11 @@ template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
+          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
@@ -15494,11 +15405,11 @@ const
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
-          stan::require_t<stan::is_col_vector<Tx__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
+template <typename Tx__, typename Ty__, typename Tdat__,
+          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+          stan::is_col_vector<Ty__>,
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
@@ -15509,11 +15420,11 @@ algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
 }
 
 template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar<Txc__>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Txc__>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
 integrand_functor__::operator()(const Tx__& x, const Txc__& xc,
                                 const Ttheta__& theta, const Tx_r__& x_r,
@@ -15524,11 +15435,11 @@ const
 }
 
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__, typename Tdata_i__,
-          stan::require_t<stan::is_col_vector<Tshared_params__>>*,
-          stan::require_t<stan::is_col_vector<Tjob_params__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
+          typename Tdata_r__,
+          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          stan::is_col_vector<Tjob_params__>,
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 foo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
@@ -15539,11 +15450,11 @@ foo_functor__::operator()(const Tshared_params__& shared_params,
 }
 
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__, typename Tdata_i__,
-          stan::require_t<stan::is_col_vector<Tshared_params__>>*,
-          stan::require_t<stan::is_col_vector<Tjob_params__>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
+          typename Tdata_r__,
+          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          stan::is_col_vector<Tjob_params__>,
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 goo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
@@ -15553,7 +15464,7 @@ goo_functor__::operator()(const Tshared_params__& shared_params,
   return goo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 map_rectfake_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -17799,31 +17710,28 @@ static constexpr std::array<const char*, 630> locations_array__ =
  " (in 'new_integrate_interface.stan', line 2, column 47 to line 4, column 3)"};
 
 struct f_functor__ {
-  template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
+  template <typename Tt__, typename Tz__, typename Ta__,
+            typename Tb__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
+            stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
              std::ostream* pstream__) const;
 };
 struct f_odefunctor__ {
-  template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
+  template <typename Tt__, typename Tz__, typename Ta__,
+            typename Tb__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
+            stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
              const Ta__& a, const Tb__& b) const;
 };
 
-template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
+template <typename Tt__, typename Tz__, typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
+          stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
   f(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
     std::ostream* pstream__) {
@@ -17842,11 +17750,10 @@ template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*,
-          stan::require_t<stan::is_col_vector<Tb__>>*>
+template <typename Tt__, typename Tz__, typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
+          stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
 f_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
                         const Tb__& b, std::ostream* pstream__)  const
@@ -17854,11 +17761,10 @@ f_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
   return f(t, z, a, b, pstream__);
 }
 
-template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*,
-          stan::require_t<stan::is_col_vector<Tb__>>*>
+template <typename Tt__, typename Tz__, typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
+          stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
 f_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                            std::ostream* pstream__, const Ta__& a,
@@ -21644,24 +21550,22 @@ static constexpr std::array<const char*, 35> locations_array__ =
 
 struct dz_dt_functor__ {
   template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Tz__& z, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
 template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
   dz_dt(const Tt__& t, const Tz__& z, const Ttheta__& theta,
         const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -21704,11 +21608,11 @@ template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
 dz_dt_functor__::operator()(const Tt__& t, const Tz__& z,
                             const Ttheta__& theta, const Tx_r__& x_r,
@@ -24018,52 +23922,42 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'overloading_templating.stan', line 34, column 25 to line 36, column 3)"};
 
 struct foo_functor__ {
-  template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_t<stan::is_col_vector<Tp__>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_t<stan::is_row_vector<Tp__>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__,
-            stan::require_t<stan::is_stan_scalar<Tp__>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_stan_scalar<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__, stan::require_t<std::is_integral<Tp__>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<std::is_integral<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
 };
 
-template <typename Tp__, stan::require_t<std::is_integral<Tp__>>* = nullptr>
+template <typename Tp__, stan::require_all_t<std::is_integral<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24079,8 +23973,7 @@ template <typename Tp__, stan::require_t<std::is_integral<Tp__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_t<stan::is_stan_scalar<Tp__>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_stan_scalar<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24096,8 +23989,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_t<stan::is_row_vector<Tp__>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24114,8 +24006,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_t<stan::is_col_vector<Tp__>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24132,8 +24023,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24150,8 +24040,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24167,8 +24056,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24185,8 +24073,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24203,8 +24090,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24221,8 +24107,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24239,8 +24124,7 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24256,84 +24140,77 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*>
+template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_t<stan::is_col_vector<Tp__>>*>
+template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_t<stan::is_row_vector<Tp__>>*>
+template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_t<stan::is_stan_scalar<Tp__>>*>
+template <typename Tp__, stan::require_all_t<stan::is_stan_scalar<Tp__>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_t<std::is_integral<Tp__>>*>
+template <typename Tp__, stan::require_all_t<std::is_integral<Tp__>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
@@ -25484,18 +25361,17 @@ static constexpr std::array<const char*, 9> locations_array__ =
  " (in 'promotion.stan', line 6, column 28 to line 8, column 4)"};
 
 struct foo_functor__ {
-  template <typename Tzs__,
-            stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
+  template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
   inline stan::return_type_t<Tzs__>
   operator()(const Tzs__& zs, std::ostream* pstream__) const;
 };
 struct ident_functor__ {
-  template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_complex<Tx__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tx__>>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_complex<Tx__>>* = nullptr>
   inline std::complex<stan::return_type_t<Tx__>>
   ident(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -25511,8 +25387,7 @@ template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tzs__,
-          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
+template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
   inline stan::return_type_t<Tzs__>
   foo(const Tzs__& zs, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tzs__>;
@@ -25528,15 +25403,14 @@ template <typename Tzs__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tzs__,
-          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>*>
+template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>*>
 inline stan::return_type_t<Tzs__>
 foo_functor__::operator()(const Tzs__& zs, std::ostream* pstream__)  const
 {
   return foo(zs, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_complex<Tx__>>*>
 inline std::complex<stan::return_type_t<Tx__>>
 ident_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -25914,69 +25788,59 @@ static constexpr std::array<const char*, 26> locations_array__ =
 
 template <bool propto__>
   struct foo_lpdf_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Ty_slice__, typename Tstart__,
-            typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
     std::ostream* pstream__) {
@@ -26001,11 +25865,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   h(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
     const Ta__& a, std::ostream* pstream__) {
@@ -26032,10 +25894,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <bool propto__, typename Ty_slice__, typename Tstart__,
-          typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   foo_lpdf(const Ty_slice__& y_slice, const Tstart__& start,
            const Tend__& end, std::ostream* pstream__) {
@@ -26052,10 +25912,9 @@ template <bool propto__, typename Ty_slice__, typename Tstart__,
     }
     }
 template <bool propto__>
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
                                            const Tstart__& start,
@@ -26066,10 +25925,8 @@ foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
 }
 
 template <bool propto__, typename Ty_slice__, typename Tstart__,
-          typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
                                const Tstart__& start, const Tend__& end,
@@ -26078,10 +25935,9 @@ foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
   return foo_lpdf<propto__>(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                         const Tend__& end, std::ostream* pstream__)  const
@@ -26090,11 +25946,9 @@ g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__,
@@ -26103,10 +25957,9 @@ h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return h(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -26115,11 +25968,9 @@ g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 h_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                         const Tend__& end, const Ta__& a,
@@ -26717,314 +26568,281 @@ static constexpr std::array<const char*, 180> locations_array__ =
  " (in 'reduce_sum_m2.stan', line 113, column 65 to line 121, column 3)"};
 
 struct g6_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h6_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h6_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h8_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h7_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h8_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h2_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h2_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h5_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h1_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct g7_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h4_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g4_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g7_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h5_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct g8_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct h3_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h7_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h1_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h3_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h4_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ty__, typename Tstart__, typename Tend__,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27042,10 +26860,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27074,10 +26891,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27106,10 +26922,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27139,10 +26954,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27179,10 +26993,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27220,10 +27033,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27261,10 +27073,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -27302,11 +27113,10 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h1(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27326,11 +27136,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h2(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27359,11 +27168,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h3(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27392,11 +27200,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h4(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27426,11 +27233,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h5(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27466,11 +27272,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h6(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27507,11 +27312,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h7(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27548,11 +27352,10 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h8(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27589,10 +27392,9 @@ template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27600,11 +27402,10 @@ g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g6(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h6_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27613,11 +27414,10 @@ h6_functor__::operator()(const Ty__& y, const Tstart__& start,
   return h6(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27626,11 +27426,10 @@ h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h6(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h8_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27639,11 +27438,10 @@ h8_functor__::operator()(const Ty__& y, const Tstart__& start,
   return h8(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h7_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27652,11 +27450,10 @@ h7_functor__::operator()(const Ty__& y, const Tstart__& start,
   return h7(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27665,11 +27462,10 @@ h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h8(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h2_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27678,10 +27474,9 @@ h2_functor__::operator()(const Ty__& y, const Tstart__& start,
   return h2(y, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27689,11 +27484,10 @@ g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g8(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27702,10 +27496,9 @@ h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h2(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27713,10 +27506,9 @@ g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g1(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27724,10 +27516,9 @@ g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g2(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27735,10 +27526,9 @@ g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27746,11 +27536,10 @@ g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27759,10 +27548,9 @@ h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h5(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27770,11 +27558,10 @@ g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h1_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27783,10 +27570,9 @@ h1_functor__::operator()(const Ty__& y, const Tstart__& start,
   return h1(y, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27794,10 +27580,9 @@ g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g7(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27805,10 +27590,9 @@ g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g5(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27816,10 +27600,9 @@ g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g5(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27827,10 +27610,9 @@ g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g6(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27838,11 +27620,10 @@ g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g4(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27851,10 +27632,9 @@ h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h4(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27862,10 +27642,9 @@ g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g4(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27873,11 +27652,10 @@ g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g7(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h5_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27886,10 +27664,9 @@ h5_functor__::operator()(const Ty__& y, const Tstart__& start,
   return h5(y, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -27897,10 +27674,9 @@ g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g8(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -27908,11 +27684,10 @@ g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g3(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27921,11 +27696,10 @@ h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h3(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27934,11 +27708,10 @@ h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h7(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27947,11 +27720,10 @@ h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
   return h1(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h3_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27960,11 +27732,10 @@ h3_functor__::operator()(const Ty__& y, const Tstart__& start,
   return h3(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+template <typename Ty__, typename Tstart__, typename Tend__,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h4_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -29696,10 +29467,9 @@ static constexpr std::array<const char*, 342> locations_array__ =
  " (in 'reduce_sum_m3.stan', line 86, column 11 to line 149, column 3)"};
 
 struct f1a_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -29710,27 +29480,23 @@ struct s_rsfunctor__ {
             typename Te__, typename Tf__, typename Tg__, typename Th__,
             typename Ti__, typename Tj__, typename Tk__, typename Tl__,
             typename Tm__, typename Tn__, typename To__, typename Tp__,
-            typename Tq__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<std::is_integral<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
-            stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+            typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
+            stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
+            stan::is_eigen_matrix_dynamic<Te__>,
+            stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
+            stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
+            stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
+            stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
+            stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
+            stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
+            stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
+            stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
+            stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
+            stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
+            stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
+            stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                       stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                           stan::return_type_t<Th__, Ti__, Tj__,
@@ -29746,70 +29512,60 @@ struct s_rsfunctor__ {
              const Tn__& n, const To__& o, const Tp__& p, const Tq__& q) const;
 };
 struct f4_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g12_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f8_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f1a_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g10_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
@@ -29820,267 +29576,228 @@ struct r_functor__ {
 };
 struct g1_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f6_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g12_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f2_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f3_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f12_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g9_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g11_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f1_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g11_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g9_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f11_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f11_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g6_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f7_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f9_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f10_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
@@ -30091,27 +29808,23 @@ struct s_functor__ {
             typename Te__, typename Tf__, typename Tg__, typename Th__,
             typename Ti__, typename Tj__, typename Tk__, typename Tl__,
             typename Tm__, typename Tn__, typename To__, typename Tp__,
-            typename Tq__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<std::is_integral<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
-            stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+            typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
+            stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
+            stan::is_eigen_matrix_dynamic<Te__>,
+            stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
+            stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
+            stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
+            stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
+            stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
+            stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
+            stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
+            stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
+            stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
+            stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
+            stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
+            stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                       stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                           stan::return_type_t<Th__, Ti__, Tj__,
@@ -30127,163 +29840,138 @@ struct s_functor__ {
              const Tp__& p, const Tq__& q, std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f9_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g1_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g7_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g7_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g8_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f10_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr>
+  template <typename Ty_slice__, typename Tstart__,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__) const;
 };
 struct g10_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-            stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-            stan::require_t<std::is_integral<Tend__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            std::is_integral<Tstart__>, std::is_integral<Tend__>,
+            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30301,10 +29989,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f1a(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30322,10 +30009,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30343,10 +30029,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30364,10 +30049,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30385,10 +30069,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30406,10 +30089,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30427,10 +30109,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30448,10 +30129,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30469,10 +30149,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
@@ -30490,10 +30169,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30511,10 +30189,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30532,10 +30209,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
@@ -30554,11 +30230,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30577,11 +30251,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30601,11 +30273,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30625,11 +30295,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30649,11 +30317,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30672,11 +30338,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30695,11 +30359,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30718,11 +30380,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30741,11 +30401,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30764,11 +30422,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       const Ta__& a, std::ostream* pstream__) {
@@ -30787,11 +30443,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       const Ta__& a, std::ostream* pstream__) {
@@ -30810,11 +30464,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       const Ta__& a, std::ostream* pstream__) {
@@ -30837,27 +30489,23 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Te__, typename Tf__, typename Tg__, typename Th__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
-          typename Tq__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>* = nullptr,
-          stan::require_t<std::is_integral<Tstart__>>* = nullptr,
-          stan::require_t<std::is_integral<Tend__>>* = nullptr,
-          stan::require_t<std::is_integral<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
-          stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
+          stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
+          stan::is_eigen_matrix_dynamic<Te__>,
+          stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
+          stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
+          stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
+          stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
+          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
+          stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
+          stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
+          stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
+          stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
+          stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
+          stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
+          stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -31201,10 +30849,9 @@ inline double r(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1a_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31218,27 +30865,23 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Te__, typename Tf__, typename Tg__, typename Th__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
-          typename Tq__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<std::is_integral<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tb__>>*,
-          stan::require_t<stan::is_col_vector<Tc__>>*,
-          stan::require_t<stan::is_row_vector<Td__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
-          stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>*,
-          stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>*,
-          stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
+          stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
+          stan::is_eigen_matrix_dynamic<Te__>,
+          stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
+          stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
+          stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
+          stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
+          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
+          stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
+          stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
+          stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
+          stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
+          stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
+          stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
+          stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -31259,10 +30902,9 @@ s_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
            m, n, o, p, q, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31271,11 +30913,9 @@ f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__,
@@ -31284,10 +30924,9 @@ g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g12(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31295,10 +30934,9 @@ f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f5(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31307,11 +30945,9 @@ f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31320,10 +30956,9 @@ g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g8(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31332,11 +30967,9 @@ f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__,
@@ -31351,11 +30984,9 @@ inline double r_functor__::operator()(std::ostream* pstream__)  const
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31365,11 +30996,9 @@ g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_col_vector<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31378,10 +31007,9 @@ g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g2(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31390,11 +31018,9 @@ f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, const Ta__& a,
@@ -31403,10 +31029,9 @@ g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g12(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31414,10 +31039,9 @@ f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31425,10 +31049,9 @@ f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31436,10 +31059,9 @@ f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f6(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31449,11 +31071,9 @@ const
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31463,11 +31083,9 @@ g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, const Ta__& a,
@@ -31476,10 +31094,9 @@ g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g11(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31487,10 +31104,9 @@ f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f3(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31498,10 +31114,9 @@ f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31510,11 +31125,9 @@ f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__,
@@ -31524,11 +31137,9 @@ g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31538,11 +31149,9 @@ g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31552,11 +31161,9 @@ g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31565,10 +31172,9 @@ g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g4(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31576,10 +31182,9 @@ f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f11(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31588,11 +31193,9 @@ f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_row_vector<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31601,10 +31204,9 @@ g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g3(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31614,11 +31216,9 @@ const
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31627,10 +31227,9 @@ g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g6(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31638,10 +31237,9 @@ f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f7(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31649,10 +31247,9 @@ f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f9(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31661,11 +31258,9 @@ f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_col_vector<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31674,10 +31269,9 @@ g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g2(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__)  const
@@ -31690,27 +31284,23 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Te__, typename Tf__, typename Tg__, typename Th__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
-          typename Tq__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<std::is_integral<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tb__>>*,
-          stan::require_t<stan::is_col_vector<Tc__>>*,
-          stan::require_t<stan::is_row_vector<Td__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
-          stan::require_all_t<stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>>*,
-          stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>*,
-          stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
+          stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
+          stan::is_eigen_matrix_dynamic<Te__>,
+          stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
+          stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
+          stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
+          stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
+          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
+          stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
+          stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
+          stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
+          stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
+          stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
+          stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
+          stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -31731,10 +31321,9 @@ s_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
            p, q, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31743,11 +31332,9 @@ f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_row_vector<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31756,10 +31343,9 @@ g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g3(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31767,10 +31353,9 @@ f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return f9(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31779,11 +31364,9 @@ f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31793,11 +31376,9 @@ g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31807,11 +31388,9 @@ g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31821,11 +31400,9 @@ g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31834,10 +31411,9 @@ g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g5(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__)  const
@@ -31846,11 +31422,9 @@ f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31860,11 +31434,9 @@ g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31874,11 +31446,9 @@ g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31887,10 +31457,9 @@ g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
   return g8(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__) 
@@ -31899,10 +31468,9 @@ const
   return f10(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*>
+template <typename Ty_slice__, typename Tstart__,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, std::ostream* pstream__)  const
@@ -31911,11 +31479,9 @@ f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>>*,
-          stan::require_t<std::is_integral<Tstart__>>*,
-          stan::require_t<std::is_integral<Tend__>>*,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          std::is_integral<Tstart__>, std::is_integral<Tend__>,
+          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, const Ta__& a,
@@ -33938,28 +33504,28 @@ static constexpr std::array<const char*, 52> locations_array__ =
  " (in 'shadowing.stan', line 2, column 43 to line 6, column 3)"};
 
 struct rhs_odefunctor__ {
-  template <typename Tt__, typename Ty__, typename Talpha__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Talpha__>>* = nullptr>
+  template <typename Tt__, typename Ty__,
+            typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Ty__>,
+            stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
              const Talpha__& alpha) const;
 };
 struct rhs_functor__ {
-  template <typename Tt__, typename Ty__, typename Talpha__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Talpha__>>* = nullptr>
+  template <typename Tt__, typename Ty__,
+            typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Ty__>,
+            stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, const Talpha__& alpha,
              std::ostream* pstream__) const;
 };
 
-template <typename Tt__, typename Ty__, typename Talpha__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Talpha__>>* = nullptr>
+template <typename Tt__, typename Ty__,
+          typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>,
+          stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
   rhs(const Tt__& t, const Ty__& y, const Talpha__& alpha,
       std::ostream* pstream__) {
@@ -33982,10 +33548,9 @@ template <typename Tt__, typename Ty__, typename Talpha__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Ty__, typename Talpha__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Talpha__>>*>
+template <typename Tt__, typename Ty__,
+          typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
 rhs_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                              std::ostream* pstream__, const Talpha__& alpha) 
@@ -33994,10 +33559,9 @@ const
   return rhs(t, y, alpha, pstream__);
 }
 
-template <typename Tt__, typename Ty__, typename Talpha__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Talpha__>>*>
+template <typename Tt__, typename Ty__,
+          typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
 rhs_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Talpha__& alpha, std::ostream* pstream__) 
@@ -34971,47 +34535,45 @@ static constexpr std::array<const char*, 13> locations_array__ =
 
 struct foo4_lp_functor__ {
   template <bool propto__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo0_lpmf_functor__ {
-  template <bool propto__, typename Ty__,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr>
+  template <bool propto__,
+            typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo1_lpmf_functor__ {
-  template <bool propto__, typename Ty__,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr>
+  template <bool propto__,
+            typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo2_lpdf_functor__ {
-  template <bool propto__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+  template <bool propto__,
+            typename Ty__, stan::require_all_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo3_lpdf_functor__ {
-  template <bool propto__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+  template <bool propto__,
+            typename Ty__, stan::require_all_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo5_lp_functor__ {
   template <bool propto__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   operator()(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename Ty__,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo0_lpmf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35025,8 +34587,8 @@ template <bool propto__, typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo1_lpmf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35041,8 +34603,7 @@ template <bool propto__, typename Ty__,
     }
     }
 template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr>
+          typename T_lp_accum__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo4_lp(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -35057,8 +34618,8 @@ template <bool propto__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo2_lpdf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35072,8 +34633,8 @@ template <bool propto__, typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo3_lpdf(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
@@ -35088,8 +34649,7 @@ template <bool propto__, typename Ty__,
     }
     }
 template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Ty__>
   foo5_lp(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -35105,7 +34665,7 @@ template <bool propto__, typename Ty__, typename T_lp__,
     }
     }
 template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_t<std::is_integral<Ty__>>*>
+          typename T_lp_accum__, stan::require_all_t<std::is_integral<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo4_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -35114,8 +34674,8 @@ foo4_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
   return foo4_lp<propto__>(y, lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__, typename Ty__,
-          stan::require_t<std::is_integral<Ty__>>*>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo0_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35123,8 +34683,8 @@ const
   return foo0_lpmf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename Ty__,
-          stan::require_t<std::is_integral<Ty__>>*>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo1_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35132,8 +34692,8 @@ const
   return foo1_lpmf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Ty__>>*>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo2_lpdf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35141,8 +34701,8 @@ const
   return foo2_lpdf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Ty__>>*>
+template <bool propto__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo3_lpdf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
@@ -35151,7 +34711,7 @@ const
 }
 
 template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Ty__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Ty__>
 foo5_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -38983,14 +38543,12 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'udf_tilde_stmt_conflict.stan', line 2, column 22 to line 4, column 3)"};
 
 struct normal_functor__ {
-  template <typename Ta__,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename Ta__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   normal(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -39006,7 +38564,7 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_t<stan::is_stan_scalar<Ta__>>*>
+template <typename Ta__, stan::require_all_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ta__>
 normal_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
@@ -39334,16 +38892,16 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'user_constrain.stan', line 2, column 36 to line 4, column 3)"};
 
 struct lb_constrain_functor__ {
-  template <typename Tx__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+  template <typename Tx__,
+            typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   operator()(const Tx__& x, const Ty__& y, std::ostream* pstream__) const;
 };
 
-template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ty__>>* = nullptr>
+template <typename Tx__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Ty__>>* = nullptr>
   inline stan::return_type_t<Tx__, Ty__>
   lb_constrain(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -39359,9 +38917,9 @@ template <typename Tx__, typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar<Ty__>>*>
+template <typename Tx__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Ty__>>*>
 inline stan::return_type_t<Tx__, Ty__>
 lb_constrain_functor__::operator()(const Tx__& x, const Ty__& y,
                                    std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1218,62 +1218,67 @@ static constexpr std::array<const char*, 427> locations_array__ =
  " (in 'complex_scalar.stan', line 33, column 45 to line 35, column 3)"};
 
 struct foo8_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
-             std::ostream* pstream__) const;
+  template <typename Tz__,
+            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  inline stan::return_type_t<Tz__>
+  operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::complex<T0__>& z, std::ostream* pstream__) const;
+  template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+  inline stan::return_type_t<Tz__>
+  operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo4_functor__ {
-  std::vector<std::complex<double>>
+  inline std::vector<std::complex<double>>
   operator()(std::ostream* pstream__) const;
 };
 struct foo6_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::complex<stan::promote_args_t<T0__>>>
-  operator()(const T0__& r, std::ostream* pstream__) const;
+  template <typename Tr__,
+            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+  inline std::vector<std::complex<stan::return_type_t<Tr__>>>
+  operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo10_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
-  operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
-             std::ostream* pstream__) const;
+  template <typename Tz__,
+            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
+  operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::complex<stan::promote_args_t<T0__>>
-  operator()(const T0__& r, std::ostream* pstream__) const;
+  template <typename Tr__,
+            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+  inline std::complex<stan::return_type_t<Tr__>>
+  operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo9_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
-  operator()(const T0__& r, std::ostream* pstream__) const;
+  template <typename Tr__,
+            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+  inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
+  operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::complex<stan::promote_args_t<T0__>>
-  operator()(const std::complex<T0__>& z, std::ostream* pstream__) const;
+  template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+  inline std::complex<stan::return_type_t<Tz__>>
+  operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo7_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::complex<stan::promote_args_t<T0__>>>
-  operator()(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) const;
+  template <typename Tz__,
+            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  inline std::vector<std::complex<stan::return_type_t<Tz__>>>
+  operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo5_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) const;
+  template <typename Tz__,
+            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  inline stan::return_type_t<Tz__>
+  operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  std::complex<double>
+  inline std::complex<double>
   operator()(std::ostream* pstream__) const;
 };
 
-std::complex<double> foo(std::ostream* pstream__) {
+inline std::complex<double> foo(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -1287,10 +1292,10 @@ std::complex<double> foo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo1(const std::complex<T0__>& z, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+  inline stan::return_type_t<Tz__>
+  foo1(const Tz__& z, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tz__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1303,10 +1308,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::complex<stan::promote_args_t<T0__>>
-  foo2(const T0__& r, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tr__,
+          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+  inline std::complex<stan::return_type_t<Tr__>>
+  foo2(const Tr__& r, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tr__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1319,10 +1325,10 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::complex<stan::promote_args_t<T0__>>
-  foo3(const std::complex<T0__>& z, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>* = nullptr>
+  inline std::complex<stan::return_type_t<Tz__>>
+  foo3(const Tz__& z, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tz__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1335,7 +1341,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-std::vector<std::complex<double>> foo4(std::ostream* pstream__) {
+inline std::vector<std::complex<double>> foo4(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -1350,10 +1356,11 @@ std::vector<std::complex<double>> foo4(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo5(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  inline stan::return_type_t<Tz__>
+  foo5(const Tz__& z, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tz__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1366,10 +1373,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::complex<stan::promote_args_t<T0__>>>
-  foo6(const T0__& r, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tr__,
+          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+  inline std::vector<std::complex<stan::return_type_t<Tr__>>>
+  foo6(const Tr__& r, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tr__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1383,10 +1391,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::complex<stan::promote_args_t<T0__>>>
-  foo7(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  inline std::vector<std::complex<stan::return_type_t<Tz__>>>
+  foo7(const Tz__& z, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tz__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1399,11 +1408,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo8(const std::vector<std::vector<std::complex<T0__>>>& z,
-       std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  inline stan::return_type_t<Tz__>
+  foo8(const Tz__& z, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tz__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1416,10 +1425,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
-  foo9(const T0__& r, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tr__,
+          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr>
+  inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
+  foo9(const Tr__& r, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tr__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1438,11 +1448,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
-  foo10(const std::vector<std::vector<std::complex<T0__>>>& z,
-        std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
+  foo10(const Tz__& z, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tz__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1455,83 +1465,81 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo8_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
-                           std::ostream* pstream__)  const
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
+inline stan::return_type_t<Tz__>
+foo8_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo8(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo1_functor__::operator()(const std::complex<T0__>& z,
-                           std::ostream* pstream__)  const
+template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>*>
+inline stan::return_type_t<Tz__>
+foo1_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo1(z, pstream__);
 }
 
-std::vector<std::complex<double>>
+inline std::vector<std::complex<double>>
 foo4_functor__::operator()(std::ostream* pstream__)  const
 {
   return foo4(pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::vector<std::complex<stan::promote_args_t<T0__>>>
-foo6_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
+template <typename Tr__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*>
+inline std::vector<std::complex<stan::return_type_t<Tr__>>>
+foo6_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
   return foo6(r, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
-foo10_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
-                            std::ostream* pstream__)  const
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
+inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
+foo10_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo10(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::complex<stan::promote_args_t<T0__>>
-foo2_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
+template <typename Tr__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*>
+inline std::complex<stan::return_type_t<Tr__>>
+foo2_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
   return foo2(r, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
-foo9_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
+template <typename Tr__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*>
+inline std::vector<std::vector<std::complex<stan::return_type_t<Tr__>>>>
+foo9_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
 {
   return foo9(r, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::complex<stan::promote_args_t<T0__>>
-foo3_functor__::operator()(const std::complex<T0__>& z,
-                           std::ostream* pstream__)  const
+template <typename Tz__, stan::require_t<stan::is_complex<Tz__>>*>
+inline std::complex<stan::return_type_t<Tz__>>
+foo3_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo3(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::vector<std::complex<stan::promote_args_t<T0__>>>
-foo7_functor__::operator()(const std::vector<std::complex<T0__>>& z,
-                           std::ostream* pstream__)  const
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
+inline std::vector<std::complex<stan::return_type_t<Tz__>>>
+foo7_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo7(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo5_functor__::operator()(const std::vector<std::complex<T0__>>& z,
-                           std::ostream* pstream__)  const
+template <typename Tz__,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
+inline stan::return_type_t<Tz__>
+foo5_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo5(z, pstream__);
 }
 
-std::complex<double> foo_functor__::operator()(std::ostream* pstream__) 
-const
+inline std::complex<double>
+foo_functor__::operator()(std::ostream* pstream__)  const
 {
   return foo(pstream__);
 }
@@ -3734,62 +3742,77 @@ static constexpr std::array<const char*, 75> locations_array__ =
  " (in 'cpp-reserved-words.stan', line 14, column 17 to column 19)"};
 
 struct _stan_asm_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& _stan_class, std::ostream* pstream__) const;
+  template <typename T_stan_class__,
+            stan::require_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
+  inline void
+  operator()(const T_stan_class__& _stan_class, std::ostream* pstream__) const;
 };
 struct _stan_char16_t_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_bitor_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_bitand_functor__ {
-  void
-  operator()(const int& _stan_constexpr, std::ostream* pstream__) const;
+  template <typename T_stan_constexpr__,
+            stan::require_t<stan::is_stan_scalar_t<T_stan_constexpr__>>* = nullptr>
+  inline void
+  operator()(const T_stan_constexpr__& _stan_constexpr, std::ostream* pstream__) const;
 };
 struct _stan_catch_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_alignas_functor__ {
-  void
-  operator()(const int& _stan_asm, std::ostream* pstream__) const;
+  template <typename T_stan_asm__,
+            stan::require_t<stan::is_stan_scalar_t<T_stan_asm__>>* = nullptr>
+  inline void
+  operator()(const T_stan_asm__& _stan_asm, std::ostream* pstream__) const;
 };
 struct _stan_alignof_functor__ {
-  void
-  operator()(const int& _stan_char, std::ostream* pstream__) const;
+  template <typename T_stan_char__,
+            stan::require_t<stan::is_stan_scalar_t<T_stan_char__>>* = nullptr>
+  inline void
+  operator()(const T_stan_char__& _stan_char, std::ostream* pstream__) const;
 };
 struct _stan_and_eq_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) const;
+  template <typename T_stan_STAN_MINOR__,
+            stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MINOR__>>* = nullptr>
+  inline void
+  operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
+             std::ostream* pstream__) const;
 };
 struct _stan_and_functor__ {
-  void
-  operator()(const int& _stan_STAN_MAJOR, std::ostream* pstream__) const;
+  template <typename T_stan_STAN_MAJOR__,
+            stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MAJOR__>>* = nullptr>
+  inline void
+  operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
+             std::ostream* pstream__) const;
 };
 struct _stan_char_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_char32_t_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_bool_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_case_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 
-void _stan_alignas(const int& _stan_asm, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename T_stan_asm__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_asm__>>* = nullptr>
+  inline void
+  _stan_alignas(const T_stan_asm__& _stan_asm, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<T_stan_asm__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3801,8 +3824,11 @@ void _stan_alignas(const int& _stan_asm, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_alignof(const int& _stan_char, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename T_stan_char__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_char__>>* = nullptr>
+  inline void
+  _stan_alignof(const T_stan_char__& _stan_char, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<T_stan_char__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3814,8 +3840,12 @@ void _stan_alignof(const int& _stan_char, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_and(const int& _stan_STAN_MAJOR, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename T_stan_STAN_MAJOR__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MAJOR__>>* = nullptr>
+  inline void
+  _stan_and(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
+            std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<T_stan_STAN_MAJOR__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3827,9 +3857,12 @@ void _stan_and(const int& _stan_STAN_MAJOR, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
-  _stan_and_eq(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename T_stan_STAN_MINOR__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MINOR__>>* = nullptr>
+  inline void
+  _stan_and_eq(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
+               std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<T_stan_STAN_MINOR__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3841,9 +3874,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr> void
-  _stan_asm(const T0__& _stan_class_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename T_stan_class__,
+          stan::require_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
+  inline void
+  _stan_asm(const T_stan_class__& _stan_class, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<T_stan_class__>;
     int current_statement__ = 0; 
     const auto& _stan_class = stan::math::to_ref(_stan_class_arg__);
     static constexpr bool propto__ = true;
@@ -3856,7 +3891,24 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr> void
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_bitand(const int& _stan_constexpr, std::ostream* pstream__) {
+template <typename T_stan_constexpr__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_constexpr__>>* = nullptr>
+  inline void
+  _stan_bitand(const T_stan_constexpr__& _stan_constexpr,
+               std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<T_stan_constexpr__>;
+    int current_statement__ = 0; 
+    static constexpr bool propto__ = true;
+    (void) propto__;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    (void) DUMMY_VAR__;  // suppress unused var warning
+    try {
+      
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+    }
+inline void _stan_bitor(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -3869,7 +3921,7 @@ void _stan_bitand(const int& _stan_constexpr, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_bitor(std::ostream* pstream__) {
+inline void _stan_bool(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -3882,7 +3934,7 @@ void _stan_bitor(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_bool(std::ostream* pstream__) {
+inline void _stan_case(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -3895,7 +3947,7 @@ void _stan_bool(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_case(std::ostream* pstream__) {
+inline void _stan_catch(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -3908,7 +3960,7 @@ void _stan_case(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_catch(std::ostream* pstream__) {
+inline void _stan_char(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -3921,7 +3973,7 @@ void _stan_catch(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_char(std::ostream* pstream__) {
+inline void _stan_char16_t(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -3934,7 +3986,7 @@ void _stan_char(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_char16_t(std::ostream* pstream__) {
+inline void _stan_char32_t(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -3947,94 +3999,93 @@ void _stan_char16_t(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void _stan_char32_t(std::ostream* pstream__) {
-    using local_scalar_t__ = double;
-    int current_statement__ = 0; 
-    static constexpr bool propto__ = true;
-    (void) propto__;
-    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
-    (void) DUMMY_VAR__;  // suppress unused var warning
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
-    }
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-void
-_stan_asm_functor__::operator()(const T0__& _stan_class,
+template <typename T_stan_class__,
+          stan::require_t<stan::is_col_vector<T_stan_class__>>*>
+inline void
+_stan_asm_functor__::operator()(const T_stan_class__& _stan_class,
                                 std::ostream* pstream__)  const
 {
   return _stan_asm(_stan_class, pstream__);
 }
 
-void _stan_char16_t_functor__::operator()(std::ostream* pstream__)  const
+inline void _stan_char16_t_functor__::operator()(std::ostream* pstream__) 
+const
 {
   return _stan_char16_t(pstream__);
 }
 
-void _stan_bitor_functor__::operator()(std::ostream* pstream__)  const
+inline void _stan_bitor_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_bitor(pstream__);
 }
 
-void
-_stan_bitand_functor__::operator()(const int& _stan_constexpr,
+template <typename T_stan_constexpr__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_constexpr__>>*>
+inline void
+_stan_bitand_functor__::operator()(const T_stan_constexpr__& _stan_constexpr,
                                    std::ostream* pstream__)  const
 {
   return _stan_bitand(_stan_constexpr, pstream__);
 }
 
-void _stan_catch_functor__::operator()(std::ostream* pstream__)  const
+inline void _stan_catch_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_catch(pstream__);
 }
 
-void
-_stan_alignas_functor__::operator()(const int& _stan_asm,
+template <typename T_stan_asm__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_asm__>>*>
+inline void
+_stan_alignas_functor__::operator()(const T_stan_asm__& _stan_asm,
                                     std::ostream* pstream__)  const
 {
   return _stan_alignas(_stan_asm, pstream__);
 }
 
-void
-_stan_alignof_functor__::operator()(const int& _stan_char,
+template <typename T_stan_char__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_char__>>*>
+inline void
+_stan_alignof_functor__::operator()(const T_stan_char__& _stan_char,
                                     std::ostream* pstream__)  const
 {
   return _stan_alignof(_stan_char, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-void
-_stan_and_eq_functor__::operator()(const T0__& _stan_STAN_MINOR,
+template <typename T_stan_STAN_MINOR__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MINOR__>>*>
+inline void
+_stan_and_eq_functor__::operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
                                    std::ostream* pstream__)  const
 {
   return _stan_and_eq(_stan_STAN_MINOR, pstream__);
 }
 
-void
-_stan_and_functor__::operator()(const int& _stan_STAN_MAJOR,
+template <typename T_stan_STAN_MAJOR__,
+          stan::require_t<stan::is_stan_scalar_t<T_stan_STAN_MAJOR__>>*>
+inline void
+_stan_and_functor__::operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
                                 std::ostream* pstream__)  const
 {
   return _stan_and(_stan_STAN_MAJOR, pstream__);
 }
 
-void _stan_char_functor__::operator()(std::ostream* pstream__)  const
+inline void _stan_char_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_char(pstream__);
 }
 
-void _stan_char32_t_functor__::operator()(std::ostream* pstream__)  const
+inline void _stan_char32_t_functor__::operator()(std::ostream* pstream__) 
+const
 {
   return _stan_char32_t(pstream__);
 }
 
-void _stan_bool_functor__::operator()(std::ostream* pstream__)  const
+inline void _stan_bool_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_bool(pstream__);
 }
 
-void _stan_case_functor__::operator()(std::ostream* pstream__)  const
+inline void _stan_case_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_case(pstream__);
 }
@@ -6462,518 +6513,551 @@ static constexpr std::array<const char*, 787> locations_array__ =
  " (in 'mother.stan', line 345, column 41 to line 349, column 3)"};
 
 struct foo_five_args_lp_functor__ {
-  template <bool propto__, typename T0__, typename T1__, typename T2__,
-            typename T3__, typename T4__, typename T5__, typename T_lp__,
+  template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
+            typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
-  operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
-             const T4__& x5, const T5__& x6, T_lp__& lp__,
+            stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx6__>>* = nullptr>
+  inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
+                      stan::return_type_t<Tx6__>>
+  operator()(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
+             const Tx4__& x4, const Tx5__& x5, const Tx6__& x6, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct f5_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lcdf_functor__ {
-  template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
+  template <typename Ty__, typename Tlambda__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tlambda__>
+  operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct covsqrt2corsqrt_functor__ {
-  template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  operator()(const T0__& mat, const int& invert, std::ostream* pstream__) const;
+  template <typename Tmat__, typename Tinvert__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tinvert__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
+  operator()(const Tmat__& mat, const Tinvert__& invert,
+             std::ostream* pstream__) const;
 };
 struct foo_1_functor__ {
-  int
-  operator()(const int& a, std::ostream* pstream__) const;
+  template <typename Ta__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline int
+  operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct unit_normal_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Tu__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
+            stan::require_t<stan::is_stan_scalar_t<Tu__>>* = nullptr>
+  inline void
+  operator()(const Tu__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo_bar0_functor__ {
-  double
+  inline double
   operator()(std::ostream* pstream__) const;
 };
 struct vecfoo_functor__ {
-  Eigen::Matrix<double, -1, 1>
+  inline Eigen::Matrix<double, -1, 1>
   operator()(std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_five_args_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
-  operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
-             const T4__& x5, std::ostream* pstream__) const;
+  template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
+            typename Tx5__,
+            stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr>
+  inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
+  operator()(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
+             const Tx4__& x4, const Tx5__& x5, std::ostream* pstream__) const;
 };
 struct foo_2_functor__ {
-  int
-  operator()(const int& a, std::ostream* pstream__) const;
+  template <typename Ta__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline int
+  operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<int>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<int>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline void
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>, -1, 1>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f11_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>, -1, -1>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>, -1, -1>>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct sho_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__>>
-  operator()(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<double>& x,
-             const std::vector<int>& x_int, std::ostream* pstream__) const;
+  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
+            typename Tx_int__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+  operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
 };
 struct foo_bar2_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
+  template <typename Tx__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Ty__>
+  operator()(const Tx__& x, const Ty__& y, std::ostream* pstream__) const;
 };
 struct matfoo_functor__ {
-  Eigen::Matrix<double, -1, -1>
+  inline Eigen::Matrix<double, -1, -1>
   operator()(std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
-             const std::vector<int>& dat_int, std::ostream* pstream__) const;
+  template <typename Tx__, typename Ty__, typename Tdat__,
+            typename Tdat_int__,
+            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+  operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
+             const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
-  template <typename T0__, typename T1__, typename RNG,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& mu, const T1__& sigma, RNG& base_rng__,
+  template <typename Tmu__, typename Tsigma__, typename RNG,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tsigma__>>* = nullptr>
+  inline stan::return_type_t<Tmu__, Tsigma__>
+  operator()(const Tmu__& mu, const Tsigma__& sigma, RNG& base_rng__,
              std::ostream* pstream__) const;
 };
 struct relative_diff_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__>
-  operator()(const T0__& x, const T1__& y, const T2__& max_, const T3__& min_,
-             std::ostream* pstream__) const;
+  template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmax___>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmin___>>* = nullptr>
+  inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
+  operator()(const Tx__& x, const Ty__& y, const Tmax___& max_,
+             const Tmin___& min_, std::ostream* pstream__) const;
 };
 struct vecmubar_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
-  operator()(const T0__& mu, std::ostream* pstream__) const;
+  template <typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
+  operator()(const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct f0_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  void
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline void
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lpmf_functor__ {
-  template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__, typename Tlambda__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tlambda__>
+  operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct foo_5_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
-  operator()(const T0__& shared_params, const T1__& job_params,
-             const std::vector<double>& data_r, const std::vector<int>& data_i,
-             std::ostream* pstream__) const;
+  template <typename Tshared_params__, typename Tjob_params__,
+            typename Tdata_r__, typename Tdata_i__,
+            stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+  operator()(const Tshared_params__& shared_params,
+             const Tjob_params__& job_params, const Tdata_r__& data_r,
+             const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f10_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>, -1, -1>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<int>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<int>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f9_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>, -1, 1>>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                       stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                            T10__, T11__>>, -1, 1>>
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lccdf_functor__ {
-  template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
+  template <typename Ty__, typename Tlambda__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tlambda__>
+  operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct vecmufoo_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
-  operator()(const T0__& mu, std::ostream* pstream__) const;
+  template <typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
+  operator()(const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Tx__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo_3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__>>
-  operator()(const T0__& t, const int& n, std::ostream* pstream__) const;
+  template <typename Tt__, typename Tn__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Tn__>>
+  operator()(const Tt__& t, const Tn__& n, std::ostream* pstream__) const;
 };
 struct foo_6_functor__ {
-  void
+  inline void
   operator()(std::ostream* pstream__) const;
 };
 struct binomialf_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
-  operator()(const T0__& phi, const T1__& theta,
-             const std::vector<double>& x_r, const std::vector<int>& x_i,
-             std::ostream* pstream__) const;
+  template <typename Tphi__, typename Ttheta__, typename Tx_r__,
+            typename Tx_i__,
+            stan::require_t<stan::is_col_vector<Tphi__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ttheta__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
+  operator()(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
+             const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
-  int
-  operator()(const int& a1, const std::vector<int>& a2,
-             const std::vector<std::vector<int>>& a3, const T3__& a4,
-             const std::vector<T4__>& a5,
-             const std::vector<std::vector<T5__>>& a6, const T6__& a7,
-             const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-             const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-             const T9__& a10,
-             const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-             const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
+  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+            typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__,
+            stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline int
+  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  int
-  operator()(const int& n, std::ostream* pstream__) const;
+  template <typename Tn__,
+            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+  inline int
+  operator()(const Tn__& n, std::ostream* pstream__) const;
 };
 
-int foo(const int& n, std::ostream* pstream__) ; 
-int foo(const int& n, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Tn__, stan::require_t<stan::is_stan_scalar_t<Tn__>>*>
+  inline int foo(const Tn__& n, std::ostream* pstream__) ; 
+template <typename Tn__,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+  inline int foo(const Tn__& n, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tn__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -6991,23 +7075,27 @@ int foo(const int& n, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__>>
-  sho(const T0__& t, const std::vector<T1__>& y,
-      const std::vector<T2__>& theta, const std::vector<double>& x,
-      const std::vector<int>& x_int, std::ostream* pstream__) ; 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__>>
-  sho(const T0__& t, const std::vector<T1__>& y,
-      const std::vector<T2__>& theta, const std::vector<double>& x,
-      const std::vector<int>& x_int, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__>;
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
+          typename Tx_int__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>*>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+  sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
+      const Tx_int__& x_int, std::ostream* pstream__) ; 
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
+          typename Tx_int__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+  sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
+      const Tx_int__& x_int, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7032,7 +7120,7 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double foo_bar0(std::ostream* pstream__) {
+inline double foo_bar0(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -7046,10 +7134,11 @@ double foo_bar0(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo_bar1(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  foo_bar1(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7062,12 +7151,12 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+template <typename Tx__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Ty__>
+  foo_bar2(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7080,11 +7169,12 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  foo_lpmf(const int& y, const T1__& lambda, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T1__>;
+template <bool propto__, typename Ty__, typename Tlambda__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tlambda__>
+  foo_lpmf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -7095,10 +7185,12 @@ template <bool propto__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T1__>;
+template <typename Ty__, typename Tlambda__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tlambda__>
+  foo_lcdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7111,10 +7203,12 @@ template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T1__>;
+template <typename Ty__, typename Tlambda__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tlambda__>
+  foo_lccdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7127,13 +7221,13 @@ template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename RNG,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  foo_rng(const T0__& mu, const T1__& sigma, RNG& base_rng__,
+template <typename Tmu__, typename Tsigma__, typename RNG,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tsigma__>>* = nullptr>
+  inline stan::return_type_t<Tmu__, Tsigma__>
+  foo_rng(const Tmu__& mu, const Tsigma__& sigma, RNG& base_rng__,
           std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+    using local_scalar_t__ = stan::return_type_t<Tmu__, Tsigma__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7146,12 +7240,13 @@ template <typename T0__, typename T1__, typename RNG,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Tu__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tu__>>* = nullptr>
+  inline void
+  unit_normal_lp(const Tu__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Tu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -7164,8 +7259,10 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int foo_1(const int& a, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline int foo_1(const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7388,8 +7485,10 @@ int foo_1(const int& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int foo_2(const int& a, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline int foo_2(const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7415,10 +7514,12 @@ int foo_2(const int& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__>>
-  foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tt__, typename Tn__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Tn__>>
+  foo_3(const Tt__& t, const Tn__& n, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tt__, Tn__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7431,12 +7532,13 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  foo_lp(const Tx__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -7447,9 +7549,10 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
-  foo_4(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline void foo_4(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7465,15 +7568,16 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__>
-  relative_diff(const T0__& x, const T1__& y, const T2__& max_,
-                const T3__& min_, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmax___>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmin___>>* = nullptr>
+  inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
+  relative_diff(const Tx__& x, const Ty__& y, const Tmax___& max_,
+                const Tmin___& min_, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7516,16 +7620,19 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
-  foo_5(const T0__& shared_params_arg__, const T1__& job_params_arg__,
-        const std::vector<double>& data_r, const std::vector<int>& data_i,
-        std::ostream* pstream__) {
+template <typename Tshared_params__, typename Tjob_params__,
+          typename Tdata_r__, typename Tdata_i__,
+          stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+  foo_5(const Tshared_params__& shared_params,
+        const Tjob_params__& job_params, const Tdata_r__& data_r,
+        const Tdata_i__& data_i, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
+                                Tdata_i__>;
     int current_statement__ = 0; 
     const auto& shared_params = stan::math::to_ref(shared_params_arg__);
     const auto& job_params = stan::math::to_ref(job_params_arg__);
@@ -7540,17 +7647,18 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
-  foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3,
-                const T3__& x4, const T4__& x5, std::ostream* pstream__) {
+template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
+          typename Tx5__,
+          stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr>
+  inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
+  foo_five_args(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
+                const Tx4__& x4, const Tx5__& x5, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>;
+            stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7563,23 +7671,24 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__, typename T2__,
-          typename T3__, typename T4__, typename T5__, typename T_lp__,
+template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
+          typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
-  foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
-                   const T3__& x4, const T4__& x5, const T5__& x6,
+          stan::require_t<stan::is_stan_scalar_t<Tx1__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx2__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx3__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx4__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx5__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tx6__>>* = nullptr>
+  inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
+                    stan::return_type_t<Tx6__>>
+  foo_five_args_lp(const Tx1__& x1, const Tx2__& x2, const Tx3__& x3,
+                   const Tx4__& x4, const Tx5__& x5, const Tx6__& x6,
                    T_lp__& lp__, T_lp_accum__& lp_accum__,
                    std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, T1__, T2__, T3__, T4__,
-                                 stan::promote_args_t<T5__>>;
+            stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
+                                stan::return_type_t<Tx6__>>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -7590,12 +7699,13 @@ template <bool propto__, typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  covsqrt2corsqrt(const T0__& mat_arg__, const int& invert,
+template <typename Tmat__, typename Tinvert__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tinvert__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
+  covsqrt2corsqrt(const Tmat__& mat, const Tinvert__& invert,
                   std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+    using local_scalar_t__ = stan::return_type_t<Tmat__, Tinvert__>;
     int current_statement__ = 0; 
     const auto& mat = stan::math::to_ref(mat_arg__);
     static constexpr bool propto__ = true;
@@ -7630,32 +7740,32 @@ template <typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr> void
-  f0(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline void
+  f0(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7673,32 +7783,32 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr> int
-  f1(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline int
+  f1(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7713,32 +7823,32 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr> std::vector<int>
-  f2(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<int>
+  f2(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7753,33 +7863,32 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<int>>
-  f3(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<int>>
+  f3(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7794,35 +7903,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>
-  f4(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>
+  f4(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7837,35 +7945,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>>
-  f5(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>>
+  f5(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7880,35 +7987,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>>>
-  f6(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>>>
+  f6(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7923,35 +8029,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, 1>
-  f7(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
+  f7(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7966,35 +8071,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, 1>>
-  f8(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
+  f8(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8009,35 +8113,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, 1>>>
-  f9(const int& a1, const std::vector<int>& a2,
-     const std::vector<std::vector<int>>& a3, const T3__& a4,
-     const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-     const T6__& a7_arg__, const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-     const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-     const T9__& a10_arg__,
-     const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-     const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-     std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
+  f9(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+     const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8052,36 +8155,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, -1>
-  f10(const int& a1, const std::vector<int>& a2,
-      const std::vector<std::vector<int>>& a3, const T3__& a4,
-      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-      const T6__& a7_arg__,
-      const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-      const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-      const T9__& a10_arg__,
-      const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-      const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-      std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
+  f10(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+      const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+      const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8096,36 +8197,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, -1>>
-  f11(const int& a1, const std::vector<int>& a2,
-      const std::vector<std::vector<int>>& a3, const T3__& a4,
-      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-      const T6__& a7_arg__,
-      const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-      const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-      const T9__& a10_arg__,
-      const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-      const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-      std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
+  f11(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+      const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+      const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8140,36 +8239,34 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, -1>>>
-  f12(const int& a1, const std::vector<int>& a2,
-      const std::vector<std::vector<int>>& a3, const T3__& a4,
-      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
-      const T6__& a7_arg__,
-      const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-      const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-      const T9__& a10_arg__,
-      const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-      const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-      std::ostream* pstream__) {
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta7__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
+  f12(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
+      const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
+      const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>,
-                                 T7__,
-                                 stan::promote_args_t<T8__,
-                                                      stan::value_type_t<T9__>,
-                                                      T10__, T11__>>;
+            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
+                                                    Ta9__, Ta10__,
+                                                    stan::return_type_t<
+                                                    Ta11__, Ta12__>>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8184,7 +8281,7 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-void foo_6(std::ostream* pstream__) {
+inline void foo_6(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -8213,7 +8310,7 @@ void foo_6(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-Eigen::Matrix<double, -1, -1> matfoo(std::ostream* pstream__) {
+inline Eigen::Matrix<double, -1, -1> matfoo(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -8231,7 +8328,7 @@ Eigen::Matrix<double, -1, -1> matfoo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-Eigen::Matrix<double, -1, 1> vecfoo(std::ostream* pstream__) {
+inline Eigen::Matrix<double, -1, 1> vecfoo(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -8246,10 +8343,11 @@ Eigen::Matrix<double, -1, 1> vecfoo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
-  vecmufoo(const T0__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
+  vecmufoo(const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tmu__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -8267,10 +8365,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
-  vecmubar(const T0__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
+  vecmubar(const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tmu__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -8290,17 +8389,16 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  algebra_system(const T0__& x_arg__, const T1__& y_arg__,
-                 const std::vector<T2__>& dat,
-                 const std::vector<int>& dat_int, std::ostream* pstream__) {
+template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
+          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+  algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
+                 const Tdat_int__& dat_int, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>, T2__>;
+            stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     const auto& y = stan::math::to_ref(y_arg__);
@@ -8327,16 +8425,17 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
-  binomialf(const T0__& phi_arg__, const T1__& theta_arg__,
-            const std::vector<double>& x_r, const std::vector<int>& x_i,
-            std::ostream* pstream__) {
+template <typename Tphi__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__,
+          stan::require_t<stan::is_col_vector<Tphi__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ttheta__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
+  binomialf(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
+            const Tx_i__& x_i, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+            stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
     const auto& phi = stan::math::to_ref(phi_arg__);
     const auto& theta = stan::math::to_ref(theta_arg__);
@@ -8356,18 +8455,20 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__, typename T2__,
-          typename T3__, typename T4__, typename T5__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*>
-stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
-foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
-                                       const T2__& x3, const T3__& x4,
-                                       const T4__& x5, const T5__& x6,
+template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
+          typename Tx4__, typename Tx5__, typename Tx6__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx1__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx2__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx3__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx4__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx5__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx6__>>*>
+inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__,
+                    stan::return_type_t<Tx6__>>
+foo_five_args_lp_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
+                                       const Tx3__& x3, const Tx4__& x4,
+                                       const Tx5__& x5, const Tx6__& x6,
                                        T_lp__& lp__,
                                        T_lp_accum__& lp_accum__,
                                        std::ostream* pstream__)  const
@@ -8376,596 +8477,597 @@ foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
            pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>>
-f5_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>>
+f5_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T1__, stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T1__>
-foo_lcdf_functor__::operator()(const int& y, const T1__& lambda,
+template <typename Ty__, typename Tlambda__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>*>
+inline stan::return_type_t<Ty__, Tlambda__>
+foo_lcdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
 {
   return foo_lcdf(y, lambda, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-covsqrt2corsqrt_functor__::operator()(const T0__& mat, const int& invert,
+template <typename Tmat__, typename Tinvert__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tmat__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tinvert__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
+covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
+                                      const Tinvert__& invert,
                                       std::ostream* pstream__)  const
 {
   return covsqrt2corsqrt(mat, invert, pstream__);
 }
 
-int foo_1_functor__::operator()(const int& a, std::ostream* pstream__)  const
+template <typename Ta__, stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline int
+foo_1_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
   return foo_1(a, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-void
-unit_normal_lp_functor__::operator()(const T0__& u, T_lp__& lp__,
+template <bool propto__, typename Tu__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tu__>>*>
+inline void
+unit_normal_lp_functor__::operator()(const Tu__& u, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
   return unit_normal_lp<propto__>(u, lp__, lp_accum__, pstream__);
 }
 
-double foo_bar0_functor__::operator()(std::ostream* pstream__)  const
+inline double foo_bar0_functor__::operator()(std::ostream* pstream__)  const
 {
   return foo_bar0(pstream__);
 }
 
-Eigen::Matrix<double, -1, 1>
+inline Eigen::Matrix<double, -1, 1>
 vecfoo_functor__::operator()(std::ostream* pstream__)  const
 {
   return vecfoo(pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>>>
-f6_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>>>
+f6_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f6(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*>
-stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
-foo_five_args_functor__::operator()(const T0__& x1, const T1__& x2,
-                                    const T2__& x3, const T3__& x4,
-                                    const T4__& x5, std::ostream* pstream__) 
+template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
+          typename Tx5__, stan::require_t<stan::is_stan_scalar_t<Tx1__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx2__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx3__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx4__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tx5__>>*>
+inline stan::return_type_t<Tx1__, Tx2__, Tx3__, Tx4__, Tx5__>
+foo_five_args_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
+                                    const Tx3__& x3, const Tx4__& x4,
+                                    const Tx5__& x5, std::ostream* pstream__) 
 const
 {
   return foo_five_args(x1, x2, x3, x4, x5, pstream__);
 }
 
-int foo_2_functor__::operator()(const int& a, std::ostream* pstream__)  const
+template <typename Ta__, stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline int
+foo_2_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
   return foo_2(a, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<std::vector<int>>
-f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<std::vector<int>>
+f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-void foo_4_functor__::operator()(const T0__& x, std::ostream* pstream__) 
-const
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline void
+foo_4_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return foo_4(x, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, 1>
-f7_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
+f7_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f7(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, -1>>
-f11_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                          const std::vector<std::vector<int>>& a3,
-                          const T3__& a4, const std::vector<T4__>& a5,
-                          const std::vector<std::vector<T5__>>& a6,
-                          const T6__& a7,
-                          const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                          const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                          const T9__& a10,
-                          const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                          const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                          std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
+f11_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                          const Ta10__& a10, const Ta11__& a11,
+                          const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, -1>>>
-f12_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                          const std::vector<std::vector<int>>& a3,
-                          const T3__& a4, const std::vector<T4__>& a5,
-                          const std::vector<std::vector<T5__>>& a6,
-                          const T6__& a7,
-                          const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                          const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                          const T9__& a10,
-                          const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                          const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                          std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
+f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                          const Ta10__& a10, const Ta11__& a11,
+                          const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-std::vector<stan::promote_args_t<T0__, T1__, T2__>>
-sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
-                          const std::vector<T2__>& theta,
-                          const std::vector<double>& x,
-                          const std::vector<int>& x_int,
-                          std::ostream* pstream__)  const
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
+          typename Tx_int__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+sho_functor__::operator()(const Tt__& t, const Ty__& y,
+                          const Ttheta__& theta, const Tx__& x,
+                          const Tx_int__& x_int, std::ostream* pstream__) 
+const
 {
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-foo_bar2_functor__::operator()(const T0__& x, const T1__& y,
+template <typename Tx__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Tx__, Ty__>
+foo_bar2_functor__::operator()(const Tx__& x, const Ty__& y,
                                std::ostream* pstream__)  const
 {
   return foo_bar2(x, y, pstream__);
 }
 
-Eigen::Matrix<double, -1, -1>
+inline Eigen::Matrix<double, -1, -1>
 matfoo_functor__::operator()(std::ostream* pstream__)  const
 {
   return matfoo(pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-algebra_system_functor__::operator()(const T0__& x, const T1__& y,
-                                     const std::vector<T2__>& dat,
-                                     const std::vector<int>& dat_int,
+template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
+          stan::require_t<stan::is_col_vector<Tx__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
+                                     const Tdat__& dat,
+                                     const Tdat_int__& dat_int,
                                      std::ostream* pstream__)  const
 {
   return algebra_system(x, y, dat, dat_int, pstream__);
 }
 
-template <typename T0__, typename T1__, typename RNG,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-foo_rng_functor__::operator()(const T0__& mu, const T1__& sigma,
+template <typename Tmu__, typename Tsigma__, typename RNG,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tsigma__>>*>
+inline stan::return_type_t<Tmu__, Tsigma__>
+foo_rng_functor__::operator()(const Tmu__& mu, const Tsigma__& sigma,
                               RNG& base_rng__, std::ostream* pstream__) 
 const
 {
   return foo_rng(mu, sigma, base_rng__, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T1__, T2__, T3__>
-relative_diff_functor__::operator()(const T0__& x, const T1__& y,
-                                    const T2__& max_, const T3__& min_,
+template <typename Tx__, typename Ty__, typename Tmax___, typename Tmin___,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmax___>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmin___>>*>
+inline stan::return_type_t<Tx__, Ty__, Tmax___, Tmin___>
+relative_diff_functor__::operator()(const Tx__& x, const Ty__& y,
+                                    const Tmax___& max_, const Tmin___& min_,
                                     std::ostream* pstream__)  const
 {
   return relative_diff(x, y, max_, min_, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
-vecmubar_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
+template <typename Tmu__, stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
+vecmubar_functor__::operator()(const Tmu__& mu, std::ostream* pstream__) 
 const
 {
   return vecmubar(mu, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-void
-f0_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline void
+f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T1__>
-foo_lpmf_functor__::operator()(const int& y, const T1__& lambda,
+template <bool propto__, typename Ty__, typename Tlambda__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>*>
+inline stan::return_type_t<Ty__, Tlambda__>
+foo_lpmf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
 {
   return foo_lpmf<propto__>(y, lambda, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
-          stan::require_col_vector_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
-foo_5_functor__::operator()(const T0__& shared_params,
-                            const T1__& job_params,
-                            const std::vector<double>& data_r,
-                            const std::vector<int>& data_i,
+template <typename Tshared_params__, typename Tjob_params__,
+          typename Tdata_r__, typename Tdata_i__,
+          stan::require_t<stan::is_col_vector<Tshared_params__>>*,
+          stan::require_t<stan::is_col_vector<Tjob_params__>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+foo_5_functor__::operator()(const Tshared_params__& shared_params,
+                            const Tjob_params__& job_params,
+                            const Tdata_r__& data_r, const Tdata_i__& data_i,
                             std::ostream* pstream__)  const
 {
   return foo_5(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>
-f4_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>
+f4_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f4(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, -1>
-f10_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                          const std::vector<std::vector<int>>& a3,
-                          const T3__& a4, const std::vector<T4__>& a5,
-                          const std::vector<std::vector<T5__>>& a6,
-                          const T6__& a7,
-                          const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                          const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                          const T9__& a10,
-                          const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                          const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                          std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
+f10_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                          const Ta10__& a10, const Ta11__& a11,
+                          const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<int>
-f2_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<int>
+f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f2(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, 1>>>
-f9_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
+f9_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f9(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
-                     stan::promote_args_t<T8__, stan::value_type_t<T9__>,
-                                          T10__, T11__>>, -1, 1>>
-f8_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
+                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
+                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
+f8_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T1__, stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T1__>
-foo_lccdf_functor__::operator()(const int& y, const T1__& lambda,
+template <typename Ty__, typename Tlambda__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tlambda__>>*>
+inline stan::return_type_t<Ty__, Tlambda__>
+foo_lccdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
                                 std::ostream* pstream__)  const
 {
   return foo_lccdf(y, lambda, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
-vecmufoo_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
+template <typename Tmu__, stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tmu__>, -1, 1>
+vecmufoo_functor__::operator()(const Tmu__& mu, std::ostream* pstream__) 
 const
 {
   return vecmufoo(mu, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_lp_functor__::operator()(const T0__& x, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+foo_lp_functor__::operator()(const Tx__& x, T_lp__& lp__,
                              T_lp_accum__& lp_accum__,
                              std::ostream* pstream__)  const
 {
   return foo_lp<propto__>(x, lp__, lp_accum__, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::vector<stan::promote_args_t<T0__>>
-foo_3_functor__::operator()(const T0__& t, const int& n,
+template <typename Tt__, typename Tn__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>*>
+inline std::vector<stan::return_type_t<Tt__, Tn__>>
+foo_3_functor__::operator()(const Tt__& t, const Tn__& n,
                             std::ostream* pstream__)  const
 {
   return foo_3(t, n, pstream__);
 }
 
-void foo_6_functor__::operator()(std::ostream* pstream__)  const
+inline void foo_6_functor__::operator()(std::ostream* pstream__)  const
 {
   return foo_6(pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
-          stan::require_col_vector_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
-binomialf_functor__::operator()(const T0__& phi, const T1__& theta,
-                                const std::vector<double>& x_r,
-                                const std::vector<int>& x_i,
+template <typename Tphi__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__, stan::require_t<stan::is_col_vector<Tphi__>>*,
+          stan::require_t<stan::is_col_vector<Ttheta__>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
+binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
+                                const Tx_r__& x_r, const Tx_i__& x_i,
                                 std::ostream* pstream__)  const
 {
   return binomialf(phi, theta, x_r, x_i, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_bar1_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+foo_bar1_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return foo_bar1(x, pstream__);
 }
 
-template <typename T3__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
-int
-f1_functor__::operator()(const int& a1, const std::vector<int>& a2,
-                         const std::vector<std::vector<int>>& a3,
-                         const T3__& a4, const std::vector<T4__>& a5,
-                         const std::vector<std::vector<T5__>>& a6,
-                         const T6__& a7,
-                         const std::vector<Eigen::Matrix<T7__, -1, 1>>& a8,
-                         const std::vector<std::vector<Eigen::Matrix<T8__, -1, 1>>>& a9,
-                         const T9__& a10,
-                         const std::vector<Eigen::Matrix<T10__, -1, -1>>& a11,
-                         const std::vector<std::vector<Eigen::Matrix<T11__, -1, -1>>>& a12,
-                         std::ostream* pstream__)  const
+template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
+          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
+          typename Ta9__, typename Ta10__, typename Ta11__, typename Ta12__,
+          stan::require_t<stan::is_stan_scalar_t<Ta1__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta2__>, stan::is_stan_scalar_t<value_type_t<Ta2__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta3__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta4__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta5__>, stan::is_stan_scalar_t<value_type_t<Ta5__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta6__>>>>*,
+          stan::require_t<stan::is_col_vector<Ta7__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta10__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+inline int
+f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+                         const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
+template <typename Tn__, stan::require_t<stan::is_stan_scalar_t<Tn__>>*>
+inline int foo_functor__::operator()(const Tn__& n, std::ostream* pstream__) 
+const
 {
   return foo(n, pstream__);
 }
@@ -15154,72 +15256,83 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'motherHOF.stan', line 25, column 45 to line 30, column 3)"};
 
 struct sho_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  operator()(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x,
-             const std::vector<int>& x_int, std::ostream* pstream__) const;
+  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
+            typename Tx_int__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+  operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
-             const std::vector<int>& dat_int, std::ostream* pstream__) const;
+  template <typename Tx__, typename Ty__, typename Tdat__,
+            typename Tdat_int__,
+            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+  operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
+             const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__>
-  operator()(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
-             const std::vector<T3__>& x_r, const std::vector<int>& x_i,
-             std::ostream* pstream__) const;
+  template <typename Tx__, typename Txc__, typename Ttheta__,
+            typename Tx_r__, typename Tx_i__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Txc__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
+  operator()(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& shared_params, const T1__& job_params,
-             const std::vector<T2__>& data_r, const std::vector<int>& data_i,
-             std::ostream* pstream__) const;
+  template <typename Tshared_params__, typename Tjob_params__,
+            typename Tdata_r__, typename Tdata_i__,
+            stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+  operator()(const Tshared_params__& shared_params,
+             const Tjob_params__& job_params, const Tdata_r__& data_r,
+             const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct goo_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& shared_params, const T1__& job_params,
-             const std::vector<T2__>& data_r, const std::vector<int>& data_i,
-             std::ostream* pstream__) const;
+  template <typename Tshared_params__, typename Tjob_params__,
+            typename Tdata_r__, typename Tdata_i__,
+            stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+  operator()(const Tshared_params__& shared_params,
+             const Tjob_params__& job_params, const Tdata_r__& data_r,
+             const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct map_rectfake_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  sho(const T0__& t, const std::vector<T1__>& y,
-      const std::vector<T2__>& theta, const std::vector<T3__>& x,
-      const std::vector<int>& x_int, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
+          typename Tx_int__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+  sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
+      const Tx_int__& x_int, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15244,16 +15357,18 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T1__, T2__, T3__>
-  integrand(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
-            const std::vector<T3__>& x_r, const std::vector<int>& x_i,
-            std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Txc__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
+  integrand(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
+            const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15266,17 +15381,19 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  foo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
-      const std::vector<T2__>& data_r, const std::vector<int>& data_i,
+template <typename Tshared_params__, typename Tjob_params__,
+          typename Tdata_r__, typename Tdata_i__,
+          stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+  foo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
+      const Tdata_r__& data_r, const Tdata_i__& data_i,
       std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>, T2__>;
+            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
+                                Tdata_i__>;
     int current_statement__ = 0; 
     const auto& shared_params = stan::math::to_ref(shared_params_arg__);
     const auto& job_params = stan::math::to_ref(job_params_arg__);
@@ -15291,17 +15408,19 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  goo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
-      const std::vector<T2__>& data_r, const std::vector<int>& data_i,
+template <typename Tshared_params__, typename Tjob_params__,
+          typename Tdata_r__, typename Tdata_i__,
+          stan::require_t<stan::is_col_vector<Tshared_params__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tjob_params__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+  goo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
+      const Tdata_r__& data_r, const Tdata_i__& data_i,
       std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>, T2__>;
+            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
+                                Tdata_i__>;
     int current_statement__ = 0; 
     const auto& shared_params = stan::math::to_ref(shared_params_arg__);
     const auto& job_params = stan::math::to_ref(job_params_arg__);
@@ -15316,10 +15435,11 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  map_rectfake(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  map_rectfake(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15332,17 +15452,16 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-  algebra_system(const T0__& x_arg__, const T1__& y_arg__,
-                 const std::vector<T2__>& dat,
-                 const std::vector<int>& dat_int, std::ostream* pstream__) {
+template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
+          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+  algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
+                 const Tdat_int__& dat_int, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>, T2__>;
+            stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     const auto& y = stan::math::to_ref(y_arg__);
@@ -15369,78 +15488,83 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
-                          const std::vector<T2__>& theta,
-                          const std::vector<T3__>& x,
-                          const std::vector<int>& x_int,
-                          std::ostream* pstream__)  const
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
+          typename Tx_int__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx__>, stan::is_stan_scalar_t<value_type_t<Tx__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_int__>, stan::is_stan_scalar_t<value_type_t<Tx_int__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+sho_functor__::operator()(const Tt__& t, const Ty__& y,
+                          const Ttheta__& theta, const Tx__& x,
+                          const Tx_int__& x_int, std::ostream* pstream__) 
+const
 {
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-algebra_system_functor__::operator()(const T0__& x, const T1__& y,
-                                     const std::vector<T2__>& dat,
-                                     const std::vector<int>& dat_int,
+template <typename Tx__, typename Ty__, typename Tdat__, typename Tdat_int__,
+          stan::require_t<stan::is_col_vector<Tx__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_all_t<stan::is_std_vector<Tdat__>, stan::is_stan_scalar_t<value_type_t<Tdat__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdat_int__>, stan::is_stan_scalar_t<value_type_t<Tdat_int__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
+                                     const Tdat__& dat,
+                                     const Tdat_int__& dat_int,
                                      std::ostream* pstream__)  const
 {
   return algebra_system(x, y, dat, dat_int, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T1__, T2__, T3__>
-integrand_functor__::operator()(const T0__& x, const T1__& xc,
-                                const std::vector<T2__>& theta,
-                                const std::vector<T3__>& x_r,
-                                const std::vector<int>& x_i,
-                                std::ostream* pstream__)  const
+template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Txc__>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
+integrand_functor__::operator()(const Tx__& x, const Txc__& xc,
+                                const Ttheta__& theta, const Tx_r__& x_r,
+                                const Tx_i__& x_i, std::ostream* pstream__) 
+const
 {
   return integrand(x, xc, theta, x_r, x_i, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-foo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
-                          const std::vector<T2__>& data_r,
-                          const std::vector<int>& data_i,
+template <typename Tshared_params__, typename Tjob_params__,
+          typename Tdata_r__, typename Tdata_i__,
+          stan::require_t<stan::is_col_vector<Tshared_params__>>*,
+          stan::require_t<stan::is_col_vector<Tjob_params__>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+foo_functor__::operator()(const Tshared_params__& shared_params,
+                          const Tjob_params__& job_params,
+                          const Tdata_r__& data_r, const Tdata_i__& data_i,
                           std::ostream* pstream__)  const
 {
   return foo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
-goo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
-                          const std::vector<T2__>& data_r,
-                          const std::vector<int>& data_i,
+template <typename Tshared_params__, typename Tjob_params__,
+          typename Tdata_r__, typename Tdata_i__,
+          stan::require_t<stan::is_col_vector<Tshared_params__>>*,
+          stan::require_t<stan::is_col_vector<Tjob_params__>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar_t<value_type_t<Tdata_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tdata_i__>, stan::is_stan_scalar_t<value_type_t<Tdata_i__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+goo_functor__::operator()(const Tshared_params__& shared_params,
+                          const Tjob_params__& job_params,
+                          const Tdata_r__& data_r, const Tdata_i__& data_i,
                           std::ostream* pstream__)  const
 {
   return goo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-map_rectfake_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+map_rectfake_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return map_rectfake(x, pstream__);
@@ -17684,40 +17808,35 @@ static constexpr std::array<const char*, 630> locations_array__ =
  " (in 'new_integrate_interface.stan', line 2, column 47 to line 4, column 3)"};
 
 struct f_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
-                       stan::value_type_t<T3__>>, -1, 1>
-  operator()(const T0__& t, const T1__& z, const T2__& a, const T3__& b,
+  template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
              std::ostream* pstream__) const;
 };
 struct f_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
-                       stan::value_type_t<T3__>>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
-             const T2__& a, const T3__& b) const;
+  template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
+             const Ta__& a, const Tb__& b) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_col_vector_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
-                     stan::value_type_t<T3__>>, -1, 1>
-  f(const T0__& t, const T1__& z_arg__, const T2__& a, const T3__& b_arg__,
+template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tb__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
+  f(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
     std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
-                                 stan::value_type_t<T3__>>;
+    using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Ta__, Tb__>;
     int current_statement__ = 0; 
     const auto& z = stan::math::to_ref(z_arg__);
     const auto& b = stan::math::to_ref(b_arg__);
@@ -17732,29 +17851,27 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_col_vector_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
-                     stan::value_type_t<T3__>>, -1, 1>
-f_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
-                        const T3__& b, std::ostream* pstream__)  const
+template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_col_vector<Tb__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
+f_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
+                        const Tb__& b, std::ostream* pstream__)  const
 {
   return f(t, z, a, b, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_col_vector_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
-                     stan::value_type_t<T3__>>, -1, 1>
-f_odefunctor__::operator()(const T0__& t, const T1__& z,
-                           std::ostream* pstream__, const T2__& a,
-                           const T3__& b)  const
+template <typename Tt__, typename Tz__, typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_col_vector<Tb__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
+f_odefunctor__::operator()(const Tt__& t, const Tz__& z,
+                           std::ostream* pstream__, const Ta__& a,
+                           const Tb__& b)  const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -21535,27 +21652,30 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'old_integrate_interface.stan', line 7, column 38 to line 19, column 3)"};
 
 struct dz_dt_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  operator()(const T0__& t, const std::vector<T1__>& z,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) const;
+  template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
+            typename Tx_i__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar_t<value_type_t<Tz__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
+  operator()(const Tt__& t, const Tz__& z, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  dz_dt(const T0__& t, const std::vector<T1__>& z,
-        const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-        const std::vector<int>& x_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar_t<value_type_t<Tz__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
+  dz_dt(const Tt__& t, const Tz__& z, const Ttheta__& theta,
+        const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -21592,17 +21712,17 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-dz_dt_functor__::operator()(const T0__& t, const std::vector<T1__>& z,
-                            const std::vector<T2__>& theta,
-                            const std::vector<T3__>& x_r,
-                            const std::vector<int>& x_i,
-                            std::ostream* pstream__)  const
+template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_stan_scalar_t<value_type_t<Tz__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
+dz_dt_functor__::operator()(const Tt__& t, const Tz__& z,
+                            const Ttheta__& theta, const Tx_r__& x_r,
+                            const Tx_i__& x_i, std::ostream* pstream__) 
+const
 {
   return dz_dt(t, z, theta, x_r, x_i, pstream__);
 }
@@ -23907,45 +24027,57 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'overloading_templating.stan', line 34, column 25 to line 36, column 3)"};
 
 struct foo_functor__ {
-  double
-  operator()(const std::vector<int>& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<T0__>>& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
-             std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
-             std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
-             std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& p, std::ostream* pstream__) const;
-  template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  stan::promote_args_t<stan::value_type_t<T0__>>
-  operator()(const T0__& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  stan::promote_args_t<stan::value_type_t<T0__>>
-  operator()(const T0__& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr>
-  stan::promote_args_t<stan::value_type_t<T0__>>
-  operator()(const T0__& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& p, std::ostream* pstream__) const;
-  double
-  operator()(const int& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_t<stan::is_col_vector<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_t<stan::is_row_vector<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
+  template <typename Tp__,
+            stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  operator()(const Tp__& p, std::ostream* pstream__) const;
 };
 
-double foo(const int& p, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Tp__,
+          stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -23958,9 +24090,11 @@ double foo(const int& p, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__> foo(const T0__& p, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tp__,
+          stan::require_t<stan::is_stan_scalar_t<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -23973,10 +24107,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr>
-  stan::promote_args_t<stan::value_type_t<T0__>>
-  foo(const T0__& p_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tp__,
+          stan::require_t<stan::is_row_vector<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     static constexpr bool propto__ = true;
@@ -23990,10 +24125,11 @@ template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  stan::promote_args_t<stan::value_type_t<T0__>>
-  foo(const T0__& p_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tp__,
+          stan::require_t<stan::is_col_vector<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     static constexpr bool propto__ = true;
@@ -24007,11 +24143,11 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  stan::promote_args_t<stan::value_type_t<T0__>>
-  foo(const T0__& p_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tp__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     static constexpr bool propto__ = true;
@@ -24025,10 +24161,11 @@ template <typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo(const std::vector<T0__>& p, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24041,11 +24178,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
-      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24059,11 +24196,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
-      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24077,11 +24214,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
-      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24095,10 +24232,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo(const std::vector<std::vector<T0__>>& p, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24112,8 +24250,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double foo(const std::vector<int>& p, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>* = nullptr>
+  inline stan::return_type_t<Tp__>
+  foo(const Tp__& p, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24126,83 +24267,86 @@ double foo(const std::vector<int>& p, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double
-foo_functor__::operator()(const std::vector<int>& p, std::ostream* pstream__) 
-const
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_functor__::operator()(const std::vector<std::vector<T0__>>& p,
-                          std::ostream* pstream__)  const
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tp__>>>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
-                          std::ostream* pstream__)  const
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
-                          std::ostream* pstream__)  const
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
-                          std::ostream* pstream__)  const
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_functor__::operator()(const std::vector<T0__>& p, std::ostream* pstream__) 
-const
+template <typename Tp__,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar_t<value_type_t<Tp__>>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
-stan::promote_args_t<stan::value_type_t<T0__>>
-foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+template <typename Tp__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-stan::promote_args_t<stan::value_type_t<T0__>>
-foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+template <typename Tp__, stan::require_t<stan::is_col_vector<Tp__>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_row_vector_t<T0__>*>
-stan::promote_args_t<stan::value_type_t<T0__>>
-foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+template <typename Tp__, stan::require_t<stan::is_row_vector<Tp__>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
+template <typename Tp__, stan::require_t<stan::is_stan_scalar_t<Tp__>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-double foo_functor__::operator()(const int& p, std::ostream* pstream__) 
-const
+template <typename Tp__, stan::require_t<stan::is_stan_scalar_t<Tp__>>*>
+inline stan::return_type_t<Tp__>
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
@@ -25351,20 +25495,21 @@ static constexpr std::array<const char*, 9> locations_array__ =
  " (in 'promotion.stan', line 6, column 28 to line 8, column 4)"};
 
 struct foo_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& zs, std::ostream* pstream__) const;
+  template <typename Tzs__,
+            stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar_t<value_type_t<Tzs__>>>* = nullptr>
+  inline stan::return_type_t<Tzs__>
+  operator()(const Tzs__& zs, std::ostream* pstream__) const;
 };
 struct ident_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::complex<stan::promote_args_t<T0__>>
-  operator()(const std::complex<T0__>& x, std::ostream* pstream__) const;
+  template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>* = nullptr>
+  inline std::complex<stan::return_type_t<Tx__>>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  std::complex<stan::promote_args_t<T0__>>
-  ident(const std::complex<T0__>& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>* = nullptr>
+  inline std::complex<stan::return_type_t<Tx__>>
+  ident(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25377,10 +25522,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo(const std::vector<T0__>& zs, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tzs__,
+          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar_t<value_type_t<Tzs__>>>* = nullptr>
+  inline stan::return_type_t<Tzs__>
+  foo(const Tzs__& zs, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tzs__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25393,18 +25539,17 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_functor__::operator()(const std::vector<T0__>& zs,
-                          std::ostream* pstream__)  const
+template <typename Tzs__,
+          stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar_t<value_type_t<Tzs__>>>*>
+inline stan::return_type_t<Tzs__>
+foo_functor__::operator()(const Tzs__& zs, std::ostream* pstream__)  const
 {
   return foo(zs, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-std::complex<stan::promote_args_t<T0__>>
-ident_functor__::operator()(const std::complex<T0__>& x,
-                            std::ostream* pstream__)  const
+template <typename Tx__, stan::require_t<stan::is_complex<Tx__>>*>
+inline std::complex<stan::return_type_t<Tx__>>
+ident_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return ident(x, pstream__);
 }
@@ -25780,54 +25925,74 @@ static constexpr std::array<const char*, 26> locations_array__ =
 
 template <bool propto__>
   struct foo_lpdf_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <bool propto__, typename Ty_slice__, typename Tstart__,
+            typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<T3__>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const std::vector<T3__>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g(const std::vector<T0__>& y_slice, const int& start, const int& end,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
     std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25846,13 +26011,17 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h(const std::vector<T0__>& y_slice, const int& start, const int& end,
-    const std::vector<T3__>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  h(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+    const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25873,12 +26042,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo_lpdf(const std::vector<T0__>& y_slice, const int& start,
-           const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <bool propto__, typename Ty_slice__, typename Tstart__,
+          typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  foo_lpdf(const Ty_slice__& y_slice, const Tstart__& start,
+           const Tend__& end, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25890,55 +26063,77 @@ template <bool propto__, typename T0__,
     }
     }
 template <bool propto__>
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
-                                           const int& start, const int& end,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
+                                           const Tstart__& start,
+                                           const Tend__& end,
                                            std::ostream* pstream__)  const
 {
   return foo_lpdf<propto__>(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo_lpdf_functor__::operator()(const std::vector<T0__>& y_slice,
-                               const int& start, const int& end,
+template <bool propto__, typename Ty_slice__, typename Tstart__,
+          typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
+                               const Tstart__& start, const Tend__& end,
                                std::ostream* pstream__)  const
 {
   return foo_lpdf<propto__>(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                        const int& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                        const Tend__& end, std::ostream* pstream__)  const
 {
   return g(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                          const int& end, std::ostream* pstream__,
-                          const std::vector<T3__>& a)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, std::ostream* pstream__,
+                          const Ta__& a)  const
 {
   return h(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                          const int& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, std::ostream* pstream__)  const
 {
   return g(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                        const int& end, const std::vector<T3__>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+h_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                        const Tend__& end, const Ta__& a,
                         std::ostream* pstream__)  const
 {
   return h(y_slice, start, end, a, pstream__);
@@ -26533,247 +26728,319 @@ static constexpr std::array<const char*, 180> locations_array__ =
  " (in 'reduce_sum_m2.stan', line 113, column 65 to line 121, column 3)"};
 
 struct g6_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h6_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct h6_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct h8_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct h7_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct h8_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct h2_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h2_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__,
-             const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h5_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__, const std::vector<std::vector<T3__>>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h1_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<T3__>& a, std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g7_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h4_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__,
-             const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g4_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g7_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h5_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g8_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct h3_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__,
-             const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct h7_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__,
-             const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct h1_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             std::ostream* pstream__, const std::vector<T3__>& a) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct h3_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct h4_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y, const int& start, const int& end,
-             const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26786,11 +27053,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26814,11 +27085,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26842,11 +27117,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26871,11 +27150,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
-     const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26907,11 +27190,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26944,11 +27231,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26981,11 +27272,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  g8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27018,13 +27313,16 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h1(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<T3__>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h1(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27039,14 +27337,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h2(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h2(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27070,14 +27370,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h3(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h3(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27101,14 +27403,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h4(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h4(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27133,13 +27437,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h5(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h5(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27170,14 +27477,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h6(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h6(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27209,14 +27518,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h7(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h7(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27248,14 +27559,16 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  h8(const std::vector<T0__>& y, const int& start, const int& end,
-     const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+  h8(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27287,317 +27600,385 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g6(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h6_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end,
-                         const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h6_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h6(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h6_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) 
-const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h6(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h8_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end,
-                         const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h8_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h8(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h7_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end,
-                         const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h7_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h7(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h8_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) 
-const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h8(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h2_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end,
-                         const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h2_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h2(y, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g8(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h2_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) 
-const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h2(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g1(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g2(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h5_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<std::vector<T3__>>& a)  const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h5(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h1_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end, const std::vector<T3__>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h1_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h1(y, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g7(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g5(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g5(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g6(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g4(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h4_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) 
-const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h4(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g4(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g7(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h5_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end,
-                         const std::vector<std::vector<T3__>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h5_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h5(y, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return g8(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-g3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return g3(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h3_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) 
-const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h3(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h7_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) 
-const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h7(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h1_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
-                           const int& end, std::ostream* pstream__,
-                           const std::vector<T3__>& a)  const
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return h1(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h3_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end,
-                         const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h3_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h3(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-h4_functor__::operator()(const std::vector<T0__>& y, const int& start,
-                         const int& end,
-                         const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
+template <typename Ty__, typename Tstart__, typename Tend__, typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
+h4_functor__::operator()(const Ty__& y, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return h4(y, start, end, a, pstream__);
@@ -29326,455 +29707,599 @@ static constexpr std::array<const char*, 342> locations_array__ =
  " (in 'reduce_sum_m3.stan', line 86, column 11 to line 149, column 3)"};
 
 struct f1a_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct s_rsfunctor__ {
-  template <typename T0__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T9__, typename T10__, typename T11__,
-            typename T12__, typename T14__, typename T15__, typename T16__,
-            typename T17__, typename T19__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_row_vector_t<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr,
-            stan::require_stan_scalar_t<T12__>* = nullptr,
-            stan::require_stan_scalar_t<T14__>* = nullptr,
-            stan::require_stan_scalar_t<T15__>* = nullptr,
-            stan::require_stan_scalar_t<T16__>* = nullptr,
-            stan::require_stan_scalar_t<T17__>* = nullptr,
-            stan::require_stan_scalar_t<T19__>* = nullptr>
-  stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
-                       stan::value_type_t<T6__>, stan::value_type_t<T7__>,
-                       stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
-                                            stan::promote_args_t<T15__, T16__,
-                                                                 T17__, T19__>>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__, const int& a,
-             const T4__& b, const T5__& c, const T6__& d, const T7__& e,
-             const std::vector<int>& f, const std::vector<T9__>& g,
-             const std::vector<Eigen::Matrix<T10__, -1, 1>>& h,
-             const std::vector<Eigen::Matrix<T11__, 1, -1>>& i,
-             const std::vector<Eigen::Matrix<T12__, -1, -1>>& j,
-             const std::vector<std::vector<int>>& k,
-             const std::vector<std::vector<T14__>>& l,
-             const std::vector<std::vector<Eigen::Matrix<T15__, -1, 1>>>& m,
-             const std::vector<std::vector<Eigen::Matrix<T16__, 1, -1>>>& n,
-             const std::vector<std::vector<Eigen::Matrix<T17__, -1, -1>>>& o,
-             const std::vector<std::vector<std::vector<int>>>& p,
-             const std::vector<std::vector<std::vector<T19__>>>& q) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__, typename Tb__, typename Tc__, typename Td__,
+            typename Te__, typename Tf__, typename Tg__, typename Th__,
+            typename Ti__, typename Tj__, typename Tk__, typename Tl__,
+            typename Tm__, typename Tn__, typename To__, typename Tp__,
+            typename Tq__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
+            stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
+                      stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
+                                          stan::return_type_t<Th__, Ti__, Tj__,
+                                                              Tk__, Tl__,
+                                                              stan::return_type_t<
+                                                              Tm__, Tn__, To__,
+                                                              Tp__, Tq__>>>>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a,
+             const Tb__& b, const Tc__& c, const Td__& d, const Te__& e,
+             const Tf__& f, const Tg__& g, const Th__& h, const Ti__& i,
+             const Tj__& j, const Tk__& k, const Tl__& l, const Tm__& m,
+             const Tn__& n, const To__& o, const Tp__& p, const Tq__& q) const;
 };
 struct f4_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g12_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f8_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f1a_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g10_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct r_functor__ {
-  double
+  inline double
   operator()(std::ostream* pstream__) const;
 };
 struct g1_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const T3__& a, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__, const T3__& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f6_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g12_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f2_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f3_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f12_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g9_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<std::vector<T3__>>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g11_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end,
-             const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f1_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g11_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g9_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const std::vector<std::vector<T3__>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const T3__& a, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__, const T3__& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f11_functor__ {
-  double
-  operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_row_vector_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const T3__& a, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f11_rsfunctor__ {
-  double
-  operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g6_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f7_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f9_rsfunctor__ {
-  double
-  operator()(const std::vector<int>& y_slice, const int& start, const int& end,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const T3__& a, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f10_functor__ {
-  double
-  operator()(const std::vector<std::vector<int>>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct s_functor__ {
-  template <typename T0__, typename T4__, typename T5__, typename T6__,
-            typename T7__, typename T9__, typename T10__, typename T11__,
-            typename T12__, typename T14__, typename T15__, typename T16__,
-            typename T17__, typename T19__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_row_vector_t<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr,
-            stan::require_stan_scalar_t<T12__>* = nullptr,
-            stan::require_stan_scalar_t<T14__>* = nullptr,
-            stan::require_stan_scalar_t<T15__>* = nullptr,
-            stan::require_stan_scalar_t<T16__>* = nullptr,
-            stan::require_stan_scalar_t<T17__>* = nullptr,
-            stan::require_stan_scalar_t<T19__>* = nullptr>
-  stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
-                       stan::value_type_t<T6__>, stan::value_type_t<T7__>,
-                       stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
-                                            stan::promote_args_t<T15__, T16__,
-                                                                 T17__, T19__>>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const int& a, const T4__& b, const T5__& c,
-             const T6__& d, const T7__& e, const std::vector<int>& f,
-             const std::vector<T9__>& g,
-             const std::vector<Eigen::Matrix<T10__, -1, 1>>& h,
-             const std::vector<Eigen::Matrix<T11__, 1, -1>>& i,
-             const std::vector<Eigen::Matrix<T12__, -1, -1>>& j,
-             const std::vector<std::vector<int>>& k,
-             const std::vector<std::vector<T14__>>& l,
-             const std::vector<std::vector<Eigen::Matrix<T15__, -1, 1>>>& m,
-             const std::vector<std::vector<Eigen::Matrix<T16__, 1, -1>>>& n,
-             const std::vector<std::vector<Eigen::Matrix<T17__, -1, -1>>>& o,
-             const std::vector<std::vector<std::vector<int>>>& p,
-             const std::vector<std::vector<std::vector<T19__>>>& q,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__, typename Tb__, typename Tc__, typename Td__,
+            typename Te__, typename Tf__, typename Tg__, typename Th__,
+            typename Ti__, typename Tj__, typename Tk__, typename Tl__,
+            typename Tm__, typename Tn__, typename To__, typename Tp__,
+            typename Tq__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
+            stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
+                      stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
+                                          stan::return_type_t<Th__, Ti__, Tj__,
+                                                              Tk__, Tl__,
+                                                              stan::return_type_t<
+                                                              Tm__, Tn__, To__,
+                                                              Tp__, Tq__>>>>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, const Tb__& b, const Tc__& c,
+             const Td__& d, const Te__& e, const Tf__& f, const Tg__& g,
+             const Th__& h, const Ti__& i, const Tj__& j, const Tk__& k,
+             const Tl__& l, const Tm__& m, const Tn__& n, const To__& o,
+             const Tp__& p, const Tq__& q, std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_row_vector_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__, const T3__& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f9_functor__ {
-  double
-  operator()(const std::vector<int>& y_slice, const int& start, const int& end,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-             const int& start, const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g1_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__, const T3__& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g7_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, const std::vector<T3__>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<T3__>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g7_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g8_rsfunctor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__,
-             const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f10_rsfunctor__ {
-  double
-  operator()(const std::vector<std::vector<int>>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, std::ostream* pstream__) const;
 };
 struct g10_functor__ {
-  template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  operator()(const std::vector<T0__>& y_slice, const int& start,
-             const int& end,
-             const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
-             std::ostream* pstream__) const;
+  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+            typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  operator()(const Ty_slice__& y_slice, const Tstart__& start,
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f1(const std::vector<T0__>& y_slice, const int& start, const int& end,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29787,11 +30312,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f1a(const std::vector<T0__>& y_slice, const int& start, const int& end,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f1a(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29804,11 +30333,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29821,11 +30354,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29838,11 +30375,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29855,11 +30396,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
-     const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29872,11 +30417,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29889,11 +30438,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29906,11 +30459,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-     const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29923,10 +30480,15 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double
-  f9(const std::vector<int>& y_slice, const int& start, const int& end,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29939,10 +30501,15 @@ double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double
-  f10(const std::vector<std::vector<int>>& y_slice, const int& start,
-      const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+      std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29955,10 +30522,15 @@ double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double
-  f11(const std::vector<std::vector<std::vector<int>>>& y_slice,
-      const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+      std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29971,11 +30543,15 @@ double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  f12(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
-      const int& start, const int& end, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+  f12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+      std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29988,13 +30564,17 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const T3__& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30007,14 +30587,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  g2(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const T3__& a_arg__, std::ostream* pstream__) {
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T3__>>;
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     static constexpr bool propto__ = true;
@@ -30028,14 +30611,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_row_vector_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  g3(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const T3__& a_arg__, std::ostream* pstream__) {
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_t<stan::is_row_vector<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T3__>>;
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     static constexpr bool propto__ = true;
@@ -30049,14 +30635,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-  g4(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const T3__& a_arg__, std::ostream* pstream__) {
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T3__>>;
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     static constexpr bool propto__ = true;
@@ -30070,13 +30659,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g5(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const std::vector<T3__>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30089,14 +30682,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g6(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
-     std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30109,14 +30705,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g7(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
-     std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30129,14 +30728,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g8(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
-     std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30149,13 +30751,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g9(const std::vector<T0__>& y_slice, const int& start, const int& end,
-     const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+     const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30168,14 +30774,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g10(const std::vector<T0__>& y_slice, const int& start, const int& end,
-      const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
-      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+      const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30188,14 +30797,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g11(const std::vector<T0__>& y_slice, const int& start, const int& end,
-      const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
-      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+      const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30208,14 +30820,17 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  stan::promote_args_t<T0__, T3__>
-  g12(const std::vector<T0__>& y_slice, const int& start, const int& end,
-      const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
-      std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T3__>;
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+  g12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+      const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30228,53 +30843,55 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T9__, typename T10__, typename T11__,
-          typename T12__, typename T14__, typename T15__, typename T16__,
-          typename T17__, typename T19__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_row_vector_t<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr,
-          stan::require_stan_scalar_t<T12__>* = nullptr,
-          stan::require_stan_scalar_t<T14__>* = nullptr,
-          stan::require_stan_scalar_t<T15__>* = nullptr,
-          stan::require_stan_scalar_t<T16__>* = nullptr,
-          stan::require_stan_scalar_t<T17__>* = nullptr,
-          stan::require_stan_scalar_t<T19__>* = nullptr>
-  stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
-                     stan::value_type_t<T6__>, stan::value_type_t<T7__>,
-                     stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
-                                          stan::promote_args_t<T15__, T16__,
-                                                               T17__, T19__>>>
-  s(const std::vector<T0__>& y_slice, const int& start, const int& end,
-    const int& a, const T4__& b, const T5__& c_arg__, const T6__& d_arg__,
-    const T7__& e_arg__, const std::vector<int>& f,
-    const std::vector<T9__>& g,
-    const std::vector<Eigen::Matrix<T10__, -1, 1>>& h,
-    const std::vector<Eigen::Matrix<T11__, 1, -1>>& i,
-    const std::vector<Eigen::Matrix<T12__, -1, -1>>& j,
-    const std::vector<std::vector<int>>& k,
-    const std::vector<std::vector<T14__>>& l,
-    const std::vector<std::vector<Eigen::Matrix<T15__, -1, 1>>>& m,
-    const std::vector<std::vector<Eigen::Matrix<T16__, 1, -1>>>& n,
-    const std::vector<std::vector<Eigen::Matrix<T17__, -1, -1>>>& o,
-    const std::vector<std::vector<std::vector<int>>>& p,
-    const std::vector<std::vector<std::vector<T19__>>>& q,
-    std::ostream* pstream__) {
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tf__, typename Tg__, typename Th__,
+          typename Ti__, typename Tj__, typename Tk__, typename Tl__,
+          typename Tm__, typename Tn__, typename To__, typename Tp__,
+          typename Tq__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tc__>>* = nullptr,
+          stan::require_t<stan::is_row_vector<Td__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
+                    stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
+                                        stan::return_type_t<Th__, Ti__, Tj__,
+                                                            Tk__, Tl__,
+                                                            stan::return_type_t<
+                                                            Tm__, Tn__, To__,
+                                                            Tp__, Tq__>>>>
+  s(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+    const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
+    const Te__& e, const Tf__& f, const Tg__& g, const Th__& h,
+    const Ti__& i, const Tj__& j, const Tk__& k, const Tl__& l,
+    const Tm__& m, const Tn__& n, const To__& o, const Tp__& p,
+    const Tq__& q, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
-                                 stan::value_type_t<T6__>,
-                                 stan::value_type_t<T7__>,
-                                 stan::promote_args_t<T9__, T10__, T11__,
-                                                      T12__, T14__,
-                                                      stan::promote_args_t<
-                                                      T15__, T16__, T17__,
-                                                      T19__>>>;
+            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
+                                stan::return_type_t<Tc__, Td__, Te__, Tf__,
+                                                    Tg__,
+                                                    stan::return_type_t<
+                                                    Th__, Ti__, Tj__, Tk__,
+                                                    Tl__,
+                                                    stan::return_type_t<
+                                                    Tm__, Tn__, To__, Tp__,
+                                                    Tq__>>>>;
     int current_statement__ = 0; 
     const auto& c = stan::math::to_ref(c_arg__);
     const auto& d = stan::math::to_ref(d_arg__);
@@ -30291,7 +30908,7 @@ template <typename T0__, typename T4__, typename T5__, typename T6__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double r(std::ostream* pstream__) {
+inline double r(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -30595,578 +31212,724 @@ double r(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f1a_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                            const int& start, const int& end,
-                            std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f1a_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                            const Tend__& end, std::ostream* pstream__) 
+const
 {
   return f1a(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T9__, typename T10__, typename T11__,
-          typename T12__, typename T14__, typename T15__, typename T16__,
-          typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_row_vector_t<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*,
-          stan::require_stan_scalar_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*,
-          stan::require_stan_scalar_t<T12__>*,
-          stan::require_stan_scalar_t<T14__>*,
-          stan::require_stan_scalar_t<T15__>*,
-          stan::require_stan_scalar_t<T16__>*,
-          stan::require_stan_scalar_t<T17__>*,
-          stan::require_stan_scalar_t<T19__>*>
-stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
-                     stan::value_type_t<T6__>, stan::value_type_t<T7__>,
-                     stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
-                                          stan::promote_args_t<T15__, T16__,
-                                                               T17__, T19__>>>
-s_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                          const int& end, std::ostream* pstream__,
-                          const int& a, const T4__& b, const T5__& c,
-                          const T6__& d, const T7__& e,
-                          const std::vector<int>& f,
-                          const std::vector<T9__>& g,
-                          const std::vector<Eigen::Matrix<T10__, -1, 1>>& h,
-                          const std::vector<Eigen::Matrix<T11__, 1, -1>>& i,
-                          const std::vector<Eigen::Matrix<T12__, -1, -1>>& j,
-                          const std::vector<std::vector<int>>& k,
-                          const std::vector<std::vector<T14__>>& l,
-                          const std::vector<std::vector<Eigen::Matrix<T15__, -1, 1>>>& m,
-                          const std::vector<std::vector<Eigen::Matrix<T16__, 1, -1>>>& n,
-                          const std::vector<std::vector<Eigen::Matrix<T17__, -1, -1>>>& o,
-                          const std::vector<std::vector<std::vector<int>>>& p,
-                          const std::vector<std::vector<std::vector<T19__>>>& q) 
-const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tf__, typename Tg__, typename Th__,
+          typename Ti__, typename Tj__, typename Tk__, typename Tl__,
+          typename Tm__, typename Tn__, typename To__, typename Tp__,
+          typename Tq__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
+          stan::require_t<stan::is_col_vector<Tc__>>*,
+          stan::require_t<stan::is_row_vector<Td__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
+          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>*,
+          stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>*,
+          stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
+                    stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
+                                        stan::return_type_t<Th__, Ti__, Tj__,
+                                                            Tk__, Tl__,
+                                                            stan::return_type_t<
+                                                            Tm__, Tn__, To__,
+                                                            Tp__, Tq__>>>>
+s_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, std::ostream* pstream__,
+                          const Ta__& a, const Tb__& b, const Tc__& c,
+                          const Td__& d, const Te__& e, const Tf__& f,
+                          const Tg__& g, const Th__& h, const Ti__& i,
+                          const Tj__& j, const Tk__& k, const Tl__& l,
+                          const Tm__& m, const Tn__& n, const To__& o,
+                          const Tp__& p, const Tq__& q)  const
 {
   return s(y_slice, start + 1, end + 1, a, b, c, d, e, f, g, h, i, j, k, l,
            m, n, o, p, q, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f4(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g12_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                            const int& start, const int& end,
-                            std::ostream* pstream__,
-                            const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) 
-const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                            const Tend__& end, std::ostream* pstream__,
+                            const Ta__& a)  const
 {
   return g12(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f5(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f8(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g8_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end,
-                         const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g8(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f1a_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                          const int& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, std::ostream* pstream__)  const
 {
   return f1a(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g10_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                            const int& start, const int& end,
-                            std::ostream* pstream__,
-                            const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) 
-const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                            const Tend__& end, std::ostream* pstream__,
+                            const Ta__& a)  const
 {
   return g10(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-double r_functor__::operator()(std::ostream* pstream__)  const
+inline double r_functor__::operator()(std::ostream* pstream__)  const
 {
   return r(pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end, const T3__& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g1(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T3__>*>
-stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-g2_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__, const T3__& a)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_col_vector<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g2(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f6(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g12_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                          const int& end,
-                          const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, const Ta__& a,
                           std::ostream* pstream__)  const
 {
   return g12(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f6(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f12_rsfunctor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
-                            const int& start, const int& end,
-                            std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                            const Tend__& end, std::ostream* pstream__) 
+const
 {
   return f12(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g9_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__,
-                           const std::vector<std::vector<T3__>>& a)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g9(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g11_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                          const int& end,
-                          const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, const Ta__& a,
                           std::ostream* pstream__)  const
 {
   return g11(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f3(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f7(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g11_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                            const int& start, const int& end,
-                            std::ostream* pstream__,
-                            const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) 
-const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                            const Tend__& end, std::ostream* pstream__,
+                            const Ta__& a)  const
 {
   return g11(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g9_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end,
-                         const std::vector<std::vector<T3__>>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g9(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-g4_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end, const T3__& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g4(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-g4_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__, const T3__& a)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g4(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-double
-f11_functor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
-                          const int& start, const int& end,
-                          std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, std::ostream* pstream__)  const
 {
   return f11(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f12_functor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
-                          const int& start, const int& end,
-                          std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, std::ostream* pstream__)  const
 {
   return f12(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_row_vector_t<T3__>*>
-stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-g3_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end, const T3__& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_row_vector<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g3(y_slice, start, end, a, pstream__);
 }
 
-double
-f11_rsfunctor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
-                            const int& start, const int& end,
-                            std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                            const Tend__& end, std::ostream* pstream__) 
+const
 {
   return f11(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g6_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end,
-                         const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g6(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f7(y_slice, start + 1, end + 1, pstream__);
 }
 
-double
-f9_rsfunctor__::operator()(const std::vector<int>& y_slice, const int& start,
-                           const int& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f9(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f4(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T3__>*>
-stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-g2_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end, const T3__& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_col_vector<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g2(y_slice, start, end, a, pstream__);
 }
 
-double
-f10_functor__::operator()(const std::vector<std::vector<int>>& y_slice,
-                          const int& start, const int& end,
-                          std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, std::ostream* pstream__)  const
 {
   return f10(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T4__, typename T5__, typename T6__,
-          typename T7__, typename T9__, typename T10__, typename T11__,
-          typename T12__, typename T14__, typename T15__, typename T16__,
-          typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_row_vector_t<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*,
-          stan::require_stan_scalar_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*,
-          stan::require_stan_scalar_t<T12__>*,
-          stan::require_stan_scalar_t<T14__>*,
-          stan::require_stan_scalar_t<T15__>*,
-          stan::require_stan_scalar_t<T16__>*,
-          stan::require_stan_scalar_t<T17__>*,
-          stan::require_stan_scalar_t<T19__>*>
-stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
-                     stan::value_type_t<T6__>, stan::value_type_t<T7__>,
-                     stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
-                                          stan::promote_args_t<T15__, T16__,
-                                                               T17__, T19__>>>
-s_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                        const int& end, const int& a, const T4__& b,
-                        const T5__& c, const T6__& d, const T7__& e,
-                        const std::vector<int>& f,
-                        const std::vector<T9__>& g,
-                        const std::vector<Eigen::Matrix<T10__, -1, 1>>& h,
-                        const std::vector<Eigen::Matrix<T11__, 1, -1>>& i,
-                        const std::vector<Eigen::Matrix<T12__, -1, -1>>& j,
-                        const std::vector<std::vector<int>>& k,
-                        const std::vector<std::vector<T14__>>& l,
-                        const std::vector<std::vector<Eigen::Matrix<T15__, -1, 1>>>& m,
-                        const std::vector<std::vector<Eigen::Matrix<T16__, 1, -1>>>& n,
-                        const std::vector<std::vector<Eigen::Matrix<T17__, -1, -1>>>& o,
-                        const std::vector<std::vector<std::vector<int>>>& p,
-                        const std::vector<std::vector<std::vector<T19__>>>& q,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tf__, typename Tg__, typename Th__,
+          typename Ti__, typename Tj__, typename Tk__, typename Tl__,
+          typename Tm__, typename Tn__, typename To__, typename Tp__,
+          typename Tq__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
+          stan::require_t<stan::is_col_vector<Tc__>>*,
+          stan::require_t<stan::is_row_vector<Td__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
+          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tg__>, stan::is_stan_scalar_t<value_type_t<Tg__>>>*,
+          stan::require_all_t<stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tk__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Tl__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>>*,
+          stan::require_all_t<stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tp__>>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar_t<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
+                    stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
+                                        stan::return_type_t<Th__, Ti__, Tj__,
+                                                            Tk__, Tl__,
+                                                            stan::return_type_t<
+                                                            Tm__, Tn__, To__,
+                                                            Tp__, Tq__>>>>
+s_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                        const Tend__& end, const Ta__& a, const Tb__& b,
+                        const Tc__& c, const Td__& d, const Te__& e,
+                        const Tf__& f, const Tg__& g, const Th__& h,
+                        const Ti__& i, const Tj__& j, const Tk__& k,
+                        const Tl__& l, const Tm__& m, const Tn__& n,
+                        const To__& o, const Tp__& p, const Tq__& q,
                         std::ostream* pstream__)  const
 {
   return s(y_slice, start, end, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o,
            p, q, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f2(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_row_vector_t<T3__>*>
-stan::promote_args_t<T0__, stan::value_type_t<T3__>>
-g3_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__, const T3__& a)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_row_vector<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g3(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-double
-f9_functor__::operator()(const std::vector<int>& y_slice, const int& start,
-                         const int& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f9(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
-                         const int& start, const int& end,
-                         std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f8(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__, const T3__& a)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g1(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g7_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end,
-                         const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g7(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g5_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end, const std::vector<T3__>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g5(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g5_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__,
-                           const std::vector<T3__>& a)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g5(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__)  const
 {
   return f5(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g6_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__,
-                           const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) 
-const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g6(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g7_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__,
-                           const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) 
-const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g7(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g8_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
-                           const int& start, const int& end,
-                           std::ostream* pstream__,
-                           const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) 
-const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                           const Tend__& end, std::ostream* pstream__,
+                           const Ta__& a)  const
 {
   return g8(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-double
-f10_rsfunctor__::operator()(const std::vector<std::vector<int>>& y_slice,
-                            const int& start, const int& end,
-                            std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty_slice__>>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                            const Tend__& end, std::ostream* pstream__) 
+const
 {
   return f10(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-f1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                         const int& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                         const Tend__& end, std::ostream* pstream__)  const
 {
   return f1(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
-stan::promote_args_t<T0__, T3__>
-g10_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
-                          const int& end,
-                          const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
+template <typename Ty_slice__, typename Tstart__, typename Tend__,
+          typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar_t<value_type_t<Ty_slice__>>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tstart__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tend__>>*,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
+g10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
+                          const Tend__& end, const Ta__& a,
                           std::ostream* pstream__)  const
 {
   return g10(y_slice, start, end, a, pstream__);
@@ -33186,33 +33949,32 @@ static constexpr std::array<const char*, 52> locations_array__ =
  " (in 'shadowing.stan', line 2, column 43 to line 6, column 3)"};
 
 struct rhs_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
-             const T2__& alpha) const;
+  template <typename Tt__, typename Ty__, typename Talpha__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Talpha__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
+  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
+             const Talpha__& alpha) const;
 };
 struct rhs_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& y, const T2__& alpha,
+  template <typename Tt__, typename Ty__, typename Talpha__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Talpha__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
+  operator()(const Tt__& t, const Ty__& y, const Talpha__& alpha,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-  rhs(const T0__& t, const T1__& y_arg__, const T2__& alpha,
+template <typename Tt__, typename Ty__, typename Talpha__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Talpha__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
+  rhs(const Tt__& t, const Ty__& y, const Talpha__& alpha,
       std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>;
+    using local_scalar_t__ = stan::return_type_t<Tt__, Ty__, Talpha__>;
     int current_statement__ = 0; 
     const auto& y = stan::math::to_ref(y_arg__);
     static constexpr bool propto__ = true;
@@ -33231,25 +33993,26 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-rhs_odefunctor__::operator()(const T0__& t, const T1__& y,
-                             std::ostream* pstream__, const T2__& alpha) 
+template <typename Tt__, typename Ty__, typename Talpha__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Talpha__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
+rhs_odefunctor__::operator()(const Tt__& t, const Ty__& y,
+                             std::ostream* pstream__, const Talpha__& alpha) 
 const
 {
   return rhs(t, y, alpha, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
-                          std::ostream* pstream__)  const
+template <typename Tt__, typename Ty__, typename Talpha__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Talpha__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
+rhs_functor__::operator()(const Tt__& t, const Ty__& y,
+                          const Talpha__& alpha, std::ostream* pstream__) 
+const
 {
   return rhs(t, y, alpha, pstream__);
 }
@@ -34218,45 +34981,51 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'single-argument-lpmf.stan', line 17, column 23 to line 19, column 3)"};
 
 struct foo4_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__>
-  double
-  operator()(const int& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
+  template <bool propto__, typename Ty__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  operator()(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo0_lpmf_functor__ {
-  template <bool propto__>
-  double
-  operator()(const int& y, std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo1_lpmf_functor__ {
-  template <bool propto__>
-  double
-  operator()(const int& y, std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo2_lpdf_functor__ {
-  template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& y, std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo3_lpdf_functor__ {
-  template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& y, std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct foo5_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  operator()(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 
-template <bool propto__> double
-  foo0_lpmf(const int& y, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  foo0_lpmf(const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34267,9 +35036,11 @@ template <bool propto__> double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__> double
-  foo1_lpmf(const int& y, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  foo1_lpmf(const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34280,10 +35051,13 @@ template <bool propto__> double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__> double
-  foo4_lp(const int& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  foo4_lp(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34294,11 +35068,11 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo2_lpdf(const T0__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  foo2_lpdf(const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34309,11 +35083,11 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo3_lpdf(const T0__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  foo3_lpdf(const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34324,12 +35098,13 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  foo5_lp(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Ty__>
+  foo5_lp(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34340,49 +35115,58 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__>
-double
-foo4_lp_functor__::operator()(const int& y, T_lp__& lp__,
+template <bool propto__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Ty__>
+foo4_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return foo4_lp<propto__>(y, lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__>
-double
-foo0_lpmf_functor__::operator()(const int& y, std::ostream* pstream__)  const
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Ty__>
+foo0_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
+const
 {
   return foo0_lpmf<propto__>(y, pstream__);
 }
 
-template <bool propto__>
-double
-foo1_lpmf_functor__::operator()(const int& y, std::ostream* pstream__)  const
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Ty__>
+foo1_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
+const
 {
   return foo1_lpmf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo2_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Ty__>
+foo2_lpdf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
 {
   return foo2_lpdf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo3_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
+template <bool propto__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Ty__>
+foo3_lpdf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
 const
 {
   return foo3_lpdf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-foo5_lp_functor__::operator()(const T0__& y, T_lp__& lp__,
+template <bool propto__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Ty__>
+foo5_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
@@ -38212,14 +38996,17 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'udf_tilde_stmt_conflict.stan', line 2, column 22 to line 4, column 3)"};
 
 struct normal_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& a, std::ostream* pstream__) const;
+  template <typename Ta__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__> normal(const T0__& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  normal(const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -38232,9 +39019,9 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-normal_functor__::operator()(const T0__& a, std::ostream* pstream__)  const
+template <typename Ta__, stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline stan::return_type_t<Ta__>
+normal_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
 {
   return normal(a, pstream__);
 }
@@ -38560,19 +39347,19 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'user_constrain.stan', line 2, column 36 to line 4, column 3)"};
 
 struct lb_constrain_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
+  template <typename Tx__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Ty__>
+  operator()(const Tx__& x, const Ty__& y, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  lb_constrain(const T0__& x, const T1__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+template <typename Tx__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Ty__>
+  lb_constrain(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -38585,10 +39372,11 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-lb_constrain_functor__::operator()(const T0__& x, const T1__& y,
+template <typename Tx__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline stan::return_type_t<Tx__, Ty__>
+lb_constrain_functor__::operator()(const Tx__& x, const Ty__& y,
                                    std::ostream* pstream__)  const
 {
   return lb_constrain(x, y, pstream__);

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -3726,7 +3726,7 @@ static constexpr std::array<const char*, 75> locations_array__ =
 struct _stan_asm_functor__ {
   template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
   inline void
-  operator()(const T_stan_class__& _stan_class_arg__, std::ostream* pstream__) const;
+  operator()(const T_stan_class__& _stan_class, std::ostream* pstream__) const;
 };
 struct _stan_char16_t_functor__ {
   inline void
@@ -3848,7 +3848,7 @@ template <typename T_stan_STAN_MINOR__, stan::require_all_t<stan::is_stan_scalar
     }
 template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
   inline void
-  _stan_asm(const T_stan_class__& _stan_class, std::ostream* pstream__) {
+  _stan_asm(const T_stan_class__& _stan_class_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<T_stan_class__>;
     int current_statement__ = 0; 
     const auto& _stan_class = stan::math::to_ref(_stan_class_arg__);
@@ -3971,7 +3971,7 @@ inline void _stan_char32_t(std::ostream* pstream__) {
     }
 template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>*>
 inline void
-_stan_asm_functor__::operator()(const T_stan_class__& _stan_class_arg__,
+_stan_asm_functor__::operator()(const T_stan_class__& _stan_class,
                                 std::ostream* pstream__)  const
 {
   return _stan_asm(_stan_class, pstream__);
@@ -6510,8 +6510,8 @@ struct f5_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lcdf_functor__ {
@@ -6526,7 +6526,7 @@ struct covsqrt2corsqrt_functor__ {
             typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
             std::is_integral<Tinvert__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-  operator()(const Tmat__& mat_arg__, const Tinvert__& invert,
+  operator()(const Tmat__& mat, const Tinvert__& invert,
              std::ostream* pstream__) const;
 };
 struct foo_1_functor__ {
@@ -6570,8 +6570,8 @@ struct f6_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_five_args_functor__ {
@@ -6608,8 +6608,8 @@ struct f3_functor__ {
   inline std::vector<std::vector<int>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
@@ -6638,8 +6638,8 @@ struct f7_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f11_functor__ {
@@ -6663,8 +6663,8 @@ struct f11_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f12_functor__ {
@@ -6688,8 +6688,8 @@ struct f12_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct sho_functor__ {
@@ -6721,7 +6721,7 @@ struct algebra_system_functor__ {
             stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
             stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-  operator()(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
+  operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
@@ -6765,8 +6765,8 @@ struct f0_functor__ {
   inline void
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lpmf_functor__ {
@@ -6784,8 +6784,8 @@ struct foo_5_functor__ {
             stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
             stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  operator()(const Tshared_params__& shared_params_arg__,
-             const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
+  operator()(const Tshared_params__& shared_params,
+             const Tjob_params__& job_params, const Tdata_r__& data_r,
              const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct f4_functor__ {
@@ -6809,8 +6809,8 @@ struct f4_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f10_functor__ {
@@ -6834,8 +6834,8 @@ struct f10_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f2_functor__ {
@@ -6857,8 +6857,8 @@ struct f2_functor__ {
   inline std::vector<int>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f9_functor__ {
@@ -6882,8 +6882,8 @@ struct f9_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f8_functor__ {
@@ -6907,8 +6907,8 @@ struct f8_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lccdf_functor__ {
@@ -6948,8 +6948,8 @@ struct binomialf_functor__ {
             stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
             stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
-  operator()(const Tphi__& phi_arg__, const Ttheta__& theta_arg__,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
+  operator()(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
+             const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
@@ -6975,8 +6975,8 @@ struct f1_functor__ {
   inline int
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_functor__ {
@@ -7551,8 +7551,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  foo_5(const Tshared_params__& shared_params,
-        const Tjob_params__& job_params, const Tdata_r__& data_r,
+  foo_5(const Tshared_params__& shared_params_arg__,
+        const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
         const Tdata_i__& data_i, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
@@ -7622,7 +7622,7 @@ template <typename Tmat__,
           typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
           std::is_integral<Tinvert__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-  covsqrt2corsqrt(const Tmat__& mat, const Tinvert__& invert,
+  covsqrt2corsqrt(const Tmat__& mat_arg__, const Tinvert__& invert,
                   std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tmat__, Tinvert__>;
     int current_statement__ = 0; 
@@ -7676,9 +7676,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline void
   f0(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -7719,9 +7719,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline int
   f1(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -7759,9 +7759,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<int>
   f2(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -7799,9 +7799,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<int>>
   f3(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -7841,9 +7841,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>
   f4(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -7883,9 +7883,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>
   f5(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -7925,9 +7925,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>>
   f6(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -7967,9 +7967,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
   f7(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -8009,9 +8009,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
   f8(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -8051,9 +8051,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
   f9(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-     const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-     const Ta12__& a12, std::ostream* pstream__) {
+     const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+     const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+     const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -8093,9 +8093,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
   f10(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-      const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-      const Ta12__& a12, std::ostream* pstream__) {
+      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -8135,9 +8135,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
   f11(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-      const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-      const Ta12__& a12, std::ostream* pstream__) {
+      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -8177,9 +8177,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
   f12(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
-      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
-      const Ta9__& a9, const Ta10__& a10, const Ta11__& a11,
-      const Ta12__& a12, std::ostream* pstream__) {
+      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
+      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
+      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                 stan::return_type_t<Ta6__, Ta7__, Ta8__,
@@ -8312,7 +8312,7 @@ template <typename Tx__, typename Ty__, typename Tdat__,
           stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
           stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-  algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
+  algebra_system(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>;
@@ -8348,8 +8348,8 @@ template <typename Tphi__, typename Ttheta__, typename Tx_r__,
           stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
           stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
-  binomialf(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
-            const Tx_i__& x_i, std::ostream* pstream__) {
+  binomialf(const Tphi__& phi_arg__, const Ttheta__& theta_arg__,
+            const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
@@ -8410,10 +8410,9 @@ inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>
 f5_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8432,7 +8431,7 @@ template <typename Tmat__,
           typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
           std::is_integral<Tinvert__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-covsqrt2corsqrt_functor__::operator()(const Tmat__& mat_arg__,
+covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
                                       const Tinvert__& invert,
                                       std::ostream* pstream__)  const
 {
@@ -8487,10 +8486,9 @@ inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, T
                                         stan::return_type_t<Ta11__, Ta12__>>>>>
 f6_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f6(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8533,10 +8531,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline std::vector<std::vector<int>>
 f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8568,10 +8565,9 @@ inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
 f7_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f7(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8596,10 +8592,9 @@ inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
 f11_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                          const Ta7__& a7_arg__, const Ta8__& a8,
-                          const Ta9__& a9, const Ta10__& a10_arg__,
-                          const Ta11__& a11, const Ta12__& a12,
-                          std::ostream* pstream__)  const
+                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                          const Ta10__& a10, const Ta11__& a11,
+                          const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8624,10 +8619,9 @@ inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, T
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
 f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                          const Ta7__& a7_arg__, const Ta8__& a8,
-                          const Ta9__& a9, const Ta10__& a10_arg__,
-                          const Ta11__& a11, const Ta12__& a12,
-                          std::ostream* pstream__)  const
+                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                          const Ta10__& a10, const Ta11__& a11,
+                          const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8669,8 +8663,8 @@ template <typename Tx__, typename Ty__, typename Tdat__,
           stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
           stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-algebra_system_functor__::operator()(const Tx__& x_arg__,
-                                     const Ty__& y_arg__, const Tdat__& dat,
+algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
+                                     const Tdat__& dat,
                                      const Tdat_int__& dat_int,
                                      std::ostream* pstream__)  const
 {
@@ -8726,10 +8720,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline void
 f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8751,8 +8744,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-foo_5_functor__::operator()(const Tshared_params__& shared_params_arg__,
-                            const Tjob_params__& job_params_arg__,
+foo_5_functor__::operator()(const Tshared_params__& shared_params,
+                            const Tjob_params__& job_params,
                             const Tdata_r__& data_r, const Tdata_i__& data_i,
                             std::ostream* pstream__)  const
 {
@@ -8779,10 +8772,9 @@ inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>
 f4_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f4(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8807,10 +8799,9 @@ inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
 f10_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                          const Ta7__& a7_arg__, const Ta8__& a8,
-                          const Ta9__& a9, const Ta10__& a10_arg__,
-                          const Ta11__& a11, const Ta12__& a12,
-                          std::ostream* pstream__)  const
+                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                          const Ta10__& a10, const Ta11__& a11,
+                          const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8833,10 +8824,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline std::vector<int>
 f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f2(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8861,10 +8851,9 @@ inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, T
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
 f9_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f9(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8889,10 +8878,9 @@ inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
 f8_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8946,8 +8934,7 @@ template <typename Tphi__, typename Ttheta__, typename Tx_r__,
           stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
           stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
-binomialf_functor__::operator()(const Tphi__& phi_arg__,
-                                const Ttheta__& theta_arg__,
+binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
                                 const Tx_r__& x_r, const Tx_i__& x_i,
                                 std::ostream* pstream__)  const
 {
@@ -8979,10 +8966,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline int
 f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7_arg__, const Ta8__& a8,
-                         const Ta9__& a9, const Ta10__& a10_arg__,
-                         const Ta11__& a11, const Ta12__& a12,
-                         std::ostream* pstream__)  const
+                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
+                         const Ta10__& a10, const Ta11__& a11,
+                         const Ta12__& a12, std::ostream* pstream__)  const
 {
   return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -15195,7 +15181,7 @@ struct algebra_system_functor__ {
             stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
             stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-  operator()(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
+  operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
@@ -15218,8 +15204,8 @@ struct foo_functor__ {
             stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
             stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  operator()(const Tshared_params__& shared_params_arg__,
-             const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
+  operator()(const Tshared_params__& shared_params,
+             const Tjob_params__& job_params, const Tdata_r__& data_r,
              const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct goo_functor__ {
@@ -15230,8 +15216,8 @@ struct goo_functor__ {
             stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
             stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  operator()(const Tshared_params__& shared_params_arg__,
-             const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
+  operator()(const Tshared_params__& shared_params,
+             const Tjob_params__& job_params, const Tdata_r__& data_r,
              const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct map_rectfake_functor__ {
@@ -15305,9 +15291,9 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  foo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
-      const Tdata_r__& data_r, const Tdata_i__& data_i,
-      std::ostream* pstream__) {
+  foo(const Tshared_params__& shared_params_arg__,
+      const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
+      const Tdata_i__& data_i, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
                                 Tdata_i__>;
@@ -15332,9 +15318,9 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  goo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
-      const Tdata_r__& data_r, const Tdata_i__& data_i,
-      std::ostream* pstream__) {
+  goo(const Tshared_params__& shared_params_arg__,
+      const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
+      const Tdata_i__& data_i, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
                                 Tdata_i__>;
@@ -15374,7 +15360,7 @@ template <typename Tx__, typename Ty__, typename Tdat__,
           stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
           stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-  algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
+  algebra_system(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>;
@@ -15425,8 +15411,8 @@ template <typename Tx__, typename Ty__, typename Tdat__,
           stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
           stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-algebra_system_functor__::operator()(const Tx__& x_arg__,
-                                     const Ty__& y_arg__, const Tdat__& dat,
+algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
+                                     const Tdat__& dat,
                                      const Tdat_int__& dat_int,
                                      std::ostream* pstream__)  const
 {
@@ -15455,8 +15441,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-foo_functor__::operator()(const Tshared_params__& shared_params_arg__,
-                          const Tjob_params__& job_params_arg__,
+foo_functor__::operator()(const Tshared_params__& shared_params,
+                          const Tjob_params__& job_params,
                           const Tdata_r__& data_r, const Tdata_i__& data_i,
                           std::ostream* pstream__)  const
 {
@@ -15470,8 +15456,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-goo_functor__::operator()(const Tshared_params__& shared_params_arg__,
-                          const Tjob_params__& job_params_arg__,
+goo_functor__::operator()(const Tshared_params__& shared_params,
+                          const Tjob_params__& job_params,
                           const Tdata_r__& data_r, const Tdata_i__& data_i,
                           std::ostream* pstream__)  const
 {
@@ -17729,8 +17715,8 @@ struct f_functor__ {
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
             stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, const Ta__& a,
-             const Tb__& b_arg__, std::ostream* pstream__) const;
+  operator()(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
+             std::ostream* pstream__) const;
 };
 struct f_odefunctor__ {
   template <typename Tt__, typename Tz__, typename Ta__,
@@ -17738,8 +17724,8 @@ struct f_odefunctor__ {
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
             stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__,
-             const Ta__& a, const Tb__& b_arg__) const;
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
+             const Ta__& a, const Tb__& b) const;
 };
 
 template <typename Tt__, typename Tz__, typename Ta__,
@@ -17747,7 +17733,7 @@ template <typename Tt__, typename Tz__, typename Ta__,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
           stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-  f(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
+  f(const Tt__& t, const Tz__& z_arg__, const Ta__& a, const Tb__& b_arg__,
     std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Ta__, Tb__>;
     int current_statement__ = 0; 
@@ -17769,8 +17755,8 @@ template <typename Tt__, typename Tz__, typename Ta__,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
           stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-f_functor__::operator()(const Tt__& t, const Tz__& z_arg__, const Ta__& a,
-                        const Tb__& b_arg__, std::ostream* pstream__)  const
+f_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
+                        const Tb__& b, std::ostream* pstream__)  const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -17780,9 +17766,9 @@ template <typename Tt__, typename Tz__, typename Ta__,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
           stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-f_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
+f_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                            std::ostream* pstream__, const Ta__& a,
-                           const Tb__& b_arg__)  const
+                           const Tb__& b)  const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -23956,13 +23942,13 @@ struct foo_functor__ {
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p_arg__, std::ostream* pstream__) const;
+  operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p_arg__, std::ostream* pstream__) const;
+  operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p_arg__, std::ostream* pstream__) const;
+  operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_stan_scalar<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
@@ -24005,7 +23991,7 @@ template <typename Tp__, stan::require_all_t<stan::is_stan_scalar<Tp__>>* = null
     }
 template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  foo(const Tp__& p, std::ostream* pstream__) {
+  foo(const Tp__& p_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -24022,7 +24008,7 @@ template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>* = nullp
     }
 template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  foo(const Tp__& p, std::ostream* pstream__) {
+  foo(const Tp__& p_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -24039,7 +24025,7 @@ template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>* = nullp
     }
 template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  foo(const Tp__& p, std::ostream* pstream__) {
+  foo(const Tp__& p_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -24198,24 +24184,21 @@ foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 
 template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>*>
 inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p_arg__, std::ostream* pstream__) 
-const
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
 template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>*>
 inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p_arg__, std::ostream* pstream__) 
-const
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
 template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>*>
 inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p_arg__, std::ostream* pstream__) 
-const
+foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
@@ -29523,11 +29506,10 @@ struct s_rsfunctor__ {
                                                               Tp__, Tq__>>>>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a,
-             const Tb__& b, const Tc__& c_arg__, const Td__& d_arg__,
-             const Te__& e_arg__, const Tf__& f, const Tg__& g, const Th__& h,
-             const Ti__& i, const Tj__& j, const Tk__& k, const Tl__& l,
-             const Tm__& m, const Tn__& n, const To__& o, const Tp__& p,
-             const Tq__& q) const;
+             const Tb__& b, const Tc__& c, const Td__& d, const Te__& e,
+             const Tf__& f, const Tg__& g, const Th__& h, const Ti__& i,
+             const Tj__& j, const Tk__& k, const Tl__& l, const Tm__& m,
+             const Tn__& n, const To__& o, const Tp__& p, const Tq__& q) const;
 };
 struct f4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29608,7 +29590,7 @@ struct g2_rsfunctor__ {
             stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a_arg__) const;
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29726,7 +29708,7 @@ struct g4_functor__ {
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a_arg__, std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
@@ -29735,7 +29717,7 @@ struct g4_rsfunctor__ {
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a_arg__) const;
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f11_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29760,7 +29742,7 @@ struct g3_functor__ {
             stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a_arg__, std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f11_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29810,7 +29792,7 @@ struct g2_functor__ {
             stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a_arg__, std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f10_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29851,12 +29833,11 @@ struct s_functor__ {
                                                               Tm__, Tn__, To__,
                                                               Tp__, Tq__>>>>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, const Tb__& b,
-             const Tc__& c_arg__, const Td__& d_arg__, const Te__& e_arg__,
-             const Tf__& f, const Tg__& g, const Th__& h, const Ti__& i,
-             const Tj__& j, const Tk__& k, const Tl__& l, const Tm__& m,
-             const Tn__& n, const To__& o, const Tp__& p, const Tq__& q,
-             std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a, const Tb__& b, const Tc__& c,
+             const Td__& d, const Te__& e, const Tf__& f, const Tg__& g,
+             const Th__& h, const Ti__& i, const Tj__& j, const Tk__& k,
+             const Tl__& l, const Tm__& m, const Tn__& n, const To__& o,
+             const Tp__& p, const Tq__& q, std::ostream* pstream__) const;
 };
 struct f2_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29873,7 +29854,7 @@ struct g3_rsfunctor__ {
             stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a_arg__) const;
+             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f9_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -30275,7 +30256,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-     const Ta__& a, std::ostream* pstream__) {
+     const Ta__& a_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
@@ -30297,7 +30278,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-     const Ta__& a, std::ostream* pstream__) {
+     const Ta__& a_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
@@ -30319,7 +30300,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-     const Ta__& a, std::ostream* pstream__) {
+     const Ta__& a_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
     int current_statement__ = 0; 
@@ -30533,8 +30514,8 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
                                                             Tm__, Tn__, To__,
                                                             Tp__, Tq__>>>>
   s(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-    const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
-    const Te__& e, const Tf__& f, const Tg__& g, const Th__& h,
+    const Ta__& a, const Tb__& b, const Tc__& c_arg__, const Td__& d_arg__,
+    const Te__& e_arg__, const Tf__& f, const Tg__& g, const Th__& h,
     const Ti__& i, const Tj__& j, const Tk__& k, const Tl__& l,
     const Tm__& m, const Tn__& n, const To__& o, const Tp__& p,
     const Tq__& q, std::ostream* pstream__) {
@@ -30910,12 +30891,12 @@ inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                                                             Tp__, Tq__>>>>
 s_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__,
-                          const Ta__& a, const Tb__& b, const Tc__& c_arg__,
-                          const Td__& d_arg__, const Te__& e_arg__,
-                          const Tf__& f, const Tg__& g, const Th__& h,
-                          const Ti__& i, const Tj__& j, const Tk__& k,
-                          const Tl__& l, const Tm__& m, const Tn__& n,
-                          const To__& o, const Tp__& p, const Tq__& q)  const
+                          const Ta__& a, const Tb__& b, const Tc__& c,
+                          const Td__& d, const Te__& e, const Tf__& f,
+                          const Tg__& g, const Th__& h, const Ti__& i,
+                          const Tj__& j, const Tk__& k, const Tl__& l,
+                          const Tm__& m, const Tn__& n, const To__& o,
+                          const Tp__& p, const Tq__& q)  const
 {
   return s(y_slice, start + 1, end + 1, a, b, c, d, e, f, g, h, i, j, k, l,
            m, n, o, p, q, pstream__);
@@ -31021,7 +31002,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a_arg__)  const
+                           const Ta__& a)  const
 {
   return g2(y_slice, start + 1, end + 1, a, pstream__);
 }
@@ -31173,7 +31154,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a_arg__,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g4(y_slice, start, end, a, pstream__);
@@ -31186,7 +31167,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a_arg__)  const
+                           const Ta__& a)  const
 {
   return g4(y_slice, start + 1, end + 1, a, pstream__);
 }
@@ -31217,7 +31198,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a_arg__,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g3(y_slice, start, end, a, pstream__);
@@ -31282,7 +31263,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a_arg__,
+                         const Tend__& end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g2(y_slice, start, end, a, pstream__);
@@ -31329,12 +31310,12 @@ inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                                                             Tp__, Tq__>>>>
 s_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                         const Tend__& end, const Ta__& a, const Tb__& b,
-                        const Tc__& c_arg__, const Td__& d_arg__,
-                        const Te__& e_arg__, const Tf__& f, const Tg__& g,
-                        const Th__& h, const Ti__& i, const Tj__& j,
-                        const Tk__& k, const Tl__& l, const Tm__& m,
-                        const Tn__& n, const To__& o, const Tp__& p,
-                        const Tq__& q, std::ostream* pstream__)  const
+                        const Tc__& c, const Td__& d, const Te__& e,
+                        const Tf__& f, const Tg__& g, const Th__& h,
+                        const Ti__& i, const Tj__& j, const Tk__& k,
+                        const Tl__& l, const Tm__& m, const Tn__& n,
+                        const To__& o, const Tp__& p, const Tq__& q,
+                        std::ostream* pstream__)  const
 {
   return s(y_slice, start, end, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o,
            p, q, pstream__);
@@ -31357,7 +31338,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a_arg__)  const
+                           const Ta__& a)  const
 {
   return g3(y_slice, start + 1, end + 1, a, pstream__);
 }
@@ -33528,7 +33509,7 @@ struct rhs_odefunctor__ {
             stan::is_col_vector<Ty__>,
             stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y_arg__, std::ostream* pstream__,
+  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
              const Talpha__& alpha) const;
 };
 struct rhs_functor__ {
@@ -33537,7 +33518,7 @@ struct rhs_functor__ {
             stan::is_col_vector<Ty__>,
             stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y_arg__, const Talpha__& alpha,
+  operator()(const Tt__& t, const Ty__& y, const Talpha__& alpha,
              std::ostream* pstream__) const;
 };
 
@@ -33546,7 +33527,7 @@ template <typename Tt__, typename Ty__,
           stan::is_col_vector<Ty__>,
           stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-  rhs(const Tt__& t, const Ty__& y, const Talpha__& alpha,
+  rhs(const Tt__& t, const Ty__& y_arg__, const Talpha__& alpha,
       std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Ty__, Talpha__>;
     int current_statement__ = 0; 
@@ -33571,7 +33552,7 @@ template <typename Tt__, typename Ty__,
           typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Ty__>, stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-rhs_odefunctor__::operator()(const Tt__& t, const Ty__& y_arg__,
+rhs_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                              std::ostream* pstream__, const Talpha__& alpha) 
 const
 {
@@ -33582,7 +33563,7 @@ template <typename Tt__, typename Ty__,
           typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Ty__>, stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-rhs_functor__::operator()(const Tt__& t, const Ty__& y_arg__,
+rhs_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Talpha__& alpha, std::ostream* pstream__) 
 const
 {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -3737,23 +3737,20 @@ struct _stan_bitor_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_bitand_functor__ {
-  template <typename T_stan_constexpr__, stan::require_all_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
   inline void
-  operator()(const T_stan_constexpr__& _stan_constexpr, std::ostream* pstream__) const;
+  operator()(const int _stan_constexpr, std::ostream* pstream__) const;
 };
 struct _stan_catch_functor__ {
   inline void
   operator()(std::ostream* pstream__) const;
 };
 struct _stan_alignas_functor__ {
-  template <typename T_stan_asm__, stan::require_all_t<std::is_integral<T_stan_asm__>>* = nullptr>
   inline void
-  operator()(const T_stan_asm__& _stan_asm, std::ostream* pstream__) const;
+  operator()(const int _stan_asm, std::ostream* pstream__) const;
 };
 struct _stan_alignof_functor__ {
-  template <typename T_stan_char__, stan::require_all_t<std::is_integral<T_stan_char__>>* = nullptr>
   inline void
-  operator()(const T_stan_char__& _stan_char, std::ostream* pstream__) const;
+  operator()(const int _stan_char, std::ostream* pstream__) const;
 };
 struct _stan_and_eq_functor__ {
   template <typename T_stan_STAN_MINOR__, stan::require_all_t<stan::is_stan_scalar<T_stan_STAN_MINOR__>>* = nullptr>
@@ -3762,10 +3759,8 @@ struct _stan_and_eq_functor__ {
              std::ostream* pstream__) const;
 };
 struct _stan_and_functor__ {
-  template <typename T_stan_STAN_MAJOR__, stan::require_all_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
   inline void
-  operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
-             std::ostream* pstream__) const;
+  operator()(const int _stan_STAN_MAJOR, std::ostream* pstream__) const;
 };
 struct _stan_char_functor__ {
   inline void
@@ -3784,10 +3779,8 @@ struct _stan_case_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 
-template <typename T_stan_asm__, stan::require_all_t<std::is_integral<T_stan_asm__>>* = nullptr>
-  inline void
-  _stan_alignas(const T_stan_asm__& _stan_asm, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<T_stan_asm__>;
+inline void _stan_alignas(const int _stan_asm, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3799,10 +3792,8 @@ template <typename T_stan_asm__, stan::require_all_t<std::is_integral<T_stan_asm
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_char__, stan::require_all_t<std::is_integral<T_stan_char__>>* = nullptr>
-  inline void
-  _stan_alignof(const T_stan_char__& _stan_char, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<T_stan_char__>;
+inline void _stan_alignof(const int _stan_char, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3814,11 +3805,8 @@ template <typename T_stan_char__, stan::require_all_t<std::is_integral<T_stan_ch
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_STAN_MAJOR__, stan::require_all_t<std::is_integral<T_stan_STAN_MAJOR__>>* = nullptr>
-  inline void
-  _stan_and(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
-            std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<T_stan_STAN_MAJOR__>;
+inline void _stan_and(const int _stan_STAN_MAJOR, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3862,11 +3850,9 @@ template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_sta
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T_stan_constexpr__, stan::require_all_t<std::is_integral<T_stan_constexpr__>>* = nullptr>
-  inline void
-  _stan_bitand(const T_stan_constexpr__& _stan_constexpr,
-               std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<T_stan_constexpr__>;
+inline void
+  _stan_bitand(const int _stan_constexpr, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -3988,9 +3974,8 @@ inline void _stan_bitor_functor__::operator()(std::ostream* pstream__)  const
   return _stan_bitor(pstream__);
 }
 
-template <typename T_stan_constexpr__, stan::require_all_t<std::is_integral<T_stan_constexpr__>>*>
 inline void
-_stan_bitand_functor__::operator()(const T_stan_constexpr__& _stan_constexpr,
+_stan_bitand_functor__::operator()(const int _stan_constexpr,
                                    std::ostream* pstream__)  const
 {
   return _stan_bitand(_stan_constexpr, pstream__);
@@ -4001,17 +3986,15 @@ inline void _stan_catch_functor__::operator()(std::ostream* pstream__)  const
   return _stan_catch(pstream__);
 }
 
-template <typename T_stan_asm__, stan::require_all_t<std::is_integral<T_stan_asm__>>*>
 inline void
-_stan_alignas_functor__::operator()(const T_stan_asm__& _stan_asm,
+_stan_alignas_functor__::operator()(const int _stan_asm,
                                     std::ostream* pstream__)  const
 {
   return _stan_alignas(_stan_asm, pstream__);
 }
 
-template <typename T_stan_char__, stan::require_all_t<std::is_integral<T_stan_char__>>*>
 inline void
-_stan_alignof_functor__::operator()(const T_stan_char__& _stan_char,
+_stan_alignof_functor__::operator()(const int _stan_char,
                                     std::ostream* pstream__)  const
 {
   return _stan_alignof(_stan_char, pstream__);
@@ -4025,9 +4008,8 @@ _stan_and_eq_functor__::operator()(const T_stan_STAN_MINOR__& _stan_STAN_MINOR,
   return _stan_and_eq(_stan_STAN_MINOR, pstream__);
 }
 
-template <typename T_stan_STAN_MAJOR__, stan::require_all_t<std::is_integral<T_stan_STAN_MAJOR__>>*>
 inline void
-_stan_and_functor__::operator()(const T_stan_STAN_MAJOR__& _stan_STAN_MAJOR,
+_stan_and_functor__::operator()(const int _stan_STAN_MAJOR,
                                 std::ostream* pstream__)  const
 {
   return _stan_and(_stan_STAN_MAJOR, pstream__);
@@ -6490,13 +6472,9 @@ struct foo_five_args_lp_functor__ {
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct f5_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6505,34 +6483,27 @@ struct f5_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline std::vector<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct foo_lcdf_functor__ {
-  template <typename Ty__,
-            typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-            stan::is_stan_scalar<Tlambda__>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tlambda__>
-  operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
+  template <typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Tlambda__>
+  operator()(const int y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct covsqrt2corsqrt_functor__ {
-  template <typename Tmat__,
-            typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
-            std::is_integral<Tinvert__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-  operator()(const Tmat__& mat, const Tinvert__& invert,
-             std::ostream* pstream__) const;
+  template <typename Tmat__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmat__>, -1, -1>
+  operator()(const Tmat__& mat, const int invert, std::ostream* pstream__) const;
 };
 struct foo_1_functor__ {
-  template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
   inline int
-  operator()(const Ta__& a, std::ostream* pstream__) const;
+  operator()(const int a, std::ostream* pstream__) const;
 };
 struct unit_normal_lp_functor__ {
   template <bool propto__, typename Tu__, typename T_lp__,
@@ -6550,13 +6521,9 @@ struct vecfoo_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6565,14 +6532,13 @@ struct f6_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline std::vector<std::vector<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>>>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct foo_five_args_functor__ {
   template <typename Tx1__, typename Tx2__, typename Tx3__, typename Tx4__,
@@ -6585,18 +6551,13 @@ struct foo_five_args_functor__ {
              const Tx4__& x4, const Tx5__& x5, std::ostream* pstream__) const;
 };
 struct foo_2_functor__ {
-  template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
   inline int
-  operator()(const Ta__& a, std::ostream* pstream__) const;
+  operator()(const int a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6606,11 +6567,11 @@ struct f3_functor__ {
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<int>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
@@ -6618,13 +6579,9 @@ struct foo_4_functor__ {
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6633,23 +6590,18 @@ struct f7_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct f11_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6658,23 +6610,18 @@ struct f11_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6683,25 +6630,24 @@ struct f12_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>>>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct sho_functor__ {
-  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-            typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+  template <typename Tt__, typename Ty__, typename Ttheta__,
+            typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
-            stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+            stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
+             const Tx__& x, const std::vector<int>& x_int,
+             std::ostream* pstream__) const;
 };
 struct foo_bar2_functor__ {
   template <typename Tx__,
@@ -6715,14 +6661,13 @@ struct matfoo_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename Tx__, typename Ty__, typename Tdat__,
-            typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+  template <typename Tx__, typename Ty__,
+            typename Tdat__, stan::require_all_t<stan::is_col_vector<Tx__>,
             stan::is_col_vector<Ty__>,
-            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
-            stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
-             const Tdat_int__& dat_int, std::ostream* pstream__) const;
+             const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
   template <typename Tmu__, typename Tsigma__,
@@ -6747,13 +6692,9 @@ struct vecmubar_functor__ {
   operator()(const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct f0_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6763,39 +6704,32 @@ struct f0_functor__ {
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline void
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct foo_lpmf_functor__ {
-  template <bool propto__, typename Ty__,
-            typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-            stan::is_stan_scalar<Tlambda__>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tlambda__>
-  operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
+  template <bool propto__,
+            typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Tlambda__>
+  operator()(const int y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct foo_5_functor__ {
   template <typename Tshared_params__, typename Tjob_params__,
-            typename Tdata_r__,
-            typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+            typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
             stan::is_col_vector<Tjob_params__>,
-            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-            stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
-             const Tdata_i__& data_i, std::ostream* pstream__) const;
+             const std::vector<int>& data_i, std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6804,23 +6738,18 @@ struct f4_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct f10_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6829,23 +6758,18 @@ struct f10_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6855,20 +6779,16 @@ struct f2_functor__ {
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<int>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct f9_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6877,23 +6797,18 @@ struct f9_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>>>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6902,21 +6817,18 @@ struct f8_functor__ {
             stan::is_eigen_matrix_dynamic<Ta10__>,
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                      stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                          stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                      stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>>
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct foo_lccdf_functor__ {
-  template <typename Ty__,
-            typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-            stan::is_stan_scalar<Tlambda__>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tlambda__>
-  operator()(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) const;
+  template <typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Tlambda__>
+  operator()(const int y, const Tlambda__& lambda, std::ostream* pstream__) const;
 };
 struct vecmufoo_functor__ {
   template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
@@ -6931,25 +6843,22 @@ struct foo_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_3_functor__ {
-  template <typename Tt__,
-            typename Tn__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            std::is_integral<Tn__>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Tn__>>
-  operator()(const Tt__& t, const Tn__& n, std::ostream* pstream__) const;
+  template <typename Tt__, stan::require_all_t<stan::is_stan_scalar<Tt__>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__>>
+  operator()(const Tt__& t, const int n, std::ostream* pstream__) const;
 };
 struct foo_6_functor__ {
   inline void
   operator()(std::ostream* pstream__) const;
 };
 struct binomialf_functor__ {
-  template <typename Tphi__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
+  template <typename Tphi__, typename Ttheta__,
+            typename Tx_r__, stan::require_all_t<stan::is_col_vector<Tphi__>,
             stan::is_col_vector<Ttheta__>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__>, -1, 1>
   operator()(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
-             const Tx_i__& x_i, std::ostream* pstream__) const;
+             const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
@@ -6957,13 +6866,9 @@ struct foo_bar1_functor__ {
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-            typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-            typename Ta9__, typename Ta10__, typename Ta11__,
-            typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-            stan::is_stan_scalar<Ta4__>,
+  template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+            typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+            typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
             stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
             stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
@@ -6973,23 +6878,20 @@ struct f1_functor__ {
             stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
             stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline int
-  operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
-             const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
-             std::ostream* pstream__) const;
+  operator()(const int a1, const std::vector<int>& a2,
+             const std::vector<std::vector<int>>& a3, const Ta4__& a4,
+             const Ta5__& a5, const Ta6__& a6, const Ta7__& a7,
+             const Ta8__& a8, const Ta9__& a9, const Ta10__& a10,
+             const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>* = nullptr>
   inline int
-  operator()(const Tn__& n, std::ostream* pstream__) const;
+  operator()(const int n, std::ostream* pstream__) const;
 };
 
-template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>*>
-  inline int foo(const Tn__& n, std::ostream* pstream__) ; 
-template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>* = nullptr>
-  inline int foo(const Tn__& n, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tn__>;
+inline int foo(const int n, std::ostream* pstream__) ; 
+inline int foo(const int n, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7007,26 +6909,23 @@ template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>*>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>>*>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
-      const Tx_int__& x_int, std::ostream* pstream__) ; 
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+      const std::vector<int>& x_int, std::ostream* pstream__) ; 
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
-      const Tx_int__& x_int, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>;
+      const std::vector<int>& x_int, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7099,12 +6998,11 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__,
-          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-          stan::is_stan_scalar<Tlambda__>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tlambda__>
-  foo_lpmf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
+template <bool propto__,
+          typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Tlambda__>
+  foo_lpmf(const int y, const Tlambda__& lambda, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tlambda__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -7115,12 +7013,10 @@ template <bool propto__, typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__,
-          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-          stan::is_stan_scalar<Tlambda__>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tlambda__>
-  foo_lcdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
+template <typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Tlambda__>
+  foo_lcdf(const int y, const Tlambda__& lambda, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tlambda__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7133,12 +7029,10 @@ template <typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__,
-          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-          stan::is_stan_scalar<Tlambda__>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tlambda__>
-  foo_lccdf(const Ty__& y, const Tlambda__& lambda, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__, Tlambda__>;
+template <typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>* = nullptr>
+  inline stan::return_type_t<Tlambda__>
+  foo_lccdf(const int y, const Tlambda__& lambda, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tlambda__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7188,9 +7082,8 @@ template <bool propto__, typename Tu__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
-  inline int foo_1(const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ta__>;
+inline int foo_1(const int a, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7413,9 +7306,8 @@ template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
-  inline int foo_2(const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ta__>;
+inline int foo_2(const int a, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7441,12 +7333,10 @@ template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__,
-          typename Tn__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          std::is_integral<Tn__>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Tn__>>
-  foo_3(const Tt__& t, const Tn__& n, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tt__, Tn__>;
+template <typename Tt__, stan::require_all_t<stan::is_stan_scalar<Tt__>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__>>
+  foo_3(const Tt__& t, const int n, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tt__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7545,18 +7435,15 @@ template <typename Tx__, typename Ty__, typename Tmax___,
     }
     }
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__,
-          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
   foo_5(const Tshared_params__& shared_params_arg__,
         const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
-        const Tdata_i__& data_i, std::ostream* pstream__) {
+        const std::vector<int>& data_i, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
-                                Tdata_i__>;
+            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>;
     int current_statement__ = 0; 
     const auto& shared_params = stan::math::to_ref(shared_params_arg__);
     const auto& job_params = stan::math::to_ref(job_params_arg__);
@@ -7618,13 +7505,11 @@ template <bool propto__, typename Tx1__, typename Tx2__, typename Tx3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tmat__,
-          typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
-          std::is_integral<Tinvert__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-  covsqrt2corsqrt(const Tmat__& mat_arg__, const Tinvert__& invert,
+template <typename Tmat__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tmat__>, -1, -1>
+  covsqrt2corsqrt(const Tmat__& mat_arg__, const int invert,
                   std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tmat__, Tinvert__>;
+    using local_scalar_t__ = stan::return_type_t<Tmat__>;
     int current_statement__ = 0; 
     const auto& mat = stan::math::to_ref(mat_arg__);
     static constexpr bool propto__ = true;
@@ -7659,13 +7544,9 @@ template <typename Tmat__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7675,16 +7556,15 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline void
-  f0(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  f0(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7702,13 +7582,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7718,16 +7594,15 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline int
-  f1(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  f1(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7742,13 +7617,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7758,16 +7629,15 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<int>
-  f2(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  f2(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7782,13 +7652,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7798,16 +7664,15 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<int>>
-  f3(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  f3(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7822,13 +7687,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7837,19 +7698,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>
-  f4(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>
+  f4(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7864,13 +7723,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7879,19 +7734,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>>
-  f5(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline std::vector<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>>
+  f5(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7906,13 +7759,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7921,19 +7770,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>>>
-  f6(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline std::vector<std::vector<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>>>
+  f6(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7948,13 +7795,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -7963,19 +7806,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
-  f7(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>
+  f7(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -7990,13 +7831,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8005,19 +7842,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
-  f8(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>>
+  f8(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8032,13 +7867,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8047,19 +7878,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
-  f9(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>>>
+  f9(const int a1, const std::vector<int>& a2,
+     const std::vector<std::vector<int>>& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
      const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
      const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8074,13 +7903,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8089,19 +7914,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
-  f10(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>
+  f10(const int a1, const std::vector<int>& a2,
+      const std::vector<std::vector<int>>& a3, const Ta4__& a4,
       const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
       const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
       const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8116,13 +7939,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8131,19 +7950,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
-  f11(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>>
+  f11(const int a1, const std::vector<int>& a2,
+      const std::vector<std::vector<int>>& a3, const Ta4__& a4,
       const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
       const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
       const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8158,13 +7975,9 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8173,19 +7986,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
-  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
-  f12(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
+  inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>>>
+  f12(const int a1, const std::vector<int>& a2,
+      const std::vector<std::vector<int>>& a3, const Ta4__& a4,
       const Ta5__& a5, const Ta6__& a6, const Ta7__& a7_arg__,
       const Ta8__& a8, const Ta9__& a9, const Ta10__& a10_arg__,
       const Ta11__& a11, const Ta12__& a12, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                                stan::return_type_t<Ta6__, Ta7__, Ta8__,
-                                                    Ta9__, Ta10__,
-                                                    stan::return_type_t<
-                                                    Ta11__, Ta12__>>>;
+            stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                                stan::return_type_t<Ta9__, Ta10__, Ta11__,
+                                                    Ta12__>>;
     int current_statement__ = 0; 
     const auto& a7 = stan::math::to_ref(a7_arg__);
     const auto& a10 = stan::math::to_ref(a10_arg__);
@@ -8306,16 +8117,14 @@ template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nu
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Ty__, typename Tdat__,
-          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+template <typename Tx__, typename Ty__,
+          typename Tdat__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__>, -1, 1>
   algebra_system(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
-                 const Tdat_int__& dat_int, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>;
+                 const std::vector<int>& dat_int, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__, Tdat__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     const auto& y = stan::math::to_ref(y_arg__);
@@ -8342,16 +8151,15 @@ template <typename Tx__, typename Ty__, typename Tdat__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tphi__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
+template <typename Tphi__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_col_vector<Tphi__>,
           stan::is_col_vector<Ttheta__>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__>, -1, 1>
   binomialf(const Tphi__& phi_arg__, const Ttheta__& theta_arg__,
-            const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>;
+            const Tx_r__& x_r, const std::vector<int>& x_i,
+            std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tphi__, Ttheta__, Tx_r__>;
     int current_statement__ = 0; 
     const auto& phi = stan::math::to_ref(phi_arg__);
     const auto& theta = stan::math::to_ref(theta_arg__);
@@ -8390,13 +8198,9 @@ foo_five_args_lp_functor__::operator()(const Tx1__& x1, const Tx2__& x2,
            pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8405,10 +8209,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>>
-f5_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline std::vector<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>>
+f5_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8417,30 +8221,24 @@ f5_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ty__,
-          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-          stan::is_stan_scalar<Tlambda__>>*>
-inline stan::return_type_t<Ty__, Tlambda__>
-foo_lcdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
+template <typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>*>
+inline stan::return_type_t<Tlambda__>
+foo_lcdf_functor__::operator()(const int y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
 {
   return foo_lcdf(y, lambda, pstream__);
 }
 
-template <typename Tmat__,
-          typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
-          std::is_integral<Tinvert__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
-                                      const Tinvert__& invert,
+template <typename Tmat__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tmat__>, -1, -1>
+covsqrt2corsqrt_functor__::operator()(const Tmat__& mat, const int invert,
                                       std::ostream* pstream__)  const
 {
   return covsqrt2corsqrt(mat, invert, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>*>
-inline int
-foo_1_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
+inline int foo_1_functor__::operator()(const int a, std::ostream* pstream__) 
+const
 {
   return foo_1(a, pstream__);
 }
@@ -8466,13 +8264,9 @@ vecfoo_functor__::operator()(std::ostream* pstream__)  const
   return vecfoo(pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8481,10 +8275,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>>>
-f6_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline std::vector<std::vector<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>>>
+f6_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8506,20 +8300,15 @@ const
   return foo_five_args(x1, x2, x3, x4, x5, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<std::is_integral<Ta__>>*>
-inline int
-foo_2_functor__::operator()(const Ta__& a, std::ostream* pstream__)  const
+inline int foo_2_functor__::operator()(const int a, std::ostream* pstream__) 
+const
 {
   return foo_2(a, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8529,7 +8318,8 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<int>>
-f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+f3_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8545,13 +8335,9 @@ foo_4_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
   return foo_4(x, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8560,10 +8346,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
-f7_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>
+f7_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8572,13 +8358,9 @@ f7_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f7(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8587,10 +8369,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
-f11_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>>
+f11_functor__::operator()(const int a1, const std::vector<int>& a2,
+                          const std::vector<std::vector<int>>& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                           const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                           const Ta10__& a10, const Ta11__& a11,
@@ -8599,13 +8381,9 @@ f11_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8614,10 +8392,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
-f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>>>
+f12_functor__::operator()(const int a1, const std::vector<int>& a2,
+                          const std::vector<std::vector<int>>& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                           const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                           const Ta10__& a10, const Ta11__& a11,
@@ -8626,17 +8404,16 @@ f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>*>
-inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
-                          const Tx_int__& x_int, std::ostream* pstream__) 
-const
+                          const std::vector<int>& x_int,
+                          std::ostream* pstream__)  const
 {
   return sho(t, y, theta, x, x_int, pstream__);
 }
@@ -8657,15 +8434,14 @@ matfoo_functor__::operator()(std::ostream* pstream__)  const
   return matfoo(pstream__);
 }
 
-template <typename Tx__, typename Ty__, typename Tdat__,
-          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+template <typename Tx__, typename Ty__,
+          typename Tdat__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
-inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
-                                     const Tdat_int__& dat_int,
+                                     const std::vector<int>& dat_int,
                                      std::ostream* pstream__)  const
 {
   return algebra_system(x, y, dat, dat_int, pstream__);
@@ -8702,13 +8478,9 @@ const
   return vecmubar(mu, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8718,7 +8490,8 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline void
-f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+f0_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8727,38 +8500,32 @@ f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <bool propto__, typename Ty__,
-          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-          stan::is_stan_scalar<Tlambda__>>*>
-inline stan::return_type_t<Ty__, Tlambda__>
-foo_lpmf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
+template <bool propto__,
+          typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>*>
+inline stan::return_type_t<Tlambda__>
+foo_lpmf_functor__::operator()(const int y, const Tlambda__& lambda,
                                std::ostream* pstream__)  const
 {
   return foo_lpmf<propto__>(y, lambda, pstream__);
 }
 
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__,
-          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
-inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
 foo_5_functor__::operator()(const Tshared_params__& shared_params,
                             const Tjob_params__& job_params,
-                            const Tdata_r__& data_r, const Tdata_i__& data_i,
+                            const Tdata_r__& data_r,
+                            const std::vector<int>& data_i,
                             std::ostream* pstream__)  const
 {
   return foo_5(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8767,10 +8534,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>
-f4_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>
+f4_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8779,13 +8546,9 @@ f4_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f4(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8794,10 +8557,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
-f10_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, -1>
+f10_functor__::operator()(const int a1, const std::vector<int>& a2,
+                          const std::vector<std::vector<int>>& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                           const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                           const Ta10__& a10, const Ta11__& a11,
@@ -8806,13 +8569,9 @@ f10_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8822,7 +8581,8 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<int>
-f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+f2_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8831,13 +8591,9 @@ f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f2(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8846,10 +8602,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
-f9_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>>>
+f9_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8858,13 +8614,9 @@ f9_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f9(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8873,10 +8625,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_eigen_matrix_dynamic<Ta10__>,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
-inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
-                    stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
-                                        stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
-f8_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+inline std::vector<Eigen::Matrix<stan::return_type_t<Ta4__, Ta5__, Ta6__, Ta7__, Ta8__,
+                    stan::return_type_t<Ta9__, Ta10__, Ta11__, Ta12__>>, -1, 1>>
+f8_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8885,11 +8637,9 @@ f8_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Ty__,
-          typename Tlambda__, stan::require_all_t<std::is_integral<Ty__>,
-          stan::is_stan_scalar<Tlambda__>>*>
-inline stan::return_type_t<Ty__, Tlambda__>
-foo_lccdf_functor__::operator()(const Ty__& y, const Tlambda__& lambda,
+template <typename Tlambda__, stan::require_all_t<stan::is_stan_scalar<Tlambda__>>*>
+inline stan::return_type_t<Tlambda__>
+foo_lccdf_functor__::operator()(const int y, const Tlambda__& lambda,
                                 std::ostream* pstream__)  const
 {
   return foo_lccdf(y, lambda, pstream__);
@@ -8913,11 +8663,9 @@ foo_lp_functor__::operator()(const Tx__& x, T_lp__& lp__,
   return foo_lp<propto__>(x, lp__, lp_accum__, pstream__);
 }
 
-template <typename Tt__,
-          typename Tn__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          std::is_integral<Tn__>>*>
-inline std::vector<stan::return_type_t<Tt__, Tn__>>
-foo_3_functor__::operator()(const Tt__& t, const Tn__& n,
+template <typename Tt__, stan::require_all_t<stan::is_stan_scalar<Tt__>>*>
+inline std::vector<stan::return_type_t<Tt__>>
+foo_3_functor__::operator()(const Tt__& t, const int n,
                             std::ostream* pstream__)  const
 {
   return foo_3(t, n, pstream__);
@@ -8928,14 +8676,14 @@ inline void foo_6_functor__::operator()(std::ostream* pstream__)  const
   return foo_6(pstream__);
 }
 
-template <typename Tphi__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
+template <typename Tphi__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_col_vector<Tphi__>,
           stan::is_col_vector<Ttheta__>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
-inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__>, -1, 1>
 binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
-                                const Tx_r__& x_r, const Tx_i__& x_i,
+                                const Tx_r__& x_r,
+                                const std::vector<int>& x_i,
                                 std::ostream* pstream__)  const
 {
   return binomialf(phi, theta, x_r, x_i, pstream__);
@@ -8948,13 +8696,9 @@ foo_bar1_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
   return foo_bar1(x, pstream__);
 }
 
-template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
-          typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
-          typename Ta9__, typename Ta10__, typename Ta11__,
-          typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
-          stan::is_stan_scalar<Ta4__>,
+template <typename Ta4__, typename Ta5__, typename Ta6__, typename Ta7__,
+          typename Ta8__, typename Ta9__, typename Ta10__, typename Ta11__,
+          typename Ta12__, stan::require_all_t<stan::is_stan_scalar<Ta4__>,
           stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
           stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
@@ -8964,7 +8708,8 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
           stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline int
-f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
+f1_functor__::operator()(const int a1, const std::vector<int>& a2,
+                         const std::vector<std::vector<int>>& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
                          const Ta10__& a10, const Ta11__& a11,
@@ -8973,8 +8718,7 @@ f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
   return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>*>
-inline int foo_functor__::operator()(const Tn__& n, std::ostream* pstream__) 
+inline int foo_functor__::operator()(const int n, std::ostream* pstream__) 
 const
 {
   return foo(n, pstream__);
@@ -15164,61 +14908,55 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'motherHOF.stan', line 25, column 45 to line 30, column 3)"};
 
 struct sho_functor__ {
-  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-            typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+  template <typename Tt__, typename Ty__, typename Ttheta__,
+            typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
-            stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+            stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
+             const Tx__& x, const std::vector<int>& x_int,
+             std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename Tx__, typename Ty__, typename Tdat__,
-            typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+  template <typename Tx__, typename Ty__,
+            typename Tdat__, stan::require_all_t<stan::is_col_vector<Tx__>,
             stan::is_col_vector<Ty__>,
-            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
-            stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
-             const Tdat_int__& dat_int, std::ostream* pstream__) const;
+             const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
   template <typename Tx__, typename Txc__, typename Ttheta__,
-            typename Tx_r__,
-            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
             stan::is_stan_scalar<Txc__>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__>
   operator()(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) const;
 };
 struct foo_functor__ {
   template <typename Tshared_params__, typename Tjob_params__,
-            typename Tdata_r__,
-            typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+            typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
             stan::is_col_vector<Tjob_params__>,
-            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-            stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
-             const Tdata_i__& data_i, std::ostream* pstream__) const;
+             const std::vector<int>& data_i, std::ostream* pstream__) const;
 };
 struct goo_functor__ {
   template <typename Tshared_params__, typename Tjob_params__,
-            typename Tdata_r__,
-            typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+            typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
             stan::is_col_vector<Tjob_params__>,
-            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-            stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
-             const Tdata_i__& data_i, std::ostream* pstream__) const;
+             const std::vector<int>& data_i, std::ostream* pstream__) const;
 };
 struct map_rectfake_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
@@ -15226,17 +14964,15 @@ struct map_rectfake_functor__ {
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
-      const Tx_int__& x_int, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>;
+      const std::vector<int>& x_int, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15261,17 +14997,17 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+template <typename Tx__, typename Txc__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
           stan::is_stan_scalar<Txc__>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__>
   integrand(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
-            const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+            const Tx_r__& x_r, const std::vector<int>& x_i,
+            std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>;
+            stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15285,18 +15021,15 @@ template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__,
-          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
   foo(const Tshared_params__& shared_params_arg__,
       const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
-      const Tdata_i__& data_i, std::ostream* pstream__) {
+      const std::vector<int>& data_i, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
-                                Tdata_i__>;
+            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>;
     int current_statement__ = 0; 
     const auto& shared_params = stan::math::to_ref(shared_params_arg__);
     const auto& job_params = stan::math::to_ref(job_params_arg__);
@@ -15312,18 +15045,15 @@ template <typename Tshared_params__, typename Tjob_params__,
     }
     }
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__,
-          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
   goo(const Tshared_params__& shared_params_arg__,
       const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
-      const Tdata_i__& data_i, std::ostream* pstream__) {
+      const std::vector<int>& data_i, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__,
-                                Tdata_i__>;
+            stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>;
     int current_statement__ = 0; 
     const auto& shared_params = stan::math::to_ref(shared_params_arg__);
     const auto& job_params = stan::math::to_ref(job_params_arg__);
@@ -15354,16 +15084,14 @@ template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, typename Ty__, typename Tdat__,
-          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+template <typename Tx__, typename Ty__,
+          typename Tdat__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__>, -1, 1>
   algebra_system(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
-                 const Tdat_int__& dat_int, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>;
+                 const std::vector<int>& dat_int, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__, Tdat__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     const auto& y = stan::math::to_ref(y_arg__);
@@ -15390,75 +15118,70 @@ template <typename Tx__, typename Ty__, typename Tdat__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
-          typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>*>
-inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
-                          const Tx_int__& x_int, std::ostream* pstream__) 
-const
+                          const std::vector<int>& x_int,
+                          std::ostream* pstream__)  const
 {
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-template <typename Tx__, typename Ty__, typename Tdat__,
-          typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
+template <typename Tx__, typename Ty__,
+          typename Tdat__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
-inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
-                                     const Tdat_int__& dat_int,
+                                     const std::vector<int>& dat_int,
                                      std::ostream* pstream__)  const
 {
   return algebra_system(x, y, dat, dat_int, pstream__);
 }
 
-template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+template <typename Tx__, typename Txc__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
           stan::is_stan_scalar<Txc__>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
-inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>*>
+inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__>
 integrand_functor__::operator()(const Tx__& x, const Txc__& xc,
                                 const Ttheta__& theta, const Tx_r__& x_r,
-                                const Tx_i__& x_i, std::ostream* pstream__) 
-const
+                                const std::vector<int>& x_i,
+                                std::ostream* pstream__)  const
 {
   return integrand(x, xc, theta, x_r, x_i, pstream__);
 }
 
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__,
-          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
-inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
 foo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
-                          const Tdata_r__& data_r, const Tdata_i__& data_i,
+                          const Tdata_r__& data_r,
+                          const std::vector<int>& data_i,
                           std::ostream* pstream__)  const
 {
   return foo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
 template <typename Tshared_params__, typename Tjob_params__,
-          typename Tdata_r__,
-          typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
+          typename Tdata_r__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
-inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__>, -1, 1>
 goo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
-                          const Tdata_r__& data_r, const Tdata_i__& data_i,
+                          const Tdata_r__& data_r,
+                          const std::vector<int>& data_i,
                           std::ostream* pstream__)  const
 {
   return goo(shared_params, job_params, data_r, data_i, pstream__);
@@ -21549,28 +21272,28 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'old_integrate_interface.stan', line 7, column 38 to line 19, column 3)"};
 
 struct dz_dt_functor__ {
-  template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+  template <typename Tt__, typename Tz__, typename Ttheta__,
+            typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_std_vector<Tz__>, stan::is_stan_scalar<stan::value_type_t<Tz__>>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__>>
   operator()(const Tt__& t, const Tz__& z, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) const;
 };
 
-template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Tz__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Tz__>, stan::is_stan_scalar<stan::value_type_t<Tz__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__>>
   dz_dt(const Tt__& t, const Tz__& z, const Ttheta__& theta,
-        const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+        const Tx_r__& x_r, const std::vector<int>& x_i,
+        std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>;
+            stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -21607,17 +21330,16 @@ template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Tz__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Tz__>, stan::is_stan_scalar<stan::value_type_t<Tz__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
-inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__>>
 dz_dt_functor__::operator()(const Tt__& t, const Tz__& z,
                             const Ttheta__& theta, const Tx_r__& x_r,
-                            const Tx_i__& x_i, std::ostream* pstream__) 
-const
+                            const std::vector<int>& x_i,
+                            std::ostream* pstream__)  const
 {
   return dz_dt(t, z, theta, x_r, x_i, pstream__);
 }
@@ -23922,9 +23644,8 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'overloading_templating.stan', line 34, column 25 to line 36, column 3)"};
 
 struct foo_functor__ {
-  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<stan::value_type_t<Tp__>>>* = nullptr>
-  inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<int>& p, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tp__>>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
@@ -23952,15 +23673,12 @@ struct foo_functor__ {
   template <typename Tp__, stan::require_all_t<stan::is_stan_scalar<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__, stan::require_all_t<std::is_integral<Tp__>>* = nullptr>
-  inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p, std::ostream* pstream__) const;
+  inline double
+  operator()(const int p, std::ostream* pstream__) const;
 };
 
-template <typename Tp__, stan::require_all_t<std::is_integral<Tp__>>* = nullptr>
-  inline stan::return_type_t<Tp__>
-  foo(const Tp__& p, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tp__>;
+inline double foo(const int p, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24124,10 +23842,8 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<stan::value_type_t<Tp__>>>* = nullptr>
-  inline stan::return_type_t<Tp__>
-  foo(const Tp__& p, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tp__>;
+inline double foo(const std::vector<int>& p, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -24140,9 +23856,9 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<stan::value_type_t<Tp__>>>*>
-inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
+inline double
+foo_functor__::operator()(const std::vector<int>& p, std::ostream* pstream__) 
+const
 {
   return foo(p, pstream__);
 }
@@ -24210,9 +23926,8 @@ foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_all_t<std::is_integral<Tp__>>*>
-inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
+inline double
+foo_functor__::operator()(const int p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
@@ -25788,64 +25503,52 @@ static constexpr std::array<const char*, 26> locations_array__ =
 
 template <bool propto__>
   struct foo_lpdf_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <bool propto__,
+            typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g(const Ty_slice__& y_slice, const int start, const int end,
     std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25864,15 +25567,13 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  h(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-    const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  h(const Ty_slice__& y_slice, const int start, const int end, const Ta__& a,
+    std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25893,14 +25594,12 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  foo_lpdf(const Ty_slice__& y_slice, const Tstart__& start,
-           const Tend__& end, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+template <bool propto__,
+          typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  foo_lpdf(const Ty_slice__& y_slice, const int start, const int end,
+           std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25912,69 +25611,58 @@ template <bool propto__, typename Ty_slice__, typename Tstart__,
     }
     }
 template <bool propto__>
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
-                                           const Tstart__& start,
-                                           const Tend__& end,
+                                           const int start, const int end,
                                            std::ostream* pstream__)  const
 {
   return foo_lpdf<propto__>(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <bool propto__, typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
-                               const Tstart__& start, const Tend__& end,
-                               std::ostream* pstream__)  const
+template <bool propto__,
+          typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+foo_lpdf_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                               const int end, std::ostream* pstream__)  const
 {
   return foo_lpdf<propto__>(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                        const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                        const int end, std::ostream* pstream__)  const
 {
   return g(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+h_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, std::ostream* pstream__,
                           const Ta__& a)  const
 {
   return h(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, std::ostream* pstream__)  const
 {
   return g(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-h_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                        const Tend__& end, const Ta__& a,
-                        std::ostream* pstream__)  const
+inline stan::return_type_t<Ty_slice__, Ta__>
+h_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                        const int end, const Ta__& a, std::ostream* pstream__) 
+const
 {
   return h(y_slice, start, end, a, pstream__);
 }
@@ -26568,286 +26256,235 @@ static constexpr std::array<const char*, 180> locations_array__ =
  " (in 'reduce_sum_m2.stan', line 113, column 65 to line 121, column 3)"};
 
 struct g6_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h6_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 struct h6_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h8_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 struct h7_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 struct h8_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h2_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h2_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h5_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h1_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 struct g7_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h4_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g4_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g7_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h5_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 struct g8_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct h3_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h7_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h1_rsfunctor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h3_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 struct h4_functor__ {
-  template <typename Ty__, typename Tstart__, typename Tend__,
+  template <typename Ty__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
-             const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty__, Ta__>
+  operator()(const Ty__& y, const int start, const int end, const Ta__& a,
+             std::ostream* pstream__) const;
 };
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g1(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26860,14 +26497,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g2(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26891,14 +26525,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g3(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26922,14 +26553,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g4(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26954,14 +26582,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g5(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26993,14 +26618,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g6(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27033,14 +26655,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g7(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27073,14 +26692,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  g8(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27113,15 +26729,13 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h1(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h1(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27136,15 +26750,13 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h2(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h2(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27168,15 +26780,13 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h3(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h3(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27200,15 +26810,13 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h4(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h4(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27233,15 +26841,13 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h5(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h5(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27272,15 +26878,13 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h6(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h6(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27312,15 +26916,13 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h7(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h7(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27352,15 +26954,13 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-  h8(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
+  inline stan::return_type_t<Ty__, Ta__>
+  h8(const Ty__& y, const int start, const int end, const Ta__& a,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -27392,354 +26992,290 @@ template <typename Ty__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g6_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g6(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h6_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h6_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h6(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h6_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h6(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h8_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h8_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h8(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h7_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h7_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h7(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h8_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h8(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h2_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h2_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h2(y, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g8_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g8(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h2_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h2(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g1_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g1(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g2_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g2(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h5_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h5(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h1_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h1_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h1(y, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g7_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g7(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g5_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g5(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g5(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g6(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g4_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g4(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h4_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h4(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g4(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g7(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h5_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h5_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h5(y, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return g8(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+g3_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return g3(y_slice, start, end, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h3_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h3(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h7_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h7(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+inline stan::return_type_t<Ty__, Ta__>
+h1_rsfunctor__::operator()(const Ty__& y, const int start, const int end,
+                           std::ostream* pstream__, const Ta__& a)  const
 {
   return h1(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h3_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h3_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h3(y, start, end, a, pstream__);
 }
 
-template <typename Ty__, typename Tstart__, typename Tend__,
+template <typename Ty__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
-h4_functor__::operator()(const Ty__& y, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
-                         std::ostream* pstream__)  const
+inline stan::return_type_t<Ty__, Ta__>
+h4_functor__::operator()(const Ty__& y, const int start, const int end,
+                         const Ta__& a, std::ostream* pstream__)  const
 {
   return h4(y, start, end, a, pstream__);
 }
@@ -29467,516 +29003,417 @@ static constexpr std::array<const char*, 342> locations_array__ =
  " (in 'reduce_sum_m3.stan', line 86, column 11 to line 149, column 3)"};
 
 struct f1a_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct s_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, typename Tb__, typename Tc__, typename Td__,
-            typename Te__, typename Tf__, typename Tg__, typename Th__,
-            typename Ti__, typename Tj__, typename Tk__, typename Tl__,
-            typename Tm__, typename Tn__, typename To__, typename Tp__,
+  template <typename Ty_slice__, typename Tb__, typename Tc__, typename Td__,
+            typename Te__, typename Tg__, typename Th__, typename Ti__,
+            typename Tj__, typename Tl__, typename Tm__, typename Tn__,
+            typename To__,
             typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
-            stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
-            stan::is_eigen_matrix_dynamic<Te__>,
-            stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+            stan::is_stan_scalar<Tb__>, stan::is_col_vector<Tc__>,
+            stan::is_row_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
             stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
             stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
             stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
             stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
-            stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
             stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
             stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
             stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
             stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
-            stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
             stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
-                      stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
-                                          stan::return_type_t<Th__, Ti__, Tj__,
-                                                              Tk__, Tl__,
-                                                              stan::return_type_t<
-                                                              Tm__, Tn__, To__,
-                                                              Tp__, Tq__>>>>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a,
-             const Tb__& b, const Tc__& c, const Td__& d, const Te__& e,
-             const Tf__& f, const Tg__& g, const Th__& h, const Ti__& i,
-             const Tj__& j, const Tk__& k, const Tl__& l, const Tm__& m,
-             const Tn__& n, const To__& o, const Tp__& p, const Tq__& q) const;
+  inline stan::return_type_t<Ty_slice__, Tb__, Tc__, Td__, Te__,
+                      stan::return_type_t<Tg__, Th__, Ti__, Tj__, Tl__,
+                                          stan::return_type_t<Tm__, Tn__, To__,
+                                                              Tq__>>>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const int a, const Tb__& b,
+             const Tc__& c, const Td__& d, const Te__& e,
+             const std::vector<int>& f, const Tg__& g, const Th__& h,
+             const Ti__& i, const Tj__& j,
+             const std::vector<std::vector<int>>& k, const Tl__& l,
+             const Tm__& m, const Tn__& n, const To__& o,
+             const std::vector<std::vector<std::vector<int>>>& p, const Tq__& q) const;
 };
 struct f4_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g12_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f8_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct f1a_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g10_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct r_functor__ {
   inline double
   operator()(std::ostream* pstream__) const;
 };
 struct g1_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_col_vector<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct f6_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g12_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct f2_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f3_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f12_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g9_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g11_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f1_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g11_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g9_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct f11_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
+             const int start, const int end, std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_row_vector<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct f11_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
+             const int start, const int end, std::ostream* pstream__) const;
 };
 struct g6_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct f7_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f9_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<int>& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_col_vector<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct f10_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<std::vector<int>>& y_slice, const int start,
+             const int end, std::ostream* pstream__) const;
 };
 struct s_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, typename Tb__, typename Tc__, typename Td__,
-            typename Te__, typename Tf__, typename Tg__, typename Th__,
-            typename Ti__, typename Tj__, typename Tk__, typename Tl__,
-            typename Tm__, typename Tn__, typename To__, typename Tp__,
+  template <typename Ty_slice__, typename Tb__, typename Tc__, typename Td__,
+            typename Te__, typename Tg__, typename Th__, typename Ti__,
+            typename Tj__, typename Tl__, typename Tm__, typename Tn__,
+            typename To__,
             typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
-            stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
-            stan::is_eigen_matrix_dynamic<Te__>,
-            stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+            stan::is_stan_scalar<Tb__>, stan::is_col_vector<Tc__>,
+            stan::is_row_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
             stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
             stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
             stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
             stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
-            stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
             stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
             stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
             stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
             stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
-            stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
             stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
-                      stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
-                                          stan::return_type_t<Th__, Ti__, Tj__,
-                                                              Tk__, Tl__,
-                                                              stan::return_type_t<
-                                                              Tm__, Tn__, To__,
-                                                              Tp__, Tq__>>>>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, const Tb__& b, const Tc__& c,
-             const Td__& d, const Te__& e, const Tf__& f, const Tg__& g,
-             const Th__& h, const Ti__& i, const Tj__& j, const Tk__& k,
-             const Tl__& l, const Tm__& m, const Tn__& n, const To__& o,
-             const Tp__& p, const Tq__& q, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Tb__, Tc__, Td__, Te__,
+                      stan::return_type_t<Tg__, Th__, Ti__, Tj__, Tl__,
+                                          stan::return_type_t<Tm__, Tn__, To__,
+                                                              Tq__>>>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const int a, const Tb__& b, const Tc__& c, const Td__& d,
+             const Te__& e, const std::vector<int>& f, const Tg__& g,
+             const Th__& h, const Ti__& i, const Tj__& j,
+             const std::vector<std::vector<int>>& k, const Tl__& l,
+             const Tm__& m, const Tn__& n, const To__& o,
+             const std::vector<std::vector<std::vector<int>>>& p,
+             const Tq__& q, std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_row_vector<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct f9_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<int>& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g1_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g7_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g7_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct g8_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__, const Ta__& a) const;
 };
 struct f10_rsfunctor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<std::vector<int>>& y_slice, const int start,
+             const int end, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__) const;
+  template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             std::ostream* pstream__) const;
 };
 struct g10_functor__ {
-  template <typename Ty_slice__, typename Tstart__, typename Tend__,
+  template <typename Ty_slice__,
             typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-            std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  operator()(const Ty_slice__& y_slice, const int start, const int end,
+             const Ta__& a, std::ostream* pstream__) const;
 };
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f1(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -29989,14 +29426,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f1a(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f1a(const Ty_slice__& y_slice, const int start, const int end,
       std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30009,14 +29443,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f2(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30029,14 +29460,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f3(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30049,14 +29477,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f4(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30069,14 +29494,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f5(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30089,14 +29511,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f6(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30109,14 +29528,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f7(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30129,14 +29545,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f8(const Ty_slice__& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30149,14 +29562,10 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+inline double
+  f9(const std::vector<int>& y_slice, const int start, const int end,
      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30169,14 +29578,10 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+inline double
+  f10(const std::vector<std::vector<int>>& y_slice, const int start,
+      const int end, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30189,14 +29594,10 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-      std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+inline double
+  f11(const std::vector<std::vector<std::vector<int>>>& y_slice,
+      const int start, const int end, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30209,14 +29610,11 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-  f12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>>* = nullptr>
+  inline stan::return_type_t<Ty_slice__>
+  f12(const Ty_slice__& y_slice, const int start, const int end,
       std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30229,15 +29627,13 @@ template <typename Ty_slice__, typename Tstart__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_stan_scalar<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g1(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30250,15 +29646,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_col_vector<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g2(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     static constexpr bool propto__ = true;
@@ -30272,15 +29666,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_row_vector<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g3(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     static constexpr bool propto__ = true;
@@ -30294,15 +29686,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g4(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     static constexpr bool propto__ = true;
@@ -30316,15 +29706,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g5(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30337,15 +29725,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g6(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30358,15 +29744,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g7(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30379,15 +29763,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g8(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30400,15 +29782,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g9(const Ty_slice__& y_slice, const int start, const int end,
      const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30421,15 +29801,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g10(const Ty_slice__& y_slice, const int start, const int end,
       const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30442,15 +29820,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g11(const Ty_slice__& y_slice, const int start, const int end,
       const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30463,15 +29839,13 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-  g12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
+  inline stan::return_type_t<Ty_slice__, Ta__>
+  g12(const Ty_slice__& y_slice, const int start, const int end,
       const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Ty_slice__, Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -30484,51 +29858,40 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, typename Tb__, typename Tc__, typename Td__,
-          typename Te__, typename Tf__, typename Tg__, typename Th__,
-          typename Ti__, typename Tj__, typename Tk__, typename Tl__,
-          typename Tm__, typename Tn__, typename To__, typename Tp__,
+template <typename Ty_slice__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tg__, typename Th__, typename Ti__,
+          typename Tj__, typename Tl__, typename Tm__, typename Tn__,
+          typename To__,
           typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
-          stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
-          stan::is_eigen_matrix_dynamic<Te__>,
-          stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+          stan::is_stan_scalar<Tb__>, stan::is_col_vector<Tc__>,
+          stan::is_row_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
           stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
           stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
           stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
-          stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
           stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
           stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
           stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
           stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
-          stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
           stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>* = nullptr>
-  inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
-                    stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
-                                        stan::return_type_t<Th__, Ti__, Tj__,
-                                                            Tk__, Tl__,
-                                                            stan::return_type_t<
-                                                            Tm__, Tn__, To__,
-                                                            Tp__, Tq__>>>>
-  s(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
-    const Ta__& a, const Tb__& b, const Tc__& c_arg__, const Td__& d_arg__,
-    const Te__& e_arg__, const Tf__& f, const Tg__& g, const Th__& h,
-    const Ti__& i, const Tj__& j, const Tk__& k, const Tl__& l,
-    const Tm__& m, const Tn__& n, const To__& o, const Tp__& p,
-    const Tq__& q, std::ostream* pstream__) {
+  inline stan::return_type_t<Ty_slice__, Tb__, Tc__, Td__, Te__,
+                    stan::return_type_t<Tg__, Th__, Ti__, Tj__, Tl__,
+                                        stan::return_type_t<Tm__, Tn__, To__,
+                                                            Tq__>>>
+  s(const Ty_slice__& y_slice, const int start, const int end, const int a,
+    const Tb__& b, const Tc__& c_arg__, const Td__& d_arg__,
+    const Te__& e_arg__, const std::vector<int>& f, const Tg__& g,
+    const Th__& h, const Ti__& i, const Tj__& j,
+    const std::vector<std::vector<int>>& k, const Tl__& l, const Tm__& m,
+    const Tn__& n, const To__& o,
+    const std::vector<std::vector<std::vector<int>>>& p, const Tq__& q,
+    std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
-                                stan::return_type_t<Tc__, Td__, Te__, Tf__,
-                                                    Tg__,
-                                                    stan::return_type_t<
-                                                    Th__, Ti__, Tj__, Tk__,
+            stan::return_type_t<Ty_slice__, Tb__, Tc__, Td__, Te__,
+                                stan::return_type_t<Tg__, Th__, Ti__, Tj__,
                                                     Tl__,
                                                     stan::return_type_t<
-                                                    Tm__, Tn__, To__, Tp__,
-                                                    Tq__>>>>;
+                                                    Tm__, Tn__, To__, Tq__>>>;
     int current_statement__ = 0; 
     const auto& c = stan::math::to_ref(c_arg__);
     const auto& d = stan::math::to_ref(d_arg__);
@@ -30849,130 +30212,110 @@ inline double r(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f1a_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                            const Tend__& end, std::ostream* pstream__) 
-const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f1a_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                            const int end, std::ostream* pstream__)  const
 {
   return f1a(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, typename Tb__, typename Tc__, typename Td__,
-          typename Te__, typename Tf__, typename Tg__, typename Th__,
-          typename Ti__, typename Tj__, typename Tk__, typename Tl__,
-          typename Tm__, typename Tn__, typename To__, typename Tp__,
+template <typename Ty_slice__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tg__, typename Th__, typename Ti__,
+          typename Tj__, typename Tl__, typename Tm__, typename Tn__,
+          typename To__,
           typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
-          stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
-          stan::is_eigen_matrix_dynamic<Te__>,
-          stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+          stan::is_stan_scalar<Tb__>, stan::is_col_vector<Tc__>,
+          stan::is_row_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
           stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
           stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
           stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
-          stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
           stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
           stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
           stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
           stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
-          stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
           stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
-                    stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
-                                        stan::return_type_t<Th__, Ti__, Tj__,
-                                                            Tk__, Tl__,
-                                                            stan::return_type_t<
-                                                            Tm__, Tn__, To__,
-                                                            Tp__, Tq__>>>>
-s_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, std::ostream* pstream__,
-                          const Ta__& a, const Tb__& b, const Tc__& c,
-                          const Td__& d, const Te__& e, const Tf__& f,
-                          const Tg__& g, const Th__& h, const Ti__& i,
-                          const Tj__& j, const Tk__& k, const Tl__& l,
-                          const Tm__& m, const Tn__& n, const To__& o,
-                          const Tp__& p, const Tq__& q)  const
+inline stan::return_type_t<Ty_slice__, Tb__, Tc__, Td__, Te__,
+                    stan::return_type_t<Tg__, Th__, Ti__, Tj__, Tl__,
+                                        stan::return_type_t<Tm__, Tn__, To__,
+                                                            Tq__>>>
+s_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, std::ostream* pstream__,
+                          const int a, const Tb__& b, const Tc__& c,
+                          const Td__& d, const Te__& e,
+                          const std::vector<int>& f, const Tg__& g,
+                          const Th__& h, const Ti__& i, const Tj__& j,
+                          const std::vector<std::vector<int>>& k,
+                          const Tl__& l, const Tm__& m, const Tn__& n,
+                          const To__& o,
+                          const std::vector<std::vector<std::vector<int>>>& p,
+                          const Tq__& q)  const
 {
   return s(y_slice, start + 1, end + 1, a, b, c, d, e, f, g, h, i, j, k, l,
            m, n, o, p, q, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f4(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                            const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                            const int end, std::ostream* pstream__,
                             const Ta__& a)  const
 {
   return g12(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f5_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f5(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f8(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g8_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g8(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f1a_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, std::ostream* pstream__)  const
 {
   return f1a(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                            const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g10_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                            const int end, std::ostream* pstream__,
                             const Ta__& a)  const
 {
   return g10(y_slice, start + 1, end + 1, a, pstream__);
@@ -30983,508 +30326,433 @@ inline double r_functor__::operator()(std::ostream* pstream__)  const
   return r(pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_stan_scalar<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g1_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g1(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_col_vector<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g2(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f6(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g12_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, const Ta__& a,
                           std::ostream* pstream__)  const
 {
   return g12(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f6_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f6(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                            const Tend__& end, std::ostream* pstream__) 
-const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f12_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                            const int end, std::ostream* pstream__)  const
 {
   return f12(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g9(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g11_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, const Ta__& a,
                           std::ostream* pstream__)  const
 {
   return g11(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f3_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f3(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f7_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f7(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                            const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                            const int end, std::ostream* pstream__,
                             const Ta__& a)  const
 {
   return g11(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g9_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g9(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_eigen_matrix_dynamic<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g4_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g4(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_eigen_matrix_dynamic<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g4(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, std::ostream* pstream__)  const
+inline double
+f11_functor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
+                          const int start, const int end,
+                          std::ostream* pstream__)  const
 {
   return f11(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f12_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, std::ostream* pstream__)  const
 {
   return f12(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_row_vector<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g3_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g3(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                            const Tend__& end, std::ostream* pstream__) 
-const
+inline double
+f11_rsfunctor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
+                            const int start, const int end,
+                            std::ostream* pstream__)  const
 {
   return f11(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g6_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g6(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f7(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+inline double
+f9_rsfunctor__::operator()(const std::vector<int>& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f9(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f4_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f4(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_col_vector<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g2_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g2(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, std::ostream* pstream__)  const
+inline double
+f10_functor__::operator()(const std::vector<std::vector<int>>& y_slice,
+                          const int start, const int end,
+                          std::ostream* pstream__)  const
 {
   return f10(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, typename Tb__, typename Tc__, typename Td__,
-          typename Te__, typename Tf__, typename Tg__, typename Th__,
-          typename Ti__, typename Tj__, typename Tk__, typename Tl__,
-          typename Tm__, typename Tn__, typename To__, typename Tp__,
+template <typename Ty_slice__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tg__, typename Th__, typename Ti__,
+          typename Tj__, typename Tl__, typename Tm__, typename Tn__,
+          typename To__,
           typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
-          stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
-          stan::is_eigen_matrix_dynamic<Te__>,
-          stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+          stan::is_stan_scalar<Tb__>, stan::is_col_vector<Tc__>,
+          stan::is_row_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
           stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
           stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
           stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
-          stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
           stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
           stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
           stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
           stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
-          stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
           stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
-                    stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
-                                        stan::return_type_t<Th__, Ti__, Tj__,
-                                                            Tk__, Tl__,
-                                                            stan::return_type_t<
-                                                            Tm__, Tn__, To__,
-                                                            Tp__, Tq__>>>>
-s_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                        const Tend__& end, const Ta__& a, const Tb__& b,
+inline stan::return_type_t<Ty_slice__, Tb__, Tc__, Td__, Te__,
+                    stan::return_type_t<Tg__, Th__, Ti__, Tj__, Tl__,
+                                        stan::return_type_t<Tm__, Tn__, To__,
+                                                            Tq__>>>
+s_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                        const int end, const int a, const Tb__& b,
                         const Tc__& c, const Td__& d, const Te__& e,
-                        const Tf__& f, const Tg__& g, const Th__& h,
-                        const Ti__& i, const Tj__& j, const Tk__& k,
+                        const std::vector<int>& f, const Tg__& g,
+                        const Th__& h, const Ti__& i, const Tj__& j,
+                        const std::vector<std::vector<int>>& k,
                         const Tl__& l, const Tm__& m, const Tn__& n,
-                        const To__& o, const Tp__& p, const Tq__& q,
-                        std::ostream* pstream__)  const
+                        const To__& o,
+                        const std::vector<std::vector<std::vector<int>>>& p,
+                        const Tq__& q, std::ostream* pstream__)  const
 {
   return s(y_slice, start, end, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o,
            p, q, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f2_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f2(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_row_vector<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g3(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+inline double
+f9_functor__::operator()(const std::vector<int>& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f9(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f8_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f8(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_stan_scalar<Ta__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g1(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g7_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g7(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g5_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, const Ta__& a,
                          std::ostream* pstream__)  const
 {
   return g5(y_slice, start, end, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g5(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>*>
+inline stan::return_type_t<Ty_slice__>
+f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__)  const
 {
   return f5(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g6(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g7(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                           const Tend__& end, std::ostream* pstream__,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const int start,
+                           const int end, std::ostream* pstream__,
                            const Ta__& a)  const
 {
   return g8(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                            const Tend__& end, std::ostream* pstream__) 
-const
+inline double
+f10_rsfunctor__::operator()(const std::vector<std::vector<int>>& y_slice,
+                            const int start, const int end,
+                            std::ostream* pstream__)  const
 {
   return f10(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
-f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, std::ostream* pstream__)  const
+template <typename Ty_slice__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>>*>
+inline stan::return_type_t<Ty_slice__>
+f1_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                         const int end, std::ostream* pstream__)  const
 {
   return f1(y_slice, start, end, pstream__);
 }
 
-template <typename Ty_slice__, typename Tstart__, typename Tend__,
+template <typename Ty_slice__,
           typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
-          std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
-inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
-g10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                          const Tend__& end, const Ta__& a,
+inline stan::return_type_t<Ty_slice__, Ta__>
+g10_functor__::operator()(const Ty_slice__& y_slice, const int start,
+                          const int end, const Ta__& a,
                           std::ostream* pstream__)  const
 {
   return g10(y_slice, start, end, a, pstream__);
@@ -34534,23 +33802,20 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'single-argument-lpmf.stan', line 17, column 23 to line 19, column 3)"};
 
 struct foo4_lp_functor__ {
-  template <bool propto__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline stan::return_type_t<Ty__>
-  operator()(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  inline double
+  operator()(const int y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo0_lpmf_functor__ {
-  template <bool propto__,
-            typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline stan::return_type_t<Ty__>
-  operator()(const Ty__& y, std::ostream* pstream__) const;
+  template <bool propto__>
+  inline double
+  operator()(const int y, std::ostream* pstream__) const;
 };
 struct foo1_lpmf_functor__ {
-  template <bool propto__,
-            typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline stan::return_type_t<Ty__>
-  operator()(const Ty__& y, std::ostream* pstream__) const;
+  template <bool propto__>
+  inline double
+  operator()(const int y, std::ostream* pstream__) const;
 };
 struct foo2_lpdf_functor__ {
   template <bool propto__,
@@ -34572,11 +33837,9 @@ struct foo5_lp_functor__ {
              std::ostream* pstream__) const;
 };
 
-template <bool propto__,
-          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline stan::return_type_t<Ty__>
-  foo0_lpmf(const Ty__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__>;
+template <bool propto__> inline double
+  foo0_lpmf(const int y, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34587,11 +33850,9 @@ template <bool propto__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__,
-          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline stan::return_type_t<Ty__>
-  foo1_lpmf(const Ty__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__>;
+template <bool propto__> inline double
+  foo1_lpmf(const int y, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34602,12 +33863,11 @@ template <bool propto__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline stan::return_type_t<Ty__>
-  foo4_lp(const Ty__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  inline double
+  foo4_lp(const int y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__>;
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -34664,30 +33924,25 @@ template <bool propto__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<std::is_integral<Ty__>>*>
-inline stan::return_type_t<Ty__>
-foo4_lp_functor__::operator()(const Ty__& y, T_lp__& lp__,
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
+inline double
+foo4_lp_functor__::operator()(const int y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return foo4_lp<propto__>(y, lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__,
-          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
-inline stan::return_type_t<Ty__>
-foo0_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
-const
+template <bool propto__>
+inline double
+foo0_lpmf_functor__::operator()(const int y, std::ostream* pstream__)  const
 {
   return foo0_lpmf<propto__>(y, pstream__);
 }
 
-template <bool propto__,
-          typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
-inline stan::return_type_t<Ty__>
-foo1_lpmf_functor__::operator()(const Ty__& y, std::ostream* pstream__) 
-const
+template <bool propto__>
+inline double
+foo1_lpmf_functor__::operator()(const int y, std::ostream* pstream__)  const
 {
   return foo1_lpmf<propto__>(y, pstream__);
 }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -3726,7 +3726,7 @@ static constexpr std::array<const char*, 75> locations_array__ =
 struct _stan_asm_functor__ {
   template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>* = nullptr>
   inline void
-  operator()(const T_stan_class__& _stan_class, std::ostream* pstream__) const;
+  operator()(const T_stan_class__& _stan_class_arg__, std::ostream* pstream__) const;
 };
 struct _stan_char16_t_functor__ {
   inline void
@@ -3971,7 +3971,7 @@ inline void _stan_char32_t(std::ostream* pstream__) {
     }
 template <typename T_stan_class__, stan::require_all_t<stan::is_col_vector<T_stan_class__>>*>
 inline void
-_stan_asm_functor__::operator()(const T_stan_class__& _stan_class,
+_stan_asm_functor__::operator()(const T_stan_class__& _stan_class_arg__,
                                 std::ostream* pstream__)  const
 {
   return _stan_asm(_stan_class, pstream__);
@@ -6510,8 +6510,8 @@ struct f5_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lcdf_functor__ {
@@ -6526,7 +6526,7 @@ struct covsqrt2corsqrt_functor__ {
             typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
             std::is_integral<Tinvert__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-  operator()(const Tmat__& mat, const Tinvert__& invert,
+  operator()(const Tmat__& mat_arg__, const Tinvert__& invert,
              std::ostream* pstream__) const;
 };
 struct foo_1_functor__ {
@@ -6570,8 +6570,8 @@ struct f6_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_five_args_functor__ {
@@ -6608,8 +6608,8 @@ struct f3_functor__ {
   inline std::vector<std::vector<int>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
@@ -6638,8 +6638,8 @@ struct f7_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f11_functor__ {
@@ -6663,8 +6663,8 @@ struct f11_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f12_functor__ {
@@ -6688,8 +6688,8 @@ struct f12_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct sho_functor__ {
@@ -6721,7 +6721,7 @@ struct algebra_system_functor__ {
             stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
             stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-  operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
+  operator()(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
@@ -6765,8 +6765,8 @@ struct f0_functor__ {
   inline void
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lpmf_functor__ {
@@ -6784,8 +6784,8 @@ struct foo_5_functor__ {
             stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
             stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  operator()(const Tshared_params__& shared_params,
-             const Tjob_params__& job_params, const Tdata_r__& data_r,
+  operator()(const Tshared_params__& shared_params_arg__,
+             const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
              const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct f4_functor__ {
@@ -6809,8 +6809,8 @@ struct f4_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f10_functor__ {
@@ -6834,8 +6834,8 @@ struct f10_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f2_functor__ {
@@ -6857,8 +6857,8 @@ struct f2_functor__ {
   inline std::vector<int>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f9_functor__ {
@@ -6882,8 +6882,8 @@ struct f9_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct f8_functor__ {
@@ -6907,8 +6907,8 @@ struct f8_functor__ {
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_lccdf_functor__ {
@@ -6948,8 +6948,8 @@ struct binomialf_functor__ {
             stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
             stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
-  operator()(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
-             const Tx_i__& x_i, std::ostream* pstream__) const;
+  operator()(const Tphi__& phi_arg__, const Ttheta__& theta_arg__,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
@@ -6975,8 +6975,8 @@ struct f1_functor__ {
   inline int
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-             const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-             const Ta10__& a10, const Ta11__& a11, const Ta12__& a12,
+             const Ta7__& a7_arg__, const Ta8__& a8, const Ta9__& a9,
+             const Ta10__& a10_arg__, const Ta11__& a11, const Ta12__& a12,
              std::ostream* pstream__) const;
 };
 struct foo_functor__ {
@@ -8410,9 +8410,10 @@ inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>
 f5_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8431,7 +8432,7 @@ template <typename Tmat__,
           typename Tinvert__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tmat__>,
           std::is_integral<Tinvert__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tmat__, Tinvert__>, -1, -1>
-covsqrt2corsqrt_functor__::operator()(const Tmat__& mat,
+covsqrt2corsqrt_functor__::operator()(const Tmat__& mat_arg__,
                                       const Tinvert__& invert,
                                       std::ostream* pstream__)  const
 {
@@ -8486,9 +8487,10 @@ inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, T
                                         stan::return_type_t<Ta11__, Ta12__>>>>>
 f6_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f6(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8531,9 +8533,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline std::vector<std::vector<int>>
 f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8565,9 +8568,10 @@ inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
 f7_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f7(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8592,9 +8596,10 @@ inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
 f11_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                          const Ta10__& a10, const Ta11__& a11,
-                          const Ta12__& a12, std::ostream* pstream__)  const
+                          const Ta7__& a7_arg__, const Ta8__& a8,
+                          const Ta9__& a9, const Ta10__& a10_arg__,
+                          const Ta11__& a11, const Ta12__& a12,
+                          std::ostream* pstream__)  const
 {
   return f11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8619,9 +8624,10 @@ inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, T
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
 f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                          const Ta10__& a10, const Ta11__& a11,
-                          const Ta12__& a12, std::ostream* pstream__)  const
+                          const Ta7__& a7_arg__, const Ta8__& a8,
+                          const Ta9__& a9, const Ta10__& a10_arg__,
+                          const Ta11__& a11, const Ta12__& a12,
+                          std::ostream* pstream__)  const
 {
   return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8663,8 +8669,8 @@ template <typename Tx__, typename Ty__, typename Tdat__,
           stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
           stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
-                                     const Tdat__& dat,
+algebra_system_functor__::operator()(const Tx__& x_arg__,
+                                     const Ty__& y_arg__, const Tdat__& dat,
                                      const Tdat_int__& dat_int,
                                      std::ostream* pstream__)  const
 {
@@ -8720,9 +8726,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline void
 f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8744,8 +8751,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-foo_5_functor__::operator()(const Tshared_params__& shared_params,
-                            const Tjob_params__& job_params,
+foo_5_functor__::operator()(const Tshared_params__& shared_params_arg__,
+                            const Tjob_params__& job_params_arg__,
                             const Tdata_r__& data_r, const Tdata_i__& data_i,
                             std::ostream* pstream__)  const
 {
@@ -8772,9 +8779,10 @@ inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>
 f4_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f4(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8799,9 +8807,10 @@ inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
 f10_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                           const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                          const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                          const Ta10__& a10, const Ta11__& a11,
-                          const Ta12__& a12, std::ostream* pstream__)  const
+                          const Ta7__& a7_arg__, const Ta8__& a8,
+                          const Ta9__& a9, const Ta10__& a10_arg__,
+                          const Ta11__& a11, const Ta12__& a12,
+                          std::ostream* pstream__)  const
 {
   return f10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8824,9 +8833,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline std::vector<int>
 f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f2(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8851,9 +8861,10 @@ inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, T
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
 f9_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f9(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8878,9 +8889,10 @@ inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
 f8_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -8934,7 +8946,8 @@ template <typename Tphi__, typename Ttheta__, typename Tx_r__,
           stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
           stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
-binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
+binomialf_functor__::operator()(const Tphi__& phi_arg__,
+                                const Ttheta__& theta_arg__,
                                 const Tx_r__& x_r, const Tx_i__& x_i,
                                 std::ostream* pstream__)  const
 {
@@ -8966,9 +8979,10 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
 inline int
 f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
-                         const Ta7__& a7, const Ta8__& a8, const Ta9__& a9,
-                         const Ta10__& a10, const Ta11__& a11,
-                         const Ta12__& a12, std::ostream* pstream__)  const
+                         const Ta7__& a7_arg__, const Ta8__& a8,
+                         const Ta9__& a9, const Ta10__& a10_arg__,
+                         const Ta11__& a11, const Ta12__& a12,
+                         std::ostream* pstream__)  const
 {
   return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
@@ -15181,7 +15195,7 @@ struct algebra_system_functor__ {
             stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
             stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-  operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
+  operator()(const Tx__& x_arg__, const Ty__& y_arg__, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
@@ -15204,8 +15218,8 @@ struct foo_functor__ {
             stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
             stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  operator()(const Tshared_params__& shared_params,
-             const Tjob_params__& job_params, const Tdata_r__& data_r,
+  operator()(const Tshared_params__& shared_params_arg__,
+             const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
              const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct goo_functor__ {
@@ -15216,8 +15230,8 @@ struct goo_functor__ {
             stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
             stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-  operator()(const Tshared_params__& shared_params,
-             const Tjob_params__& job_params, const Tdata_r__& data_r,
+  operator()(const Tshared_params__& shared_params_arg__,
+             const Tjob_params__& job_params_arg__, const Tdata_r__& data_r,
              const Tdata_i__& data_i, std::ostream* pstream__) const;
 };
 struct map_rectfake_functor__ {
@@ -15411,8 +15425,8 @@ template <typename Tx__, typename Ty__, typename Tdat__,
           stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
           stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
-algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
-                                     const Tdat__& dat,
+algebra_system_functor__::operator()(const Tx__& x_arg__,
+                                     const Ty__& y_arg__, const Tdat__& dat,
                                      const Tdat_int__& dat_int,
                                      std::ostream* pstream__)  const
 {
@@ -15441,8 +15455,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-foo_functor__::operator()(const Tshared_params__& shared_params,
-                          const Tjob_params__& job_params,
+foo_functor__::operator()(const Tshared_params__& shared_params_arg__,
+                          const Tjob_params__& job_params_arg__,
                           const Tdata_r__& data_r, const Tdata_i__& data_i,
                           std::ostream* pstream__)  const
 {
@@ -15456,8 +15470,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
           stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
-goo_functor__::operator()(const Tshared_params__& shared_params,
-                          const Tjob_params__& job_params,
+goo_functor__::operator()(const Tshared_params__& shared_params_arg__,
+                          const Tjob_params__& job_params_arg__,
                           const Tdata_r__& data_r, const Tdata_i__& data_i,
                           std::ostream* pstream__)  const
 {
@@ -17715,8 +17729,8 @@ struct f_functor__ {
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
             stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, const Ta__& a, const Tb__& b,
-             std::ostream* pstream__) const;
+  operator()(const Tt__& t, const Tz__& z_arg__, const Ta__& a,
+             const Tb__& b_arg__, std::ostream* pstream__) const;
 };
 struct f_odefunctor__ {
   template <typename Tt__, typename Tz__, typename Ta__,
@@ -17724,8 +17738,8 @@ struct f_odefunctor__ {
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
             stan::is_col_vector<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
-             const Ta__& a, const Tb__& b) const;
+  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__,
+             const Ta__& a, const Tb__& b_arg__) const;
 };
 
 template <typename Tt__, typename Tz__, typename Ta__,
@@ -17755,8 +17769,8 @@ template <typename Tt__, typename Tz__, typename Ta__,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
           stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-f_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
-                        const Tb__& b, std::ostream* pstream__)  const
+f_functor__::operator()(const Tt__& t, const Tz__& z_arg__, const Ta__& a,
+                        const Tb__& b_arg__, std::ostream* pstream__)  const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -17766,9 +17780,9 @@ template <typename Tt__, typename Tz__, typename Ta__,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>,
           stan::is_col_vector<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__, Tb__>, -1, 1>
-f_odefunctor__::operator()(const Tt__& t, const Tz__& z,
+f_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
                            std::ostream* pstream__, const Ta__& a,
-                           const Tb__& b)  const
+                           const Tb__& b_arg__)  const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -23942,13 +23956,13 @@ struct foo_functor__ {
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
-  operator()(const Tp__& p, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_stan_scalar<Tp__>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
@@ -24184,21 +24198,24 @@ foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 
 template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>*>
 inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
+foo_functor__::operator()(const Tp__& p_arg__, std::ostream* pstream__) 
+const
 {
   return foo(p, pstream__);
 }
 
 template <typename Tp__, stan::require_all_t<stan::is_col_vector<Tp__>>*>
 inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
+foo_functor__::operator()(const Tp__& p_arg__, std::ostream* pstream__) 
+const
 {
   return foo(p, pstream__);
 }
 
 template <typename Tp__, stan::require_all_t<stan::is_row_vector<Tp__>>*>
 inline stan::return_type_t<Tp__>
-foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
+foo_functor__::operator()(const Tp__& p_arg__, std::ostream* pstream__) 
+const
 {
   return foo(p, pstream__);
 }
@@ -29506,10 +29523,11 @@ struct s_rsfunctor__ {
                                                               Tp__, Tq__>>>>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a,
-             const Tb__& b, const Tc__& c, const Td__& d, const Te__& e,
-             const Tf__& f, const Tg__& g, const Th__& h, const Ti__& i,
-             const Tj__& j, const Tk__& k, const Tl__& l, const Tm__& m,
-             const Tn__& n, const To__& o, const Tp__& p, const Tq__& q) const;
+             const Tb__& b, const Tc__& c_arg__, const Td__& d_arg__,
+             const Te__& e_arg__, const Tf__& f, const Tg__& g, const Th__& h,
+             const Ti__& i, const Tj__& j, const Tk__& k, const Tl__& l,
+             const Tm__& m, const Tn__& n, const To__& o, const Tp__& p,
+             const Tq__& q) const;
 };
 struct f4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29590,7 +29608,7 @@ struct g2_rsfunctor__ {
             stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+             const Tend__& end, std::ostream* pstream__, const Ta__& a_arg__) const;
 };
 struct f6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29708,7 +29726,7 @@ struct g4_functor__ {
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a_arg__, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
@@ -29717,7 +29735,7 @@ struct g4_rsfunctor__ {
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+             const Tend__& end, std::ostream* pstream__, const Ta__& a_arg__) const;
 };
 struct f11_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29742,7 +29760,7 @@ struct g3_functor__ {
             stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a_arg__, std::ostream* pstream__) const;
 };
 struct f11_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29792,7 +29810,7 @@ struct g2_functor__ {
             stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a_arg__, std::ostream* pstream__) const;
 };
 struct f10_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29833,11 +29851,12 @@ struct s_functor__ {
                                                               Tm__, Tn__, To__,
                                                               Tp__, Tq__>>>>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, const Ta__& a, const Tb__& b, const Tc__& c,
-             const Td__& d, const Te__& e, const Tf__& f, const Tg__& g,
-             const Th__& h, const Ti__& i, const Tj__& j, const Tk__& k,
-             const Tl__& l, const Tm__& m, const Tn__& n, const To__& o,
-             const Tp__& p, const Tq__& q, std::ostream* pstream__) const;
+             const Tend__& end, const Ta__& a, const Tb__& b,
+             const Tc__& c_arg__, const Td__& d_arg__, const Te__& e_arg__,
+             const Tf__& f, const Tg__& g, const Th__& h, const Ti__& i,
+             const Tj__& j, const Tk__& k, const Tl__& l, const Tm__& m,
+             const Tn__& n, const To__& o, const Tp__& p, const Tq__& q,
+             std::ostream* pstream__) const;
 };
 struct f2_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -29854,7 +29873,7 @@ struct g3_rsfunctor__ {
             stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
-             const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
+             const Tend__& end, std::ostream* pstream__, const Ta__& a_arg__) const;
 };
 struct f9_functor__ {
   template <typename Ty_slice__, typename Tstart__,
@@ -30891,12 +30910,12 @@ inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                                                             Tp__, Tq__>>>>
 s_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__,
-                          const Ta__& a, const Tb__& b, const Tc__& c,
-                          const Td__& d, const Te__& e, const Tf__& f,
-                          const Tg__& g, const Th__& h, const Ti__& i,
-                          const Tj__& j, const Tk__& k, const Tl__& l,
-                          const Tm__& m, const Tn__& n, const To__& o,
-                          const Tp__& p, const Tq__& q)  const
+                          const Ta__& a, const Tb__& b, const Tc__& c_arg__,
+                          const Td__& d_arg__, const Te__& e_arg__,
+                          const Tf__& f, const Tg__& g, const Th__& h,
+                          const Ti__& i, const Tj__& j, const Tk__& k,
+                          const Tl__& l, const Tm__& m, const Tn__& n,
+                          const To__& o, const Tp__& p, const Tq__& q)  const
 {
   return s(y_slice, start + 1, end + 1, a, b, c, d, e, f, g, h, i, j, k, l,
            m, n, o, p, q, pstream__);
@@ -31002,7 +31021,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+                           const Ta__& a_arg__)  const
 {
   return g2(y_slice, start + 1, end + 1, a, pstream__);
 }
@@ -31154,7 +31173,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+                         const Tend__& end, const Ta__& a_arg__,
                          std::ostream* pstream__)  const
 {
   return g4(y_slice, start, end, a, pstream__);
@@ -31167,7 +31186,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+                           const Ta__& a_arg__)  const
 {
   return g4(y_slice, start + 1, end + 1, a, pstream__);
 }
@@ -31198,7 +31217,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+                         const Tend__& end, const Ta__& a_arg__,
                          std::ostream* pstream__)  const
 {
   return g3(y_slice, start, end, a, pstream__);
@@ -31263,7 +31282,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
-                         const Tend__& end, const Ta__& a,
+                         const Tend__& end, const Ta__& a_arg__,
                          std::ostream* pstream__)  const
 {
   return g2(y_slice, start, end, a, pstream__);
@@ -31310,12 +31329,12 @@ inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                                                             Tp__, Tq__>>>>
 s_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                         const Tend__& end, const Ta__& a, const Tb__& b,
-                        const Tc__& c, const Td__& d, const Te__& e,
-                        const Tf__& f, const Tg__& g, const Th__& h,
-                        const Ti__& i, const Tj__& j, const Tk__& k,
-                        const Tl__& l, const Tm__& m, const Tn__& n,
-                        const To__& o, const Tp__& p, const Tq__& q,
-                        std::ostream* pstream__)  const
+                        const Tc__& c_arg__, const Td__& d_arg__,
+                        const Te__& e_arg__, const Tf__& f, const Tg__& g,
+                        const Th__& h, const Ti__& i, const Tj__& j,
+                        const Tk__& k, const Tl__& l, const Tm__& m,
+                        const Tn__& n, const To__& o, const Tp__& p,
+                        const Tq__& q, std::ostream* pstream__)  const
 {
   return s(y_slice, start, end, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o,
            p, q, pstream__);
@@ -31338,7 +31357,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
-                           const Ta__& a)  const
+                           const Ta__& a_arg__)  const
 {
   return g3(y_slice, start + 1, end + 1, a, pstream__);
 }
@@ -33509,7 +33528,7 @@ struct rhs_odefunctor__ {
             stan::is_col_vector<Ty__>,
             stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
+  operator()(const Tt__& t, const Ty__& y_arg__, std::ostream* pstream__,
              const Talpha__& alpha) const;
 };
 struct rhs_functor__ {
@@ -33518,7 +33537,7 @@ struct rhs_functor__ {
             stan::is_col_vector<Ty__>,
             stan::is_stan_scalar<Talpha__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y, const Talpha__& alpha,
+  operator()(const Tt__& t, const Ty__& y_arg__, const Talpha__& alpha,
              std::ostream* pstream__) const;
 };
 
@@ -33552,7 +33571,7 @@ template <typename Tt__, typename Ty__,
           typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Ty__>, stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-rhs_odefunctor__::operator()(const Tt__& t, const Ty__& y,
+rhs_odefunctor__::operator()(const Tt__& t, const Ty__& y_arg__,
                              std::ostream* pstream__, const Talpha__& alpha) 
 const
 {
@@ -33563,7 +33582,7 @@ template <typename Tt__, typename Ty__,
           typename Talpha__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Ty__>, stan::is_stan_scalar<Talpha__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Talpha__>, -1, 1>
-rhs_functor__::operator()(const Tt__& t, const Ty__& y,
+rhs_functor__::operator()(const Tt__& t, const Ty__& y_arg__,
                           const Talpha__& alpha, std::ostream* pstream__) 
 const
 {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1218,7 +1218,7 @@ static constexpr std::array<const char*, 427> locations_array__ =
  " (in 'complex_scalar.stan', line 33, column 45 to line 35, column 3)"};
 
 struct foo8_functor__ {
-  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<stan::value_type_t<Tz__>>, stan::is_complex<stan::value_type_t<stan::value_type_t<Tz__>>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
@@ -1237,7 +1237,7 @@ struct foo6_functor__ {
   operator()(const Tr__& r, std::ostream* pstream__) const;
 };
 struct foo10_functor__ {
-  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<stan::value_type_t<Tz__>>, stan::is_complex<stan::value_type_t<stan::value_type_t<Tz__>>>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
@@ -1257,12 +1257,12 @@ struct foo3_functor__ {
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo7_functor__ {
-  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<stan::value_type_t<Tz__>>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tz__>>>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
 struct foo5_functor__ {
-  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+  template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<stan::value_type_t<Tz__>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   operator()(const Tz__& z, std::ostream* pstream__) const;
 };
@@ -1348,7 +1348,7 @@ inline std::vector<std::complex<double>> foo4(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<stan::value_type_t<Tz__>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   foo5(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1381,7 +1381,7 @@ template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<stan::value_type_t<Tz__>>>* = nullptr>
   inline std::vector<std::complex<stan::return_type_t<Tz__>>>
   foo7(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1397,7 +1397,7 @@ template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<stan::value_type_t<Tz__>>, stan::is_complex<stan::value_type_t<stan::value_type_t<Tz__>>>>* = nullptr>
   inline stan::return_type_t<Tz__>
   foo8(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1435,7 +1435,7 @@ template <typename Tr__, stan::require_all_t<stan::is_stan_scalar<Tr__>>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>* = nullptr>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<stan::value_type_t<Tz__>>, stan::is_complex<stan::value_type_t<stan::value_type_t<Tz__>>>>* = nullptr>
   inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
   foo10(const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tz__>;
@@ -1451,7 +1451,7 @@ template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<stan::value_type_t<Tz__>>, stan::is_complex<stan::value_type_t<stan::value_type_t<Tz__>>>>*>
 inline stan::return_type_t<Tz__>
 foo8_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
@@ -1478,7 +1478,7 @@ foo6_functor__::operator()(const Tr__& r, std::ostream* pstream__)  const
   return foo6(r, pstream__);
 }
 
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<value_type_t<Tz__>>, stan::is_complex<value_type_t<value_type_t<Tz__>>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_std_vector<stan::value_type_t<Tz__>>, stan::is_complex<stan::value_type_t<stan::value_type_t<Tz__>>>>*>
 inline std::vector<std::vector<std::complex<stan::return_type_t<Tz__>>>>
 foo10_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
@@ -1506,14 +1506,14 @@ foo3_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
   return foo3(z, pstream__);
 }
 
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<stan::value_type_t<Tz__>>>*>
 inline std::vector<std::complex<stan::return_type_t<Tz__>>>
 foo7_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
   return foo7(z, pstream__);
 }
 
-template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<value_type_t<Tz__>>>*>
+template <typename Tz__, stan::require_all_t<stan::is_std_vector<Tz__>, stan::is_complex<stan::value_type_t<Tz__>>>*>
 inline stan::return_type_t<Tz__>
 foo5_functor__::operator()(const Tz__& z, std::ostream* pstream__)  const
 {
@@ -6494,17 +6494,17 @@ struct f5_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>>
@@ -6554,17 +6554,17 @@ struct f6_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>>>
@@ -6594,17 +6594,17 @@ struct f3_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<int>>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -6622,17 +6622,17 @@ struct f7_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
@@ -6647,17 +6647,17 @@ struct f11_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
@@ -6672,17 +6672,17 @@ struct f12_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
@@ -6695,10 +6695,10 @@ struct f12_functor__ {
 struct sho_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
             typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
-            stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
+            stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
@@ -6718,8 +6718,8 @@ struct algebra_system_functor__ {
   template <typename Tx__, typename Ty__, typename Tdat__,
             typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
             stan::is_col_vector<Ty__>,
-            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
-            stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
+            stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
@@ -6751,17 +6751,17 @@ struct f0_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline void
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -6781,8 +6781,8 @@ struct foo_5_functor__ {
             typename Tdata_r__,
             typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
             stan::is_col_vector<Tjob_params__>,
-            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-            stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+            stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -6793,17 +6793,17 @@ struct f4_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>
@@ -6818,17 +6818,17 @@ struct f10_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
@@ -6843,17 +6843,17 @@ struct f2_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<int>
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -6866,17 +6866,17 @@ struct f9_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
@@ -6891,17 +6891,17 @@ struct f8_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                       stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                           stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
@@ -6945,8 +6945,8 @@ struct binomialf_functor__ {
   template <typename Tphi__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
             stan::is_col_vector<Ttheta__>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
   operator()(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
              const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -6961,17 +6961,17 @@ struct f1_functor__ {
             typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
             typename Ta9__, typename Ta10__, typename Ta11__,
             typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-            stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-            stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+            stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+            stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
             stan::is_stan_scalar<Ta4__>,
-            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-            stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+            stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+            stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
             stan::is_col_vector<Ta7__>,
-            stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-            stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+            stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+            stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
             stan::is_eigen_matrix_dynamic<Ta10__>,
-            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-            stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+            stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+            stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline int
   operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
              const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -7009,19 +7009,19 @@ template <typename Tn__, stan::require_all_t<std::is_integral<Tn__>>* = nullptr>
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
           typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>*>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) ; 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
           typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) {
@@ -7548,8 +7548,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__,
           typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   foo_5(const Tshared_params__& shared_params,
         const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -7663,17 +7663,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline void
   f0(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7706,17 +7706,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline int
   f1(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7746,17 +7746,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<int>
   f2(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7786,17 +7786,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<int>>
   f3(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3, const Ta4__& a4,
      const Ta5__& a5, const Ta6__& a6, const Ta7__& a7, const Ta8__& a8,
@@ -7826,17 +7826,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>
@@ -7868,17 +7868,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>
@@ -7910,17 +7910,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>>
@@ -7952,17 +7952,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
@@ -7994,17 +7994,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
@@ -8036,17 +8036,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
@@ -8078,17 +8078,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
@@ -8120,17 +8120,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
@@ -8162,17 +8162,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>* = nullptr>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>* = nullptr>
   inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
@@ -8309,8 +8309,8 @@ template <typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nu
 template <typename Tx__, typename Ty__, typename Tdat__,
           typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
@@ -8345,8 +8345,8 @@ template <typename Tx__, typename Ty__, typename Tdat__,
 template <typename Tphi__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
           stan::is_col_vector<Ttheta__>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
   binomialf(const Tphi__& phi, const Ttheta__& theta, const Tx_r__& x_r,
             const Tx_i__& x_i, std::ostream* pstream__) {
@@ -8394,17 +8394,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>
@@ -8470,17 +8470,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>>>
@@ -8517,17 +8517,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<int>>
 f3_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -8549,17 +8549,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>
@@ -8576,17 +8576,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>
@@ -8603,17 +8603,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>>>
@@ -8628,10 +8628,10 @@ f12_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
           typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
@@ -8660,8 +8660,8 @@ matfoo_functor__::operator()(std::ostream* pstream__)  const
 template <typename Tx__, typename Ty__, typename Tdat__,
           typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
@@ -8706,17 +8706,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline void
 f0_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -8741,8 +8741,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__,
           typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 foo_5_functor__::operator()(const Tshared_params__& shared_params,
                             const Tjob_params__& job_params,
@@ -8756,17 +8756,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>
@@ -8783,17 +8783,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, -1>
@@ -8810,17 +8810,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<int>
 f2_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -8835,17 +8835,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>>
@@ -8862,17 +8862,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline std::vector<Eigen::Matrix<stan::return_type_t<Ta1__, Ta2__, Ta3__, Ta4__, Ta5__,
                     stan::return_type_t<Ta6__, Ta7__, Ta8__, Ta9__, Ta10__,
                                         stan::return_type_t<Ta11__, Ta12__>>>, -1, 1>>
@@ -8931,8 +8931,8 @@ inline void foo_6_functor__::operator()(std::ostream* pstream__)  const
 template <typename Tphi__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_col_vector<Tphi__>,
           stan::is_col_vector<Ttheta__>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tphi__, Ttheta__, Tx_r__, Tx_i__>, -1, 1>
 binomialf_functor__::operator()(const Tphi__& phi, const Ttheta__& theta,
                                 const Tx_r__& x_r, const Tx_i__& x_i,
@@ -8952,17 +8952,17 @@ template <typename Ta1__, typename Ta2__, typename Ta3__, typename Ta4__,
           typename Ta5__, typename Ta6__, typename Ta7__, typename Ta8__,
           typename Ta9__, typename Ta10__, typename Ta11__,
           typename Ta12__, stan::require_all_t<std::is_integral<Ta1__>,
-          stan::is_std_vector<Ta2__>, std::is_integral<value_type_t<Ta2__>>,
-          stan::is_std_vector<Ta3__>, stan::is_std_vector<value_type_t<Ta3__>>, std::is_integral<value_type_t<value_type_t<Ta3__>>>,
+          stan::is_std_vector<Ta2__>, std::is_integral<stan::value_type_t<Ta2__>>,
+          stan::is_std_vector<Ta3__>, stan::is_std_vector<stan::value_type_t<Ta3__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ta3__>>>,
           stan::is_stan_scalar<Ta4__>,
-          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<value_type_t<Ta5__>>,
-          stan::is_std_vector<Ta6__>, stan::is_std_vector<value_type_t<Ta6__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta6__>>>,
+          stan::is_std_vector<Ta5__>, stan::is_stan_scalar<stan::value_type_t<Ta5__>>,
+          stan::is_std_vector<Ta6__>, stan::is_std_vector<stan::value_type_t<Ta6__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta6__>>>,
           stan::is_col_vector<Ta7__>,
-          stan::is_std_vector<Ta8__>, stan::is_col_vector<value_type_t<Ta8__>>,
-          stan::is_std_vector<Ta9__>, stan::is_std_vector<value_type_t<Ta9__>>, stan::is_col_vector<value_type_t<value_type_t<Ta9__>>>,
+          stan::is_std_vector<Ta8__>, stan::is_col_vector<stan::value_type_t<Ta8__>>,
+          stan::is_std_vector<Ta9__>, stan::is_std_vector<stan::value_type_t<Ta9__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta9__>>>,
           stan::is_eigen_matrix_dynamic<Ta10__>,
-          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta11__>>,
-          stan::is_std_vector<Ta12__>, stan::is_std_vector<value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta12__>>>>*>
+          stan::is_std_vector<Ta11__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta11__>>,
+          stan::is_std_vector<Ta12__>, stan::is_std_vector<stan::value_type_t<Ta12__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta12__>>>>*>
 inline int
 f1_functor__::operator()(const Ta1__& a1, const Ta2__& a2, const Ta3__& a3,
                          const Ta4__& a4, const Ta5__& a5, const Ta6__& a6,
@@ -15166,10 +15166,10 @@ static constexpr std::array<const char*, 158> locations_array__ =
 struct sho_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
             typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
-            stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
+            stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx__& x, const Tx_int__& x_int, std::ostream* pstream__) const;
@@ -15178,8 +15178,8 @@ struct algebra_system_functor__ {
   template <typename Tx__, typename Ty__, typename Tdat__,
             typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
             stan::is_col_vector<Ty__>,
-            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
-            stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+            stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
+            stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   operator()(const Tx__& x, const Ty__& y, const Tdat__& dat,
              const Tdat_int__& dat_int, std::ostream* pstream__) const;
@@ -15189,9 +15189,9 @@ struct integrand_functor__ {
             typename Tx_r__,
             typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
             stan::is_stan_scalar<Txc__>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
   operator()(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -15201,8 +15201,8 @@ struct foo_functor__ {
             typename Tdata_r__,
             typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
             stan::is_col_vector<Tjob_params__>,
-            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-            stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+            stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -15213,8 +15213,8 @@ struct goo_functor__ {
             typename Tdata_r__,
             typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
             stan::is_col_vector<Tjob_params__>,
-            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-            stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+            stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+            stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   operator()(const Tshared_params__& shared_params,
              const Tjob_params__& job_params, const Tdata_r__& data_r,
@@ -15228,10 +15228,10 @@ struct map_rectfake_functor__ {
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
           typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>* = nullptr>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
   sho(const Tt__& t, const Ty__& y, const Ttheta__& theta, const Tx__& x,
       const Tx_int__& x_int, std::ostream* pstream__) {
@@ -15264,9 +15264,9 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
 template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
           stan::is_stan_scalar<Txc__>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
   integrand(const Tx__& x, const Txc__& xc, const Ttheta__& theta,
             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -15288,8 +15288,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__,
           typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   foo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
       const Tdata_r__& data_r, const Tdata_i__& data_i,
@@ -15315,8 +15315,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__,
           typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>* = nullptr>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
   goo(const Tshared_params__& shared_params, const Tjob_params__& job_params,
       const Tdata_r__& data_r, const Tdata_i__& data_i,
@@ -15357,8 +15357,8 @@ template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = null
 template <typename Tx__, typename Ty__, typename Tdat__,
           typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>* = nullptr>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
   algebra_system(const Tx__& x, const Ty__& y, const Tdat__& dat,
                  const Tdat_int__& dat_int, std::ostream* pstream__) {
@@ -15392,10 +15392,10 @@ template <typename Tx__, typename Ty__, typename Tdat__,
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx__,
           typename Tx_int__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx__>, stan::is_stan_scalar<value_type_t<Tx__>>,
-          stan::is_std_vector<Tx_int__>, std::is_integral<value_type_t<Tx_int__>>>*>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx__>, stan::is_stan_scalar<stan::value_type_t<Tx__>>,
+          stan::is_std_vector<Tx_int__>, std::is_integral<stan::value_type_t<Tx_int__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx__, Tx_int__>>
 sho_functor__::operator()(const Tt__& t, const Ty__& y,
                           const Ttheta__& theta, const Tx__& x,
@@ -15408,8 +15408,8 @@ const
 template <typename Tx__, typename Ty__, typename Tdat__,
           typename Tdat_int__, stan::require_all_t<stan::is_col_vector<Tx__>,
           stan::is_col_vector<Ty__>,
-          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<value_type_t<Tdat__>>,
-          stan::is_std_vector<Tdat_int__>, std::is_integral<value_type_t<Tdat_int__>>>*>
+          stan::is_std_vector<Tdat__>, stan::is_stan_scalar<stan::value_type_t<Tdat__>>,
+          stan::is_std_vector<Tdat_int__>, std::is_integral<stan::value_type_t<Tdat_int__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tdat__, Tdat_int__>, -1, 1>
 algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
                                      const Tdat__& dat,
@@ -15422,9 +15422,9 @@ algebra_system_functor__::operator()(const Tx__& x, const Ty__& y,
 template <typename Tx__, typename Txc__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
           stan::is_stan_scalar<Txc__>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline stan::return_type_t<Tx__, Txc__, Ttheta__, Tx_r__, Tx_i__>
 integrand_functor__::operator()(const Tx__& x, const Txc__& xc,
                                 const Ttheta__& theta, const Tx_r__& x_r,
@@ -15438,8 +15438,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__,
           typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 foo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
@@ -15453,8 +15453,8 @@ template <typename Tshared_params__, typename Tjob_params__,
           typename Tdata_r__,
           typename Tdata_i__, stan::require_all_t<stan::is_col_vector<Tshared_params__>,
           stan::is_col_vector<Tjob_params__>,
-          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<value_type_t<Tdata_r__>>,
-          stan::is_std_vector<Tdata_i__>, std::is_integral<value_type_t<Tdata_i__>>>*>
+          stan::is_std_vector<Tdata_r__>, stan::is_stan_scalar<stan::value_type_t<Tdata_r__>>,
+          stan::is_std_vector<Tdata_i__>, std::is_integral<stan::value_type_t<Tdata_i__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Tshared_params__, Tjob_params__, Tdata_r__, Tdata_i__>, -1, 1>
 goo_functor__::operator()(const Tshared_params__& shared_params,
                           const Tjob_params__& job_params,
@@ -21551,10 +21551,10 @@ static constexpr std::array<const char*, 35> locations_array__ =
 struct dz_dt_functor__ {
   template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            stan::is_std_vector<Tz__>, stan::is_stan_scalar<stan::value_type_t<Tz__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Tz__& z, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -21562,10 +21562,10 @@ struct dz_dt_functor__ {
 
 template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          stan::is_std_vector<Tz__>, stan::is_stan_scalar<stan::value_type_t<Tz__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
   dz_dt(const Tt__& t, const Tz__& z, const Ttheta__& theta,
         const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -21609,10 +21609,10 @@ template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
     }
 template <typename Tt__, typename Tz__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Tz__>, stan::is_stan_scalar<value_type_t<Tz__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          stan::is_std_vector<Tz__>, stan::is_stan_scalar<stan::value_type_t<Tz__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Tz__, Ttheta__, Tx_r__, Tx_i__>>
 dz_dt_functor__::operator()(const Tt__& t, const Tz__& z,
                             const Ttheta__& theta, const Tx_r__& x_r,
@@ -23922,22 +23922,22 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'overloading_templating.stan', line 34, column 25 to line 36, column 3)"};
 
 struct foo_functor__ {
-  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tp__>>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
-  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
+  template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   operator()(const Tp__& p, std::ostream* pstream__) const;
   template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr>
@@ -24040,7 +24040,7 @@ template <typename Tp__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24056,7 +24056,7 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24073,7 +24073,7 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24090,7 +24090,7 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24107,7 +24107,7 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tp__>>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24124,7 +24124,7 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>* = nullptr>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<stan::value_type_t<Tp__>>>* = nullptr>
   inline stan::return_type_t<Tp__>
   foo(const Tp__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__>;
@@ -24140,42 +24140,42 @@ template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, std::is_integral<stan::value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tp__>>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tp__>>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_col_vector<stan::value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_row_vector<stan::value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<value_type_t<Tp__>>>*>
+template <typename Tp__, stan::require_all_t<stan::is_std_vector<Tp__>, stan::is_stan_scalar<stan::value_type_t<Tp__>>>*>
 inline stan::return_type_t<Tp__>
 foo_functor__::operator()(const Tp__& p, std::ostream* pstream__)  const
 {
@@ -25361,7 +25361,7 @@ static constexpr std::array<const char*, 9> locations_array__ =
  " (in 'promotion.stan', line 6, column 28 to line 8, column 4)"};
 
 struct foo_functor__ {
-  template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
+  template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<stan::value_type_t<Tzs__>>>* = nullptr>
   inline stan::return_type_t<Tzs__>
   operator()(const Tzs__& zs, std::ostream* pstream__) const;
 };
@@ -25387,7 +25387,7 @@ template <typename Tx__, stan::require_all_t<stan::is_complex<Tx__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>* = nullptr>
+template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<stan::value_type_t<Tzs__>>>* = nullptr>
   inline stan::return_type_t<Tzs__>
   foo(const Tzs__& zs, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tzs__>;
@@ -25403,7 +25403,7 @@ template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<value_type_t<Tzs__>>>*>
+template <typename Tzs__, stan::require_all_t<stan::is_std_vector<Tzs__>, stan::is_stan_scalar<stan::value_type_t<Tzs__>>>*>
 inline stan::return_type_t<Tzs__>
 foo_functor__::operator()(const Tzs__& zs, std::ostream* pstream__)  const
 {
@@ -25789,7 +25789,7 @@ static constexpr std::array<const char*, 26> locations_array__ =
 template <bool propto__>
   struct foo_lpdf_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -25797,7 +25797,7 @@ template <bool propto__>
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -25805,7 +25805,7 @@ struct foo_lpdf_functor__ {
 };
 struct g_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -25813,16 +25813,16 @@ struct g_functor__ {
 };
 struct h_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -25830,16 +25830,16 @@ struct g_rsfunctor__ {
 };
 struct h_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -25865,9 +25865,9 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   h(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
     const Ta__& a, std::ostream* pstream__) {
@@ -25894,7 +25894,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <bool propto__, typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   foo_lpdf(const Ty_slice__& y_slice, const Tstart__& start,
@@ -25913,7 +25913,7 @@ template <bool propto__, typename Ty_slice__, typename Tstart__,
     }
 template <bool propto__>
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
@@ -25925,7 +25925,7 @@ foo_lpdf_rsfunctor__<propto__>::operator()(const Ty_slice__& y_slice,
 }
 
 template <bool propto__, typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
@@ -25936,7 +25936,7 @@ foo_lpdf_functor__::operator()(const Ty_slice__& y_slice,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -25946,9 +25946,9 @@ g_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, std::ostream* pstream__,
@@ -25958,7 +25958,7 @@ h_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -25968,9 +25968,9 @@ g_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 h_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                         const Tend__& end, const Ta__& a,
@@ -26569,7 +26569,7 @@ static constexpr std::array<const char*, 180> locations_array__ =
 
 struct g6_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26577,61 +26577,61 @@ struct g6_functor__ {
 };
 struct h6_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h6_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h8_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h7_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h8_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h2_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26639,16 +26639,16 @@ struct g8_functor__ {
 };
 struct h2_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26656,7 +26656,7 @@ struct g1_functor__ {
 };
 struct g2_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26664,7 +26664,7 @@ struct g2_functor__ {
 };
 struct g2_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26672,7 +26672,7 @@ struct g2_rsfunctor__ {
 };
 struct g3_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26680,16 +26680,16 @@ struct g3_rsfunctor__ {
 };
 struct h5_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g1_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26697,16 +26697,16 @@ struct g1_rsfunctor__ {
 };
 struct h1_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct g7_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26714,7 +26714,7 @@ struct g7_functor__ {
 };
 struct g5_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26722,7 +26722,7 @@ struct g5_functor__ {
 };
 struct g5_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26730,7 +26730,7 @@ struct g5_rsfunctor__ {
 };
 struct g6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26738,7 +26738,7 @@ struct g6_rsfunctor__ {
 };
 struct g4_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26746,16 +26746,16 @@ struct g4_functor__ {
 };
 struct h4_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct g4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26763,7 +26763,7 @@ struct g4_rsfunctor__ {
 };
 struct g7_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26771,16 +26771,16 @@ struct g7_rsfunctor__ {
 };
 struct h5_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct g8_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26788,7 +26788,7 @@ struct g8_rsfunctor__ {
 };
 struct g3_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -26796,52 +26796,52 @@ struct g3_functor__ {
 };
 struct h3_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h7_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h1_rsfunctor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              std::ostream* pstream__, const Ta__& a) const;
 };
 struct h3_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 struct h4_functor__ {
   template <typename Ty__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   operator()(const Ty__& y, const Tstart__& start, const Tend__& end,
              const Ta__& a, std::ostream* pstream__) const;
 };
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -26861,7 +26861,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -26892,7 +26892,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -26923,7 +26923,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -26955,7 +26955,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -26994,7 +26994,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -27034,7 +27034,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -27074,7 +27074,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -27114,9 +27114,9 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h1(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27137,9 +27137,9 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h2(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27169,9 +27169,9 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h3(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27201,9 +27201,9 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h4(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27234,9 +27234,9 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h5(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27273,9 +27273,9 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h6(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27313,9 +27313,9 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h7(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27353,9 +27353,9 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
   h8(const Ty__& y, const Tstart__& start, const Tend__& end, const Ta__& a,
      std::ostream* pstream__) {
@@ -27393,7 +27393,7 @@ template <typename Ty__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27403,9 +27403,9 @@ g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h6_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27415,9 +27415,9 @@ h6_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27427,9 +27427,9 @@ h6_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h8_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27439,9 +27439,9 @@ h8_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h7_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27451,9 +27451,9 @@ h7_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27463,9 +27463,9 @@ h8_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h2_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27475,7 +27475,7 @@ h2_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27485,9 +27485,9 @@ g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27497,7 +27497,7 @@ h2_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27507,7 +27507,7 @@ g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27517,7 +27517,7 @@ g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27527,7 +27527,7 @@ g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27537,9 +27537,9 @@ g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27549,7 +27549,7 @@ h5_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27559,9 +27559,9 @@ g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h1_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27571,7 +27571,7 @@ h1_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27581,7 +27581,7 @@ g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27591,7 +27591,7 @@ g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27601,7 +27601,7 @@ g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27611,7 +27611,7 @@ g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27621,9 +27621,9 @@ g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27633,7 +27633,7 @@ h4_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27643,7 +27643,7 @@ g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27653,9 +27653,9 @@ g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h5_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27665,7 +27665,7 @@ h5_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27675,7 +27675,7 @@ g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -27685,9 +27685,9 @@ g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27697,9 +27697,9 @@ h3_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27709,9 +27709,9 @@ h7_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -27721,9 +27721,9 @@ h1_rsfunctor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h3_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -27733,9 +27733,9 @@ h3_functor__::operator()(const Ty__& y, const Tstart__& start,
 }
 
 template <typename Ty__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty__, Tstart__, Tend__, Ta__>
 h4_functor__::operator()(const Ty__& y, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -29468,7 +29468,7 @@ static constexpr std::array<const char*, 342> locations_array__ =
 
 struct f1a_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29480,23 +29480,23 @@ struct s_rsfunctor__ {
             typename Te__, typename Tf__, typename Tg__, typename Th__,
             typename Ti__, typename Tj__, typename Tk__, typename Tl__,
             typename Tm__, typename Tn__, typename To__, typename Tp__,
-            typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
             stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
             stan::is_eigen_matrix_dynamic<Te__>,
-            stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
-            stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
-            stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
-            stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
-            stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
-            stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
-            stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
-            stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
-            stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
-            stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
-            stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
-            stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+            stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+            stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
+            stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
+            stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
+            stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
+            stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
+            stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
+            stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
+            stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
+            stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
+            stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
+            stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                       stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                           stan::return_type_t<Th__, Ti__, Tj__,
@@ -29513,7 +29513,7 @@ struct s_rsfunctor__ {
 };
 struct f4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29521,16 +29521,16 @@ struct f4_rsfunctor__ {
 };
 struct g12_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29538,7 +29538,7 @@ struct f5_functor__ {
 };
 struct f8_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29546,16 +29546,16 @@ struct f8_rsfunctor__ {
 };
 struct g8_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f1a_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29563,9 +29563,9 @@ struct f1a_functor__ {
 };
 struct g10_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
@@ -29576,7 +29576,7 @@ struct r_functor__ {
 };
 struct g1_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29585,7 +29585,7 @@ struct g1_functor__ {
 };
 struct g2_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29594,7 +29594,7 @@ struct g2_rsfunctor__ {
 };
 struct f6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29602,16 +29602,16 @@ struct f6_rsfunctor__ {
 };
 struct g12_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f2_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29619,7 +29619,7 @@ struct f2_rsfunctor__ {
 };
 struct f3_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29627,7 +29627,7 @@ struct f3_rsfunctor__ {
 };
 struct f6_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29635,7 +29635,7 @@ struct f6_functor__ {
 };
 struct f12_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29643,25 +29643,25 @@ struct f12_rsfunctor__ {
 };
 struct g9_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g11_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29669,7 +29669,7 @@ struct f3_functor__ {
 };
 struct f1_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29677,7 +29677,7 @@ struct f1_rsfunctor__ {
 };
 struct f7_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29685,25 +29685,25 @@ struct f7_functor__ {
 };
 struct g11_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g9_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29712,7 +29712,7 @@ struct g4_functor__ {
 };
 struct g4_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29721,7 +29721,7 @@ struct g4_rsfunctor__ {
 };
 struct f11_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29729,7 +29729,7 @@ struct f11_functor__ {
 };
 struct f12_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29737,7 +29737,7 @@ struct f12_functor__ {
 };
 struct g3_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29746,7 +29746,7 @@ struct g3_functor__ {
 };
 struct f11_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29754,16 +29754,16 @@ struct f11_rsfunctor__ {
 };
 struct g6_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct f7_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29771,7 +29771,7 @@ struct f7_rsfunctor__ {
 };
 struct f9_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29779,7 +29779,7 @@ struct f9_rsfunctor__ {
 };
 struct f4_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29787,7 +29787,7 @@ struct f4_functor__ {
 };
 struct g2_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29796,7 +29796,7 @@ struct g2_functor__ {
 };
 struct f10_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29808,23 +29808,23 @@ struct s_functor__ {
             typename Te__, typename Tf__, typename Tg__, typename Th__,
             typename Ti__, typename Tj__, typename Tk__, typename Tl__,
             typename Tm__, typename Tn__, typename To__, typename Tp__,
-            typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
             stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
             stan::is_eigen_matrix_dynamic<Te__>,
-            stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
-            stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
-            stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
-            stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
-            stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
-            stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
-            stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
-            stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
-            stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
-            stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
-            stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
-            stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+            stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+            stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
+            stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
+            stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
+            stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
+            stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
+            stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
+            stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
+            stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
+            stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
+            stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
+            stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                       stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                           stan::return_type_t<Th__, Ti__, Tj__,
@@ -29841,7 +29841,7 @@ struct s_functor__ {
 };
 struct f2_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29849,7 +29849,7 @@ struct f2_functor__ {
 };
 struct g3_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29858,7 +29858,7 @@ struct g3_rsfunctor__ {
 };
 struct f9_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29866,7 +29866,7 @@ struct f9_functor__ {
 };
 struct f8_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29874,7 +29874,7 @@ struct f8_functor__ {
 };
 struct g1_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -29883,34 +29883,34 @@ struct g1_rsfunctor__ {
 };
 struct g7_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f5_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29918,34 +29918,34 @@ struct f5_rsfunctor__ {
 };
 struct g6_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g7_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct g8_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, std::ostream* pstream__, const Ta__& a) const;
 };
 struct f10_rsfunctor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29953,7 +29953,7 @@ struct f10_rsfunctor__ {
 };
 struct f1_functor__ {
   template <typename Ty_slice__, typename Tstart__,
-            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -29961,16 +29961,16 @@ struct f1_functor__ {
 };
 struct g10_functor__ {
   template <typename Ty_slice__, typename Tstart__, typename Tend__,
-            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+            typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
             std::is_integral<Tstart__>, std::is_integral<Tend__>,
-            stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+            stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   operator()(const Ty_slice__& y_slice, const Tstart__& start,
              const Tend__& end, const Ta__& a, std::ostream* pstream__) const;
 };
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f1(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -29990,7 +29990,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f1a(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30010,7 +30010,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f2(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30030,7 +30030,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f3(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30050,7 +30050,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f4(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30070,7 +30070,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30090,7 +30090,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30110,7 +30110,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30130,7 +30130,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30150,7 +30150,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30170,7 +30170,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30190,7 +30190,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30210,7 +30210,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
   f12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
@@ -30230,7 +30230,7 @@ template <typename Ty_slice__, typename Tstart__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -30251,7 +30251,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_col_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -30273,7 +30273,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_row_vector<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -30295,7 +30295,7 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -30317,9 +30317,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g5(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30338,9 +30338,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g6(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30359,9 +30359,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g7(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30380,9 +30380,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g8(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30401,9 +30401,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g9(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
      const Ta__& a, std::ostream* pstream__) {
@@ -30422,9 +30422,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g10(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       const Ta__& a, std::ostream* pstream__) {
@@ -30443,9 +30443,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g11(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       const Ta__& a, std::ostream* pstream__) {
@@ -30464,9 +30464,9 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
     }
     }
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>* = nullptr>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
   g12(const Ty_slice__& y_slice, const Tstart__& start, const Tend__& end,
       const Ta__& a, std::ostream* pstream__) {
@@ -30489,23 +30489,23 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Te__, typename Tf__, typename Tg__, typename Th__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
-          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
           stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
           stan::is_eigen_matrix_dynamic<Te__>,
-          stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
-          stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
-          stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
-          stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
-          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
-          stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
-          stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
-          stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
-          stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
-          stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
-          stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
-          stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>* = nullptr>
+          stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+          stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
+          stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
+          stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
+          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
+          stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
+          stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
+          stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
+          stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
+          stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
+          stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
+          stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>* = nullptr>
   inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -30850,7 +30850,7 @@ inline double r(std::ostream* pstream__) {
     }
     }
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1a_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30865,23 +30865,23 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Te__, typename Tf__, typename Tg__, typename Th__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
-          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
           stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
           stan::is_eigen_matrix_dynamic<Te__>,
-          stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
-          stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
-          stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
-          stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
-          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
-          stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
-          stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
-          stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
-          stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
-          stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
-          stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
-          stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+          stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+          stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
+          stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
+          stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
+          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
+          stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
+          stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
+          stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
+          stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
+          stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
+          stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
+          stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -30903,7 +30903,7 @@ s_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30913,9 +30913,9 @@ f4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__,
@@ -30925,7 +30925,7 @@ g12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30935,7 +30935,7 @@ f5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30945,9 +30945,9 @@ f8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -30957,7 +30957,7 @@ g8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -30967,9 +30967,9 @@ f1a_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__,
@@ -30984,7 +30984,7 @@ inline double r_functor__::operator()(std::ostream* pstream__)  const
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -30996,7 +30996,7 @@ g1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -31008,7 +31008,7 @@ g2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31018,9 +31018,9 @@ f6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, const Ta__& a,
@@ -31030,7 +31030,7 @@ g12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31040,7 +31040,7 @@ f2_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31050,7 +31050,7 @@ f3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_col_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31060,7 +31060,7 @@ f6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f12_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31071,9 +31071,9 @@ const
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31083,9 +31083,9 @@ g9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, const Ta__& a,
@@ -31095,7 +31095,7 @@ g11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_row_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31105,7 +31105,7 @@ f3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31115,7 +31115,7 @@ f1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31125,9 +31125,9 @@ f7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_row_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                             const Tend__& end, std::ostream* pstream__,
@@ -31137,9 +31137,9 @@ g11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31149,7 +31149,7 @@ g9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -31161,7 +31161,7 @@ g4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_eigen_matrix_dynamic<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -31173,7 +31173,7 @@ g4_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31183,7 +31183,7 @@ f11_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31193,7 +31193,7 @@ f12_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -31205,7 +31205,7 @@ g3_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_std_vector<value_type_t<value_type_t<Ty_slice__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Ty_slice__>>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Ty_slice__>>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f11_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31216,9 +31216,9 @@ const
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31228,7 +31228,7 @@ g6_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_row_vector<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31238,7 +31238,7 @@ f7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31248,7 +31248,7 @@ f9_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31258,7 +31258,7 @@ f4_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_col_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -31270,7 +31270,7 @@ g2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31284,23 +31284,23 @@ template <typename Ty_slice__, typename Tstart__, typename Tend__,
           typename Te__, typename Tf__, typename Tg__, typename Th__,
           typename Ti__, typename Tj__, typename Tk__, typename Tl__,
           typename Tm__, typename Tn__, typename To__, typename Tp__,
-          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tq__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           std::is_integral<Ta__>, stan::is_stan_scalar<Tb__>,
           stan::is_col_vector<Tc__>, stan::is_row_vector<Td__>,
           stan::is_eigen_matrix_dynamic<Te__>,
-          stan::is_std_vector<Tf__>, std::is_integral<value_type_t<Tf__>>,
-          stan::is_std_vector<Tg__>, stan::is_stan_scalar<value_type_t<Tg__>>,
-          stan::is_std_vector<Th__>, stan::is_col_vector<value_type_t<Th__>>,
-          stan::is_std_vector<Ti__>, stan::is_row_vector<value_type_t<Ti__>>,
-          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<value_type_t<Tj__>>,
-          stan::is_std_vector<Tk__>, stan::is_std_vector<value_type_t<Tk__>>, std::is_integral<value_type_t<value_type_t<Tk__>>>,
-          stan::is_std_vector<Tl__>, stan::is_std_vector<value_type_t<Tl__>>, stan::is_stan_scalar<value_type_t<value_type_t<Tl__>>>,
-          stan::is_std_vector<Tm__>, stan::is_std_vector<value_type_t<Tm__>>, stan::is_col_vector<value_type_t<value_type_t<Tm__>>>,
-          stan::is_std_vector<Tn__>, stan::is_std_vector<value_type_t<Tn__>>, stan::is_row_vector<value_type_t<value_type_t<Tn__>>>,
-          stan::is_std_vector<To__>, stan::is_std_vector<value_type_t<To__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<To__>>>,
-          stan::is_std_vector<Tp__>, stan::is_std_vector<value_type_t<Tp__>>, stan::is_std_vector<value_type_t<value_type_t<Tp__>>>, std::is_integral<value_type_t<value_type_t<value_type_t<Tp__>>>>,
-          stan::is_std_vector<Tq__>, stan::is_std_vector<value_type_t<Tq__>>, stan::is_std_vector<value_type_t<value_type_t<Tq__>>>, stan::is_stan_scalar<value_type_t<value_type_t<value_type_t<Tq__>>>>>*>
+          stan::is_std_vector<Tf__>, std::is_integral<stan::value_type_t<Tf__>>,
+          stan::is_std_vector<Tg__>, stan::is_stan_scalar<stan::value_type_t<Tg__>>,
+          stan::is_std_vector<Th__>, stan::is_col_vector<stan::value_type_t<Th__>>,
+          stan::is_std_vector<Ti__>, stan::is_row_vector<stan::value_type_t<Ti__>>,
+          stan::is_std_vector<Tj__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tj__>>,
+          stan::is_std_vector<Tk__>, stan::is_std_vector<stan::value_type_t<Tk__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Tk__>>>,
+          stan::is_std_vector<Tl__>, stan::is_std_vector<stan::value_type_t<Tl__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Tl__>>>,
+          stan::is_std_vector<Tm__>, stan::is_std_vector<stan::value_type_t<Tm__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Tm__>>>,
+          stan::is_std_vector<Tn__>, stan::is_std_vector<stan::value_type_t<Tn__>>, stan::is_row_vector<stan::value_type_t<stan::value_type_t<Tn__>>>,
+          stan::is_std_vector<To__>, stan::is_std_vector<stan::value_type_t<To__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<To__>>>,
+          stan::is_std_vector<Tp__>, stan::is_std_vector<stan::value_type_t<Tp__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tp__>>>, std::is_integral<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tp__>>>>,
+          stan::is_std_vector<Tq__>, stan::is_std_vector<stan::value_type_t<Tq__>>, stan::is_std_vector<stan::value_type_t<stan::value_type_t<Tq__>>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<stan::value_type_t<Tq__>>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__, Tb__,
                     stan::return_type_t<Tc__, Td__, Te__, Tf__, Tg__,
                                         stan::return_type_t<Th__, Ti__, Tj__,
@@ -31322,7 +31322,7 @@ s_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_col_vector<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31332,7 +31332,7 @@ f2_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_row_vector<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -31344,7 +31344,7 @@ g3_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, std::is_integral<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31354,7 +31354,7 @@ f9_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_eigen_matrix_dynamic<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31364,7 +31364,7 @@ f8_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
           stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
@@ -31376,9 +31376,9 @@ g1_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31388,9 +31388,9 @@ g7_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                          const Tend__& end, const Ta__& a,
@@ -31400,9 +31400,9 @@ g5_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31412,7 +31412,7 @@ g5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, stan::is_stan_scalar<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, stan::is_stan_scalar<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31422,9 +31422,9 @@ f5_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_col_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_col_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31434,9 +31434,9 @@ g6_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_row_vector<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_row_vector<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31446,9 +31446,9 @@ g7_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<value_type_t<Ta__>>>*>
+          stan::is_std_vector<Ta__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                            const Tend__& end, std::ostream* pstream__,
@@ -31458,7 +31458,7 @@ g8_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<value_type_t<Ty_slice__>>, std::is_integral<value_type_t<value_type_t<Ty_slice__>>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_std_vector<stan::value_type_t<Ty_slice__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty_slice__>>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f10_rsfunctor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31469,7 +31469,7 @@ const
 }
 
 template <typename Ty_slice__, typename Tstart__,
-          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Tend__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__>
 f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
@@ -31479,9 +31479,9 @@ f1_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
 }
 
 template <typename Ty_slice__, typename Tstart__, typename Tend__,
-          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<value_type_t<Ty_slice__>>,
+          typename Ta__, stan::require_all_t<stan::is_std_vector<Ty_slice__>, stan::is_stan_scalar<stan::value_type_t<Ty_slice__>>,
           std::is_integral<Tstart__>, std::is_integral<Tend__>,
-          stan::is_std_vector<Ta__>, stan::is_std_vector<value_type_t<Ta__>>, stan::is_col_vector<value_type_t<value_type_t<Ta__>>>>*>
+          stan::is_std_vector<Ta__>, stan::is_std_vector<stan::value_type_t<Ta__>>, stan::is_col_vector<stan::value_type_t<stan::value_type_t<Ta__>>>>*>
 inline stan::return_type_t<Ty_slice__, Tstart__, Tend__, Ta__>
 g10_functor__::operator()(const Ty_slice__& y_slice, const Tstart__& start,
                           const Tend__& end, const Ta__& a,

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1455,8 +1455,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo8_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
                            std::ostream* pstream__)  const
@@ -1464,8 +1463,7 @@ foo8_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z
   return foo8(z, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo1_functor__::operator()(const std::complex<T0__>& z,
                            std::ostream* pstream__)  const
@@ -1473,23 +1471,20 @@ foo1_functor__::operator()(const std::complex<T0__>& z,
   return foo1(z, pstream__);
 }
 
-
 std::vector<std::complex<double>>
 foo4_functor__::operator()(std::ostream* pstream__)  const
 {
   return foo4(pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::vector<std::complex<stan::promote_args_t<T0__>>>
 foo6_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
   return foo6(r, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
 foo10_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
                             std::ostream* pstream__)  const
@@ -1497,24 +1492,21 @@ foo10_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& 
   return foo10(z, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::complex<stan::promote_args_t<T0__>>
 foo2_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
   return foo2(r, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
 foo9_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
   return foo9(r, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::complex<stan::promote_args_t<T0__>>
 foo3_functor__::operator()(const std::complex<T0__>& z,
                            std::ostream* pstream__)  const
@@ -1522,8 +1514,7 @@ foo3_functor__::operator()(const std::complex<T0__>& z,
   return foo3(z, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::vector<std::complex<stan::promote_args_t<T0__>>>
 foo7_functor__::operator()(const std::vector<std::complex<T0__>>& z,
                            std::ostream* pstream__)  const
@@ -1531,15 +1522,13 @@ foo7_functor__::operator()(const std::vector<std::complex<T0__>>& z,
   return foo7(z, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo5_functor__::operator()(const std::vector<std::complex<T0__>>& z,
                            std::ostream* pstream__)  const
 {
   return foo5(z, pstream__);
 }
-
 
 std::complex<double> foo_functor__::operator()(std::ostream* pstream__) 
 const
@@ -3745,7 +3734,8 @@ static constexpr std::array<const char*, 75> locations_array__ =
  " (in 'cpp-reserved-words.stan', line 14, column 17 to column 19)"};
 
 struct _stan_asm_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr> void
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+  void
   operator()(const T0__& _stan_class, std::ostream* pstream__) const;
 };
 struct _stan_char16_t_functor__ {
@@ -3773,7 +3763,8 @@ struct _stan_alignof_functor__ {
   operator()(const int& _stan_char, std::ostream* pstream__) const;
 };
 struct _stan_and_eq_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  void
   operator()(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) const;
 };
 struct _stan_and_functor__ {
@@ -3969,26 +3960,23 @@ void _stan_char32_t(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr> void
+template <typename T0__, stan::require_col_vector_t<T0__>*>
+void
 _stan_asm_functor__::operator()(const T0__& _stan_class,
                                 std::ostream* pstream__)  const
 {
   return _stan_asm(_stan_class, pstream__);
 }
 
-
 void _stan_char16_t_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_char16_t(pstream__);
 }
 
-
 void _stan_bitor_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_bitor(pstream__);
 }
-
 
 void
 _stan_bitand_functor__::operator()(const int& _stan_constexpr,
@@ -3997,12 +3985,10 @@ _stan_bitand_functor__::operator()(const int& _stan_constexpr,
   return _stan_bitand(_stan_constexpr, pstream__);
 }
 
-
 void _stan_catch_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_catch(pstream__);
 }
-
 
 void
 _stan_alignas_functor__::operator()(const int& _stan_asm,
@@ -4011,7 +3997,6 @@ _stan_alignas_functor__::operator()(const int& _stan_asm,
   return _stan_alignas(_stan_asm, pstream__);
 }
 
-
 void
 _stan_alignof_functor__::operator()(const int& _stan_char,
                                     std::ostream* pstream__)  const
@@ -4019,14 +4004,13 @@ _stan_alignof_functor__::operator()(const int& _stan_char,
   return _stan_alignof(_stan_char, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+void
 _stan_and_eq_functor__::operator()(const T0__& _stan_STAN_MINOR,
                                    std::ostream* pstream__)  const
 {
   return _stan_and_eq(_stan_STAN_MINOR, pstream__);
 }
-
 
 void
 _stan_and_functor__::operator()(const int& _stan_STAN_MAJOR,
@@ -4035,24 +4019,20 @@ _stan_and_functor__::operator()(const int& _stan_STAN_MAJOR,
   return _stan_and(_stan_STAN_MAJOR, pstream__);
 }
 
-
 void _stan_char_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_char(pstream__);
 }
-
 
 void _stan_char32_t_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_char32_t(pstream__);
 }
 
-
 void _stan_bool_functor__::operator()(std::ostream* pstream__)  const
 {
   return _stan_bool(pstream__);
 }
-
 
 void _stan_case_functor__::operator()(std::ostream* pstream__)  const
 {
@@ -6482,14 +6462,32 @@ static constexpr std::array<const char*, 787> locations_array__ =
  " (in 'mother.stan', line 345, column 41 to line 349, column 3)"};
 
 struct foo_five_args_lp_functor__ {
-  template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr>
+  template <bool propto__, typename T0__, typename T1__, typename T2__,
+            typename T3__, typename T4__, typename T5__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
   operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
              const T4__& x5, const T5__& x6, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct f5_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>>
@@ -6510,7 +6508,8 @@ struct foo_lcdf_functor__ {
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct covsqrt2corsqrt_functor__ {
-  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& mat, const int& invert, std::ostream* pstream__) const;
 };
@@ -6519,7 +6518,9 @@ struct foo_1_functor__ {
   operator()(const int& a, std::ostream* pstream__) const;
 };
 struct unit_normal_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -6533,7 +6534,17 @@ struct vecfoo_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>>>
@@ -6549,7 +6560,12 @@ struct f6_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_five_args_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
   operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
              const T4__& x5, std::ostream* pstream__) const;
@@ -6559,7 +6575,17 @@ struct foo_2_functor__ {
   operator()(const int& a, std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<int>>
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6573,11 +6599,22 @@ struct f3_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  void
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>
@@ -6593,7 +6630,17 @@ struct f7_functor__ {
              std::ostream* pstream__) const;
 };
 struct f11_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>>
@@ -6609,7 +6656,17 @@ struct f11_functor__ {
              std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>>>
@@ -6625,14 +6682,19 @@ struct f12_functor__ {
              std::ostream* pstream__) const;
 };
 struct sho_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<double>& x,
              const std::vector<int>& x_int, std::ostream* pstream__) const;
 };
 struct foo_bar2_functor__ {
-  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
 };
@@ -6641,19 +6703,28 @@ struct matfoo_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
              const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
-  template <typename T0__, typename T1__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__, typename RNG,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& mu, const T1__& sigma, RNG& base_rng__,
              std::ostream* pstream__) const;
 };
 struct relative_diff_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   operator()(const T0__& x, const T1__& y, const T2__& max_, const T3__& min_,
              std::ostream* pstream__) const;
@@ -6664,7 +6735,17 @@ struct vecmubar_functor__ {
   operator()(const T0__& mu, std::ostream* pstream__) const;
 };
 struct f0_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   void
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6678,19 +6759,32 @@ struct f0_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lpmf_functor__ {
-  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T1__,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct foo_5_functor__ {
-  template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<double>& data_r, const std::vector<int>& data_i,
              std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>
@@ -6706,7 +6800,17 @@ struct f4_functor__ {
              std::ostream* pstream__) const;
 };
 struct f10_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>
@@ -6722,7 +6826,17 @@ struct f10_functor__ {
              std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<int>
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6736,7 +6850,17 @@ struct f2_functor__ {
              std::ostream* pstream__) const;
 };
 struct f9_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>>>
@@ -6752,7 +6876,17 @@ struct f9_functor__ {
              std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>>
@@ -6778,7 +6912,9 @@ struct vecmufoo_functor__ {
   operator()(const T0__& mu, std::ostream* pstream__) const;
 };
 struct foo_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -6793,7 +6929,9 @@ struct foo_6_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct binomialf_functor__ {
-  template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& phi, const T1__& theta,
              const std::vector<double>& x_r, const std::vector<int>& x_i,
@@ -6805,7 +6943,17 @@ struct foo_bar1_functor__ {
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+  template <typename T3__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T8__, typename T9__, typename T10__,
+            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_stan_scalar_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T8__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr>
   int
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -6843,12 +6991,18 @@ int foo(const int& n, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<double>& x,
       const std::vector<int>& x_int, std::ostream* pstream__) ; 
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<double>& x,
@@ -6908,7 +7062,9 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -6924,7 +7080,8 @@ template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   foo_lpmf(const int& y, const T1__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -6970,7 +7127,9 @@ template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, typename RNG,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_rng(const T0__& mu, const T1__& sigma, RNG& base_rng__,
           std::ostream* pstream__) {
@@ -6987,7 +7146,8 @@ template <typename T0__, typename T1__, typename RNG, stan::require_stan_scalar_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
@@ -7271,7 +7431,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
@@ -7304,7 +7465,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   relative_diff(const T0__& x, const T1__& y, const T2__& max_,
                 const T3__& min_, std::ostream* pstream__) {
@@ -7351,7 +7516,9 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   foo_5(const T0__& shared_params_arg__, const T1__& job_params_arg__,
         const std::vector<double>& data_r, const std::vector<int>& data_i,
@@ -7373,7 +7540,12 @@ template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
   foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3,
                 const T3__& x4, const T4__& x5, std::ostream* pstream__) {
@@ -7391,7 +7563,15 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__, typename T2__,
+          typename T3__, typename T4__, typename T5__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
   foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
                    const T3__& x4, const T4__& x5, const T5__& x6,
@@ -7410,7 +7590,8 @@ template <bool propto__, typename T0__, typename T1__, typename T2__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   covsqrt2corsqrt(const T0__& mat_arg__, const int& invert,
                   std::ostream* pstream__) {
@@ -7449,8 +7630,17 @@ template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
-  void
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr> void
   f0(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
@@ -7483,8 +7673,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
-  int
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr> int
   f1(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
@@ -7514,8 +7713,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
-  std::vector<int>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr> std::vector<int>
   f2(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
@@ -7545,7 +7753,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<int>>
   f3(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -7576,7 +7794,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>
@@ -7609,7 +7837,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>
@@ -7642,7 +7880,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>>
@@ -7675,7 +7923,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>
@@ -7708,7 +7966,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>
@@ -7741,7 +8009,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>>
@@ -7774,7 +8052,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>
@@ -7808,7 +8096,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>
@@ -7842,7 +8140,17 @@ template <typename T3__, typename T4__, typename T5__, typename T6__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_stan_scalar_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T8__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>>
@@ -7982,7 +8290,10 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   algebra_system(const T0__& x_arg__, const T1__& y_arg__,
                  const std::vector<T2__>& dat,
@@ -8016,7 +8327,9 @@ template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
   binomialf(const T0__& phi_arg__, const T1__& theta_arg__,
             const std::vector<double>& x_r, const std::vector<int>& x_i,
@@ -8043,8 +8356,14 @@ template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__, typename T2__,
+          typename T3__, typename T4__, typename T5__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
 foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
                                        const T2__& x3, const T3__& x4,
@@ -8057,8 +8376,17 @@ foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
            pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>
@@ -8077,8 +8405,7 @@ f5_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T1__, stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T1__>
 foo_lcdf_functor__::operator()(const int& y, const T1__& lambda,
                                std::ostream* pstream__)  const
@@ -8086,8 +8413,7 @@ foo_lcdf_functor__::operator()(const int& y, const T1__& lambda,
   return foo_lcdf(y, lambda, pstream__);
 }
 
-
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 covsqrt2corsqrt_functor__::operator()(const T0__& mat, const int& invert,
                                       std::ostream* pstream__)  const
@@ -8095,14 +8421,13 @@ covsqrt2corsqrt_functor__::operator()(const T0__& mat, const int& invert,
   return covsqrt2corsqrt(mat, invert, pstream__);
 }
 
-
 int foo_1_functor__::operator()(const int& a, std::ostream* pstream__)  const
 {
   return foo_1(a, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 void
 unit_normal_lp_functor__::operator()(const T0__& u, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -8111,12 +8436,10 @@ unit_normal_lp_functor__::operator()(const T0__& u, T_lp__& lp__,
   return unit_normal_lp<propto__>(u, lp__, lp_accum__, pstream__);
 }
 
-
 double foo_bar0_functor__::operator()(std::ostream* pstream__)  const
 {
   return foo_bar0(pstream__);
 }
-
 
 Eigen::Matrix<double, -1, 1>
 vecfoo_functor__::operator()(std::ostream* pstream__)  const
@@ -8124,8 +8447,17 @@ vecfoo_functor__::operator()(std::ostream* pstream__)  const
   return vecfoo(pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>>>
@@ -8144,8 +8476,12 @@ f6_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f6(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
 foo_five_args_functor__::operator()(const T0__& x1, const T1__& x2,
                                     const T2__& x3, const T3__& x4,
@@ -8155,14 +8491,22 @@ const
   return foo_five_args(x1, x2, x3, x4, x5, pstream__);
 }
 
-
 int foo_2_functor__::operator()(const int& a, std::ostream* pstream__)  const
 {
   return foo_2(a, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<std::vector<int>>
 f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -8179,15 +8523,24 @@ f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
-foo_4_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+void foo_4_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+const
 {
   return foo_4(x, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>
@@ -8206,8 +8559,17 @@ f7_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f7(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>
@@ -8226,8 +8588,17 @@ f11_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>>
@@ -8246,8 +8617,10 @@ f12_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__>>
 sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                           const std::vector<T2__>& theta,
@@ -8258,8 +8631,8 @@ sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 foo_bar2_functor__::operator()(const T0__& x, const T1__& y,
                                std::ostream* pstream__)  const
@@ -8267,15 +8640,16 @@ foo_bar2_functor__::operator()(const T0__& x, const T1__& y,
   return foo_bar2(x, y, pstream__);
 }
 
-
 Eigen::Matrix<double, -1, -1>
 matfoo_functor__::operator()(std::ostream* pstream__)  const
 {
   return matfoo(pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 algebra_system_functor__::operator()(const T0__& x, const T1__& y,
                                      const std::vector<T2__>& dat,
@@ -8285,8 +8659,9 @@ algebra_system_functor__::operator()(const T0__& x, const T1__& y,
   return algebra_system(x, y, dat, dat_int, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, typename RNG,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 foo_rng_functor__::operator()(const T0__& mu, const T1__& sigma,
                               RNG& base_rng__, std::ostream* pstream__) 
@@ -8295,8 +8670,11 @@ const
   return foo_rng(mu, sigma, base_rng__, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__>
 relative_diff_functor__::operator()(const T0__& x, const T1__& y,
                                     const T2__& max_, const T3__& min_,
@@ -8305,8 +8683,7 @@ relative_diff_functor__::operator()(const T0__& x, const T1__& y,
   return relative_diff(x, y, max_, min_, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmubar_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
 const
@@ -8314,8 +8691,17 @@ const
   return vecmubar(mu, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 void
 f0_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -8332,8 +8718,7 @@ f0_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T1__>
 foo_lpmf_functor__::operator()(const int& y, const T1__& lambda,
                                std::ostream* pstream__)  const
@@ -8341,8 +8726,8 @@ foo_lpmf_functor__::operator()(const int& y, const T1__& lambda,
   return foo_lpmf<propto__>(y, lambda, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
+          stan::require_col_vector_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
 foo_5_functor__::operator()(const T0__& shared_params,
                             const T1__& job_params,
@@ -8353,8 +8738,17 @@ foo_5_functor__::operator()(const T0__& shared_params,
   return foo_5(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>
@@ -8373,8 +8767,17 @@ f4_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f4(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>
@@ -8393,8 +8796,17 @@ f10_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<int>
 f2_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -8411,8 +8823,17 @@ f2_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f2(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>>
@@ -8431,8 +8852,17 @@ f9_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f9(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::value_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::value_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>
@@ -8451,8 +8881,7 @@ f8_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-
-template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T1__, stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T1__>
 foo_lccdf_functor__::operator()(const int& y, const T1__& lambda,
                                 std::ostream* pstream__)  const
@@ -8460,8 +8889,7 @@ foo_lccdf_functor__::operator()(const int& y, const T1__& lambda,
   return foo_lccdf(y, lambda, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmufoo_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
 const
@@ -8469,8 +8897,8 @@ const
   return vecmufoo(mu, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_lp_functor__::operator()(const T0__& x, T_lp__& lp__,
                              T_lp_accum__& lp_accum__,
@@ -8479,8 +8907,7 @@ foo_lp_functor__::operator()(const T0__& x, T_lp__& lp__,
   return foo_lp<propto__>(x, lp__, lp_accum__, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::vector<stan::promote_args_t<T0__>>
 foo_3_functor__::operator()(const T0__& t, const int& n,
                             std::ostream* pstream__)  const
@@ -8488,14 +8915,13 @@ foo_3_functor__::operator()(const T0__& t, const int& n,
   return foo_3(t, n, pstream__);
 }
 
-
 void foo_6_functor__::operator()(std::ostream* pstream__)  const
 {
   return foo_6(pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
+          stan::require_col_vector_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, 1>
 binomialf_functor__::operator()(const T0__& phi, const T1__& theta,
                                 const std::vector<double>& x_r,
@@ -8505,16 +8931,24 @@ binomialf_functor__::operator()(const T0__& phi, const T1__& theta,
   return binomialf(phi, theta, x_r, x_i, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_bar1_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return foo_bar1(x, pstream__);
 }
 
-
-template <typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T8__, typename T9__, typename T10__, typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_stan_scalar_t<T7__>* = nullptr, stan::require_stan_scalar_t<T8__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr>
+template <typename T3__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T8__, typename T9__, typename T10__,
+          typename T11__, stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_stan_scalar_t<T7__>*,
+          stan::require_stan_scalar_t<T8__>*,
+          stan::require_eigen_matrix_dynamic_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*>
 int
 f1_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -8530,7 +8964,6 @@ f1_functor__::operator()(const int& a1, const std::vector<int>& a2,
 {
   return f1(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
-
 
 int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
 {
@@ -14721,34 +15154,51 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'motherHOF.stan', line 25, column 45 to line 30, column 3)"};
 
 struct sho_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x,
              const std::vector<int>& x_int, std::ostream* pstream__) const;
 };
 struct algebra_system_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
              const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   operator()(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
              const std::vector<T3__>& x_r, const std::vector<int>& x_i,
              std::ostream* pstream__) const;
 };
 struct foo_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<T2__>& data_r, const std::vector<int>& data_i,
              std::ostream* pstream__) const;
 };
 struct goo_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -14760,7 +15210,11 @@ struct map_rectfake_functor__ {
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<T3__>& x,
@@ -14790,7 +15244,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   integrand(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
             const std::vector<T3__>& x_r, const std::vector<int>& x_i,
@@ -14808,7 +15266,10 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   foo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
       const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -14830,7 +15291,10 @@ template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   goo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
       const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -14868,7 +15332,10 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
   algebra_system(const T0__& x_arg__, const T1__& y_arg__,
                  const std::vector<T2__>& dat,
@@ -14902,8 +15369,11 @@ template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                           const std::vector<T2__>& theta,
@@ -14914,8 +15384,10 @@ sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 algebra_system_functor__::operator()(const T0__& x, const T1__& y,
                                      const std::vector<T2__>& dat,
@@ -14925,8 +15397,11 @@ algebra_system_functor__::operator()(const T0__& x, const T1__& y,
   return algebra_system(x, y, dat, dat_int, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__>
 integrand_functor__::operator()(const T0__& x, const T1__& xc,
                                 const std::vector<T2__>& theta,
@@ -14937,8 +15412,10 @@ integrand_functor__::operator()(const T0__& x, const T1__& xc,
   return integrand(x, xc, theta, x_r, x_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 foo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
                           const std::vector<T2__>& data_r,
@@ -14948,8 +15425,10 @@ foo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
   return foo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>, T2__>, -1, 1>
 goo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
                           const std::vector<T2__>& data_r,
@@ -14959,8 +15438,7 @@ goo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
   return goo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 map_rectfake_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -17206,21 +17684,33 @@ static constexpr std::array<const char*, 630> locations_array__ =
  " (in 'new_integrate_interface.stan', line 2, column 47 to line 4, column 3)"};
 
 struct f_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_col_vector_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                        stan::value_type_t<T3__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, const T2__& a, const T3__& b,
              std::ostream* pstream__) const;
 };
 struct f_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_col_vector_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                        stan::value_type_t<T3__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& a, const T3__& b) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_col_vector_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                      stan::value_type_t<T3__>>, -1, 1>
   f(const T0__& t, const T1__& z_arg__, const T2__& a, const T3__& b_arg__,
@@ -17242,8 +17732,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_col_vector_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                      stan::value_type_t<T3__>>, -1, 1>
 f_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
@@ -17252,8 +17745,11 @@ f_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
   return f(t, z, a, b, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_col_vector_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__,
                      stan::value_type_t<T3__>>, -1, 1>
 f_odefunctor__::operator()(const T0__& t, const T1__& z,
@@ -21039,14 +21535,22 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'old_integrate_interface.stan', line 7, column 38 to line 19, column 3)"};
 
 struct dz_dt_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& z,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   dz_dt(const T0__& t, const std::vector<T1__>& z,
         const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -21088,8 +21592,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 dz_dt_functor__::operator()(const T0__& t, const std::vector<T1__>& z,
                             const std::vector<T2__>& theta,
@@ -23420,7 +23927,8 @@ struct foo_functor__ {
   template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   stan::promote_args_t<stan::value_type_t<T0__>>
   operator()(const T0__& p, std::ostream* pstream__) const;
   template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
@@ -23499,7 +24007,8 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   stan::promote_args_t<stan::value_type_t<T0__>>
   foo(const T0__& p_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -23617,7 +24126,6 @@ double foo(const std::vector<int>& p, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 double
 foo_functor__::operator()(const std::vector<int>& p, std::ostream* pstream__) 
 const
@@ -23625,8 +24133,7 @@ const
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<std::vector<T0__>>& p,
                           std::ostream* pstream__)  const
@@ -23634,8 +24141,7 @@ foo_functor__::operator()(const std::vector<std::vector<T0__>>& p,
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
                           std::ostream* pstream__)  const
@@ -23643,8 +24149,7 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
                           std::ostream* pstream__)  const
@@ -23652,8 +24157,7 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
                           std::ostream* pstream__)  const
@@ -23661,8 +24165,7 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<T0__>& p, std::ostream* pstream__) 
 const
@@ -23670,38 +24173,33 @@ const
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
 stan::promote_args_t<stan::value_type_t<T0__>>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 stan::promote_args_t<stan::value_type_t<T0__>>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_row_vector_t<T0__>*>
 stan::promote_args_t<stan::value_type_t<T0__>>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
-
 
 double foo_functor__::operator()(const int& p, std::ostream* pstream__) 
 const
@@ -24895,8 +25393,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<T0__>& zs,
                           std::ostream* pstream__)  const
@@ -24904,8 +25401,7 @@ foo_functor__::operator()(const std::vector<T0__>& zs,
   return foo(zs, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 std::complex<stan::promote_args_t<T0__>>
 ident_functor__::operator()(const std::complex<T0__>& x,
                             std::ostream* pstream__)  const
@@ -25282,14 +25778,15 @@ static constexpr std::array<const char*, 26> locations_array__ =
  " (in 'reduce_sum_m1.stan', line 17, column 4 to column 39)",
  " (in 'reduce_sum_m1.stan', line 16, column 58 to line 18, column 3)"};
 
-template <bool propto__> struct foo_lpdf_rsfunctor__ {
+bool propto__struct foo_lpdf_rsfunctor__ {
   template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
@@ -25301,7 +25798,9 @@ struct g_functor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct h_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -25314,7 +25813,9 @@ struct g_rsfunctor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct h_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<T3__>& a,
@@ -25344,7 +25845,9 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<T3__>& a, std::ostream* pstream__) {
@@ -25369,7 +25872,8 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   foo_lpdf(const std::vector<T0__>& y_slice, const int& start,
            const int& end, std::ostream* pstream__) {
@@ -25384,8 +25888,7 @@ template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__> 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+bool propto__template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
                                            const int& start, const int& end,
@@ -25394,8 +25897,7 @@ foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
   return foo_lpdf<propto__>(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo_lpdf_functor__::operator()(const std::vector<T0__>& y_slice,
                                const int& start, const int& end,
@@ -25404,8 +25906,7 @@ foo_lpdf_functor__::operator()(const std::vector<T0__>& y_slice,
   return foo_lpdf<propto__>(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                         const int& end, std::ostream* pstream__)  const
@@ -25413,8 +25914,8 @@ g_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__,
@@ -25423,8 +25924,7 @@ h_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return h(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__)  const
@@ -25432,8 +25932,8 @@ g_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                         const int& end, const std::vector<T3__>& a,
@@ -26037,42 +26537,54 @@ struct g6_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h6_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
              std::ostream* pstream__) const;
 };
 struct h6_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a) const;
 };
 struct h8_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
              std::ostream* pstream__) const;
 };
 struct h7_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
              std::ostream* pstream__) const;
 };
 struct h8_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) const;
 };
 struct h2_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -26085,7 +26597,9 @@ struct g8_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h2_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
@@ -26116,7 +26630,9 @@ struct g3_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h5_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__, const std::vector<std::vector<T3__>>& a) const;
@@ -26128,7 +26644,9 @@ struct g1_rsfunctor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct h1_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<T3__>& a, std::ostream* pstream__) const;
@@ -26164,7 +26682,9 @@ struct g4_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h4_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
@@ -26183,7 +26703,9 @@ struct g7_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h5_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) const;
@@ -26201,34 +26723,44 @@ struct g3_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h3_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) const;
 };
 struct h7_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) const;
 };
 struct h1_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__, const std::vector<T3__>& a) const;
 };
 struct h3_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
              std::ostream* pstream__) const;
 };
 struct h4_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -26484,7 +27016,9 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h1(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<T3__>& a, std::ostream* pstream__) {
@@ -26503,7 +27037,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h2(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -26532,7 +27068,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h3(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -26561,7 +27099,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h4(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -26591,7 +27131,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h5(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
@@ -26626,7 +27168,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h6(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
@@ -26663,7 +27207,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h7(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
@@ -26700,7 +27246,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h8(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
@@ -26737,8 +27285,7 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                          const int& start, const int& end,
@@ -26747,8 +27294,8 @@ g6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1
   return g6(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h6_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -26758,8 +27305,8 @@ h6_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h6(y, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h6_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -26769,8 +27316,8 @@ const
   return h6(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h8_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -26780,8 +27327,8 @@ h8_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h8(y, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h7_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -26791,8 +27338,8 @@ h7_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h7(y, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h8_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -26802,8 +27349,8 @@ const
   return h8(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h2_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -26813,8 +27360,7 @@ h2_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h2(y, start, end, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -26823,8 +27369,8 @@ g8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -
   return g8(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h2_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -26834,8 +27380,7 @@ const
   return h2(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, std::ostream* pstream__)  const
@@ -26843,8 +27388,7 @@ g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g1(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                          const int& start, const int& end,
@@ -26853,8 +27397,7 @@ g2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
   return g2(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                            const int& start, const int& end,
@@ -26863,8 +27406,7 @@ g2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slic
   return g2(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -26873,8 +27415,8 @@ g3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slic
   return g3(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h5_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -26883,8 +27425,7 @@ h5_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
   return h5(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -26893,8 +27434,8 @@ g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g1(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h1_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end, const std::vector<T3__>& a,
@@ -26903,8 +27444,7 @@ h1_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h1(y, start, end, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -26913,8 +27453,7 @@ g7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1
   return g7(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                          const int& start, const int& end,
@@ -26923,8 +27462,7 @@ g5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return g5(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                            const int& start, const int& end,
@@ -26933,8 +27471,7 @@ g5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return g5(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                            const int& start, const int& end,
@@ -26943,8 +27480,7 @@ g6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return g6(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -26953,8 +27489,8 @@ g4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice
   return g4(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h4_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -26964,8 +27500,7 @@ const
   return h4(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -26974,8 +27509,7 @@ g4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_sli
   return g4(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -26984,8 +27518,8 @@ g7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, 
   return g7(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h5_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -26995,8 +27529,7 @@ h5_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h5(y, start, end, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -27005,8 +27538,7 @@ g8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return g8(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 g3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -27015,8 +27547,8 @@ g3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
   return g3(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h3_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -27026,8 +27558,8 @@ const
   return h3(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h7_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -27037,8 +27569,8 @@ const
   return h7(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h1_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -27047,8 +27579,8 @@ h1_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
   return h1(y, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h3_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -27058,8 +27590,8 @@ h3_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h3(y, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 h4_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -28798,7 +29330,24 @@ struct f1a_rsfunctor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct s_rsfunctor__ {
-  template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
+  template <typename T0__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T9__, typename T10__, typename T11__,
+            typename T12__, typename T14__, typename T15__, typename T16__,
+            typename T17__, typename T19__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_col_vector_t<T5__>* = nullptr,
+            stan::require_row_vector_t<T6__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr,
+            stan::require_stan_scalar_t<T12__>* = nullptr,
+            stan::require_stan_scalar_t<T14__>* = nullptr,
+            stan::require_stan_scalar_t<T15__>* = nullptr,
+            stan::require_stan_scalar_t<T16__>* = nullptr,
+            stan::require_stan_scalar_t<T17__>* = nullptr,
+            stan::require_stan_scalar_t<T19__>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                        stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                        stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -28826,7 +29375,9 @@ struct f4_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g12_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -28845,7 +29396,9 @@ struct f8_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -28858,7 +29411,9 @@ struct f1a_functor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct g10_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -28869,13 +29424,17 @@ struct r_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct g1_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
@@ -28887,7 +29446,9 @@ struct f6_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g12_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
@@ -28919,14 +29480,18 @@ struct f12_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g9_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<std::vector<T3__>>& a) const;
 };
 struct g11_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
@@ -28952,27 +29517,35 @@ struct f7_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g11_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a) const;
 };
 struct g9_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<std::vector<T3__>>& a,
              std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
@@ -28989,7 +29562,9 @@ struct f12_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_row_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
@@ -29000,7 +29575,9 @@ struct f11_rsfunctor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g6_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -29024,7 +29601,9 @@ struct f4_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
@@ -29035,7 +29614,24 @@ struct f10_functor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct s_functor__ {
-  template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
+  template <typename T0__, typename T4__, typename T5__, typename T6__,
+            typename T7__, typename T9__, typename T10__, typename T11__,
+            typename T12__, typename T14__, typename T15__, typename T16__,
+            typename T17__, typename T19__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_col_vector_t<T5__>* = nullptr,
+            stan::require_row_vector_t<T6__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
+            stan::require_stan_scalar_t<T9__>* = nullptr,
+            stan::require_stan_scalar_t<T10__>* = nullptr,
+            stan::require_stan_scalar_t<T11__>* = nullptr,
+            stan::require_stan_scalar_t<T12__>* = nullptr,
+            stan::require_stan_scalar_t<T14__>* = nullptr,
+            stan::require_stan_scalar_t<T15__>* = nullptr,
+            stan::require_stan_scalar_t<T16__>* = nullptr,
+            stan::require_stan_scalar_t<T17__>* = nullptr,
+            stan::require_stan_scalar_t<T19__>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                        stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                        stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -29064,7 +29660,9 @@ struct f2_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_row_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
@@ -29081,27 +29679,35 @@ struct f8_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g1_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
 };
 struct g7_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
              std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<T3__>& a,
              std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -29114,21 +29720,27 @@ struct f5_rsfunctor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) const;
 };
 struct g7_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, 1, -1>>& a) const;
 };
 struct g8_rsfunctor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -29146,7 +29758,9 @@ struct f1_functor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct g10_functor__ {
-  template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
@@ -29372,7 +29986,9 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a, std::ostream* pstream__) {
@@ -29389,7 +30005,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   g2(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -29408,7 +30026,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_row_vector_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   g3(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -29427,7 +30047,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, stan::value_type_t<T3__>>
   g4(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -29446,7 +30068,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g5(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<T3__>& a, std::ostream* pstream__) {
@@ -29463,7 +30087,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g6(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -29481,7 +30107,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g7(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -29499,7 +30127,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g8(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -29517,7 +30147,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g9(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
@@ -29534,7 +30166,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g10(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
@@ -29552,7 +30186,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g11(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
@@ -29570,7 +30206,9 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g12(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
@@ -29588,7 +30226,24 @@ template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
+template <typename T0__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T9__, typename T10__, typename T11__,
+          typename T12__, typename T14__, typename T15__, typename T16__,
+          typename T17__, typename T19__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_col_vector_t<T5__>* = nullptr,
+          stan::require_row_vector_t<T6__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
+          stan::require_stan_scalar_t<T9__>* = nullptr,
+          stan::require_stan_scalar_t<T10__>* = nullptr,
+          stan::require_stan_scalar_t<T11__>* = nullptr,
+          stan::require_stan_scalar_t<T12__>* = nullptr,
+          stan::require_stan_scalar_t<T14__>* = nullptr,
+          stan::require_stan_scalar_t<T15__>* = nullptr,
+          stan::require_stan_scalar_t<T16__>* = nullptr,
+          stan::require_stan_scalar_t<T17__>* = nullptr,
+          stan::require_stan_scalar_t<T19__>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                      stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -29938,8 +30593,7 @@ double r(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f1a_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -29948,8 +30602,23 @@ f1a_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return f1a(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
+template <typename T0__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T9__, typename T10__, typename T11__,
+          typename T12__, typename T14__, typename T15__, typename T16__,
+          typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_col_vector_t<T5__>*,
+          stan::require_row_vector_t<T6__>*,
+          stan::require_eigen_matrix_dynamic_t<T7__>*,
+          stan::require_stan_scalar_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*,
+          stan::require_stan_scalar_t<T12__>*,
+          stan::require_stan_scalar_t<T14__>*,
+          stan::require_stan_scalar_t<T15__>*,
+          stan::require_stan_scalar_t<T16__>*,
+          stan::require_stan_scalar_t<T17__>*,
+          stan::require_stan_scalar_t<T19__>*>
 stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                      stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -29977,8 +30646,7 @@ const
            m, n, o, p, q, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -29987,8 +30655,8 @@ f4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_sli
   return f4(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g12_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -29999,8 +30667,7 @@ const
   return g12(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                          const int& start, const int& end,
@@ -30009,8 +30676,7 @@ f5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return f5(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -30019,8 +30685,8 @@ f8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return f8(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g8_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -30030,8 +30696,7 @@ g8_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g8(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f1a_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__)  const
@@ -30039,8 +30704,8 @@ f1a_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return f1a(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g10_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -30051,14 +30716,13 @@ const
   return g10(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
 double r_functor__::operator()(std::ostream* pstream__)  const
 {
   return r(pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -30067,8 +30731,8 @@ g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g1(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T3__>*>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g2_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30077,8 +30741,7 @@ g2_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g2(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                            const int& start, const int& end,
@@ -30087,8 +30750,8 @@ f6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return f6(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g12_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
@@ -30098,8 +30761,7 @@ g12_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g12(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                            const int& start, const int& end,
@@ -30108,8 +30770,7 @@ f2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slic
   return f2(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -30118,8 +30779,7 @@ f3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slic
   return f3(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                          const int& start, const int& end,
@@ -30128,8 +30788,7 @@ f6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1
   return f6(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f12_rsfunctor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
                             const int& start, const int& end,
@@ -30138,8 +30797,8 @@ f12_rsfunctor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y
   return f12(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g9_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30149,8 +30808,8 @@ g9_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g9(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g11_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
@@ -30160,8 +30819,7 @@ g11_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g11(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -30170,8 +30828,7 @@ f3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
   return f3(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30180,8 +30837,7 @@ f1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return f1(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -30190,8 +30846,8 @@ f7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1
   return f7(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g11_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -30202,8 +30858,8 @@ const
   return g11(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g9_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -30213,8 +30869,8 @@ g9_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g9(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g4_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -30223,8 +30879,8 @@ g4_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g4(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g4_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30232,7 +30888,6 @@ g4_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 {
   return g4(y_slice, start + 1, end + 1, a, pstream__);
 }
-
 
 double
 f11_functor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
@@ -30242,8 +30897,7 @@ f11_functor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_sl
   return f11(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f12_functor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
                           const int& start, const int& end,
@@ -30252,8 +30906,8 @@ f12_functor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_s
   return f12(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_row_vector_t<T3__>*>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g3_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -30261,7 +30915,6 @@ g3_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 {
   return g3(y_slice, start, end, a, pstream__);
 }
-
 
 double
 f11_rsfunctor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_slice,
@@ -30271,8 +30924,8 @@ f11_rsfunctor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_
   return f11(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g6_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -30282,8 +30935,7 @@ g6_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g6(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -30292,7 +30944,6 @@ f7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, 
   return f7(y_slice, start + 1, end + 1, pstream__);
 }
 
-
 double
 f9_rsfunctor__::operator()(const std::vector<int>& y_slice, const int& start,
                            const int& end, std::ostream* pstream__)  const
@@ -30300,8 +30951,7 @@ f9_rsfunctor__::operator()(const std::vector<int>& y_slice, const int& start,
   return f9(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -30310,8 +30960,8 @@ f4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice
   return f4(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T3__>*>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g2_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -30319,7 +30969,6 @@ g2_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
 {
   return g2(y_slice, start, end, a, pstream__);
 }
-
 
 double
 f10_functor__::operator()(const std::vector<std::vector<int>>& y_slice,
@@ -30329,8 +30978,23 @@ f10_functor__::operator()(const std::vector<std::vector<int>>& y_slice,
   return f10(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T4__, typename T5__, typename T6__, typename T7__, typename T9__, typename T10__, typename T11__, typename T12__, typename T14__, typename T15__, typename T16__, typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_row_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr, stan::require_stan_scalar_t<T9__>* = nullptr, stan::require_stan_scalar_t<T10__>* = nullptr, stan::require_stan_scalar_t<T11__>* = nullptr, stan::require_stan_scalar_t<T12__>* = nullptr, stan::require_stan_scalar_t<T14__>* = nullptr, stan::require_stan_scalar_t<T15__>* = nullptr, stan::require_stan_scalar_t<T16__>* = nullptr, stan::require_stan_scalar_t<T17__>* = nullptr, stan::require_stan_scalar_t<T19__>* = nullptr>
+template <typename T0__, typename T4__, typename T5__, typename T6__,
+          typename T7__, typename T9__, typename T10__, typename T11__,
+          typename T12__, typename T14__, typename T15__, typename T16__,
+          typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_col_vector_t<T5__>*,
+          stan::require_row_vector_t<T6__>*,
+          stan::require_eigen_matrix_dynamic_t<T7__>*,
+          stan::require_stan_scalar_t<T9__>*,
+          stan::require_stan_scalar_t<T10__>*,
+          stan::require_stan_scalar_t<T11__>*,
+          stan::require_stan_scalar_t<T12__>*,
+          stan::require_stan_scalar_t<T14__>*,
+          stan::require_stan_scalar_t<T15__>*,
+          stan::require_stan_scalar_t<T16__>*,
+          stan::require_stan_scalar_t<T17__>*,
+          stan::require_stan_scalar_t<T19__>*>
 stan::promote_args_t<T0__, T4__, stan::value_type_t<T5__>,
                      stan::value_type_t<T6__>, stan::value_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -30357,8 +31021,7 @@ s_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
            p, q, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                          const int& start, const int& end,
@@ -30367,8 +31030,8 @@ f2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
   return f2(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_row_vector_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_row_vector_t<T3__>*>
 stan::promote_args_t<T0__, stan::value_type_t<T3__>>
 g3_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30377,7 +31040,6 @@ g3_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g3(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
 double
 f9_functor__::operator()(const std::vector<int>& y_slice, const int& start,
                          const int& end, std::ostream* pstream__)  const
@@ -30385,8 +31047,7 @@ f9_functor__::operator()(const std::vector<int>& y_slice, const int& start,
   return f9(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -30395,8 +31056,8 @@ f8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -
   return f8(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30405,8 +31066,8 @@ g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g1(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g7_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -30416,8 +31077,8 @@ g7_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g7(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g5_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const std::vector<T3__>& a,
@@ -30426,8 +31087,8 @@ g5_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g5(y_slice, start, end, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g5_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30437,8 +31098,7 @@ g5_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g5(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                            const int& start, const int& end,
@@ -30447,8 +31107,8 @@ f5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return f5(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g6_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30459,8 +31119,8 @@ const
   return g6(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g7_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30471,8 +31131,8 @@ const
   return g7(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g8_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -30483,7 +31143,6 @@ const
   return g8(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-
 double
 f10_rsfunctor__::operator()(const std::vector<std::vector<int>>& y_slice,
                             const int& start, const int& end,
@@ -30492,8 +31151,7 @@ f10_rsfunctor__::operator()(const std::vector<std::vector<int>>& y_slice,
   return f10(y_slice, start + 1, end + 1, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 f1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, std::ostream* pstream__)  const
@@ -30501,8 +31159,8 @@ f1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return f1(y_slice, start, end, pstream__);
 }
 
-
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T3__>*>
 stan::promote_args_t<T0__, T3__>
 g10_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
@@ -32526,19 +33184,28 @@ static constexpr std::array<const char*, 52> locations_array__ =
  " (in 'shadowing.stan', line 2, column 43 to line 6, column 3)"};
 
 struct rhs_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& alpha) const;
 };
 struct rhs_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& alpha,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   rhs(const T0__& t, const T1__& y_arg__, const T2__& alpha,
       std::ostream* pstream__) {
@@ -32562,8 +33229,10 @@ template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 rhs_odefunctor__::operator()(const T0__& t, const T1__& y,
                              std::ostream* pstream__, const T2__& alpha) 
@@ -32572,8 +33241,10 @@ const
   return rhs(t, y, alpha, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
                           std::ostream* pstream__)  const
@@ -33545,30 +34216,37 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'single-argument-lpmf.stan', line 17, column 23 to line 19, column 3)"};
 
 struct foo4_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__> double
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  double
   operator()(const int& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo0_lpmf_functor__ {
-  template <bool propto__> double
+  template <bool propto__>
+  double
   operator()(const int& y, std::ostream* pstream__) const;
 };
 struct foo1_lpmf_functor__ {
-  template <bool propto__> double
+  template <bool propto__>
+  double
   operator()(const int& y, std::ostream* pstream__) const;
 };
 struct foo2_lpdf_functor__ {
-  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& y, std::ostream* pstream__) const;
 };
 struct foo3_lpdf_functor__ {
-  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& y, std::ostream* pstream__) const;
 };
 struct foo5_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -33614,7 +34292,8 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   foo2_lpdf(const T0__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -33628,7 +34307,8 @@ template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   foo3_lpdf(const T0__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -33642,7 +34322,8 @@ template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   foo5_lp(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -33657,8 +34338,8 @@ template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, 
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T_lp__, typename T_lp_accum__> double
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
+double
 foo4_lp_functor__::operator()(const int& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
@@ -33666,22 +34347,21 @@ foo4_lp_functor__::operator()(const int& y, T_lp__& lp__,
   return foo4_lp<propto__>(y, lp__, lp_accum__, pstream__);
 }
 
-
-template <bool propto__> double
+template <bool propto__>
+double
 foo0_lpmf_functor__::operator()(const int& y, std::ostream* pstream__)  const
 {
   return foo0_lpmf<propto__>(y, pstream__);
 }
 
-
-template <bool propto__> double
+template <bool propto__>
+double
 foo1_lpmf_functor__::operator()(const int& y, std::ostream* pstream__)  const
 {
   return foo1_lpmf<propto__>(y, pstream__);
 }
 
-
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo2_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
 const
@@ -33689,8 +34369,7 @@ const
   return foo2_lpdf<propto__>(y, pstream__);
 }
 
-
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo3_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
 const
@@ -33698,8 +34377,8 @@ const
   return foo3_lpdf<propto__>(y, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 foo5_lp_functor__::operator()(const T0__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -37551,8 +38230,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 normal_functor__::operator()(const T0__& a, std::ostream* pstream__)  const
 {
@@ -37880,12 +38558,16 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'user_constrain.stan', line 2, column 36 to line 4, column 3)"};
 
 struct lb_constrain_functor__ {
-  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   lb_constrain(const T0__& x, const T1__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -37901,8 +38583,8 @@ template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 lb_constrain_functor__::operator()(const T0__& x, const T1__& y,
                                    std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -25,15 +25,13 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'simple_function.stan', line 11, column 37 to line 13, column 3)"};
 
 struct foo1_functor__ {
-  template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
-            typename Te__,
+  template <typename Ta__, typename Tc__, typename Td__, typename Te__,
             typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
-            std::is_integral<Tb__>,
             stan::is_std_vector<Tc__>, stan::is_stan_scalar<stan::value_type_t<Tc__>>,
             stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
             stan::is_row_vector<Tf__>>* = nullptr>
-  inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
-  operator()(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
+  inline stan::return_type_t<Ta__, Tc__, Td__, Te__, Tf__>
+  operator()(const Ta__& a, const int b, const Tc__& c, const Td__& d,
              const Te__& e, const Tf__& f, std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
@@ -60,19 +58,16 @@ struct add_udf_functor__ {
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 
-template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
-          typename Te__,
+template <typename Ta__, typename Tc__, typename Td__, typename Te__,
           typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
-          std::is_integral<Tb__>,
           stan::is_std_vector<Tc__>, stan::is_stan_scalar<stan::value_type_t<Tc__>>,
           stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_row_vector<Tf__>>* = nullptr>
-  inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
-  foo1(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d_arg__,
+  inline stan::return_type_t<Ta__, Tc__, Td__, Te__, Tf__>
+  foo1(const Ta__& a, const int b, const Tc__& c, const Td__& d_arg__,
        const Te__& e_arg__, const Tf__& f_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__,
-                                stan::return_type_t<Tf__>>;
+            stan::return_type_t<Ta__, Tc__, Td__, Te__, Tf__>;
     int current_statement__ = 0; 
     const auto& d = stan::math::to_ref(d_arg__);
     const auto& e = stan::math::to_ref(e_arg__);
@@ -149,15 +144,13 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
-          typename Te__,
+template <typename Ta__, typename Tc__, typename Td__, typename Te__,
           typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
-          std::is_integral<Tb__>,
           stan::is_std_vector<Tc__>, stan::is_stan_scalar<stan::value_type_t<Tc__>>,
           stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_row_vector<Tf__>>*>
-inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
-foo1_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
+inline stan::return_type_t<Ta__, Tc__, Td__, Te__, Tf__>
+foo1_functor__::operator()(const Ta__& a, const int b, const Tc__& c,
                            const Td__& d, const Te__& e, const Tf__& f,
                            std::ostream* pstream__)  const
 {

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -26,49 +26,47 @@ static constexpr std::array<const char*, 13> locations_array__ =
 
 struct foo1_functor__ {
   template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
-            typename Te__, typename Tf__,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-            stan::require_t<std::is_integral<Tb__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Td__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-            stan::require_t<stan::is_row_vector<Tf__>>* = nullptr>
+            typename Te__,
+            typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+            std::is_integral<Tb__>,
+            stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>,
+            stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
+            stan::is_row_vector<Tf__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
   operator()(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
              const Te__& e, const Tf__& f, std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename Ta__, typename Tb__, typename Tc__,
-            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
+  template <typename Ta__, typename Tb__,
+            typename Tc__, stan::require_all_t<stan::is_col_vector<Ta__>,
+            stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>,
+            stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
   operator()(const Ta__& a, const Tb__& b, const Tc__& c,
              std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename Ta__, typename Tb__,
-            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+  template <typename Ta__,
+            typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
+            stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct add_udf_functor__ {
-  template <typename Ta__, typename Tb__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+  template <typename Ta__,
+            typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
+            stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 
 template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
-          typename Te__, typename Tf__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-          stan::require_t<std::is_integral<Tb__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Td__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
-          stan::require_t<stan::is_row_vector<Tf__>>* = nullptr>
+          typename Te__,
+          typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+          std::is_integral<Tb__>,
+          stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>,
+          stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
+          stan::is_row_vector<Tf__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
   foo1(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
        const Te__& e, const Tf__& f, std::ostream* pstream__) {
@@ -90,10 +88,10 @@ template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__, typename Tc__,
-          stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
+template <typename Ta__, typename Tb__,
+          typename Tc__, stan::require_all_t<stan::is_col_vector<Ta__>,
+          stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>,
+          stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
   foo2(const Ta__& a, const Tb__& b, const Tc__& c, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__, Tc__>;
@@ -110,9 +108,9 @@ template <typename Ta__, typename Tb__, typename Tc__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
+          stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
   foo3(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -130,9 +128,9 @@ template <typename Ta__, typename Tb__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
+          stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
   add_udf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -151,13 +149,12 @@ template <typename Ta__, typename Tb__,
     }
     }
 template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
-          typename Te__, typename Tf__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*,
-          stan::require_t<std::is_integral<Tb__>>*,
-          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>>*,
-          stan::require_t<stan::is_col_vector<Td__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
-          stan::require_t<stan::is_row_vector<Tf__>>*>
+          typename Te__,
+          typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+          std::is_integral<Tb__>,
+          stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>,
+          stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
+          stan::is_row_vector<Tf__>>*>
 inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
 foo1_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
                            const Td__& d, const Te__& e, const Tf__& f,
@@ -166,10 +163,10 @@ foo1_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
   return foo1(a, b, c, d, e, f, pstream__);
 }
 
-template <typename Ta__, typename Tb__, typename Tc__,
-          stan::require_t<stan::is_col_vector<Ta__>>*,
-          stan::require_all_t<stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>*>
+template <typename Ta__, typename Tb__,
+          typename Tc__, stan::require_all_t<stan::is_col_vector<Ta__>,
+          stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>,
+          stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
 foo2_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
                            std::ostream* pstream__)  const
@@ -177,9 +174,9 @@ foo2_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
   return foo2(a, b, c, pstream__);
 }
 
-template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_col_vector<Ta__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>*>
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
+          stan::is_eigen_matrix_dynamic<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
 foo3_functor__::operator()(const Ta__& a, const Tb__& b,
                            std::ostream* pstream__)  const
@@ -187,9 +184,9 @@ foo3_functor__::operator()(const Ta__& a, const Tb__& b,
   return foo3(a, b, pstream__);
 }
 
-template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>*>
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
+          stan::is_eigen_matrix_dynamic<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
 add_udf_functor__::operator()(const Ta__& a, const Tb__& b,
                               std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -25,7 +25,12 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'simple_function.stan', line 11, column 37 to line 13, column 3)"};
 
 struct foo1_functor__ {
-  template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_row_vector_t<T5__>* = nullptr>
+  template <typename T0__, typename T2__, typename T3__, typename T4__,
+            typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_col_vector_t<T3__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+            stan::require_row_vector_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
                        stan::value_type_t<T4__>, stan::value_type_t<T5__>>
   operator()(const T0__& a, const int& b, const std::vector<T2__>& c,
@@ -33,24 +38,36 @@ struct foo1_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
   operator()(const T0__& a, const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
              const std::vector<Eigen::Matrix<T2__, 1, -1>>& c,
              std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_col_vector_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct add_udf_functor__ {
-  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_row_vector_t<T5__>* = nullptr>
+template <typename T0__, typename T2__, typename T3__, typename T4__,
+          typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_col_vector_t<T3__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+          stan::require_row_vector_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
                      stan::value_type_t<T4__>, stan::value_type_t<T5__>>
   foo1(const T0__& a, const int& b, const std::vector<T2__>& c,
@@ -75,7 +92,10 @@ template <typename T0__, typename T2__, typename T3__, typename T4__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
   foo2(const T0__& a_arg__,
        const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
@@ -96,7 +116,9 @@ template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_col_vector_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   foo3(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -116,7 +138,9 @@ template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   add_udf(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -136,8 +160,12 @@ template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_row_vector_t<T5__>* = nullptr>
+template <typename T0__, typename T2__, typename T3__, typename T4__,
+          typename T5__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_col_vector_t<T3__>*,
+          stan::require_eigen_matrix_dynamic_t<T4__>*,
+          stan::require_row_vector_t<T5__>*>
 stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
                      stan::value_type_t<T4__>, stan::value_type_t<T5__>>
 foo1_functor__::operator()(const T0__& a, const int& b,
@@ -148,8 +176,10 @@ foo1_functor__::operator()(const T0__& a, const int& b,
   return foo1(a, b, c, d, e, f, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_col_vector_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
 foo2_functor__::operator()(const T0__& a,
                            const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
@@ -159,8 +189,8 @@ foo2_functor__::operator()(const T0__& a,
   return foo2(a, b, c, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 foo3_functor__::operator()(const T0__& a, const T1__& b,
                            std::ostream* pstream__)  const
@@ -168,8 +198,9 @@ foo3_functor__::operator()(const T0__& a, const T1__& b,
   return foo3(a, b, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 add_udf_functor__::operator()(const T0__& a, const T1__& b,
                               std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -27,9 +27,9 @@ static constexpr std::array<const char*, 13> locations_array__ =
 struct foo1_functor__ {
   template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
             typename Te__, typename Tf__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar_t<value_type_t<Tc__>>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
+            stan::require_t<std::is_integral<Tb__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>>* = nullptr,
             stan::require_t<stan::is_col_vector<Td__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
             stan::require_t<stan::is_row_vector<Tf__>>* = nullptr>
@@ -63,9 +63,9 @@ struct add_udf_functor__ {
 
 template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
           typename Te__, typename Tf__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar_t<value_type_t<Tc__>>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
+          stan::require_t<std::is_integral<Tb__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>>* = nullptr,
           stan::require_t<stan::is_col_vector<Td__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
           stan::require_t<stan::is_row_vector<Tf__>>* = nullptr>
@@ -152,9 +152,9 @@ template <typename Ta__, typename Tb__,
     }
 template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
           typename Te__, typename Tf__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
-          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar_t<value_type_t<Tc__>>>*,
+          stan::require_t<stan::is_stan_scalar<Ta__>>*,
+          stan::require_t<std::is_integral<Tb__>>*,
+          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>>*,
           stan::require_t<stan::is_col_vector<Td__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
           stan::require_t<stan::is_row_vector<Tf__>>*>

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -29,7 +29,7 @@ struct foo1_functor__ {
             typename Te__,
             typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
             std::is_integral<Tb__>,
-            stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>,
+            stan::is_std_vector<Tc__>, stan::is_stan_scalar<stan::value_type_t<Tc__>>,
             stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
             stan::is_row_vector<Tf__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
@@ -39,8 +39,8 @@ struct foo1_functor__ {
 struct foo2_functor__ {
   template <typename Ta__, typename Tb__,
             typename Tc__, stan::require_all_t<stan::is_col_vector<Ta__>,
-            stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>,
-            stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
+            stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
+            stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
   operator()(const Ta__& a, const Tb__& b, const Tc__& c,
              std::ostream* pstream__) const;
@@ -64,7 +64,7 @@ template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
           typename Te__,
           typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
           std::is_integral<Tb__>,
-          stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>,
+          stan::is_std_vector<Tc__>, stan::is_stan_scalar<stan::value_type_t<Tc__>>,
           stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_row_vector<Tf__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
@@ -90,8 +90,8 @@ template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
     }
 template <typename Ta__, typename Tb__,
           typename Tc__, stan::require_all_t<stan::is_col_vector<Ta__>,
-          stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>,
-          stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
+          stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
+          stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
   foo2(const Ta__& a, const Tb__& b, const Tc__& c, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__, Tc__>;
@@ -152,7 +152,7 @@ template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
           typename Te__,
           typename Tf__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
           std::is_integral<Tb__>,
-          stan::is_std_vector<Tc__>, stan::is_stan_scalar<value_type_t<Tc__>>,
+          stan::is_std_vector<Tc__>, stan::is_stan_scalar<stan::value_type_t<Tc__>>,
           stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_row_vector<Tf__>>*>
 inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
@@ -165,8 +165,8 @@ foo1_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
 
 template <typename Ta__, typename Tb__,
           typename Tc__, stan::require_all_t<stan::is_col_vector<Ta__>,
-          stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>,
-          stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>*>
+          stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
+          stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
 foo2_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
                            std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -33,8 +33,8 @@ struct foo1_functor__ {
             stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
             stan::is_row_vector<Tf__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
-  operator()(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d_arg__,
-             const Te__& e_arg__, const Tf__& f_arg__, std::ostream* pstream__) const;
+  operator()(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
+             const Te__& e, const Tf__& f, std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
   template <typename Ta__, typename Tb__,
@@ -42,7 +42,7 @@ struct foo2_functor__ {
             stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
             stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
-  operator()(const Ta__& a_arg__, const Tb__& b, const Tc__& c,
+  operator()(const Ta__& a, const Tb__& b, const Tc__& c,
              std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
@@ -50,14 +50,14 @@ struct foo3_functor__ {
             typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
             stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-  operator()(const Ta__& a_arg__, const Tb__& b_arg__, std::ostream* pstream__) const;
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct add_udf_functor__ {
   template <typename Ta__,
             typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
             stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-  operator()(const Ta__& a_arg__, const Tb__& b_arg__, std::ostream* pstream__) const;
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 
 template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
@@ -68,8 +68,8 @@ template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
           stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
           stan::is_row_vector<Tf__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
-  foo1(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
-       const Te__& e, const Tf__& f, std::ostream* pstream__) {
+  foo1(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d_arg__,
+       const Te__& e_arg__, const Tf__& f_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__,
                                 stan::return_type_t<Tf__>>;
@@ -93,7 +93,8 @@ template <typename Ta__, typename Tb__,
           stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
           stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
-  foo2(const Ta__& a, const Tb__& b, const Tc__& c, std::ostream* pstream__) {
+  foo2(const Ta__& a_arg__, const Tb__& b, const Tc__& c,
+       std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__, Tc__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
@@ -112,7 +113,7 @@ template <typename Ta__,
           typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
           stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-  foo3(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
+  foo3(const Ta__& a_arg__, const Tb__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
@@ -132,7 +133,7 @@ template <typename Ta__,
           typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
           stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-  add_udf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
+  add_udf(const Ta__& a_arg__, const Tb__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
@@ -157,9 +158,8 @@ template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
           stan::is_row_vector<Tf__>>*>
 inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
 foo1_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
-                           const Td__& d_arg__, const Te__& e_arg__,
-                           const Tf__& f_arg__, std::ostream* pstream__) 
-const
+                           const Td__& d, const Te__& e, const Tf__& f,
+                           std::ostream* pstream__)  const
 {
   return foo1(a, b, c, d, e, f, pstream__);
 }
@@ -169,7 +169,7 @@ template <typename Ta__, typename Tb__,
           stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
           stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
-foo2_functor__::operator()(const Ta__& a_arg__, const Tb__& b, const Tc__& c,
+foo2_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
                            std::ostream* pstream__)  const
 {
   return foo2(a, b, c, pstream__);
@@ -179,7 +179,7 @@ template <typename Ta__,
           typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
           stan::is_eigen_matrix_dynamic<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-foo3_functor__::operator()(const Ta__& a_arg__, const Tb__& b_arg__,
+foo3_functor__::operator()(const Ta__& a, const Tb__& b,
                            std::ostream* pstream__)  const
 {
   return foo3(a, b, pstream__);
@@ -189,7 +189,7 @@ template <typename Ta__,
           typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
           stan::is_eigen_matrix_dynamic<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-add_udf_functor__::operator()(const Ta__& a_arg__, const Tb__& b_arg__,
+add_udf_functor__::operator()(const Ta__& a, const Tb__& b,
                               std::ostream* pstream__)  const
 {
   return add_udf(a, b, pstream__);

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -33,8 +33,8 @@ struct foo1_functor__ {
             stan::is_col_vector<Td__>, stan::is_eigen_matrix_dynamic<Te__>,
             stan::is_row_vector<Tf__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
-  operator()(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
-             const Te__& e, const Tf__& f, std::ostream* pstream__) const;
+  operator()(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d_arg__,
+             const Te__& e_arg__, const Tf__& f_arg__, std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
   template <typename Ta__, typename Tb__,
@@ -42,7 +42,7 @@ struct foo2_functor__ {
             stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
             stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
-  operator()(const Ta__& a, const Tb__& b, const Tc__& c,
+  operator()(const Ta__& a_arg__, const Tb__& b, const Tc__& c,
              std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
@@ -50,14 +50,14 @@ struct foo3_functor__ {
             typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
             stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
+  operator()(const Ta__& a_arg__, const Tb__& b_arg__, std::ostream* pstream__) const;
 };
 struct add_udf_functor__ {
   template <typename Ta__,
             typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
             stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
+  operator()(const Ta__& a_arg__, const Tb__& b_arg__, std::ostream* pstream__) const;
 };
 
 template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
@@ -157,8 +157,9 @@ template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
           stan::is_row_vector<Tf__>>*>
 inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
 foo1_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
-                           const Td__& d, const Te__& e, const Tf__& f,
-                           std::ostream* pstream__)  const
+                           const Td__& d_arg__, const Te__& e_arg__,
+                           const Tf__& f_arg__, std::ostream* pstream__) 
+const
 {
   return foo1(a, b, c, d, e, f, pstream__);
 }
@@ -168,7 +169,7 @@ template <typename Ta__, typename Tb__,
           stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tb__>>,
           stan::is_std_vector<Tc__>, stan::is_row_vector<stan::value_type_t<Tc__>>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
-foo2_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
+foo2_functor__::operator()(const Ta__& a_arg__, const Tb__& b, const Tc__& c,
                            std::ostream* pstream__)  const
 {
   return foo2(a, b, c, pstream__);
@@ -178,7 +179,7 @@ template <typename Ta__,
           typename Tb__, stan::require_all_t<stan::is_col_vector<Ta__>,
           stan::is_eigen_matrix_dynamic<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-foo3_functor__::operator()(const Ta__& a, const Tb__& b,
+foo3_functor__::operator()(const Ta__& a_arg__, const Tb__& b_arg__,
                            std::ostream* pstream__)  const
 {
   return foo3(a, b, pstream__);
@@ -188,7 +189,7 @@ template <typename Ta__,
           typename Tb__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Ta__>,
           stan::is_eigen_matrix_dynamic<Tb__>>*>
 inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
-add_udf_functor__::operator()(const Ta__& a, const Tb__& b,
+add_udf_functor__::operator()(const Ta__& a_arg__, const Tb__& b_arg__,
                               std::ostream* pstream__)  const
 {
   return add_udf(a, b, pstream__);

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -25,58 +25,56 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'simple_function.stan', line 11, column 37 to line 13, column 3)"};
 
 struct foo1_functor__ {
-  template <typename T0__, typename T2__, typename T3__, typename T4__,
-            typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_row_vector_t<T5__>* = nullptr>
-  stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
-                       stan::value_type_t<T4__>, stan::value_type_t<T5__>>
-  operator()(const T0__& a, const int& b, const std::vector<T2__>& c,
-             const T3__& d, const T4__& e, const T5__& f,
-             std::ostream* pstream__) const;
+  template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
+            typename Te__, typename Tf__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar_t<value_type_t<Tc__>>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Td__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
+            stan::require_t<stan::is_row_vector<Tf__>>* = nullptr>
+  inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
+  operator()(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
+             const Te__& e, const Tf__& f, std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
-  operator()(const T0__& a, const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
-             const std::vector<Eigen::Matrix<T2__, 1, -1>>& c,
+  template <typename Ta__, typename Tb__, typename Tc__,
+            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
+  operator()(const Ta__& a, const Tb__& b, const Tc__& c,
              std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
+  template <typename Ta__, typename Tb__,
+            stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct add_udf_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
+  template <typename Ta__, typename Tb__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T2__, typename T3__, typename T4__,
-          typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_col_vector_t<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_row_vector_t<T5__>* = nullptr>
-  stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
-                     stan::value_type_t<T4__>, stan::value_type_t<T5__>>
-  foo1(const T0__& a, const int& b, const std::vector<T2__>& c,
-       const T3__& d_arg__, const T4__& e_arg__, const T5__& f_arg__,
-       std::ostream* pstream__) {
+template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tf__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar_t<value_type_t<Tc__>>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Td__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>* = nullptr,
+          stan::require_t<stan::is_row_vector<Tf__>>* = nullptr>
+  inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
+  foo1(const Ta__& a, const Tb__& b, const Tc__& c, const Td__& d,
+       const Te__& e, const Tf__& f, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
-                                 stan::value_type_t<T4__>,
-                                 stan::value_type_t<T5__>>;
+            stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__,
+                                stan::return_type_t<Tf__>>;
     int current_statement__ = 0; 
     const auto& d = stan::math::to_ref(d_arg__);
     const auto& e = stan::math::to_ref(e_arg__);
@@ -92,17 +90,13 @@ template <typename T0__, typename T2__, typename T3__, typename T4__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
-  foo2(const T0__& a_arg__,
-       const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
-       const std::vector<Eigen::Matrix<T2__, 1, -1>>& c,
-       std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>;
+template <typename Ta__, typename Tb__, typename Tc__,
+          stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
+  foo2(const Ta__& a, const Tb__& b, const Tc__& c, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__, Tc__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     static constexpr bool propto__ = true;
@@ -116,14 +110,12 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  foo3(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_col_vector<Ta__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
+  foo3(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     const auto& b = stan::math::to_ref(b_arg__);
@@ -138,14 +130,12 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  add_udf(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
+  add_udf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     const auto& a = stan::math::to_ref(a_arg__);
     const auto& b = stan::math::to_ref(b_arg__);
@@ -160,49 +150,48 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T2__, typename T3__, typename T4__,
-          typename T5__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_col_vector_t<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_row_vector_t<T5__>*>
-stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
-                     stan::value_type_t<T4__>, stan::value_type_t<T5__>>
-foo1_functor__::operator()(const T0__& a, const int& b,
-                           const std::vector<T2__>& c, const T3__& d,
-                           const T4__& e, const T5__& f,
+template <typename Ta__, typename Tb__, typename Tc__, typename Td__,
+          typename Te__, typename Tf__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
+          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_stan_scalar_t<value_type_t<Tc__>>>*,
+          stan::require_t<stan::is_col_vector<Td__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Te__>>*,
+          stan::require_t<stan::is_row_vector<Tf__>>*>
+inline stan::return_type_t<Ta__, Tb__, Tc__, Td__, Te__, stan::return_type_t<Tf__>>
+foo1_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
+                           const Td__& d, const Te__& e, const Tf__& f,
                            std::ostream* pstream__)  const
 {
   return foo1(a, b, c, d, e, f, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
-foo2_functor__::operator()(const T0__& a,
-                           const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
-                           const std::vector<Eigen::Matrix<T2__, 1, -1>>& c,
+template <typename Ta__, typename Tb__, typename Tc__,
+          stan::require_t<stan::is_col_vector<Ta__>>*,
+          stan::require_all_t<stan::is_std_vector<Tb__>, stan::is_eigen_matrix_dynamic<value_type_t<Tb__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tc__>, stan::is_row_vector<value_type_t<Tc__>>>*>
+inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__, Tc__>, -1, 1>
+foo2_functor__::operator()(const Ta__& a, const Tb__& b, const Tc__& c,
                            std::ostream* pstream__)  const
 {
   return foo2(a, b, c, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-foo3_functor__::operator()(const T0__& a, const T1__& b,
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_col_vector<Ta__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>*>
+inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
+foo3_functor__::operator()(const Ta__& a, const Tb__& b,
                            std::ostream* pstream__)  const
 {
   return foo3(a, b, pstream__);
 }
 
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-add_udf_functor__::operator()(const T0__& a, const T1__& b,
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ta__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tb__>>*>
+inline Eigen::Matrix<stan::return_type_t<Ta__, Tb__>, -1, -1>
+add_udf_functor__::operator()(const Ta__& a, const Tb__& b,
                               std::ostream* pstream__)  const
 {
   return add_udf(a, b, pstream__);

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -25,7 +25,7 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'simple_function.stan', line 11, column 37 to line 13, column 3)"};
 
 struct foo1_functor__ {
-  template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__>
+  template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_row_vector_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
                        stan::value_type_t<T4__>, stan::value_type_t<T5__>>
   operator()(const T0__& a, const int& b, const std::vector<T2__>& c,
@@ -33,24 +33,24 @@ struct foo1_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
   operator()(const T0__& a, const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
              const std::vector<Eigen::Matrix<T2__, 1, -1>>& c,
              std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct add_udf_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__>
+template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_row_vector_t<T5__>* = nullptr>
   stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
                      stan::value_type_t<T4__>, stan::value_type_t<T5__>>
   foo1(const T0__& a, const int& b, const std::vector<T2__>& c,
@@ -75,7 +75,7 @@ template <typename T0__, typename T2__, typename T3__, typename T4__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
   foo2(const T0__& a_arg__,
        const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
@@ -96,7 +96,7 @@ template <typename T0__, typename T1__, typename T2__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   foo3(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -116,7 +116,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   add_udf(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -137,7 +137,7 @@ template <typename T0__, typename T1__>
     }
     }
 
-template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__>
+template <typename T0__, typename T2__, typename T3__, typename T4__, typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_col_vector_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_row_vector_t<T5__>* = nullptr>
 stan::promote_args_t<T0__, T2__, stan::value_type_t<T3__>,
                      stan::value_type_t<T4__>, stan::value_type_t<T5__>>
 foo1_functor__::operator()(const T0__& a, const int& b,
@@ -149,7 +149,7 @@ foo1_functor__::operator()(const T0__& a, const int& b,
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, T1__, T2__>, -1, 1>
 foo2_functor__::operator()(const T0__& a,
                            const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
@@ -160,7 +160,7 @@ foo2_functor__::operator()(const T0__& a,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 foo3_functor__::operator()(const T0__& a, const T1__& b,
                            std::ostream* pstream__)  const
@@ -169,7 +169,7 @@ foo3_functor__::operator()(const T0__& a, const T1__& b,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 add_udf_functor__::operator()(const T0__& a, const T1__& b,
                               std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -53,7 +53,7 @@ struct f_2_arg_functor__ {
             stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, const Tb__& b, const Ta__& a,
+  operator()(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
@@ -61,14 +61,14 @@ struct f_0_arg_functor__ {
             typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__) const;
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
   template <typename Tt__, typename Tz__,
             typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, const Ta__& a,
+  operator()(const Tt__& t, const Tz__& z, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
@@ -76,7 +76,7 @@ struct f_1_arg_odefunctor__ {
             typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__,
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
              const Ta__& a) const;
 };
 struct f_0_arg_odefunctor__ {
@@ -84,7 +84,7 @@ struct f_0_arg_odefunctor__ {
             typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__) const;
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
   template <typename Tt__, typename Tz__, typename Tb__,
@@ -92,7 +92,7 @@ struct f_2_arg_odefunctor__ {
             stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__,
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
              const Tb__& b, const Ta__& a) const;
 };
 
@@ -100,7 +100,7 @@ template <typename Tt__,
           typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-  f_0_arg(const Tt__& t, const Tz__& z, std::ostream* pstream__) {
+  f_0_arg(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Tz__>;
     int current_statement__ = 0; 
     const auto& z = stan::math::to_ref(z_arg__);
@@ -119,7 +119,7 @@ template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-  f_1_arg(const Tt__& t, const Tz__& z, const Ta__& a,
+  f_1_arg(const Tt__& t, const Tz__& z_arg__, const Ta__& a,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Ta__>;
     int current_statement__ = 0; 
@@ -140,7 +140,7 @@ template <typename Tt__, typename Tz__, typename Tb__,
           stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
           stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-  f_2_arg(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
+  f_2_arg(const Tt__& t, const Tz__& z_arg__, const Tb__& b, const Ta__& a,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Tb__, Ta__>;
     int current_statement__ = 0; 
@@ -161,9 +161,8 @@ template <typename Tt__, typename Tz__, typename Tb__,
           stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
           stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z_arg__,
-                              const Tb__& b, const Ta__& a,
-                              std::ostream* pstream__)  const
+f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
+                              const Ta__& a, std::ostream* pstream__)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
 }
@@ -172,7 +171,7 @@ template <typename Tt__,
           typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z_arg__,
+f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z,
                               std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
@@ -182,8 +181,8 @@ template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z_arg__,
-                              const Ta__& a, std::ostream* pstream__)  const
+f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
+                              std::ostream* pstream__)  const
 {
   return f_1_arg(t, z, a, pstream__);
 }
@@ -192,7 +191,7 @@ template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-f_1_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
+f_1_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__, const Ta__& a) 
 const
 {
@@ -203,7 +202,7 @@ template <typename Tt__,
           typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
+f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
@@ -214,7 +213,7 @@ template <typename Tt__, typename Tz__, typename Tb__,
           stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
           stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
+f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__, const Tb__& b,
                                  const Ta__& a)  const
 {
@@ -843,7 +842,7 @@ struct simple_SIR_functor__ {
             std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y_arg__, const Tbeta__& beta,
+  operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
              const Tdelta__& delta, const Tunused__& unused,
              std::ostream* pstream__) const;
@@ -856,7 +855,7 @@ struct simple_SIR_functor__ {
             stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y_arg__, const Tbeta__& beta,
+  operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
              const Tdelta__& delta, std::ostream* pstream__) const;
 };
@@ -871,7 +870,7 @@ struct simple_SIR_odefunctor__ {
             std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y_arg__, std::ostream* pstream__,
+  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
              const Tbeta__& beta, const Tkappa__& kappa, const Tgamma__& gamma,
              const Txi__& xi, const Tdelta__& delta, const Tunused__& unused) const;
   template <typename Tt__, typename Ty__, typename Tbeta__,
@@ -883,7 +882,7 @@ struct simple_SIR_odefunctor__ {
             stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y_arg__, std::ostream* pstream__,
+  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
              const Tbeta__& beta, const Tkappa__& kappa, const Tgamma__& gamma,
              const Txi__& xi, const Tdelta__& delta) const;
 };
@@ -897,7 +896,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-  simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+  simple_SIR(const Tt__& t, const Ty__& y_arg__, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
              const Tdelta__& delta, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -949,7 +948,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-  simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+  simple_SIR(const Tt__& t, const Ty__& y_arg__, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
              const Tdelta__& delta, const Tunused__& unused,
              std::ostream* pstream__) {
@@ -1008,7 +1007,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y_arg__,
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Tbeta__& beta, const Tkappa__& kappa,
                                  const Tgamma__& gamma, const Txi__& xi,
                                  const Tdelta__& delta,
@@ -1026,7 +1025,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y_arg__,
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Tbeta__& beta, const Tkappa__& kappa,
                                  const Tgamma__& gamma, const Txi__& xi,
                                  const Tdelta__& delta,
@@ -1044,7 +1043,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y_arg__,
+simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                                     std::ostream* pstream__,
                                     const Tbeta__& beta,
                                     const Tkappa__& kappa,
@@ -1063,7 +1062,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y_arg__,
+simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                                     std::ostream* pstream__,
                                     const Tbeta__& beta,
                                     const Tkappa__& kappa,

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -53,7 +53,7 @@ struct f_2_arg_functor__ {
             stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
+  operator()(const Tt__& t, const Tz__& z_arg__, const Tb__& b, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
@@ -61,14 +61,14 @@ struct f_0_arg_functor__ {
             typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
+  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
   template <typename Tt__, typename Tz__,
             typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, const Ta__& a,
+  operator()(const Tt__& t, const Tz__& z_arg__, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
@@ -76,7 +76,7 @@ struct f_1_arg_odefunctor__ {
             typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
+  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__,
              const Ta__& a) const;
 };
 struct f_0_arg_odefunctor__ {
@@ -84,7 +84,7 @@ struct f_0_arg_odefunctor__ {
             typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
+  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
   template <typename Tt__, typename Tz__, typename Tb__,
@@ -92,7 +92,7 @@ struct f_2_arg_odefunctor__ {
             stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
             stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
+  operator()(const Tt__& t, const Tz__& z_arg__, std::ostream* pstream__,
              const Tb__& b, const Ta__& a) const;
 };
 
@@ -161,8 +161,9 @@ template <typename Tt__, typename Tz__, typename Tb__,
           stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
           stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
-                              const Ta__& a, std::ostream* pstream__)  const
+f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z_arg__,
+                              const Tb__& b, const Ta__& a,
+                              std::ostream* pstream__)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
 }
@@ -171,7 +172,7 @@ template <typename Tt__,
           typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z,
+f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z_arg__,
                               std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
@@ -181,8 +182,8 @@ template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
-                              std::ostream* pstream__)  const
+f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z_arg__,
+                              const Ta__& a, std::ostream* pstream__)  const
 {
   return f_1_arg(t, z, a, pstream__);
 }
@@ -191,7 +192,7 @@ template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
-f_1_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
+f_1_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
                                  std::ostream* pstream__, const Ta__& a) 
 const
 {
@@ -202,7 +203,7 @@ template <typename Tt__,
           typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
-f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
+f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
                                  std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
@@ -213,7 +214,7 @@ template <typename Tt__, typename Tz__, typename Tb__,
           stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
           stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
+f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z_arg__,
                                  std::ostream* pstream__, const Tb__& b,
                                  const Ta__& a)  const
 {
@@ -842,7 +843,7 @@ struct simple_SIR_functor__ {
             std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+  operator()(const Tt__& t, const Ty__& y_arg__, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
              const Tdelta__& delta, const Tunused__& unused,
              std::ostream* pstream__) const;
@@ -855,7 +856,7 @@ struct simple_SIR_functor__ {
             stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+  operator()(const Tt__& t, const Ty__& y_arg__, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
              const Tdelta__& delta, std::ostream* pstream__) const;
 };
@@ -870,7 +871,7 @@ struct simple_SIR_odefunctor__ {
             std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
+  operator()(const Tt__& t, const Ty__& y_arg__, std::ostream* pstream__,
              const Tbeta__& beta, const Tkappa__& kappa, const Tgamma__& gamma,
              const Txi__& xi, const Tdelta__& delta, const Tunused__& unused) const;
   template <typename Tt__, typename Ty__, typename Tbeta__,
@@ -882,7 +883,7 @@ struct simple_SIR_odefunctor__ {
             stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
+  operator()(const Tt__& t, const Ty__& y_arg__, std::ostream* pstream__,
              const Tbeta__& beta, const Tkappa__& kappa, const Tgamma__& gamma,
              const Txi__& xi, const Tdelta__& delta) const;
 };
@@ -1007,7 +1008,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y_arg__,
                                  const Tbeta__& beta, const Tkappa__& kappa,
                                  const Tgamma__& gamma, const Txi__& xi,
                                  const Tdelta__& delta,
@@ -1025,7 +1026,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y_arg__,
                                  const Tbeta__& beta, const Tkappa__& kappa,
                                  const Tgamma__& gamma, const Txi__& xi,
                                  const Tdelta__& delta,
@@ -1043,7 +1044,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
+simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y_arg__,
                                     std::ostream* pstream__,
                                     const Tbeta__& beta,
                                     const Tkappa__& kappa,
@@ -1062,7 +1063,7 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
+simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y_arg__,
                                     std::ostream* pstream__,
                                     const Tbeta__& beta,
                                     const Tkappa__& kappa,

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -48,63 +48,64 @@ static constexpr std::array<const char*, 36> locations_array__ =
  " (in 'ode_adjoint_test_model.stan', line 8, column 50 to line 10, column 3)"};
 
 struct f_2_arg_functor__ {
-  template <typename T0__, typename T1__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, const int& b, const T3__& a,
+  template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
+  template <typename Tt__, typename Tz__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, const T2__& a,
+  template <typename Tt__, typename Tz__, typename Ta__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
-             const T2__& a) const;
+  template <typename Tt__, typename Tz__, typename Ta__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
+             const Ta__& a) const;
 };
 struct f_0_arg_odefunctor__ {
-  template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
+  template <typename Tt__, typename Tz__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
-             const int& b, const T3__& a) const;
+  template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
+             const Tb__& b, const Ta__& a) const;
 };
 
-template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
-  f_0_arg(const T0__& t, const T1__& z_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>>;
+template <typename Tt__, typename Tz__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
+  f_0_arg(const Tt__& t, const Tz__& z, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tt__, Tz__>;
     int current_statement__ = 0; 
     const auto& z = stan::math::to_ref(z_arg__);
     static constexpr bool propto__ = true;
@@ -118,15 +119,14 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-  f_1_arg(const T0__& t, const T1__& z_arg__, const T2__& a,
+template <typename Tt__, typename Tz__, typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+  f_1_arg(const Tt__& t, const Tz__& z, const Ta__& a,
           std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>;
+    using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Ta__>;
     int current_statement__ = 0; 
     const auto& z = stan::math::to_ref(z_arg__);
     static constexpr bool propto__ = true;
@@ -140,15 +140,15 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
-  f_2_arg(const T0__& t, const T1__& z_arg__, const int& b, const T3__& a,
+template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
+  f_2_arg(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
           std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>;
+    using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Tb__, Ta__>;
     int current_statement__ = 0; 
     const auto& z = stan::math::to_ref(z_arg__);
     static constexpr bool propto__ = true;
@@ -162,66 +162,70 @@ template <typename T0__, typename T1__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
-f_2_arg_functor__::operator()(const T0__& t, const T1__& z, const int& b,
-                              const T3__& a, std::ostream* pstream__)  const
+template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
+f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
+                              const Ta__& a, std::ostream* pstream__)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
-f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
+template <typename Tt__, typename Tz__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
+f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z,
                               std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
+template <typename Tt__, typename Tz__, typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
                               std::ostream* pstream__)  const
 {
   return f_1_arg(t, z, a, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
-f_1_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
-                                 std::ostream* pstream__, const T2__& a) 
+template <typename Tt__, typename Tz__, typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+f_1_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
+                                 std::ostream* pstream__, const Ta__& a) 
 const
 {
   return f_1_arg(t, z, a, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
-f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
+template <typename Tt__, typename Tz__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
+f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
-f_2_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
-                                 std::ostream* pstream__, const int& b,
-                                 const T3__& a)  const
+template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Tz__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
+f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
+                                 std::ostream* pstream__, const Tb__& b,
+                                 const Ta__& a)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
 }
@@ -838,83 +842,90 @@ static constexpr std::array<const char*, 55> locations_array__ =
  " (in 'overloaded-ode.stan', line 29, column 22 to line 39, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                       stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
-             const T4__& gamma, const T5__& xi, const T6__& delta,
-             const int& unused, std::ostream* pstream__) const;
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                       stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
-             const T4__& gamma, const T5__& xi, const T6__& delta,
+  template <typename Tt__, typename Ty__, typename Tbeta__,
+            typename Tkappa__, typename Tgamma__, typename Txi__,
+            typename Tdelta__, typename Tunused__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tunused__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                      stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+  operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+             const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
+             const Tdelta__& delta, const Tunused__& unused,
              std::ostream* pstream__) const;
+  template <typename Tt__, typename Ty__, typename Tbeta__,
+            typename Tkappa__, typename Tgamma__, typename Txi__,
+            typename Tdelta__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                      stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
+  operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+             const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
+             const Tdelta__& delta, std::ostream* pstream__) const;
 };
 struct simple_SIR_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                       stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
-             const T2__& beta, const T3__& kappa, const T4__& gamma,
-             const T5__& xi, const T6__& delta, const int& unused) const;
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                       stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
-             const T2__& beta, const T3__& kappa, const T4__& gamma,
-             const T5__& xi, const T6__& delta) const;
+  template <typename Tt__, typename Ty__, typename Tbeta__,
+            typename Tkappa__, typename Tgamma__, typename Txi__,
+            typename Tdelta__, typename Tunused__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tunused__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                      stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
+             const Tbeta__& beta, const Tkappa__& kappa, const Tgamma__& gamma,
+             const Txi__& xi, const Tdelta__& delta, const Tunused__& unused) const;
+  template <typename Tt__, typename Ty__, typename Tbeta__,
+            typename Tkappa__, typename Tgamma__, typename Txi__,
+            typename Tdelta__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                      stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
+  operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
+             const Tbeta__& beta, const Tkappa__& kappa, const Tgamma__& gamma,
+             const Txi__& xi, const Tdelta__& delta) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_stan_scalar_t<T6__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                     stan::promote_args_t<T5__, T6__>>, -1, 1>
-  simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
-             const T3__& kappa, const T4__& gamma, const T5__& xi,
-             const T6__& delta, std::ostream* pstream__) {
+template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
+          typename Tgamma__, typename Txi__, typename Tdelta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                    stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
+  simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+             const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
+             const Tdelta__& delta, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__,
-                                 T4__, stan::promote_args_t<T5__, T6__>>;
+            stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                                stan::return_type_t<Txi__, Tdelta__>>;
     int current_statement__ = 0; 
     const auto& y = stan::math::to_ref(y_arg__);
     static constexpr bool propto__ = true;
@@ -952,23 +963,27 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_stan_scalar_t<T6__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                     stan::promote_args_t<T5__, T6__>>, -1, 1>
-  simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
-             const T3__& kappa, const T4__& gamma, const T5__& xi,
-             const T6__& delta, const int& unused, std::ostream* pstream__) {
+template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
+          typename Tgamma__, typename Txi__, typename Tdelta__,
+          typename Tunused__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tunused__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                    stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+  simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
+             const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
+             const Tdelta__& delta, const Tunused__& unused,
+             std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__,
-                                 T4__, stan::promote_args_t<T5__, T6__>>;
+            stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                                stan::return_type_t<Txi__, Tdelta__,
+                                                    Tunused__>>;
     int current_statement__ = 0; 
     const auto& y = stan::math::to_ref(y_arg__);
     static constexpr bool propto__ = true;
@@ -1011,83 +1026,88 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                     stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
-                                 const T2__& beta, const T3__& kappa,
-                                 const T4__& gamma, const T5__& xi,
-                                 const T6__& delta, const int& unused,
+template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
+          typename Tgamma__, typename Txi__, typename Tdelta__,
+          typename Tunused__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tunused__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                    stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
+                                 const Tbeta__& beta, const Tkappa__& kappa,
+                                 const Tgamma__& gamma, const Txi__& xi,
+                                 const Tdelta__& delta,
+                                 const Tunused__& unused,
                                  std::ostream* pstream__)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                     stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
-                                 const T2__& beta, const T3__& kappa,
-                                 const T4__& gamma, const T5__& xi,
-                                 const T6__& delta, std::ostream* pstream__) 
-const
+template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
+          typename Tgamma__, typename Txi__, typename Tdelta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                    stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
+                                 const Tbeta__& beta, const Tkappa__& kappa,
+                                 const Tgamma__& gamma, const Txi__& xi,
+                                 const Tdelta__& delta,
+                                 std::ostream* pstream__)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                     stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,
+template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
+          typename Tgamma__, typename Txi__, typename Tdelta__,
+          typename Tunused__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tunused__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                    stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                                     std::ostream* pstream__,
-                                    const T2__& beta, const T3__& kappa,
-                                    const T4__& gamma, const T5__& xi,
-                                    const T6__& delta, const int& unused) 
-const
+                                    const Tbeta__& beta,
+                                    const Tkappa__& kappa,
+                                    const Tgamma__& gamma, const Txi__& xi,
+                                    const Tdelta__& delta,
+                                    const Tunused__& unused)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
-                     stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,
+template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
+          typename Tgamma__, typename Txi__, typename Tdelta__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_col_vector<Ty__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
+                    stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
+simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                                     std::ostream* pstream__,
-                                    const T2__& beta, const T3__& kappa,
-                                    const T4__& gamma, const T5__& xi,
-                                    const T6__& delta)  const
+                                    const Tbeta__& beta,
+                                    const Tkappa__& kappa,
+                                    const Tgamma__& gamma, const Txi__& xi,
+                                    const Tdelta__& delta)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, pstream__);
 }

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -48,41 +48,59 @@ static constexpr std::array<const char*, 36> locations_array__ =
  " (in 'ode_adjoint_test_model.stan', line 8, column 50 to line 10, column 3)"};
 
 struct f_2_arg_functor__ {
-  template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
   operator()(const T0__& t, const T1__& z, const int& b, const T3__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
-  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& z, const T2__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& a) const;
 };
 struct f_0_arg_odefunctor__ {
-  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const int& b, const T3__& a) const;
 };
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
   f_0_arg(const T0__& t, const T1__& z_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -100,7 +118,10 @@ template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   f_1_arg(const T0__& t, const T1__& z_arg__, const T2__& a,
           std::ostream* pstream__) {
@@ -119,7 +140,10 @@ template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
   f_2_arg(const T0__& t, const T1__& z_arg__, const int& b, const T3__& a,
           std::ostream* pstream__) {
@@ -138,8 +162,10 @@ template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
 f_2_arg_functor__::operator()(const T0__& t, const T1__& z, const int& b,
                               const T3__& a, std::ostream* pstream__)  const
@@ -147,8 +173,8 @@ f_2_arg_functor__::operator()(const T0__& t, const T1__& z, const int& b,
   return f_2_arg(t, z, b, a, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
 f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
                               std::ostream* pstream__)  const
@@ -156,8 +182,10 @@ f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
   return f_0_arg(t, z, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
                               std::ostream* pstream__)  const
@@ -165,8 +193,10 @@ f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
   return f_1_arg(t, z, a, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 f_1_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__, const T2__& a) 
@@ -175,8 +205,8 @@ const
   return f_1_arg(t, z, a, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
 f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__)  const
@@ -184,8 +214,10 @@ f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
   return f_0_arg(t, z, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
 f_2_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__, const int& b,
@@ -806,13 +838,29 @@ static constexpr std::array<const char*, 55> locations_array__ =
  " (in 'overloaded-ode.stan', line 29, column 22 to line 39, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            typename T4__, typename T5__, typename T6__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
              const T4__& gamma, const T5__& xi, const T6__& delta,
              const int& unused, std::ostream* pstream__) const;
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            typename T4__, typename T5__, typename T6__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
@@ -820,13 +868,29 @@ struct simple_SIR_functor__ {
              std::ostream* pstream__) const;
 };
 struct simple_SIR_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            typename T4__, typename T5__, typename T6__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& beta, const T3__& kappa, const T4__& gamma,
              const T5__& xi, const T6__& delta, const int& unused) const;
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            typename T4__, typename T5__, typename T6__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_col_vector_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr,
+            stan::require_stan_scalar_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
@@ -834,7 +898,15 @@ struct simple_SIR_odefunctor__ {
              const T5__& xi, const T6__& delta) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, typename T5__, typename T6__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
   simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
@@ -880,7 +952,15 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, typename T5__, typename T6__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_col_vector_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr,
+          stan::require_stan_scalar_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
   simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
@@ -931,8 +1011,15 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, typename T5__, typename T6__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_stan_scalar_t<T6__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
@@ -944,8 +1031,15 @@ simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, typename T5__, typename T6__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_stan_scalar_t<T6__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
@@ -957,8 +1051,15 @@ const
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, typename T5__, typename T6__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_stan_scalar_t<T6__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,
@@ -971,8 +1072,15 @@ const
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
 }
 
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          typename T4__, typename T5__, typename T6__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_col_vector_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*,
+          stan::require_stan_scalar_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_stan_scalar_t<T6__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -48,41 +48,41 @@ static constexpr std::array<const char*, 36> locations_array__ =
  " (in 'ode_adjoint_test_model.stan', line 8, column 50 to line 10, column 3)"};
 
 struct f_2_arg_functor__ {
-  template <typename T0__, typename T1__, typename T3__>
+  template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
   operator()(const T0__& t, const T1__& z, const int& b, const T3__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& z, const T2__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__>
+  template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& a) const;
 };
 struct f_0_arg_odefunctor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T3__>
+  template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const int& b, const T3__& a) const;
 };
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
   f_0_arg(const T0__& t, const T1__& z_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -100,7 +100,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
   f_1_arg(const T0__& t, const T1__& z_arg__, const T2__& a,
           std::ostream* pstream__) {
@@ -119,7 +119,7 @@ template <typename T0__, typename T1__, typename T2__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T3__>
+template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
   f_2_arg(const T0__& t, const T1__& z_arg__, const int& b, const T3__& a,
           std::ostream* pstream__) {
@@ -139,7 +139,7 @@ template <typename T0__, typename T1__, typename T3__>
     }
     }
 
-template <typename T0__, typename T1__, typename T3__>
+template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
 f_2_arg_functor__::operator()(const T0__& t, const T1__& z, const int& b,
                               const T3__& a, std::ostream* pstream__)  const
@@ -148,7 +148,7 @@ f_2_arg_functor__::operator()(const T0__& t, const T1__& z, const int& b,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
 f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
                               std::ostream* pstream__)  const
@@ -157,7 +157,7 @@ f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
                               std::ostream* pstream__)  const
@@ -166,7 +166,7 @@ f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
 }
 
 
-template <typename T0__, typename T1__, typename T2__>
+template <typename T0__, typename T1__, typename T2__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__>, -1, 1>
 f_1_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__, const T2__& a) 
@@ -176,7 +176,7 @@ const
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, 1>
 f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__)  const
@@ -185,7 +185,7 @@ f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
 }
 
 
-template <typename T0__, typename T1__, typename T3__>
+template <typename T0__, typename T1__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T3__>, -1, 1>
 f_2_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__, const int& b,
@@ -806,13 +806,13 @@ static constexpr std::array<const char*, 55> locations_array__ =
  " (in 'overloaded-ode.stan', line 29, column 22 to line 39, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
              const T4__& gamma, const T5__& xi, const T6__& delta,
              const int& unused, std::ostream* pstream__) const;
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
@@ -820,13 +820,13 @@ struct simple_SIR_functor__ {
              std::ostream* pstream__) const;
 };
 struct simple_SIR_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& beta, const T3__& kappa, const T4__& gamma,
              const T5__& xi, const T6__& delta, const int& unused) const;
-  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
@@ -834,7 +834,7 @@ struct simple_SIR_odefunctor__ {
              const T5__& xi, const T6__& delta) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
   simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
@@ -880,7 +880,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
   simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
@@ -932,7 +932,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, typename T
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
@@ -945,7 +945,7 @@ simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
 }
 
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
@@ -958,7 +958,7 @@ const
 }
 
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,
@@ -972,7 +972,7 @@ const
 }
 
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, typename T4__, typename T5__, typename T6__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_col_vector_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr, stan::require_stan_scalar_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_stan_scalar_t<T6__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -48,12 +48,11 @@ static constexpr std::array<const char*, 36> locations_array__ =
  " (in 'ode_adjoint_test_model.stan', line 8, column 50 to line 10, column 3)"};
 
 struct f_2_arg_functor__ {
-  template <typename Tt__, typename Tz__, typename Tb__,
+  template <typename Tt__, typename Tz__,
             typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
-            stan::is_stan_scalar<Ta__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-  operator()(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
+            stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+  operator()(const Tt__& t, const Tz__& z, const int b, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
@@ -87,13 +86,12 @@ struct f_0_arg_odefunctor__ {
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
-  template <typename Tt__, typename Tz__, typename Tb__,
+  template <typename Tt__, typename Tz__,
             typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
-            stan::is_stan_scalar<Ta__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
+            stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
-             const Tb__& b, const Ta__& a) const;
+             const int b, const Ta__& a) const;
 };
 
 template <typename Tt__,
@@ -135,14 +133,13 @@ template <typename Tt__, typename Tz__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tz__, typename Tb__,
+template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
-          stan::is_stan_scalar<Ta__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-  f_2_arg(const Tt__& t, const Tz__& z_arg__, const Tb__& b, const Ta__& a,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+  f_2_arg(const Tt__& t, const Tz__& z_arg__, const int b, const Ta__& a,
           std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Tb__, Ta__>;
+    using local_scalar_t__ = stan::return_type_t<Tt__, Tz__, Ta__>;
     int current_statement__ = 0; 
     const auto& z = stan::math::to_ref(z_arg__);
     static constexpr bool propto__ = true;
@@ -156,12 +153,11 @@ template <typename Tt__, typename Tz__, typename Tb__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tz__, typename Tb__,
+template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
-          stan::is_stan_scalar<Ta__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
-f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
+f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const int b,
                               const Ta__& a, std::ostream* pstream__)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
@@ -208,13 +204,12 @@ f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
   return f_0_arg(t, z, pstream__);
 }
 
-template <typename Tt__, typename Tz__, typename Tb__,
+template <typename Tt__, typename Tz__,
           typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
-          stan::is_stan_scalar<Ta__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
 f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
-                                 std::ostream* pstream__, const Tb__& b,
+                                 std::ostream* pstream__, const int b,
                                  const Ta__& a)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
@@ -834,18 +829,16 @@ static constexpr std::array<const char*, 55> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
-            typename Tdelta__,
-            typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
             stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
-            stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
-            std::is_integral<Tunused__>>* = nullptr>
+            stan::is_stan_scalar<Txi__>,
+            stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
-                      stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+                      stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
-             const Tdelta__& delta, const Tunused__& unused,
-             std::ostream* pstream__) const;
+             const Tdelta__& delta, const int unused, std::ostream* pstream__) const;
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
             typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
@@ -862,17 +855,16 @@ struct simple_SIR_functor__ {
 struct simple_SIR_odefunctor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
-            typename Tdelta__,
-            typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
             stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
-            stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
-            std::is_integral<Tunused__>>* = nullptr>
+            stan::is_stan_scalar<Txi__>,
+            stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
-                      stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+                      stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
              const Tbeta__& beta, const Tkappa__& kappa, const Tgamma__& gamma,
-             const Txi__& xi, const Tdelta__& delta, const Tunused__& unused) const;
+             const Txi__& xi, const Tdelta__& delta, const int unused) const;
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
             typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
@@ -940,22 +932,20 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
     }
     }
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
-          typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          typename Tgamma__, typename Txi__,
+          typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
           stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
-          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
-          std::is_integral<Tunused__>>* = nullptr>
+          stan::is_stan_scalar<Txi__>,
+          stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
-                    stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+                    stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   simple_SIR(const Tt__& t, const Ty__& y_arg__, const Tbeta__& beta,
              const Tkappa__& kappa, const Tgamma__& gamma, const Txi__& xi,
-             const Tdelta__& delta, const Tunused__& unused,
-             std::ostream* pstream__) {
+             const Tdelta__& delta, const int unused, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
-                                stan::return_type_t<Txi__, Tdelta__,
-                                                    Tunused__>>;
+                                stan::return_type_t<Txi__, Tdelta__>>;
     int current_statement__ = 0; 
     const auto& y = stan::math::to_ref(y_arg__);
     static constexpr bool propto__ = true;
@@ -999,19 +989,17 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
     }
     }
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
-          typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          typename Tgamma__, typename Txi__,
+          typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
           stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
-          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
-          std::is_integral<Tunused__>>*>
+          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
-                    stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+                    stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Tbeta__& beta, const Tkappa__& kappa,
                                  const Tgamma__& gamma, const Txi__& xi,
-                                 const Tdelta__& delta,
-                                 const Tunused__& unused,
+                                 const Tdelta__& delta, const int unused,
                                  std::ostream* pstream__)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
@@ -1035,21 +1023,20 @@ simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
 }
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
-          typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          typename Tgamma__, typename Txi__,
+          typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
           stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
-          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
-          std::is_integral<Tunused__>>*>
+          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
-                    stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
+                    stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
                                     std::ostream* pstream__,
                                     const Tbeta__& beta,
                                     const Tkappa__& kappa,
                                     const Tgamma__& gamma, const Txi__& xi,
-                                    const Tdelta__& delta,
-                                    const Tunused__& unused)  const
+                                    const Tdelta__& delta, const int unused) 
+const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
 }

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -48,61 +48,57 @@ static constexpr std::array<const char*, 36> locations_array__ =
  " (in 'ode_adjoint_test_model.stan', line 8, column 50 to line 10, column 3)"};
 
 struct f_2_arg_functor__ {
-  template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<std::is_integral<Tb__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  template <typename Tt__, typename Tz__, typename Tb__,
+            typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
+            stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
-  template <typename Tt__, typename Tz__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
+  template <typename Tt__,
+            typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
-  template <typename Tt__, typename Tz__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  template <typename Tt__, typename Tz__,
+            typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
-  template <typename Tt__, typename Tz__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  template <typename Tt__, typename Tz__,
+            typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
              const Ta__& a) const;
 };
 struct f_0_arg_odefunctor__ {
-  template <typename Tt__, typename Tz__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
+  template <typename Tt__,
+            typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
-  template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<std::is_integral<Tb__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  template <typename Tt__, typename Tz__, typename Tb__,
+            typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
+            stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
              const Tb__& b, const Ta__& a) const;
 };
 
-template <typename Tt__, typename Tz__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
+template <typename Tt__,
+          typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
   f_0_arg(const Tt__& t, const Tz__& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tt__, Tz__>;
@@ -119,10 +115,9 @@ template <typename Tt__, typename Tz__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tz__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+template <typename Tt__, typename Tz__,
+          typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
   f_1_arg(const Tt__& t, const Tz__& z, const Ta__& a,
           std::ostream* pstream__) {
@@ -140,11 +135,10 @@ template <typename Tt__, typename Tz__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-          stan::require_t<std::is_integral<Tb__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+template <typename Tt__, typename Tz__, typename Tb__,
+          typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
+          stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
   f_2_arg(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
           std::ostream* pstream__) {
@@ -162,11 +156,10 @@ template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<std::is_integral<Tb__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+template <typename Tt__, typename Tz__, typename Tb__,
+          typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
+          stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
 f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
                               const Ta__& a, std::ostream* pstream__)  const
@@ -174,9 +167,9 @@ f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
   return f_2_arg(t, z, b, a, pstream__);
 }
 
-template <typename Tt__, typename Tz__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*>
+template <typename Tt__,
+          typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
 f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z,
                               std::ostream* pstream__)  const
@@ -184,10 +177,9 @@ f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z,
   return f_0_arg(t, z, pstream__);
 }
 
-template <typename Tt__, typename Tz__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+template <typename Tt__, typename Tz__,
+          typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
 f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
                               std::ostream* pstream__)  const
@@ -195,10 +187,9 @@ f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
   return f_1_arg(t, z, a, pstream__);
 }
 
-template <typename Tt__, typename Tz__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+template <typename Tt__, typename Tz__,
+          typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
 f_1_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__, const Ta__& a) 
@@ -207,9 +198,9 @@ const
   return f_1_arg(t, z, a, pstream__);
 }
 
-template <typename Tt__, typename Tz__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*>
+template <typename Tt__,
+          typename Tz__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
 f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__)  const
@@ -217,11 +208,10 @@ f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
   return f_0_arg(t, z, pstream__);
 }
 
-template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<std::is_integral<Tb__>>*,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+template <typename Tt__, typename Tz__, typename Tb__,
+          typename Ta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Tz__>, std::is_integral<Tb__>,
+          stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
 f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__, const Tb__& b,
@@ -844,15 +834,12 @@ static constexpr std::array<const char*, 55> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
-            typename Tdelta__, typename Tunused__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr,
-            stan::require_t<std::is_integral<Tunused__>>* = nullptr>
+            typename Tdelta__,
+            typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+            stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+            stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
+            std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -861,14 +848,11 @@ struct simple_SIR_functor__ {
              std::ostream* pstream__) const;
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
-            typename Tdelta__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr>
+            typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+            stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+            stan::is_stan_scalar<Txi__>,
+            stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -878,15 +862,12 @@ struct simple_SIR_functor__ {
 struct simple_SIR_odefunctor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
-            typename Tdelta__, typename Tunused__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr,
-            stan::require_t<std::is_integral<Tunused__>>* = nullptr>
+            typename Tdelta__,
+            typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+            stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+            stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
+            std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
@@ -894,14 +875,11 @@ struct simple_SIR_odefunctor__ {
              const Txi__& xi, const Tdelta__& delta, const Tunused__& unused) const;
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
-            typename Tdelta__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr>
+            typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+            stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+            stan::is_stan_scalar<Txi__>,
+            stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
@@ -910,14 +888,12 @@ struct simple_SIR_odefunctor__ {
 };
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
-          typename Tgamma__, typename Txi__, typename Tdelta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr>
+          typename Tgamma__, typename Txi__,
+          typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+          stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+          stan::is_stan_scalar<Txi__>,
+          stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -965,15 +941,11 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
     }
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr,
-          stan::require_t<std::is_integral<Tunused__>>* = nullptr>
+          typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+          stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
+          std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
   simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -1028,14 +1000,11 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
     }
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar<Tdelta__>>*,
-          stan::require_t<std::is_integral<Tunused__>>*>
+          typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+          stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
+          std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
@@ -1049,14 +1018,11 @@ simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
 }
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
-          typename Tgamma__, typename Txi__, typename Tdelta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar<Tdelta__>>*>
+          typename Tgamma__, typename Txi__,
+          typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+          stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
@@ -1070,14 +1036,11 @@ simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar<Tdelta__>>*,
-          stan::require_t<std::is_integral<Tunused__>>*>
+          typename Tunused__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+          stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>,
+          std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
@@ -1092,14 +1055,11 @@ simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
 }
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
-          typename Tgamma__, typename Txi__, typename Tdelta__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar<Tdelta__>>*>
+          typename Tgamma__, typename Txi__,
+          typename Tdelta__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_col_vector<Ty__>, stan::is_stan_scalar<Tbeta__>,
+          stan::is_stan_scalar<Tkappa__>, stan::is_stan_scalar<Tgamma__>,
+          stan::is_stan_scalar<Txi__>, stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -49,59 +49,59 @@ static constexpr std::array<const char*, 36> locations_array__ =
 
 struct f_2_arg_functor__ {
   template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<std::is_integral<Tb__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
   template <typename Tt__, typename Tz__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
   template <typename Tt__, typename Tz__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, const Ta__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
   template <typename Tt__, typename Tz__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
              const Ta__& a) const;
 };
 struct f_0_arg_odefunctor__ {
   template <typename Tt__, typename Tz__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
   template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<std::is_integral<Tb__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
   operator()(const Tt__& t, const Tz__& z, std::ostream* pstream__,
              const Tb__& b, const Ta__& a) const;
 };
 
 template <typename Tt__, typename Tz__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tz__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
   f_0_arg(const Tt__& t, const Tz__& z, std::ostream* pstream__) {
@@ -120,9 +120,9 @@ template <typename Tt__, typename Tz__,
     }
     }
 template <typename Tt__, typename Tz__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
   f_1_arg(const Tt__& t, const Tz__& z, const Ta__& a,
           std::ostream* pstream__) {
@@ -141,10 +141,10 @@ template <typename Tt__, typename Tz__, typename Ta__,
     }
     }
 template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tz__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+          stan::require_t<std::is_integral<Tb__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
   f_2_arg(const Tt__& t, const Tz__& z, const Tb__& b, const Ta__& a,
           std::ostream* pstream__) {
@@ -163,10 +163,10 @@ template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
     }
     }
 template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_t<std::is_integral<Tb__>>*,
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
 f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
                               const Ta__& a, std::ostream* pstream__)  const
@@ -175,7 +175,7 @@ f_2_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Tb__& b,
 }
 
 template <typename Tt__, typename Tz__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
 f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z,
@@ -185,9 +185,9 @@ f_0_arg_functor__::operator()(const Tt__& t, const Tz__& z,
 }
 
 template <typename Tt__, typename Tz__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
 f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
                               std::ostream* pstream__)  const
@@ -196,9 +196,9 @@ f_1_arg_functor__::operator()(const Tt__& t, const Tz__& z, const Ta__& a,
 }
 
 template <typename Tt__, typename Tz__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Ta__>, -1, 1>
 f_1_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__, const Ta__& a) 
@@ -208,7 +208,7 @@ const
 }
 
 template <typename Tt__, typename Tz__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__>, -1, 1>
 f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
@@ -218,10 +218,10 @@ f_0_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
 }
 
 template <typename Tt__, typename Tz__, typename Tb__, typename Ta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Tz__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_t<std::is_integral<Tb__>>*,
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Tz__, Tb__, Ta__>, -1, 1>
 f_2_arg_odefunctor__::operator()(const Tt__& t, const Tz__& z,
                                  std::ostream* pstream__, const Tb__& b,
@@ -845,14 +845,14 @@ struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
             typename Tdelta__, typename Tunused__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tunused__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr,
+            stan::require_t<std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -862,13 +862,13 @@ struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
             typename Tdelta__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -879,14 +879,14 @@ struct simple_SIR_odefunctor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
             typename Tdelta__, typename Tunused__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tunused__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr,
+            stan::require_t<std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
@@ -895,13 +895,13 @@ struct simple_SIR_odefunctor__ {
   template <typename Tt__, typename Ty__, typename Tbeta__,
             typename Tkappa__, typename Tgamma__, typename Txi__,
             typename Tdelta__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                       stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   operator()(const Tt__& t, const Ty__& y, std::ostream* pstream__,
@@ -911,13 +911,13 @@ struct simple_SIR_odefunctor__ {
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
   simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -966,14 +966,14 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
           typename Tunused__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Ty__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Txi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tunused__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tbeta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tkappa__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tgamma__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Txi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tdelta__>>* = nullptr,
+          stan::require_t<std::is_integral<Tunused__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
   simple_SIR(const Tt__& t, const Ty__& y, const Tbeta__& beta,
@@ -1028,14 +1028,14 @@ template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
     }
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          typename Tunused__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tunused__>>*>
+          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar<Tdelta__>>*,
+          stan::require_t<std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
@@ -1050,13 +1050,13 @@ simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*>
+          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
@@ -1070,14 +1070,14 @@ simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          typename Tunused__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          typename Tunused__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tunused__>>*>
+          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar<Tdelta__>>*,
+          stan::require_t<std::is_integral<Tunused__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__, Tunused__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
@@ -1093,13 +1093,13 @@ simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,
 
 template <typename Tt__, typename Ty__, typename Tbeta__, typename Tkappa__,
           typename Tgamma__, typename Txi__, typename Tdelta__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_t<stan::is_stan_scalar<Tt__>>*,
           stan::require_t<stan::is_col_vector<Ty__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tbeta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tkappa__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tgamma__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Txi__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tdelta__>>*>
+          stan::require_t<stan::is_stan_scalar<Tbeta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tkappa__>>*,
+          stan::require_t<stan::is_stan_scalar<Tgamma__>>*,
+          stan::require_t<stan::is_stan_scalar<Txi__>>*,
+          stan::require_t<stan::is_stan_scalar<Tdelta__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tt__, Ty__, Tbeta__, Tkappa__, Tgamma__,
                     stan::return_type_t<Txi__, Tdelta__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const Tt__& t, const Ty__& y,

--- a/test/integration/good/code-gen/overloading_templating.stan
+++ b/test/integration/good/code-gen/overloading_templating.stan
@@ -1,0 +1,55 @@
+functions {
+  real foo(int p){
+    return p + 1.0;
+  }
+
+   real foo(real p) {
+   	return p + 2;
+   }
+   real foo(row_vector p) {
+   	return sum(p) + 3;
+   }
+   real foo(vector p) {
+   	return sum(p) + 4;
+   }
+   real foo(matrix p) {
+   	return sum(p) + 5;
+   }
+   real foo(array[] real p) {
+   	return sum(p) + 6;
+   }
+
+  real foo(array[] row_vector p) {
+   	return sum(p[1]) + 7;
+   }
+   real foo(array[] vector p) {
+   	return sum(p[1]) + 8;
+   }
+   real foo(array[] matrix p) {
+   	return sum(p[1]) + 9;
+   }
+   real foo(array[,] real p) {
+   	return sum(p[1]) + 10;
+   }
+  real foo(array[] int p){
+    return sum(p) + 12;
+  }
+}
+transformed data{
+   vector[5] a = [0.1, 0.1, 0.1, 0.1, 0.1]';
+}
+parameters {
+    real y;
+    real z;
+}
+model {
+    y ~ normal(foo(1), 1);
+    y ~ normal(foo(1.5), 1);
+    a ~ normal(foo(z), 1);
+    y ~ normal(foo(a), 1);
+    y ~ normal(foo(a'), 1);
+    y ~ normal(foo({a}), 1);
+    y ~ normal(foo({1,2}), 1);
+    y ~ normal(foo({1,2.3}), 1);
+    {5.5,6.5} ~ normal(foo({z,2.3}), 1);
+}

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -33,11 +33,8 @@ static constexpr std::array<const char*, 21> locations_array__ =
  " (in 'basic.stan', line 36, column 33 to line 38, column 3)"};
 
 struct int_only_multiplication_functor__ {
-  template <typename Ta__,
-            typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
-            std::is_integral<Tb__>>* = nullptr>
   inline int
-  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
+  operator()(const int a, const int b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
@@ -52,9 +49,8 @@ struct test_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ta__>
-  operator()(const Ta__& a, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<int>& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
   template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
@@ -117,10 +113,9 @@ template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ta__>
-  int_array_fun(const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ta__>;
+inline double
+  int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -159,12 +154,9 @@ template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullp
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
-          std::is_integral<Tb__>>* = nullptr> inline int
-  int_only_multiplication(const Ta__& a, const Tb__& b,
-                          std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
+inline int
+  int_only_multiplication(const int a, const int b, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -242,11 +234,8 @@ template <bool propto__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
-          std::is_integral<Tb__>>*>
 inline int
-int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
+int_only_multiplication_functor__::operator()(const int a, const int b,
                                               std::ostream* pstream__)  const
 {
   return int_only_multiplication(a, b, pstream__);
@@ -270,10 +259,9 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ta__>
-int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
-const
+inline double
+int_array_fun_functor__::operator()(const std::vector<int>& a,
+                                    std::ostream* pstream__)  const
 {
   return int_array_fun(a, pstream__);
 }
@@ -429,11 +417,8 @@ static constexpr std::array<const char*, 21> locations_array__ =
  " (in 'basic.stanfunctions', line 35, column 31 to line 37, column 1)"};
 
 struct int_only_multiplication_functor__ {
-  template <typename Ta__,
-            typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
-            std::is_integral<Tb__>>* = nullptr>
   inline int
-  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
+  operator()(const int a, const int b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
@@ -448,9 +433,8 @@ struct test_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ta__>
-  operator()(const Ta__& a, std::ostream* pstream__) const;
+  inline double
+  operator()(const std::vector<int>& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
   template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
@@ -513,10 +497,9 @@ template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
-  inline stan::return_type_t<Ta__>
-  int_array_fun(const Ta__& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ta__>;
+inline double
+  int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -555,12 +538,9 @@ template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullp
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
-          std::is_integral<Tb__>>* = nullptr> inline int
-  int_only_multiplication(const Ta__& a, const Tb__& b,
-                          std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
+inline int
+  int_only_multiplication(const int a, const int b, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -638,11 +618,8 @@ template <bool propto__, typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
-          std::is_integral<Tb__>>*>
 inline int
-int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
+int_only_multiplication_functor__::operator()(const int a, const int b,
                                               std::ostream* pstream__)  const
 {
   return int_only_multiplication(a, b, pstream__);
@@ -666,10 +643,9 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>*>
-inline stan::return_type_t<Ta__>
-int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
-const
+inline double
+int_array_fun_functor__::operator()(const std::vector<int>& a,
+                                    std::ostream* pstream__)  const
 {
   return int_array_fun(a, pstream__);
 }
@@ -815,15 +791,15 @@ static constexpr std::array<const char*, 11> locations_array__ =
  " (in 'integrate.stan', line 14, column 23 to line 24, column 3)"};
 
 struct integrand_ode_functor__ {
-  template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
+  template <typename Tr__, typename Tf__, typename Ttheta__,
+            typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
             stan::is_std_vector<Tf__>, stan::is_stan_scalar<stan::value_type_t<Tf__>>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__>>
   operator()(const Tr__& r, const Tf__& f, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) const;
 };
 struct ode_integrate_functor__ {
   inline double
@@ -852,17 +828,17 @@ template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullp
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
+template <typename Tr__, typename Tf__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
           stan::is_std_vector<Tf__>, stan::is_stan_scalar<stan::value_type_t<Tf__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__>>
   integrand_ode(const Tr__& r, const Tf__& f, const Ttheta__& theta,
-                const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+                const Tx_r__& x_r, const std::vector<int>& x_i,
+                std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>;
+            stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -906,16 +882,15 @@ inline double ode_integrate(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
+template <typename Tr__, typename Tf__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
           stan::is_std_vector<Tf__>, stan::is_stan_scalar<stan::value_type_t<Tf__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
-inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>*>
+inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__>>
 integrand_ode_functor__::operator()(const Tr__& r, const Tf__& f,
                                     const Ttheta__& theta, const Tx_r__& x_r,
-                                    const Tx_i__& x_i,
+                                    const std::vector<int>& x_i,
                                     std::ostream* pstream__)  const
 {
   return integrand_ode(r, f, theta, x_r, x_i, pstream__);

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -69,7 +69,7 @@ struct my_log1p_exp_functor__ {
 struct my_vector_mul_by_5_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  operator()(const Tx__& x, std::ostream* pstream__) const;
+  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename Ta__,
@@ -296,7 +296,7 @@ const
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-my_vector_mul_by_5_functor__::operator()(const Tx__& x,
+my_vector_mul_by_5_functor__::operator()(const Tx__& x_arg__,
                                          std::ostream* pstream__)  const
 {
   return my_vector_mul_by_5(x, pstream__);
@@ -465,7 +465,7 @@ struct my_log1p_exp_functor__ {
 struct my_vector_mul_by_5_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  operator()(const Tx__& x, std::ostream* pstream__) const;
+  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename Ta__,
@@ -692,7 +692,7 @@ const
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-my_vector_mul_by_5_functor__::operator()(const Tx__& x,
+my_vector_mul_by_5_functor__::operator()(const Tx__& x_arg__,
                                          std::ostream* pstream__)  const
 {
   return my_vector_mul_by_5(x, pstream__);
@@ -832,7 +832,7 @@ struct ode_integrate_functor__ {
 struct integrand_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  operator()(const Tx__& x, std::ostream* pstream__) const;
+  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
 };
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
@@ -929,7 +929,7 @@ const
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-integrand_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
+integrand_functor__::operator()(const Tx__& x_arg__, std::ostream* pstream__) 
 const
 {
   return integrand(x, pstream__);

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -37,11 +37,12 @@ struct int_only_multiplication_functor__ {
   operator()(const int& a, const int& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -51,29 +52,33 @@ struct int_array_fun_functor__ {
   operator()(const std::vector<int>& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__>
+  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename T0__, typename RNG> stan::promote_args_t<T0__>
+  template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   my_log1p_exp(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -88,7 +93,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -117,7 +123,7 @@ double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -158,7 +164,8 @@ int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   test_lgamma(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -173,7 +180,7 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -188,7 +195,8 @@ template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename RNG> stan::promote_args_t<T0__>
+template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -203,7 +211,7 @@ template <typename T0__, typename RNG> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -226,7 +234,8 @@ int_only_multiplication_functor__::operator()(const int& a, const int& b,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
 {
@@ -234,7 +243,7 @@ const
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 void
 test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -252,7 +261,8 @@ int_array_fun_functor__::operator()(const std::vector<int>& a,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 array_fun_functor__::operator()(const std::vector<T0__>& a,
                                 std::ostream* pstream__)  const
 {
@@ -260,7 +270,8 @@ array_fun_functor__::operator()(const std::vector<T0__>& a,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
 {
@@ -268,7 +279,7 @@ const
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const T0__& x,
                                          std::ostream* pstream__)  const
@@ -277,7 +288,7 @@ my_vector_mul_by_5_functor__::operator()(const T0__& x,
 }
 
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
 stan::promote_args_t<T0__, T1__>
 test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
                                 std::ostream* pstream__)  const
@@ -286,7 +297,8 @@ test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
 }
 
 
-template <typename T0__, typename RNG> stan::promote_args_t<T0__>
+template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
 {
@@ -405,11 +417,12 @@ struct int_only_multiplication_functor__ {
   operator()(const int& a, const int& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -419,29 +432,33 @@ struct int_array_fun_functor__ {
   operator()(const std::vector<int>& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__>
+  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename T0__, typename RNG> stan::promote_args_t<T0__>
+  template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   my_log1p_exp(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -456,7 +473,8 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -485,7 +503,7 @@ double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -526,7 +544,8 @@ int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   test_lgamma(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -541,7 +560,7 @@ template <typename T0__> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -556,7 +575,8 @@ template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename RNG> stan::promote_args_t<T0__>
+template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -571,7 +591,7 @@ template <typename T0__, typename RNG> stan::promote_args_t<T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -594,7 +614,8 @@ int_only_multiplication_functor__::operator()(const int& a, const int& b,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
 {
@@ -602,7 +623,7 @@ const
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 void
 test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -620,7 +641,8 @@ int_array_fun_functor__::operator()(const std::vector<int>& a,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 array_fun_functor__::operator()(const std::vector<T0__>& a,
                                 std::ostream* pstream__)  const
 {
@@ -628,7 +650,8 @@ array_fun_functor__::operator()(const std::vector<T0__>& a,
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
 {
@@ -636,7 +659,7 @@ const
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const T0__& x,
                                          std::ostream* pstream__)  const
@@ -645,7 +668,7 @@ my_vector_mul_by_5_functor__::operator()(const T0__& x,
 }
 
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
 stan::promote_args_t<T0__, T1__>
 test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
                                 std::ostream* pstream__)  const
@@ -654,7 +677,8 @@ test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
 }
 
 
-template <typename T0__, typename RNG> stan::promote_args_t<T0__>
+template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
 {
@@ -759,7 +783,7 @@ static constexpr std::array<const char*, 11> locations_array__ =
  " (in 'integrate.stan', line 14, column 23 to line 24, column 3)"};
 
 struct integrand_ode_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& r, const std::vector<T1__>& f,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -770,12 +794,12 @@ struct ode_integrate_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   integrand(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -792,7 +816,7 @@ template <typename T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   integrand_ode(const T0__& r, const std::vector<T1__>& f,
                 const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -842,7 +866,7 @@ double ode_integrate(std::ostream* pstream__) {
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 integrand_ode_functor__::operator()(const T0__& r,
                                     const std::vector<T1__>& f,
@@ -861,7 +885,7 @@ double ode_integrate_functor__::operator()(std::ostream* pstream__)  const
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 integrand_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -34,40 +34,40 @@ static constexpr std::array<const char*, 21> locations_array__ =
 
 struct int_only_multiplication_functor__ {
   template <typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+            stan::require_t<std::is_integral<Ta__>>* = nullptr,
+            stan::require_t<std::is_integral<Tb__>>* = nullptr>
   inline int
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
   template <bool propto__, typename Ta__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline void
   operator()(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
   template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
   template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
@@ -79,20 +79,20 @@ struct my_vector_mul_by_5_functor__ {
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
   template <typename Ta__, typename RNG,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   my_log1p_exp(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -109,7 +109,7 @@ template <typename Tx__,
     }
     }
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -126,7 +126,7 @@ template <typename Ta__,
     }
     }
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   int_array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -170,9 +170,8 @@ template <typename Tx__,
     }
     }
 template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
-  inline int
+          stan::require_t<std::is_integral<Ta__>>* = nullptr,
+          stan::require_t<std::is_integral<Tb__>>* = nullptr> inline int
   int_only_multiplication(const Ta__& a, const Tb__& b,
                           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -189,7 +188,7 @@ template <typename Ta__, typename Tb__,
     }
     }
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   test_lgamma(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -207,8 +206,7 @@ template <typename Tx__,
     }
 template <bool propto__, typename Ta__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
-  inline void
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr> inline void
   test_lp(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -223,7 +221,7 @@ template <bool propto__, typename Ta__, typename T_lp__,
     }
     }
 template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   test_rng(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -240,8 +238,8 @@ template <typename Ta__, typename RNG,
     }
     }
 template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   test_lpdf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -256,8 +254,8 @@ template <bool propto__, typename Ta__, typename Tb__,
     }
     }
 template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+          stan::require_t<std::is_integral<Ta__>>*,
+          stan::require_t<std::is_integral<Tb__>>*>
 inline int
 int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
                                               std::ostream* pstream__)  const
@@ -265,7 +263,7 @@ int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 test_lgamma_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -274,8 +272,7 @@ const
 }
 
 template <bool propto__, typename Ta__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline void
 test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -285,7 +282,7 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
 }
 
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -294,7 +291,7 @@ const
 }
 
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -302,7 +299,7 @@ const
   return array_fun(a, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 my_log1p_exp_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -319,8 +316,8 @@ my_vector_mul_by_5_functor__::operator()(const Tx__& x,
 }
 
 template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+          stan::require_t<stan::is_stan_scalar<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tb__>>*>
 inline stan::return_type_t<Ta__, Tb__>
 test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
                                 std::ostream* pstream__)  const
@@ -329,7 +326,7 @@ test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
 }
 
 template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ta__>
 test_rng_functor__::operator()(const Ta__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -446,40 +443,40 @@ static constexpr std::array<const char*, 21> locations_array__ =
 
 struct int_only_multiplication_functor__ {
   template <typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+            stan::require_t<std::is_integral<Ta__>>* = nullptr,
+            stan::require_t<std::is_integral<Tb__>>* = nullptr>
   inline int
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
   template <bool propto__, typename Ta__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline void
   operator()(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
   template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
   template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
@@ -491,20 +488,20 @@ struct my_vector_mul_by_5_functor__ {
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
   template <typename Ta__, typename RNG,
-            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   my_log1p_exp(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -521,7 +518,7 @@ template <typename Tx__,
     }
     }
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -538,7 +535,7 @@ template <typename Ta__,
     }
     }
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   int_array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -582,9 +579,8 @@ template <typename Tx__,
     }
     }
 template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
-  inline int
+          stan::require_t<std::is_integral<Ta__>>* = nullptr,
+          stan::require_t<std::is_integral<Tb__>>* = nullptr> inline int
   int_only_multiplication(const Ta__& a, const Tb__& b,
                           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -601,7 +597,7 @@ template <typename Ta__, typename Tb__,
     }
     }
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   test_lgamma(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -619,8 +615,7 @@ template <typename Tx__,
     }
 template <bool propto__, typename Ta__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
-  inline void
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr> inline void
   test_lp(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -635,7 +630,7 @@ template <bool propto__, typename Ta__, typename T_lp__,
     }
     }
 template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   test_rng(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -652,8 +647,8 @@ template <typename Ta__, typename RNG,
     }
     }
 template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   test_lpdf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -668,8 +663,8 @@ template <bool propto__, typename Ta__, typename Tb__,
     }
     }
 template <typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+          stan::require_t<std::is_integral<Ta__>>*,
+          stan::require_t<std::is_integral<Tb__>>*>
 inline int
 int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
                                               std::ostream* pstream__)  const
@@ -677,7 +672,7 @@ int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 test_lgamma_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -686,8 +681,7 @@ const
 }
 
 template <bool propto__, typename Ta__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline void
 test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -697,7 +691,7 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
 }
 
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -706,7 +700,7 @@ const
 }
 
 template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -714,7 +708,7 @@ const
   return array_fun(a, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 my_log1p_exp_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -731,8 +725,8 @@ my_vector_mul_by_5_functor__::operator()(const Tx__& x,
 }
 
 template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+          stan::require_t<stan::is_stan_scalar<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar<Tb__>>*>
 inline stan::return_type_t<Ta__, Tb__>
 test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
                                 std::ostream* pstream__)  const
@@ -741,7 +735,7 @@ test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
 }
 
 template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+          stan::require_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ta__>
 test_rng_functor__::operator()(const Ta__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -849,11 +843,11 @@ static constexpr std::array<const char*, 11> locations_array__ =
 struct integrand_ode_functor__ {
   template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tr__& r, const Tf__& f, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -889,11 +883,11 @@ template <typename Tx__,
     }
 template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
   integrand_ode(const Tr__& r, const Tf__& f, const Ttheta__& theta,
                 const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -943,11 +937,11 @@ inline double ode_integrate(std::ostream* pstream__) {
     }
     }
 template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*,
-          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tr__>>*,
+          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
 integrand_ode_functor__::operator()(const Tr__& r, const Tf__& f,
                                     const Ttheta__& theta, const Tx_r__& x_r,

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -33,66 +33,59 @@ static constexpr std::array<const char*, 21> locations_array__ =
  " (in 'basic.stan', line 36, column 33 to line 38, column 3)"};
 
 struct int_only_multiplication_functor__ {
-  template <typename Ta__, typename Tb__,
-            stan::require_t<std::is_integral<Ta__>>* = nullptr,
-            stan::require_t<std::is_integral<Tb__>>* = nullptr>
+  template <typename Ta__,
+            typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
+            std::is_integral<Tb__>>* = nullptr>
   inline int
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
   template <bool propto__, typename Ta__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline void
   operator()(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
+  template <bool propto__, typename Ta__,
+            typename Tb__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+            stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename Ta__, typename RNG,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  template <typename Ta__,
+            typename RNG, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   my_log1p_exp(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -108,8 +101,7 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -125,8 +117,7 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   int_array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -142,8 +133,7 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
   my_vector_mul_by_5(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -169,9 +159,9 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__,
-          stan::require_t<std::is_integral<Ta__>>* = nullptr,
-          stan::require_t<std::is_integral<Tb__>>* = nullptr> inline int
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
+          std::is_integral<Tb__>>* = nullptr> inline int
   int_only_multiplication(const Ta__& a, const Tb__& b,
                           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -187,8 +177,7 @@ template <typename Ta__, typename Tb__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   test_lgamma(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -205,8 +194,8 @@ template <typename Tx__,
     }
     }
 template <bool propto__, typename Ta__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr> inline void
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  inline void
   test_lp(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -220,8 +209,8 @@ template <bool propto__, typename Ta__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+template <typename Ta__,
+          typename RNG, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   test_rng(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -237,9 +226,9 @@ template <typename Ta__, typename RNG,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
+template <bool propto__, typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+          stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   test_lpdf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -253,9 +242,9 @@ template <bool propto__, typename Ta__, typename Tb__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__,
-          stan::require_t<std::is_integral<Ta__>>*,
-          stan::require_t<std::is_integral<Tb__>>*>
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
+          std::is_integral<Tb__>>*>
 inline int
 int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
                                               std::ostream* pstream__)  const
@@ -263,7 +252,7 @@ int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 test_lgamma_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -272,7 +261,7 @@ const
 }
 
 template <bool propto__, typename Ta__, typename T_lp__,
-          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Ta__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ta__>>*>
 inline void
 test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -281,8 +270,7 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -290,8 +278,7 @@ const
   return int_array_fun(a, pstream__);
 }
 
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -299,7 +286,7 @@ const
   return array_fun(a, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 my_log1p_exp_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -307,7 +294,7 @@ const
   return my_log1p_exp(x, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_col_vector<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const Tx__& x,
                                          std::ostream* pstream__)  const
@@ -315,9 +302,9 @@ my_vector_mul_by_5_functor__::operator()(const Tx__& x,
   return my_vector_mul_by_5(x, pstream__);
 }
 
-template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tb__>>*>
+template <bool propto__, typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+          stan::is_stan_scalar<Tb__>>*>
 inline stan::return_type_t<Ta__, Tb__>
 test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
                                 std::ostream* pstream__)  const
@@ -325,8 +312,8 @@ test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+template <typename Ta__,
+          typename RNG, stan::require_all_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ta__>
 test_rng_functor__::operator()(const Ta__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -442,66 +429,59 @@ static constexpr std::array<const char*, 21> locations_array__ =
  " (in 'basic.stanfunctions', line 35, column 31 to line 37, column 1)"};
 
 struct int_only_multiplication_functor__ {
-  template <typename Ta__, typename Tb__,
-            stan::require_t<std::is_integral<Ta__>>* = nullptr,
-            stan::require_t<std::is_integral<Tb__>>* = nullptr>
+  template <typename Ta__,
+            typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
+            std::is_integral<Tb__>>* = nullptr>
   inline int
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
   template <bool propto__, typename Ta__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline void
   operator()(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename Ta__,
-            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename Ta__, typename Tb__,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
+  template <bool propto__, typename Ta__,
+            typename Tb__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+            stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename Ta__, typename RNG,
-            stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  template <typename Ta__,
+            typename RNG, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   my_log1p_exp(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -517,8 +497,7 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -534,8 +513,7 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   int_array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -551,8 +529,7 @@ template <typename Ta__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
   my_vector_mul_by_5(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -578,9 +555,9 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__,
-          stan::require_t<std::is_integral<Ta__>>* = nullptr,
-          stan::require_t<std::is_integral<Tb__>>* = nullptr> inline int
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
+          std::is_integral<Tb__>>* = nullptr> inline int
   int_only_multiplication(const Ta__& a, const Tb__& b,
                           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -596,8 +573,7 @@ template <typename Ta__, typename Tb__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   test_lgamma(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -614,8 +590,8 @@ template <typename Tx__,
     }
     }
 template <bool propto__, typename Ta__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr> inline void
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+  inline void
   test_lp(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -629,8 +605,8 @@ template <bool propto__, typename Ta__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr>
+template <typename Ta__,
+          typename RNG, stan::require_all_t<stan::is_stan_scalar<Ta__>>* = nullptr>
   inline stan::return_type_t<Ta__>
   test_rng(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -646,9 +622,9 @@ template <typename Ta__, typename RNG,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tb__>>* = nullptr>
+template <bool propto__, typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+          stan::is_stan_scalar<Tb__>>* = nullptr>
   inline stan::return_type_t<Ta__, Tb__>
   test_lpdf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
@@ -662,9 +638,9 @@ template <bool propto__, typename Ta__, typename Tb__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, typename Tb__,
-          stan::require_t<std::is_integral<Ta__>>*,
-          stan::require_t<std::is_integral<Tb__>>*>
+template <typename Ta__,
+          typename Tb__, stan::require_all_t<std::is_integral<Ta__>,
+          std::is_integral<Tb__>>*>
 inline int
 int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
                                               std::ostream* pstream__)  const
@@ -672,7 +648,7 @@ int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 test_lgamma_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -681,7 +657,7 @@ const
 }
 
 template <bool propto__, typename Ta__, typename T_lp__,
-          typename T_lp_accum__, stan::require_t<stan::is_stan_scalar<Ta__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Ta__>>*>
 inline void
 test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -690,8 +666,7 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -699,8 +674,7 @@ const
   return int_array_fun(a, pstream__);
 }
 
-template <typename Ta__,
-          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -708,7 +682,7 @@ const
   return array_fun(a, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 my_log1p_exp_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -716,7 +690,7 @@ const
   return my_log1p_exp(x, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_col_vector<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const Tx__& x,
                                          std::ostream* pstream__)  const
@@ -724,9 +698,9 @@ my_vector_mul_by_5_functor__::operator()(const Tx__& x,
   return my_vector_mul_by_5(x, pstream__);
 }
 
-template <bool propto__, typename Ta__, typename Tb__,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*,
-          stan::require_t<stan::is_stan_scalar<Tb__>>*>
+template <bool propto__, typename Ta__,
+          typename Tb__, stan::require_all_t<stan::is_stan_scalar<Ta__>,
+          stan::is_stan_scalar<Tb__>>*>
 inline stan::return_type_t<Ta__, Tb__>
 test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
                                 std::ostream* pstream__)  const
@@ -734,8 +708,8 @@ test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-template <typename Ta__, typename RNG,
-          stan::require_t<stan::is_stan_scalar<Ta__>>*>
+template <typename Ta__,
+          typename RNG, stan::require_all_t<stan::is_stan_scalar<Ta__>>*>
 inline stan::return_type_t<Ta__>
 test_rng_functor__::operator()(const Ta__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -842,12 +816,11 @@ static constexpr std::array<const char*, 11> locations_array__ =
 
 struct integrand_ode_functor__ {
   template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
+            stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tr__& r, const Tf__& f, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -857,14 +830,12 @@ struct ode_integrate_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename Tx__,
-          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
   integrand(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -882,12 +853,11 @@ template <typename Tx__,
     }
     }
 template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar<Tr__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
+          stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
   integrand_ode(const Tr__& r, const Tf__& f, const Ttheta__& theta,
                 const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -937,11 +907,11 @@ inline double ode_integrate(std::ostream* pstream__) {
     }
     }
 template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tr__>>*,
-          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
+          stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
 integrand_ode_functor__::operator()(const Tr__& r, const Tf__& f,
                                     const Ttheta__& theta, const Tx_r__& x_r,
@@ -957,7 +927,7 @@ const
   return ode_integrate(pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_col_vector<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
 integrand_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -33,59 +33,69 @@ static constexpr std::array<const char*, 21> locations_array__ =
  " (in 'basic.stan', line 36, column 33 to line 38, column 3)"};
 
 struct int_only_multiplication_functor__ {
-  int
-  operator()(const int& a, const int& b, std::ostream* pstream__) const;
+  template <typename Ta__, typename Tb__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline int
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Ta__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline void
+  operator()(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  double
-  operator()(const std::vector<int>& a, std::ostream* pstream__) const;
+  template <typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& a, std::ostream* pstream__) const;
+  template <typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
+  template <bool propto__, typename Ta__, typename Tb__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline stan::return_type_t<Ta__, Tb__>
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename T0__, typename RNG,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
+  template <typename Ta__, typename RNG,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  operator()(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  my_log1p_exp(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  my_log1p_exp(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -98,10 +108,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  array_fun(const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -114,8 +125,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  int_array_fun(const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -128,10 +142,11 @@ double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tx__,
+          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+  my_vector_mul_by_5(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     static constexpr bool propto__ = true;
@@ -154,9 +169,13 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-  int_only_multiplication(const int& a, const int& b, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline int
+  int_only_multiplication(const Ta__& a, const Tb__& b,
+                          std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -169,10 +188,11 @@ int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  test_lgamma(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  test_lgamma(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -185,12 +205,13 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ta__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline void
+  test_lp(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -201,11 +222,11 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename RNG,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ta__, typename RNG,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  test_rng(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -218,12 +239,12 @@ template <typename T0__, typename RNG,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+template <bool propto__, typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline stan::return_type_t<Ta__, Tb__>
+  test_lpdf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -234,75 +255,83 @@ template <bool propto__, typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-int_only_multiplication_functor__::operator()(const int& a, const int& b,
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+inline int
+int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
                                               std::ostream* pstream__)  const
 {
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+test_lgamma_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return test_lgamma(x, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-void
-test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
+template <bool propto__, typename Ta__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline void
+test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-double
-int_array_fun_functor__::operator()(const std::vector<int>& a,
-                                    std::ostream* pstream__)  const
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ta__>
+int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
+const
 {
   return int_array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-array_fun_functor__::operator()(const std::vector<T0__>& a,
-                                std::ostream* pstream__)  const
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ta__>
+array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
+const
 {
   return array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+my_log1p_exp_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return my_log1p_exp(x, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-my_vector_mul_by_5_functor__::operator()(const T0__& x,
+template <typename Tx__, stan::require_t<stan::is_col_vector<Tx__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+my_vector_mul_by_5_functor__::operator()(const Tx__& x,
                                          std::ostream* pstream__)  const
 {
   return my_vector_mul_by_5(x, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
+template <bool propto__, typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+inline stan::return_type_t<Ta__, Tb__>
+test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
                                 std::ostream* pstream__)  const
 {
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
+template <typename Ta__, typename RNG,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline stan::return_type_t<Ta__>
+test_rng_functor__::operator()(const Ta__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
 {
   return test_rng(a, base_rng__, pstream__);
@@ -416,59 +445,69 @@ static constexpr std::array<const char*, 21> locations_array__ =
  " (in 'basic.stanfunctions', line 35, column 31 to line 37, column 1)"};
 
 struct int_only_multiplication_functor__ {
-  int
-  operator()(const int& a, const int& b, std::ostream* pstream__) const;
+  template <typename Ta__, typename Tb__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline int
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Ta__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline void
+  operator()(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  double
-  operator()(const std::vector<int>& a, std::ostream* pstream__) const;
+  template <typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const std::vector<T0__>& a, std::ostream* pstream__) const;
+  template <typename Ta__,
+            stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
+  template <bool propto__, typename Ta__, typename Tb__,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline stan::return_type_t<Ta__, Tb__>
+  operator()(const Ta__& a, const Tb__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename T0__, typename RNG,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
+  template <typename Ta__, typename RNG,
+            stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  operator()(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  my_log1p_exp(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  my_log1p_exp(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -481,10 +520,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  array_fun(const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -497,8 +537,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  int_array_fun(const Ta__& a, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -511,10 +554,11 @@ double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tx__,
+          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+  my_vector_mul_by_5(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     static constexpr bool propto__ = true;
@@ -537,9 +581,13 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-  int_only_multiplication(const int& a, const int& b, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline int
+  int_only_multiplication(const Ta__& a, const Tb__& b,
+                          std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -552,10 +600,11 @@ int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  test_lgamma(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  test_lgamma(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -568,12 +617,13 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ta__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline void
+  test_lp(const Ta__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -584,11 +634,11 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename RNG,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Ta__, typename RNG,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr>
+  inline stan::return_type_t<Ta__>
+  test_rng(const Ta__& a, RNG& base_rng__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -601,12 +651,12 @@ template <typename T0__, typename RNG,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+template <bool propto__, typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>* = nullptr>
+  inline stan::return_type_t<Ta__, Tb__>
+  test_lpdf(const Ta__& a, const Tb__& b, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ta__, Tb__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -617,75 +667,83 @@ template <bool propto__, typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-int_only_multiplication_functor__::operator()(const int& a, const int& b,
+template <typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+inline int
+int_only_multiplication_functor__::operator()(const Ta__& a, const Tb__& b,
                                               std::ostream* pstream__)  const
 {
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+test_lgamma_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return test_lgamma(x, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-void
-test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
+template <bool propto__, typename Ta__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline void
+test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-double
-int_array_fun_functor__::operator()(const std::vector<int>& a,
-                                    std::ostream* pstream__)  const
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ta__>
+int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
+const
 {
   return int_array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-array_fun_functor__::operator()(const std::vector<T0__>& a,
-                                std::ostream* pstream__)  const
+template <typename Ta__,
+          stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar_t<value_type_t<Ta__>>>*>
+inline stan::return_type_t<Ta__>
+array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
+const
 {
   return array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+my_log1p_exp_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return my_log1p_exp(x, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-my_vector_mul_by_5_functor__::operator()(const T0__& x,
+template <typename Tx__, stan::require_t<stan::is_col_vector<Tx__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+my_vector_mul_by_5_functor__::operator()(const Tx__& x,
                                          std::ostream* pstream__)  const
 {
   return my_vector_mul_by_5(x, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
+template <bool propto__, typename Ta__, typename Tb__,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tb__>>*>
+inline stan::return_type_t<Ta__, Tb__>
+test_lpdf_functor__::operator()(const Ta__& a, const Tb__& b,
                                 std::ostream* pstream__)  const
 {
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
+template <typename Ta__, typename RNG,
+          stan::require_t<stan::is_stan_scalar_t<Ta__>>*>
+inline stan::return_type_t<Ta__>
+test_rng_functor__::operator()(const Ta__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
 {
   return test_rng(a, base_rng__, pstream__);
@@ -789,30 +847,33 @@ static constexpr std::array<const char*, 11> locations_array__ =
  " (in 'integrate.stan', line 14, column 23 to line 24, column 3)"};
 
 struct integrand_ode_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  operator()(const T0__& r, const std::vector<T1__>& f,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) const;
+  template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
+            typename Tx_i__,
+            stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
+  operator()(const Tr__& r, const Tf__& f, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 struct ode_integrate_functor__ {
-  double
+  inline double
   operator()(std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  integrand(const T0__& x_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tx__,
+          stan::require_t<stan::is_col_vector<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+  integrand(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     static constexpr bool propto__ = true;
@@ -826,16 +887,18 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  integrand_ode(const T0__& r, const std::vector<T1__>& f,
-                const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-                const std::vector<int>& x_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__,
+          stan::require_t<stan::is_stan_scalar_t<Tr__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
+  integrand_ode(const Tr__& r, const Tf__& f, const Ttheta__& theta,
+                const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -857,7 +920,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double ode_integrate(std::ostream* pstream__) {
+inline double ode_integrate(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -879,30 +942,30 @@ double ode_integrate(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-integrand_ode_functor__::operator()(const T0__& r,
-                                    const std::vector<T1__>& f,
-                                    const std::vector<T2__>& theta,
-                                    const std::vector<T3__>& x_r,
-                                    const std::vector<int>& x_i,
+template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tr__>>*,
+          stan::require_all_t<stan::is_std_vector<Tf__>, stan::is_stan_scalar_t<value_type_t<Tf__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
+integrand_ode_functor__::operator()(const Tr__& r, const Tf__& f,
+                                    const Ttheta__& theta, const Tx_r__& x_r,
+                                    const Tx_i__& x_i,
                                     std::ostream* pstream__)  const
 {
   return integrand_ode(r, f, theta, x_r, x_i, pstream__);
 }
 
-double ode_integrate_functor__::operator()(std::ostream* pstream__)  const
+inline double ode_integrate_functor__::operator()(std::ostream* pstream__) 
+const
 {
   return ode_integrate(pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-integrand_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__, stan::require_t<stan::is_col_vector<Tx__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
+integrand_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return integrand(x, pstream__);

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -42,7 +42,9 @@ struct test_lgamma_functor__ {
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -67,12 +69,15 @@ struct my_vector_mul_by_5_functor__ {
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__, typename RNG,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
@@ -180,7 +185,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -195,7 +201,8 @@ template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, 
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, typename RNG,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -211,7 +218,9 @@ template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -225,7 +234,6 @@ template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 int_only_multiplication_functor__::operator()(const int& a, const int& b,
                                               std::ostream* pstream__)  const
@@ -233,8 +241,7 @@ int_only_multiplication_functor__::operator()(const int& a, const int& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -242,8 +249,8 @@ const
   return test_lgamma(x, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 void
 test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -252,7 +259,6 @@ test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-
 double
 int_array_fun_functor__::operator()(const std::vector<int>& a,
                                     std::ostream* pstream__)  const
@@ -260,8 +266,7 @@ int_array_fun_functor__::operator()(const std::vector<int>& a,
   return int_array_fun(a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 array_fun_functor__::operator()(const std::vector<T0__>& a,
                                 std::ostream* pstream__)  const
@@ -269,8 +274,7 @@ array_fun_functor__::operator()(const std::vector<T0__>& a,
   return array_fun(a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -278,8 +282,7 @@ const
   return my_log1p_exp(x, pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const T0__& x,
                                          std::ostream* pstream__)  const
@@ -287,8 +290,9 @@ my_vector_mul_by_5_functor__::operator()(const T0__& x,
   return my_vector_mul_by_5(x, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
                                 std::ostream* pstream__)  const
@@ -296,8 +300,7 @@ test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -422,7 +425,9 @@ struct test_lgamma_functor__ {
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -447,12 +452,15 @@ struct my_vector_mul_by_5_functor__ {
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
-  template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__, typename RNG,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
@@ -560,7 +568,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -575,7 +584,8 @@ template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, 
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, typename RNG,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -591,7 +601,9 @@ template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -605,7 +617,6 @@ template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 int_only_multiplication_functor__::operator()(const int& a, const int& b,
                                               std::ostream* pstream__)  const
@@ -613,8 +624,7 @@ int_only_multiplication_functor__::operator()(const int& a, const int& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -622,8 +632,8 @@ const
   return test_lgamma(x, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 void
 test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -632,7 +642,6 @@ test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-
 double
 int_array_fun_functor__::operator()(const std::vector<int>& a,
                                     std::ostream* pstream__)  const
@@ -640,8 +649,7 @@ int_array_fun_functor__::operator()(const std::vector<int>& a,
   return int_array_fun(a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 array_fun_functor__::operator()(const std::vector<T0__>& a,
                                 std::ostream* pstream__)  const
@@ -649,8 +657,7 @@ array_fun_functor__::operator()(const std::vector<T0__>& a,
   return array_fun(a, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -658,8 +665,7 @@ const
   return my_log1p_exp(x, pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const T0__& x,
                                          std::ostream* pstream__)  const
@@ -667,8 +673,9 @@ my_vector_mul_by_5_functor__::operator()(const T0__& x,
   return my_vector_mul_by_5(x, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
                                 std::ostream* pstream__)  const
@@ -676,8 +683,7 @@ test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -783,7 +789,11 @@ static constexpr std::array<const char*, 11> locations_array__ =
  " (in 'integrate.stan', line 14, column 23 to line 24, column 3)"};
 
 struct integrand_ode_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& r, const std::vector<T1__>& f,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -816,7 +826,11 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   integrand_ode(const T0__& r, const std::vector<T1__>& f,
                 const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -865,8 +879,11 @@ double ode_integrate(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 integrand_ode_functor__::operator()(const T0__& r,
                                     const std::vector<T1__>& f,
@@ -878,14 +895,12 @@ integrand_ode_functor__::operator()(const T0__& r,
   return integrand_ode(r, f, theta, x_r, x_i, pstream__);
 }
 
-
 double ode_integrate_functor__::operator()(std::ostream* pstream__)  const
 {
   return ode_integrate(pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 integrand_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -69,7 +69,7 @@ struct my_log1p_exp_functor__ {
 struct my_vector_mul_by_5_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename Ta__,
@@ -135,7 +135,7 @@ template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_
     }
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  my_vector_mul_by_5(const Tx__& x, std::ostream* pstream__) {
+  my_vector_mul_by_5(const Tx__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
@@ -296,7 +296,7 @@ const
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-my_vector_mul_by_5_functor__::operator()(const Tx__& x_arg__,
+my_vector_mul_by_5_functor__::operator()(const Tx__& x,
                                          std::ostream* pstream__)  const
 {
   return my_vector_mul_by_5(x, pstream__);
@@ -465,7 +465,7 @@ struct my_log1p_exp_functor__ {
 struct my_vector_mul_by_5_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename Ta__,
@@ -531,7 +531,7 @@ template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_
     }
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  my_vector_mul_by_5(const Tx__& x, std::ostream* pstream__) {
+  my_vector_mul_by_5(const Tx__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
@@ -692,7 +692,7 @@ const
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-my_vector_mul_by_5_functor__::operator()(const Tx__& x_arg__,
+my_vector_mul_by_5_functor__::operator()(const Tx__& x,
                                          std::ostream* pstream__)  const
 {
   return my_vector_mul_by_5(x, pstream__);
@@ -832,12 +832,12 @@ struct ode_integrate_functor__ {
 struct integrand_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-  integrand(const Tx__& x, std::ostream* pstream__) {
+  integrand(const Tx__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
@@ -929,7 +929,7 @@ const
 
 template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, 1>
-integrand_functor__::operator()(const Tx__& x_arg__, std::ostream* pstream__) 
+integrand_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return integrand(x, pstream__);

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -52,12 +52,12 @@ struct test_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
@@ -101,7 +101,7 @@ template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -117,7 +117,7 @@ template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   int_array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -270,7 +270,7 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -278,7 +278,7 @@ const
   return int_array_fun(a, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -448,12 +448,12 @@ struct test_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct int_array_fun_functor__ {
-  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+  template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   operator()(const Ta__& a, std::ostream* pstream__) const;
 };
@@ -497,7 +497,7 @@ template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -513,7 +513,7 @@ template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>* = nullptr>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>* = nullptr>
   inline stan::return_type_t<Ta__>
   int_array_fun(const Ta__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ta__>;
@@ -666,7 +666,7 @@ test_lp_functor__::operator()(const Ta__& a, T_lp__& lp__,
   return test_lp<propto__>(a, lp__, lp_accum__, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, std::is_integral<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 int_array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -674,7 +674,7 @@ const
   return int_array_fun(a, pstream__);
 }
 
-template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<value_type_t<Ta__>>>*>
+template <typename Ta__, stan::require_all_t<stan::is_std_vector<Ta__>, stan::is_stan_scalar<stan::value_type_t<Ta__>>>*>
 inline stan::return_type_t<Ta__>
 array_fun_functor__::operator()(const Ta__& a, std::ostream* pstream__) 
 const
@@ -817,10 +817,10 @@ static constexpr std::array<const char*, 11> locations_array__ =
 struct integrand_ode_functor__ {
   template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
-            stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            stan::is_std_vector<Tf__>, stan::is_stan_scalar<stan::value_type_t<Tf__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tr__& r, const Tf__& f, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -854,10 +854,10 @@ template <typename Tx__, stan::require_all_t<stan::is_col_vector<Tx__>>* = nullp
     }
 template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
-          stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          stan::is_std_vector<Tf__>, stan::is_stan_scalar<stan::value_type_t<Tf__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
   integrand_ode(const Tr__& r, const Tf__& f, const Ttheta__& theta,
                 const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -908,10 +908,10 @@ inline double ode_integrate(std::ostream* pstream__) {
     }
 template <typename Tr__, typename Tf__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tr__>,
-          stan::is_std_vector<Tf__>, stan::is_stan_scalar<value_type_t<Tf__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          stan::is_std_vector<Tf__>, stan::is_stan_scalar<stan::value_type_t<Tf__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tr__, Tf__, Ttheta__, Tx_r__, Tx_i__>>
 integrand_ode_functor__::operator()(const Tr__& r, const Tf__& f,
                                     const Ttheta__& theta, const Tx_r__& x_r,

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2014,27 +2014,30 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  operator()(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) const;
+  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+            typename Tx_i__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+  operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  simple_SIR(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+  simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2084,17 +2087,17 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
-                                 const std::vector<T2__>& theta,
-                                 const std::vector<T3__>& x_r,
-                                 const std::vector<int>& x_i,
-                                 std::ostream* pstream__)  const
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
+                                 const Ttheta__& theta, const Tx_r__& x_r,
+                                 const Tx_i__& x_i, std::ostream* pstream__) 
+const
 {
   return simple_SIR(t, y, theta, x_r, x_i, pstream__);
 }
@@ -2782,24 +2785,33 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'copy_fail.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2833,8 +2845,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2874,16 +2888,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -3032,28 +3047,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -9213,24 +9234,33 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 47, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -9264,8 +9294,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -9305,16 +9337,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -9463,28 +9496,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -10969,39 +11008,48 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
+  template <typename Tp__, typename Tphi__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__,
-            typename T6__, typename T7__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
-  void
-  operator()(const std::vector<std::vector<int>>& y,
-             const std::vector<int>& first, const std::vector<int>& last,
-             const T3__& p, const T4__& phi, const T5__& psi, const T6__& nu,
-             const T7__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
-             std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__, typename Tfirst__,
+            typename Tlast__, typename Tp__, typename Tphi__,
+            typename Tpsi__, typename Tnu__, typename Tchi__,
+            typename T_lp__, typename T_lp_accum__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+             T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11035,8 +11083,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11076,15 +11126,12 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11240,24 +11287,25 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr> void
-  js_super_lp(const std::vector<std::vector<int>>& y,
-              const std::vector<int>& first, const std::vector<int>& last,
-              const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
-              const T6__& nu_arg__, const T7__& chi_arg__, T_lp__& lp__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
+          typename Tchi__, typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T3__>,
-                                 stan::value_type_t<T4__>, T5__,
-                                 stan::value_type_t<T6__>,
-                                 stan::value_type_t<T7__>>;
+            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
+                                stan::return_type_t<Tpsi__, Tnu__, Tchi__>>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11804,45 +11852,51 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*>
-void
-js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
-                                  const std::vector<int>& first,
-                                  const std::vector<int>& last,
-                                  const T3__& p, const T4__& phi,
-                                  const T5__& psi, const T6__& nu,
-                                  const T7__& chi, T_lp__& lp__,
-                                  T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
+          typename Tchi__, typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>*,
+          stan::require_t<stan::is_col_vector<Tnu__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+inline void
+js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
+                                  const Tlast__& last, const Tp__& p,
+                                  const Tphi__& phi, const Tpsi__& psi,
+                                  const Tnu__& nu, const Tchi__& chi,
+                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -15831,24 +15885,33 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'fails-test.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15882,8 +15945,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15923,16 +15988,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -16081,28 +16147,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -17632,42 +17704,53 @@ static constexpr std::array<const char*, 144> locations_array__ =
  " (in 'inlining-fail2.stan', line 157, column 4 to column 26)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__,
-            typename T6__, typename T_lp__, typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
-  void
-  operator()(const std::vector<std::vector<int>>& y,
-             const std::vector<int>& first, const std::vector<int>& last,
-             const T3__& p, const T4__& phi, const T5__& gamma,
-             const T6__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+  template <bool propto__, typename Ty__, typename Tfirst__,
+            typename Tlast__, typename Tp__, typename Tphi__,
+            typename Tgamma__, typename Tchi__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  operator()(const T0__& gamma, std::ostream* pstream__) const;
+  template <typename Tgamma__,
+            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
+  template <typename Tp__, typename Tphi__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -17701,8 +17784,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -17742,15 +17827,12 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -17906,23 +17988,24 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr> void
-  jolly_seber_lp(const std::vector<std::vector<int>>& y,
-                 const std::vector<int>& first, const std::vector<int>& last,
-                 const T3__& p_arg__, const T4__& phi_arg__,
-                 const T5__& gamma_arg__, const T6__& chi_arg__,
-                 T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
+          typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+                 const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+                 const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T3__>,
-                                 stan::value_type_t<T4__>,
-                                 stan::value_type_t<T5__>,
-                                 stan::value_type_t<T6__>>;
+            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
+                                stan::return_type_t<Tgamma__, Tchi__>>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -18461,10 +18544,11 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tgamma__,
+          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+  seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tgamma__>;
     int current_statement__ = 0; 
     const auto& gamma = stan::math::to_ref(gamma_arg__);
     static constexpr bool propto__ = true;
@@ -18523,52 +18607,60 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_eigen_matrix_dynamic_t<T6__>*>
-void
-jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
-                                     const std::vector<int>& first,
-                                     const std::vector<int>& last,
-                                     const T3__& p, const T4__& phi,
-                                     const T5__& gamma, const T6__& chi,
-                                     T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
+          typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
+          stan::require_t<stan::is_col_vector<Tgamma__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+inline void
+jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
+                                     const Tlast__& last, const Tp__& p,
+                                     const Tphi__& phi,
+                                     const Tgamma__& gamma,
+                                     const Tchi__& chi, T_lp__& lp__,
+                                     T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
   return jolly_seber_lp<propto__>(y, first, last, p, phi, gamma, chi, lp__,
            lp_accum__, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
-const
+template <typename Tgamma__, stan::require_t<stan::is_col_vector<Tgamma__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+seq_cprob_functor__::operator()(const Tgamma__& gamma,
+                                std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
 }
 
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -21845,24 +21937,33 @@ static constexpr std::array<const char*, 65> locations_array__ =
  " (in 'lcm-fails2.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -21896,8 +21997,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -21937,16 +22040,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -22095,28 +22199,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -23366,31 +23476,32 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'lupdf-inlining.stan', line 9, column 8 to column 32)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <bool propto__, typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
+  template <bool propto__, typename Tn__, typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tn__, Tmu__>
+  operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
+  template <bool propto__, typename Tx__, typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Tmu__>
+  operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+template <bool propto__, typename Tx__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Tmu__>
+  foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -23404,11 +23515,12 @@ template <bool propto__, typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T1__>;
+template <bool propto__, typename Tn__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tn__, Tmu__>
+  bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -23422,11 +23534,11 @@ template <bool propto__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  baz_lpdf(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <bool propto__, typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  baz_lpdf(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -23440,26 +23552,29 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
+template <bool propto__, typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T1__>
-bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
+template <bool propto__, typename Tn__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline stan::return_type_t<Tn__, Tmu__>
+bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
+template <bool propto__, typename Tx__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline stan::return_type_t<Tx__, Tmu__>
+foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return foo_lpdf<propto__>(x, mu, pstream__);
@@ -25685,29 +25800,34 @@ static constexpr std::array<const char*, 93> locations_array__ =
  " (in 'optimizations.stan', line 16, column 8 to column 18)"};
 
 struct rfun_functor__ {
-  int
-  operator()(const int& y, std::ostream* pstream__) const;
+  template <typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline int
+  operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
   template <bool propto__, typename T_lp__, typename T_lp_accum__>
-  int
+  inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& x, const int& y, T_lp__& lp__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline void
+  operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline void
+  nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25726,8 +25846,10 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int rfun(const int& y, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline int rfun(const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25750,7 +25872,7 @@ int rfun(const int& y, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -25767,23 +25889,27 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int rfun_functor__::operator()(const int& y, std::ostream* pstream__)  const
+template <typename Ty__, stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline int
+rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
 template <bool propto__, typename T_lp__, typename T_lp_accum__>
-int
+inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-void
-nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline void
+nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
                                std::ostream* pstream__)  const
 {
@@ -26789,16 +26915,21 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  double
-  operator()(const int& x, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__> dumb(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  dumb(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26814,8 +26945,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double dumb(const int& x, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  dumb(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26831,15 +26965,16 @@ double dumb(const int& x, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double dumb_functor__::operator()(const int& x, std::ostream* pstream__) 
-const
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2014,28 +2014,28 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+  template <typename Tt__, typename Ty__, typename Ttheta__,
+            typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) const;
 };
 
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>;
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2085,17 +2085,16 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
-inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
-                                 const Tx_i__& x_i, std::ostream* pstream__) 
-const
+                                 const std::vector<int>& x_i,
+                                 std::ostream* pstream__)  const
 {
   return simple_SIR(t, y, theta, x_r, x_i, pstream__);
 }
@@ -2783,29 +2782,25 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'copy_fail.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2839,9 +2834,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2881,17 +2876,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -3040,32 +3031,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -9225,29 +9211,25 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 47, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -9281,9 +9263,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -9323,17 +9305,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -9482,32 +9460,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -10992,9 +10965,8 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tp__,
@@ -11004,32 +10976,27 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename Ty__, typename Tfirst__,
-            typename Tlast__, typename Tp__, typename Tphi__,
-            typename Tpsi__, typename Tnu__, typename Tchi__,
-            typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+            typename Tnu__, typename Tchi__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
-  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  operator()(const std::vector<std::vector<int>>& y,
+             const std::vector<int>& first, const std::vector<int>& last,
              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11063,9 +11030,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11267,24 +11234,20 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+          typename Tnu__, typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
-  js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  js_super_lp(const std::vector<std::vector<int>>& y,
+              const std::vector<int>& first, const std::vector<int>& last,
               const Tp__& p_arg__, const Tphi__& phi_arg__,
               const Tpsi__& psi, const Tnu__& nu_arg__,
               const Tchi__& chi_arg__, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
-                                stan::return_type_t<Tpsi__, Tnu__, Tchi__>>;
+            stan::return_type_t<Tp__, Tphi__, Tpsi__, Tnu__, Tchi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11831,9 +11794,8 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
@@ -11849,30 +11811,27 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+          typename Tnu__, typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
-js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p,
-                                  const Tphi__& phi, const Tpsi__& psi,
-                                  const Tnu__& nu, const Tchi__& chi,
-                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
+js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
+                                  const std::vector<int>& first,
+                                  const std::vector<int>& last,
+                                  const Tp__& p, const Tphi__& phi,
+                                  const Tpsi__& psi, const Tnu__& nu,
+                                  const Tchi__& chi, T_lp__& lp__,
+                                  T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -15861,29 +15820,25 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'fails-test.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15917,9 +15872,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -15959,17 +15914,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -16118,32 +16069,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -17673,26 +17619,22 @@ static constexpr std::array<const char*, 144> locations_array__ =
  " (in 'inlining-fail2.stan', line 157, column 4 to column 26)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename Ty__, typename Tfirst__,
-            typename Tlast__, typename Tp__, typename Tphi__,
-            typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+            typename Tchi__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_col_vector<Tgamma__>,
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
-  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  operator()(const std::vector<std::vector<int>>& y,
+             const std::vector<int>& first, const std::vector<int>& last,
              const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
              const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
@@ -17700,9 +17642,8 @@ struct seq_cprob_functor__ {
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tp__,
@@ -17712,9 +17653,9 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -17748,9 +17689,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -17952,24 +17893,20 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
-  jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  jolly_seber_lp(const std::vector<std::vector<int>>& y,
+                 const std::vector<int>& first, const std::vector<int>& last,
                  const Tp__& p_arg__, const Tphi__& phi_arg__,
                  const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
-                                stan::return_type_t<Tgamma__, Tchi__>>;
+            stan::return_type_t<Tp__, Tphi__, Tgamma__, Tchi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -18570,20 +18507,17 @@ template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
-jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last, const Tp__& p,
-                                     const Tphi__& phi,
+jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
+                                     const std::vector<int>& first,
+                                     const std::vector<int>& last,
+                                     const Tp__& p, const Tphi__& phi,
                                      const Tgamma__& gamma,
                                      const Tchi__& chi, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -18593,10 +18527,9 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -18609,9 +18542,8 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
@@ -21898,29 +21830,25 @@ static constexpr std::array<const char*, 65> locations_array__ =
  " (in 'lcm-fails2.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -21954,9 +21882,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -21996,17 +21924,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -22155,32 +22079,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -23436,11 +23355,10 @@ struct baz_lpdf_functor__ {
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename Tn__,
-            typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-            stan::is_stan_scalar<Tmu__>>* = nullptr>
-  inline stan::return_type_t<Tn__, Tmu__>
-  operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
+  template <bool propto__,
+            typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tmu__>
+  operator()(const int n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Tx__,
@@ -23469,12 +23387,11 @@ template <bool propto__, typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tn__,
-          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-          stan::is_stan_scalar<Tmu__>>* = nullptr>
-  inline stan::return_type_t<Tn__, Tmu__>
-  bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
+template <bool propto__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tmu__>
+  bar_lpmf(const int n, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -23514,11 +23431,10 @@ baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename Tn__,
-          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-          stan::is_stan_scalar<Tmu__>>*>
-inline stan::return_type_t<Tn__, Tmu__>
-bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
+template <bool propto__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>*>
+inline stan::return_type_t<Tmu__>
+bar_lpmf_functor__::operator()(const int n, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return bar_lpmf<propto__>(n, mu, pstream__);
@@ -25754,31 +25670,28 @@ static constexpr std::array<const char*, 93> locations_array__ =
  " (in 'optimizations.stan', line 16, column 8 to column 18)"};
 
 struct rfun_functor__ {
-  template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int
-  operator()(const Ty__& y, std::ostream* pstream__) const;
+  operator()(const int y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<>* = nullptr>
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
   inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-            std::is_integral<Ty__>>* = nullptr>
+  template <bool propto__, typename Tx__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline void
-  operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
+  operator()(const Tx__& x, const int y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-          std::is_integral<Ty__>>* = nullptr> inline void
-  nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  inline void
+  nrfun_lp(const Tx__& x, const int y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -25797,9 +25710,8 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline int rfun(const Ty__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__>;
+inline int rfun(const int y, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -25822,8 +25734,7 @@ template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<>* = nullptr> inline int
+template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -25840,15 +25751,13 @@ template <bool propto__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
-inline int
-rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
+inline int rfun_functor__::operator()(const int y, std::ostream* pstream__) 
+const
 {
   return rfun(y, pstream__);
 }
 
-template <bool propto__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<>*>
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
 inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
@@ -25856,11 +25765,10 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-          std::is_integral<Ty__>>*>
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline void
-nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
+nrfun_lp_functor__::operator()(const Tx__& x, const int y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
                                std::ostream* pstream__)  const
 {
@@ -26866,9 +26774,8 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
-  inline stan::return_type_t<Tx__>
-  operator()(const Tx__& x, std::ostream* pstream__) const;
+  inline double
+  operator()(const int x, std::ostream* pstream__) const;
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
@@ -26893,10 +26800,8 @@ template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
-  inline stan::return_type_t<Tx__>
-  dumb(const Tx__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tx__>;
+inline double dumb(const int x, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -26912,9 +26817,8 @@ template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>*>
-inline stan::return_type_t<Tx__>
-dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
+inline double
+dumb_functor__::operator()(const int x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2795,8 +2795,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -2889,7 +2888,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -3056,8 +3056,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -9238,8 +9237,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -9332,7 +9330,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -9499,8 +9498,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -11003,8 +11001,7 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11025,8 +11022,8 @@ struct js_super_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p_arg__, const Tphi__& phi_arg__, const Tpsi__& psi,
-             const Tnu__& nu_arg__, const Tchi__& chi_arg__, T_lp__& lp__,
+             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
@@ -11112,7 +11109,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+  prob_uncaptured(const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -11280,8 +11278,9 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
-              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+              const Tp__& p_arg__, const Tphi__& phi_arg__,
+              const Tpsi__& psi, const Tnu__& nu_arg__,
+              const Tchi__& chi_arg__, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
@@ -11844,8 +11843,7 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -11871,11 +11869,10 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p_arg__,
-                                  const Tphi__& phi_arg__, const Tpsi__& psi,
-                                  const Tnu__& nu_arg__,
-                                  const Tchi__& chi_arg__, T_lp__& lp__,
-                                  T_lp_accum__& lp_accum__,
+                                  const Tlast__& last, const Tp__& p,
+                                  const Tphi__& phi, const Tpsi__& psi,
+                                  const Tnu__& nu, const Tchi__& chi,
+                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -15876,8 +15873,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -15970,7 +15966,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -16137,8 +16134,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -17689,9 +17685,9 @@ struct jolly_seber_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
-             T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -17701,7 +17697,7 @@ struct last_capture_functor__ {
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  operator()(const Tgamma__& gamma_arg__, std::ostream* pstream__) const;
+  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -17713,8 +17709,7 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -17799,7 +17794,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+  prob_uncaptured(const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -17967,8 +17963,9 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-                 const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
-                 const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+                 const Tp__& p_arg__, const Tphi__& phi_arg__,
+                 const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
+                 T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
@@ -18513,7 +18510,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
     }
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
+  seq_cprob(const Tgamma__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tgamma__>;
     int current_statement__ = 0; 
     const auto& gamma = stan::math::to_ref(gamma_arg__);
@@ -18585,11 +18582,10 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last,
-                                     const Tp__& p_arg__,
-                                     const Tphi__& phi_arg__,
-                                     const Tgamma__& gamma_arg__,
-                                     const Tchi__& chi_arg__, T_lp__& lp__,
+                                     const Tlast__& last, const Tp__& p,
+                                     const Tphi__& phi,
+                                     const Tgamma__& gamma,
+                                     const Tchi__& chi, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
@@ -18607,7 +18603,7 @@ const
 
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-seq_cprob_functor__::operator()(const Tgamma__& gamma_arg__,
+seq_cprob_functor__::operator()(const Tgamma__& gamma,
                                 std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
@@ -18625,8 +18621,7 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -21915,8 +21910,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -22009,7 +22003,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -22176,8 +22171,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2014,14 +2014,22 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -2076,8 +2084,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -2775,7 +2786,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -2861,7 +2874,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -3017,7 +3032,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -3025,8 +3039,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -3035,7 +3050,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -9203,7 +9217,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -9289,7 +9305,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -9445,7 +9463,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -9453,8 +9470,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -9463,7 +9481,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -10956,7 +10973,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -10965,7 +10984,14 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
+  template <bool propto__, typename T3__, typename T4__, typename T5__,
+            typename T6__, typename T7__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11050,7 +11076,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -11212,8 +11240,14 @@ template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
-  void
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T7__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr> void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
               const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
@@ -11770,7 +11804,6 @@ template <bool propto__, typename T3__, typename T4__, typename T5__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -11778,15 +11811,15 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -11795,8 +11828,13 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T7__, typename T_lp__,
+          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
+          stan::require_eigen_matrix_dynamic_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_eigen_matrix_dynamic_t<T7__>*>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -15797,7 +15835,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -15883,7 +15923,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -16039,7 +16081,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -16047,8 +16088,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -16057,7 +16099,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -17591,7 +17632,12 @@ static constexpr std::array<const char*, 144> locations_array__ =
  " (in 'inlining-fail2.stan', line 157, column 4 to column 26)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
+  template <bool propto__, typename T3__, typename T4__, typename T5__,
+            typename T6__, typename T_lp__, typename T_lp_accum__,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+            stan::require_col_vector_t<T5__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -17613,7 +17659,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -17694,7 +17742,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -17856,8 +17906,12 @@ template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
-  void
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T_lp__, typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+          stan::require_col_vector_t<T5__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr> void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
                  const T3__& p_arg__, const T4__& phi_arg__,
@@ -18469,8 +18523,12 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T_lp__, typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>*,
+          stan::require_eigen_matrix_dynamic_t<T4__>*,
+          stan::require_col_vector_t<T5__>*,
+          stan::require_eigen_matrix_dynamic_t<T6__>*>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -18484,7 +18542,6 @@ jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
            lp_accum__, pstream__);
 }
 
-
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
                                    std::ostream* pstream__)  const
@@ -18492,15 +18549,13 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
 {
   return seq_cprob(gamma, pstream__);
 }
-
 
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -18509,8 +18564,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -21793,7 +21849,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -21879,7 +21937,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -22035,7 +22095,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -22043,8 +22102,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -22053,7 +22113,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -23307,22 +23366,28 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'lupdf-inlining.stan', line 9, column 8 to column 32)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T1__,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -23339,7 +23404,8 @@ template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -23356,7 +23422,8 @@ template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -23373,16 +23440,14 @@ template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -23390,8 +23455,9 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -25623,17 +25689,21 @@ struct rfun_functor__ {
   operator()(const int& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
@@ -25697,22 +25767,21 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int rfun_functor__::operator()(const int& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
-
-template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
+int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -26762,15 +26831,13 @@ double dumb(const int& x, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 double dumb_functor__::operator()(const int& x, std::ostream* pstream__) 
 const
 {
   return dumb(x, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2016,10 +2016,10 @@ static constexpr std::array<const char*, 35> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -2027,10 +2027,10 @@ struct simple_SIR_functor__ {
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -2087,10 +2087,10 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -2783,7 +2783,7 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'copy_fail.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -2798,12 +2798,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -2839,7 +2839,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -3039,7 +3039,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -3061,7 +3061,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -9224,7 +9224,7 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 47, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -9239,12 +9239,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -9280,7 +9280,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -9480,7 +9480,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -9502,7 +9502,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -10990,7 +10990,7 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11002,7 +11002,7 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11011,9 +11011,9 @@ struct js_super_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
             typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
             stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -11025,7 +11025,7 @@ struct js_super_lp_functor__ {
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11061,7 +11061,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11267,9 +11267,9 @@ template <typename Tp__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -11827,7 +11827,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -11845,7 +11845,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11856,9 +11856,9 @@ const
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -15857,7 +15857,7 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'fails-test.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -15872,12 +15872,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -15913,7 +15913,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -16113,7 +16113,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -16135,7 +16135,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -17671,9 +17671,9 @@ struct jolly_seber_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
             stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_col_vector<Tgamma__>,
@@ -17685,7 +17685,7 @@ struct jolly_seber_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -17695,7 +17695,7 @@ struct seq_cprob_functor__ {
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -17707,7 +17707,7 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -17743,7 +17743,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -17949,9 +17949,9 @@ template <typename Tp__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
@@ -18566,9 +18566,9 @@ template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
@@ -18586,7 +18586,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -18602,7 +18602,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -21891,7 +21891,7 @@ static constexpr std::array<const char*, 65> locations_array__ =
  " (in 'lcm-fails2.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -21906,12 +21906,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -21947,7 +21947,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -22147,7 +22147,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -22169,7 +22169,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2014,14 +2014,14 @@ static constexpr std::array<const char*, 35> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -2077,7 +2077,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -2775,7 +2775,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -2861,7 +2861,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -3026,7 +3026,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -9203,7 +9203,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -9289,7 +9289,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -9454,7 +9454,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -10956,7 +10956,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -10965,7 +10965,7 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11050,7 +11050,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -11212,7 +11212,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
@@ -11779,7 +11779,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -11796,7 +11796,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -15797,7 +15797,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -15883,7 +15883,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -16048,7 +16048,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -17591,7 +17591,7 @@ static constexpr std::array<const char*, 144> locations_array__ =
  " (in 'inlining-fail2.stan', line 157, column 4 to column 26)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -17604,7 +17604,7 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   operator()(const T0__& gamma, std::ostream* pstream__) const;
 };
@@ -17613,7 +17613,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -17694,7 +17694,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -17856,7 +17856,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
@@ -18407,7 +18407,7 @@ template <bool propto__, typename T3__, typename T4__, typename T5__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -18470,7 +18470,7 @@ template <typename T0__>
     }
     }
 
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -18493,7 +18493,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
@@ -18510,7 +18510,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -21793,7 +21793,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -21879,7 +21879,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -22044,7 +22044,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -23307,20 +23307,22 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'lupdf-inlining.stan', line 9, column 8 to column 32)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__>
+  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -23337,7 +23339,8 @@ template <bool propto__, typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
     int current_statement__ = 0; 
@@ -23353,7 +23356,8 @@ template <bool propto__, typename T1__> stan::promote_args_t<T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -23370,14 +23374,16 @@ template <bool propto__, typename T0__> stan::promote_args_t<T0__>
     }
     }
 
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
 
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
 {
@@ -23385,7 +23391,7 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
 }
 
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -25621,13 +25627,13 @@ struct rfun_lp_functor__ {
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
@@ -25706,7 +25712,7 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -26716,12 +26722,13 @@ static constexpr std::array<const char*, 6> locations_array__ =
 struct dumb_functor__ {
   double
   operator()(const int& x, std::ostream* pstream__) const;
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
-  dumb(const T0__& x, std::ostream* pstream__) {
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__> dumb(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -26763,7 +26770,8 @@ const
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2015,24 +2015,22 @@ static constexpr std::array<const char*, 35> locations_array__ =
 
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -2088,11 +2086,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -2785,31 +2783,27 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'copy_fail.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -2845,8 +2839,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -2889,11 +2882,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -3047,8 +3039,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -3057,10 +3048,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -3070,8 +3061,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -9234,31 +9224,27 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 47, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -9294,8 +9280,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -9338,11 +9323,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -9496,8 +9480,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -9506,10 +9489,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -9519,8 +9502,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11008,21 +10990,19 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tp__, typename Tphi__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11030,15 +11010,14 @@ struct js_super_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
-            typename T_lp__, typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+            typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>,
+            stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+            stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
@@ -11046,8 +11025,7 @@ struct js_super_lp_functor__ {
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11083,8 +11061,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11126,9 +11103,9 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
@@ -11289,16 +11266,14 @@ template <typename Tp__, typename Tphi__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
-  inline void
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
               const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
               const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
@@ -11852,8 +11827,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -11861,9 +11835,9 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
@@ -11871,8 +11845,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11882,15 +11855,14 @@ const
 
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_stan_scalar<Tpsi__>>*,
-          stan::require_t<stan::is_col_vector<Tnu__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
                                   const Tlast__& last, const Tp__& p,
@@ -15885,31 +15857,27 @@ static constexpr std::array<const char*, 69> locations_array__ =
  " (in 'fails-test.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -15945,8 +15913,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -15989,11 +15956,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -16147,8 +16113,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -16157,10 +16122,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -16170,8 +16135,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -17707,14 +17671,13 @@ struct jolly_seber_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>,
+            stan::is_col_vector<Tgamma__>,
+            stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
              const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
@@ -17722,33 +17685,29 @@ struct jolly_seber_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename Tgamma__,
-            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tp__, typename Tphi__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -17784,8 +17743,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -17827,9 +17785,9 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
@@ -17990,15 +17948,14 @@ template <typename Tp__, typename Tphi__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
-  inline void
+          typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_col_vector<Tgamma__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
                  const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
                  const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
@@ -18544,8 +18501,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tgamma__,
-          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
   seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tgamma__>;
@@ -18609,14 +18565,14 @@ template <typename Tgamma__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_col_vector<Tgamma__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+          typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_col_vector<Tgamma__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
                                      const Tlast__& last, const Tp__& p,
@@ -18630,8 +18586,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -18639,7 +18594,7 @@ const
   return last_capture(y_i, pstream__);
 }
 
-template <typename Tgamma__, stan::require_t<stan::is_col_vector<Tgamma__>>*>
+template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
 seq_cprob_functor__::operator()(const Tgamma__& gamma,
                                 std::ostream* pstream__)  const
@@ -18647,8 +18602,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -18656,9 +18610,9 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
@@ -21937,31 +21891,27 @@ static constexpr std::array<const char*, 65> locations_array__ =
  " (in 'lcm-fails2.stan', line 45, column 4 to column 15)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -21997,8 +21947,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -22041,11 +21990,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -22199,8 +22147,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -22209,10 +22156,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -22222,8 +22169,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -23476,29 +23422,29 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'lupdf-inlining.stan', line 9, column 8 to column 32)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <bool propto__,
+            typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename Tn__, typename Tmu__,
-            stan::require_t<std::is_integral<Tn__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <bool propto__, typename Tn__,
+            typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+            stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename Tx__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <bool propto__, typename Tx__,
+            typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <bool propto__, typename Tx__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
@@ -23515,9 +23461,9 @@ template <bool propto__, typename Tx__, typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<std::is_integral<Tn__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <bool propto__, typename Tn__,
+          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+          stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
@@ -23534,8 +23480,8 @@ template <bool propto__, typename Tn__, typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <bool propto__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   baz_lpdf(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -23552,17 +23498,17 @@ template <bool propto__, typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <bool propto__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<std::is_integral<Tn__>>*,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <bool propto__, typename Tn__,
+          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+          stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tn__, Tmu__>
 bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -23570,9 +23516,9 @@ bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <bool propto__, typename Tx__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tx__, Tmu__>
 foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -25800,29 +25746,28 @@ static constexpr std::array<const char*, 93> locations_array__ =
  " (in 'optimizations.stan', line 16, column 8 to column 18)"};
 
 struct rfun_functor__ {
-  template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
+  template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<>* = nullptr>
   inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
   template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            std::is_integral<Ty__>>* = nullptr>
   inline void
   operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr> inline void
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          std::is_integral<Ty__>>* = nullptr> inline void
   nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -25844,7 +25789,7 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
+template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int rfun(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
@@ -25869,7 +25814,8 @@ template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
+template <bool propto__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<>* = nullptr> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -25886,14 +25832,15 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<std::is_integral<Ty__>>*>
+template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
 inline int
 rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
-template <bool propto__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<>*>
 inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
@@ -25902,9 +25849,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<std::is_integral<Ty__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          std::is_integral<Ty__>>*>
 inline void
 nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -26912,17 +26858,15 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -26941,7 +26885,7 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -26960,14 +26904,14 @@ template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_t<std::is_integral<Tx__>>*>
+template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2016,11 +2016,11 @@ static constexpr std::array<const char*, 35> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -2028,11 +2028,11 @@ struct simple_SIR_functor__ {
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -2088,11 +2088,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -2786,15 +2786,15 @@ static constexpr std::array<const char*, 69> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -2803,13 +2803,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -2846,7 +2846,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -2890,8 +2890,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -3048,7 +3048,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -3057,8 +3057,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -3071,7 +3071,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -9235,15 +9235,15 @@ static constexpr std::array<const char*, 71> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -9252,13 +9252,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -9295,7 +9295,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -9339,8 +9339,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -9497,7 +9497,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -9506,8 +9506,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -9520,7 +9520,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11009,7 +11009,7 @@ static constexpr std::array<const char*, 146> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11022,7 +11022,7 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11031,12 +11031,12 @@ struct js_super_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
             typename T_lp__, typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
@@ -11047,7 +11047,7 @@ struct js_super_lp_functor__ {
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11084,7 +11084,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11290,12 +11290,12 @@ template <typename Tp__, typename Tphi__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
@@ -11853,7 +11853,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -11872,7 +11872,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11883,12 +11883,12 @@ const
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>*,
+          stan::require_t<stan::is_stan_scalar<Tpsi__>>*,
           stan::require_t<stan::is_col_vector<Tnu__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
@@ -15886,15 +15886,15 @@ static constexpr std::array<const char*, 69> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -15903,13 +15903,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -15946,7 +15946,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -15990,8 +15990,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -16148,7 +16148,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -16157,8 +16157,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -16171,7 +16171,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -17708,9 +17708,9 @@ struct jolly_seber_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
@@ -17723,7 +17723,7 @@ struct jolly_seber_lp_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -17735,7 +17735,7 @@ struct seq_cprob_functor__ {
 };
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -17748,7 +17748,7 @@ struct prob_uncaptured_functor__ {
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -17785,7 +17785,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -17991,9 +17991,9 @@ template <typename Tp__, typename Tphi__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
@@ -18610,9 +18610,9 @@ template <typename Tgamma__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
           stan::require_t<stan::is_col_vector<Tgamma__>>*,
@@ -18631,7 +18631,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -18648,7 +18648,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -21938,15 +21938,15 @@ static constexpr std::array<const char*, 65> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -21955,13 +21955,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -21998,7 +21998,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -22042,8 +22042,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -22200,7 +22200,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -22209,8 +22209,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -22223,7 +22223,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -23477,28 +23477,28 @@ static constexpr std::array<const char*, 13> locations_array__ =
 
 struct baz_lpdf_functor__ {
   template <bool propto__, typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
   template <bool propto__, typename Tn__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<std::is_integral<Tn__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Tx__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
@@ -23516,8 +23516,8 @@ template <bool propto__, typename Tx__, typename Tmu__,
     }
     }
 template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<std::is_integral<Tn__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
@@ -23535,7 +23535,7 @@ template <bool propto__, typename Tn__, typename Tmu__,
     }
     }
 template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   baz_lpdf(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -23553,7 +23553,7 @@ template <bool propto__, typename Tx__,
     }
     }
 template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -23561,8 +23561,8 @@ baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 }
 
 template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+          stan::require_t<std::is_integral<Tn__>>*,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tn__, Tmu__>
 bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -23571,8 +23571,8 @@ bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
 }
 
 template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tx__, Tmu__>
 foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -25800,8 +25800,7 @@ static constexpr std::array<const char*, 93> locations_array__ =
  " (in 'optimizations.stan', line 16, column 8 to column 18)"};
 
 struct rfun_functor__ {
-  template <typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline int
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
@@ -25813,8 +25812,8 @@ struct rfun_lp_functor__ {
 struct nrfun_lp_functor__ {
   template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline void
   operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
@@ -25822,9 +25821,8 @@ struct nrfun_lp_functor__ {
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
-  inline void
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<std::is_integral<Ty__>>* = nullptr> inline void
   nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -25846,8 +25844,7 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline int rfun(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
@@ -25889,7 +25886,7 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+template <typename Ty__, stan::require_t<std::is_integral<Ty__>>*>
 inline int
 rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
@@ -25906,8 +25903,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<std::is_integral<Ty__>>*>
 inline void
 nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -26915,18 +26912,17 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -26945,8 +26941,7 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -26965,14 +26960,14 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<std::is_integral<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2795,7 +2795,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -3055,7 +3056,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -9236,7 +9238,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -9496,7 +9499,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -10999,7 +11003,8 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11020,8 +11025,8 @@ struct js_super_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
-             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+             const Tp__& p_arg__, const Tphi__& phi_arg__, const Tpsi__& psi,
+             const Tnu__& nu_arg__, const Tchi__& chi_arg__, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
@@ -11839,7 +11844,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
+prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -11865,10 +11871,11 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p,
-                                  const Tphi__& phi, const Tpsi__& psi,
-                                  const Tnu__& nu, const Tchi__& chi,
-                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
+                                  const Tlast__& last, const Tp__& p_arg__,
+                                  const Tphi__& phi_arg__, const Tpsi__& psi,
+                                  const Tnu__& nu_arg__,
+                                  const Tchi__& chi_arg__, T_lp__& lp__,
+                                  T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -15869,7 +15876,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -16129,7 +16137,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -17680,9 +17689,9 @@ struct jolly_seber_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
-             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
-             std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
+             T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -17692,7 +17701,7 @@ struct last_capture_functor__ {
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
+  operator()(const Tgamma__& gamma_arg__, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -17704,7 +17713,8 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -18575,10 +18585,11 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last, const Tp__& p,
-                                     const Tphi__& phi,
-                                     const Tgamma__& gamma,
-                                     const Tchi__& chi, T_lp__& lp__,
+                                     const Tlast__& last,
+                                     const Tp__& p_arg__,
+                                     const Tphi__& phi_arg__,
+                                     const Tgamma__& gamma_arg__,
+                                     const Tchi__& chi_arg__, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
@@ -18596,7 +18607,7 @@ const
 
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-seq_cprob_functor__::operator()(const Tgamma__& gamma,
+seq_cprob_functor__::operator()(const Tgamma__& gamma_arg__,
                                 std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
@@ -18614,7 +18625,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
+prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -21903,7 +21915,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -22163,7 +22176,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -678,14 +678,14 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -736,7 +736,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -1821,7 +1821,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -1878,7 +1878,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -1950,7 +1950,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -7056,7 +7056,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -7113,7 +7113,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -7189,7 +7189,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -8121,7 +8121,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -8130,7 +8130,7 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -8186,7 +8186,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -8254,7 +8254,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
@@ -8508,7 +8508,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -8525,7 +8525,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -10918,7 +10918,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -10975,7 +10975,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -11047,7 +11047,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -11969,7 +11969,7 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11982,7 +11982,7 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   operator()(const T0__& gamma, std::ostream* pstream__) const;
 };
@@ -11991,7 +11991,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -12043,7 +12043,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -12111,7 +12111,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
@@ -12355,7 +12355,7 @@ template <bool propto__, typename T3__, typename T4__, typename T5__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -12398,7 +12398,7 @@ template <typename T0__>
     }
     }
 
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -12421,7 +12421,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
@@ -12438,7 +12438,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -14491,7 +14491,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -14548,7 +14548,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -14620,7 +14620,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -15316,20 +15316,22 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__>
+  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -15343,7 +15345,8 @@ template <bool propto__, typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
     int current_statement__ = 0; 
@@ -15356,7 +15359,8 @@ template <bool propto__, typename T1__> stan::promote_args_t<T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -15370,14 +15374,16 @@ template <bool propto__, typename T0__> stan::promote_args_t<T0__>
     }
     }
 
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
 
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
 {
@@ -15385,7 +15391,7 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
 }
 
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -17334,13 +17340,13 @@ struct rfun_lp_functor__ {
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
@@ -17409,7 +17415,7 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -18130,12 +18136,13 @@ static constexpr std::array<const char*, 6> locations_array__ =
 struct dumb_functor__ {
   double
   operator()(const int& x, std::ostream* pstream__) const;
-  template <typename T0__> stan::promote_args_t<T0__>
+  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__> stan::promote_args_t<T0__>
-  dumb(const T0__& x, std::ostream* pstream__) {
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__> dumb(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -18171,7 +18178,8 @@ const
 }
 
 
-template <typename T0__> stan::promote_args_t<T0__>
+template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -678,28 +678,28 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+  template <typename Tt__, typename Ty__, typename Ttheta__,
+            typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) const;
 };
 
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>;
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -744,17 +744,16 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
-inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
-                                 const Tx_i__& x_i, std::ostream* pstream__) 
-const
+                                 const std::vector<int>& x_i,
+                                 std::ostream* pstream__)  const
 {
   return simple_SIR(t, y, theta, x_r, x_i, pstream__);
 }
@@ -1829,29 +1828,25 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1872,9 +1867,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1898,17 +1893,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -1964,32 +1955,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -7078,29 +7064,25 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7121,9 +7103,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7147,17 +7129,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -7217,32 +7195,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -8157,9 +8130,8 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tp__,
@@ -8169,32 +8141,27 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename Ty__, typename Tfirst__,
-            typename Tlast__, typename Tp__, typename Tphi__,
-            typename Tpsi__, typename Tnu__, typename Tchi__,
-            typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+            typename Tnu__, typename Tchi__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
-  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  operator()(const std::vector<std::vector<int>>& y,
+             const std::vector<int>& first, const std::vector<int>& last,
              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -8215,9 +8182,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -8309,24 +8276,20 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+          typename Tnu__, typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
-  js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  js_super_lp(const std::vector<std::vector<int>>& y,
+              const std::vector<int>& first, const std::vector<int>& last,
               const Tp__& p_arg__, const Tphi__& phi_arg__,
               const Tpsi__& psi, const Tnu__& nu_arg__,
               const Tchi__& chi_arg__, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
-                                stan::return_type_t<Tpsi__, Tnu__, Tchi__>>;
+            stan::return_type_t<Tp__, Tphi__, Tpsi__, Tnu__, Tchi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -8560,9 +8523,8 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
@@ -8578,30 +8540,27 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+          typename Tnu__, typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
-js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p,
-                                  const Tphi__& phi, const Tpsi__& psi,
-                                  const Tnu__& nu, const Tchi__& chi,
-                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
+js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
+                                  const std::vector<int>& first,
+                                  const std::vector<int>& last,
+                                  const Tp__& p, const Tphi__& phi,
+                                  const Tpsi__& psi, const Tnu__& nu,
+                                  const Tchi__& chi, T_lp__& lp__,
+                                  T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10982,29 +10941,25 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11025,9 +10980,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11051,17 +11006,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11117,32 +11068,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -12051,26 +11997,22 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename Ty__, typename Tfirst__,
-            typename Tlast__, typename Tp__, typename Tphi__,
-            typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+            typename Tchi__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_col_vector<Tgamma__>,
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
-  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  operator()(const std::vector<std::vector<int>>& y,
+             const std::vector<int>& first, const std::vector<int>& last,
              const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
              const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
@@ -12078,9 +12020,8 @@ struct seq_cprob_functor__ {
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tp__,
@@ -12090,9 +12031,9 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -12113,9 +12054,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -12207,24 +12148,20 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
-  jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  jolly_seber_lp(const std::vector<std::vector<int>>& y,
+                 const std::vector<int>& first, const std::vector<int>& last,
                  const Tp__& p_arg__, const Tphi__& phi_arg__,
                  const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
-                                stan::return_type_t<Tgamma__, Tchi__>>;
+            stan::return_type_t<Tp__, Tphi__, Tgamma__, Tchi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -12498,20 +12435,17 @@ template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
-jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last, const Tp__& p,
-                                     const Tphi__& phi,
+jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
+                                     const std::vector<int>& first,
+                                     const std::vector<int>& last,
+                                     const Tp__& p, const Tphi__& phi,
                                      const Tgamma__& gamma,
                                      const Tchi__& chi, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -12521,10 +12455,9 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -12537,9 +12470,8 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
@@ -14596,29 +14528,25 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14639,9 +14567,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14665,17 +14593,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -14731,32 +14655,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -15445,11 +15364,10 @@ struct baz_lpdf_functor__ {
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename Tn__,
-            typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-            stan::is_stan_scalar<Tmu__>>* = nullptr>
-  inline stan::return_type_t<Tn__, Tmu__>
-  operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
+  template <bool propto__,
+            typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tmu__>
+  operator()(const int n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Tx__,
@@ -15475,12 +15393,11 @@ template <bool propto__, typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tn__,
-          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-          stan::is_stan_scalar<Tmu__>>* = nullptr>
-  inline stan::return_type_t<Tn__, Tmu__>
-  bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
+template <bool propto__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tmu__>
+  bar_lpmf(const int n, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -15514,11 +15431,10 @@ baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename Tn__,
-          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-          stan::is_stan_scalar<Tmu__>>*>
-inline stan::return_type_t<Tn__, Tmu__>
-bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
+template <bool propto__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>*>
+inline stan::return_type_t<Tmu__>
+bar_lpmf_functor__::operator()(const int n, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return bar_lpmf<propto__>(n, mu, pstream__);
@@ -17467,31 +17383,28 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int
-  operator()(const Ty__& y, std::ostream* pstream__) const;
+  operator()(const int y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<>* = nullptr>
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
   inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-            std::is_integral<Ty__>>* = nullptr>
+  template <bool propto__, typename Tx__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline void
-  operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
+  operator()(const Tx__& x, const int y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-          std::is_integral<Ty__>>* = nullptr> inline void
-  nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  inline void
+  nrfun_lp(const Tx__& x, const int y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -17507,9 +17420,8 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline int rfun(const Ty__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__>;
+inline int rfun(const int y, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -17527,8 +17439,7 @@ template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<>* = nullptr> inline int
+template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -17543,15 +17454,13 @@ template <bool propto__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
-inline int
-rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
+inline int rfun_functor__::operator()(const int y, std::ostream* pstream__) 
+const
 {
   return rfun(y, pstream__);
 }
 
-template <bool propto__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<>*>
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
 inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
@@ -17559,11 +17468,10 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-          std::is_integral<Ty__>>*>
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline void
-nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
+nrfun_lp_functor__::operator()(const Tx__& x, const int y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
                                std::ostream* pstream__)  const
 {
@@ -18280,9 +18188,8 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
-  inline stan::return_type_t<Tx__>
-  operator()(const Tx__& x, std::ostream* pstream__) const;
+  inline double
+  operator()(const int x, std::ostream* pstream__) const;
   template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
@@ -18304,10 +18211,8 @@ template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = null
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
-  inline stan::return_type_t<Tx__>
-  dumb(const Tx__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tx__>;
+inline double dumb(const int x, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -18320,9 +18225,8 @@ template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>*>
-inline stan::return_type_t<Tx__>
-dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
+inline double
+dumb_functor__::operator()(const int x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -680,10 +680,10 @@ static constexpr std::array<const char*, 37> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -691,10 +691,10 @@ struct simple_SIR_functor__ {
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -746,10 +746,10 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -1829,7 +1829,7 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -1844,12 +1844,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1872,7 +1872,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1963,7 +1963,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -1985,7 +1985,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -7077,7 +7077,7 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -7092,12 +7092,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7120,7 +7120,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7215,7 +7215,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -7237,7 +7237,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8155,7 +8155,7 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -8167,7 +8167,7 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -8176,9 +8176,9 @@ struct js_super_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
             typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
             stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -8190,7 +8190,7 @@ struct js_super_lp_functor__ {
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -8213,7 +8213,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -8309,9 +8309,9 @@ template <typename Tp__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -8556,7 +8556,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -8574,7 +8574,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8585,9 +8585,9 @@ const
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -10978,7 +10978,7 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -10993,12 +10993,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11021,7 +11021,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11112,7 +11112,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -11134,7 +11134,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12049,9 +12049,9 @@ struct jolly_seber_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
             stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_col_vector<Tgamma__>,
@@ -12063,7 +12063,7 @@ struct jolly_seber_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -12073,7 +12073,7 @@ struct seq_cprob_functor__ {
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -12085,7 +12085,7 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -12108,7 +12108,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -12204,9 +12204,9 @@ template <typename Tp__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
@@ -12494,9 +12494,9 @@ template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
@@ -12514,7 +12514,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12530,7 +12530,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14589,7 +14589,7 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -14604,12 +14604,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14632,7 +14632,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14723,7 +14723,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14745,7 +14745,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -679,24 +679,22 @@ static constexpr std::array<const char*, 37> locations_array__ =
 
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -747,11 +745,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -1831,31 +1829,27 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1878,8 +1872,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1906,11 +1899,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -1971,8 +1963,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -1981,10 +1972,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -1994,8 +1985,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -7087,31 +7077,27 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7134,8 +7120,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7162,11 +7147,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -7231,8 +7215,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -7241,10 +7224,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -7254,8 +7237,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8173,21 +8155,19 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tp__, typename Tphi__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -8195,15 +8175,14 @@ struct js_super_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
-            typename T_lp__, typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+            typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>,
+            stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+            stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
@@ -8211,8 +8190,7 @@ struct js_super_lp_functor__ {
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -8235,8 +8213,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -8262,9 +8239,9 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
@@ -8331,16 +8308,14 @@ template <typename Tp__, typename Tphi__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
-  inline void
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
               const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
               const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
@@ -8581,8 +8556,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -8590,9 +8564,9 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
@@ -8600,8 +8574,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8611,15 +8584,14 @@ const
 
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_stan_scalar<Tpsi__>>*,
-          stan::require_t<stan::is_col_vector<Tnu__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
                                   const Tlast__& last, const Tp__& p,
@@ -11006,31 +10978,27 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11053,8 +11021,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11081,11 +11048,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -11146,8 +11112,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -11156,10 +11121,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -11169,8 +11134,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12085,14 +12049,13 @@ struct jolly_seber_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>,
+            stan::is_col_vector<Tgamma__>,
+            stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
              const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
@@ -12100,33 +12063,29 @@ struct jolly_seber_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename Tgamma__,
-            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tp__, typename Tphi__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -12149,8 +12108,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -12176,9 +12134,9 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
@@ -12245,15 +12203,14 @@ template <typename Tp__, typename Tphi__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
-  inline void
+          typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_col_vector<Tgamma__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
                  const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
                  const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
@@ -12492,8 +12449,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tgamma__,
-          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
   seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tgamma__>;
@@ -12537,14 +12493,14 @@ template <typename Tgamma__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_col_vector<Tgamma__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+          typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_col_vector<Tgamma__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
                                      const Tlast__& last, const Tp__& p,
@@ -12558,8 +12514,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12567,7 +12522,7 @@ const
   return last_capture(y_i, pstream__);
 }
 
-template <typename Tgamma__, stan::require_t<stan::is_col_vector<Tgamma__>>*>
+template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
 seq_cprob_functor__::operator()(const Tgamma__& gamma,
                                 std::ostream* pstream__)  const
@@ -12575,8 +12530,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -12584,9 +12538,9 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
@@ -14635,31 +14589,27 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14682,8 +14632,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14710,11 +14659,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -14775,8 +14723,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14785,10 +14732,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -14798,8 +14745,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -15485,29 +15431,29 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <bool propto__,
+            typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename Tn__, typename Tmu__,
-            stan::require_t<std::is_integral<Tn__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <bool propto__, typename Tn__,
+            typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+            stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename Tx__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <bool propto__, typename Tx__,
+            typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <bool propto__, typename Tx__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
@@ -15521,9 +15467,9 @@ template <bool propto__, typename Tx__, typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<std::is_integral<Tn__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <bool propto__, typename Tn__,
+          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+          stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
@@ -15537,8 +15483,8 @@ template <bool propto__, typename Tn__, typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <bool propto__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   baz_lpdf(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -15552,17 +15498,17 @@ template <bool propto__, typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <bool propto__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<std::is_integral<Tn__>>*,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <bool propto__, typename Tn__,
+          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+          stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tn__, Tmu__>
 bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -15570,9 +15516,9 @@ bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <bool propto__, typename Tx__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tx__, Tmu__>
 foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -17513,29 +17459,28 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
+  template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<>* = nullptr>
   inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
   template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            std::is_integral<Ty__>>* = nullptr>
   inline void
   operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr> inline void
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          std::is_integral<Ty__>>* = nullptr> inline void
   nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -17554,7 +17499,7 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
+template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int rfun(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
@@ -17574,7 +17519,8 @@ template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
+template <bool propto__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<>* = nullptr> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -17589,14 +17535,15 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<std::is_integral<Ty__>>*>
+template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
 inline int
 rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
-template <bool propto__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<>*>
 inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
@@ -17605,9 +17552,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<std::is_integral<Ty__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          std::is_integral<Ty__>>*>
 inline void
 nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -18326,17 +18272,15 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -18352,7 +18296,7 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -18368,14 +18312,14 @@ template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_t<std::is_integral<Tx__>>*>
+template <typename Tx__, stan::require_all_t<std::is_integral<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -1841,7 +1841,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -1979,7 +1980,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -7089,7 +7091,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -7231,7 +7234,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -8164,7 +8168,8 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -8185,8 +8190,8 @@ struct js_super_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
-             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+             const Tp__& p_arg__, const Tphi__& phi_arg__, const Tpsi__& psi,
+             const Tnu__& nu_arg__, const Tchi__& chi_arg__, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
@@ -8568,7 +8573,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
+prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -8594,10 +8600,11 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p,
-                                  const Tphi__& phi, const Tpsi__& psi,
-                                  const Tnu__& nu, const Tchi__& chi,
-                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
+                                  const Tlast__& last, const Tp__& p_arg__,
+                                  const Tphi__& phi_arg__, const Tpsi__& psi,
+                                  const Tnu__& nu_arg__,
+                                  const Tchi__& chi_arg__, T_lp__& lp__,
+                                  T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10990,7 +10997,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11128,7 +11136,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -12058,9 +12067,9 @@ struct jolly_seber_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
-             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
-             std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
+             T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -12070,7 +12079,7 @@ struct last_capture_functor__ {
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
+  operator()(const Tgamma__& gamma_arg__, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -12082,7 +12091,8 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -12503,10 +12513,11 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last, const Tp__& p,
-                                     const Tphi__& phi,
-                                     const Tgamma__& gamma,
-                                     const Tchi__& chi, T_lp__& lp__,
+                                     const Tlast__& last,
+                                     const Tp__& p_arg__,
+                                     const Tphi__& phi_arg__,
+                                     const Tgamma__& gamma_arg__,
+                                     const Tchi__& chi_arg__, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
@@ -12524,7 +12535,7 @@ const
 
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-seq_cprob_functor__::operator()(const Tgamma__& gamma,
+seq_cprob_functor__::operator()(const Tgamma__& gamma_arg__,
                                 std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
@@ -12542,7 +12553,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
+prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -14601,7 +14613,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -14739,7 +14752,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -1841,8 +1841,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -1906,7 +1905,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -1980,8 +1980,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -7091,8 +7090,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -7156,7 +7154,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -7234,8 +7233,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -8168,8 +8166,7 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -8190,8 +8187,8 @@ struct js_super_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p_arg__, const Tphi__& phi_arg__, const Tpsi__& psi,
-             const Tnu__& nu_arg__, const Tchi__& chi_arg__, T_lp__& lp__,
+             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
@@ -8248,7 +8245,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+  prob_uncaptured(const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -8322,8 +8320,9 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
-              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+              const Tp__& p_arg__, const Tphi__& phi_arg__,
+              const Tpsi__& psi, const Tnu__& nu_arg__,
+              const Tchi__& chi_arg__, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
@@ -8573,8 +8572,7 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -8600,11 +8598,10 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p_arg__,
-                                  const Tphi__& phi_arg__, const Tpsi__& psi,
-                                  const Tnu__& nu_arg__,
-                                  const Tchi__& chi_arg__, T_lp__& lp__,
-                                  T_lp_accum__& lp_accum__,
+                                  const Tlast__& last, const Tp__& p,
+                                  const Tphi__& phi, const Tpsi__& psi,
+                                  const Tnu__& nu, const Tchi__& chi,
+                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10997,8 +10994,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11062,7 +11058,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -11136,8 +11133,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -12067,9 +12063,9 @@ struct jolly_seber_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
-             T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -12079,7 +12075,7 @@ struct last_capture_functor__ {
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  operator()(const Tgamma__& gamma_arg__, std::ostream* pstream__) const;
+  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -12091,8 +12087,7 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -12148,7 +12143,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+  prob_uncaptured(const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -12222,8 +12218,9 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-                 const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
-                 const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+                 const Tp__& p_arg__, const Tphi__& phi_arg__,
+                 const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
+                 T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
@@ -12461,7 +12458,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
     }
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
+  seq_cprob(const Tgamma__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tgamma__>;
     int current_statement__ = 0; 
     const auto& gamma = stan::math::to_ref(gamma_arg__);
@@ -12513,11 +12510,10 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last,
-                                     const Tp__& p_arg__,
-                                     const Tphi__& phi_arg__,
-                                     const Tgamma__& gamma_arg__,
-                                     const Tchi__& chi_arg__, T_lp__& lp__,
+                                     const Tlast__& last, const Tp__& p,
+                                     const Tphi__& phi,
+                                     const Tgamma__& gamma,
+                                     const Tchi__& chi, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
@@ -12535,7 +12531,7 @@ const
 
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-seq_cprob_functor__::operator()(const Tgamma__& gamma_arg__,
+seq_cprob_functor__::operator()(const Tgamma__& gamma,
                                 std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
@@ -12553,8 +12549,7 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -14613,8 +14608,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -14678,7 +14672,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -14752,8 +14747,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -678,27 +678,30 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  operator()(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) const;
+  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+            typename Tx_i__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+  operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  simple_SIR(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+  simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -743,17 +746,17 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
-                                 const std::vector<T2__>& theta,
-                                 const std::vector<T3__>& x_r,
-                                 const std::vector<int>& x_i,
-                                 std::ostream* pstream__)  const
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
+                                 const Ttheta__& theta, const Tx_r__& x_r,
+                                 const Tx_i__& x_i, std::ostream* pstream__) 
+const
 {
   return simple_SIR(t, y, theta, x_r, x_i, pstream__);
 }
@@ -1828,24 +1831,33 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1866,8 +1878,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1891,16 +1905,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -1956,28 +1971,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -7066,24 +7087,33 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7104,8 +7134,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7129,16 +7161,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -7198,28 +7231,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -8134,39 +8173,48 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
+  template <typename Tp__, typename Tphi__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__,
-            typename T6__, typename T7__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
-  void
-  operator()(const std::vector<std::vector<int>>& y,
-             const std::vector<int>& first, const std::vector<int>& last,
-             const T3__& p, const T4__& phi, const T5__& psi, const T6__& nu,
-             const T7__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
-             std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__, typename Tfirst__,
+            typename Tlast__, typename Tp__, typename Tphi__,
+            typename Tpsi__, typename Tnu__, typename Tchi__,
+            typename T_lp__, typename T_lp_accum__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+             T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -8187,8 +8235,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -8212,15 +8262,12 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -8282,24 +8329,25 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr> void
-  js_super_lp(const std::vector<std::vector<int>>& y,
-              const std::vector<int>& first, const std::vector<int>& last,
-              const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
-              const T6__& nu_arg__, const T7__& chi_arg__, T_lp__& lp__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
+          typename Tchi__, typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T3__>,
-                                 stan::value_type_t<T4__>, T5__,
-                                 stan::value_type_t<T6__>,
-                                 stan::value_type_t<T7__>>;
+            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
+                                stan::return_type_t<Tpsi__, Tnu__, Tchi__>>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -8533,45 +8581,51 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*>
-void
-js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
-                                  const std::vector<int>& first,
-                                  const std::vector<int>& last,
-                                  const T3__& p, const T4__& phi,
-                                  const T5__& psi, const T6__& nu,
-                                  const T7__& chi, T_lp__& lp__,
-                                  T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
+          typename Tchi__, typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>*,
+          stan::require_t<stan::is_col_vector<Tnu__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+inline void
+js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
+                                  const Tlast__& last, const Tp__& p,
+                                  const Tphi__& phi, const Tpsi__& psi,
+                                  const Tnu__& nu, const Tchi__& chi,
+                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10952,24 +11006,33 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -10990,8 +11053,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11015,16 +11080,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11080,28 +11146,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -12010,42 +12082,53 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__,
-            typename T6__, typename T_lp__, typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
-  void
-  operator()(const std::vector<std::vector<int>>& y,
-             const std::vector<int>& first, const std::vector<int>& last,
-             const T3__& p, const T4__& phi, const T5__& gamma,
-             const T6__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+  template <bool propto__, typename Ty__, typename Tfirst__,
+            typename Tlast__, typename Tp__, typename Tphi__,
+            typename Tgamma__, typename Tchi__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  operator()(const T0__& gamma, std::ostream* pstream__) const;
+  template <typename Tgamma__,
+            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
+  template <typename Tp__, typename Tphi__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -12066,8 +12149,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -12091,15 +12176,12 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -12161,23 +12243,24 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr> void
-  jolly_seber_lp(const std::vector<std::vector<int>>& y,
-                 const std::vector<int>& first, const std::vector<int>& last,
-                 const T3__& p_arg__, const T4__& phi_arg__,
-                 const T5__& gamma_arg__, const T6__& chi_arg__,
-                 T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
+          typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+                 const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+                 const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T3__>,
-                                 stan::value_type_t<T4__>,
-                                 stan::value_type_t<T5__>,
-                                 stan::value_type_t<T6__>>;
+            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
+                                stan::return_type_t<Tgamma__, Tchi__>>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -12409,10 +12492,11 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tgamma__,
+          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+  seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tgamma__>;
     int current_statement__ = 0; 
     const auto& gamma = stan::math::to_ref(gamma_arg__);
     static constexpr bool propto__ = true;
@@ -12451,52 +12535,60 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_eigen_matrix_dynamic_t<T6__>*>
-void
-jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
-                                     const std::vector<int>& first,
-                                     const std::vector<int>& last,
-                                     const T3__& p, const T4__& phi,
-                                     const T5__& gamma, const T6__& chi,
-                                     T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
+          typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
+          stan::require_t<stan::is_col_vector<Tgamma__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+inline void
+jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
+                                     const Tlast__& last, const Tp__& p,
+                                     const Tphi__& phi,
+                                     const Tgamma__& gamma,
+                                     const Tchi__& chi, T_lp__& lp__,
+                                     T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
   return jolly_seber_lp<propto__>(y, first, last, p, phi, gamma, chi, lp__,
            lp_accum__, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
-const
+template <typename Tgamma__, stan::require_t<stan::is_col_vector<Tgamma__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+seq_cprob_functor__::operator()(const Tgamma__& gamma,
+                                std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
 }
 
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -14543,24 +14635,33 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14581,8 +14682,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14606,16 +14709,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -14671,28 +14775,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -15375,31 +15485,32 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <bool propto__, typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
+  template <bool propto__, typename Tn__, typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tn__, Tmu__>
+  operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
+  template <bool propto__, typename Tx__, typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Tmu__>
+  operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+template <bool propto__, typename Tx__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Tmu__>
+  foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -15410,11 +15521,12 @@ template <bool propto__, typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T1__>;
+template <bool propto__, typename Tn__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tn__, Tmu__>
+  bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -15425,11 +15537,11 @@ template <bool propto__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  baz_lpdf(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <bool propto__, typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  baz_lpdf(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -15440,26 +15552,29 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
+template <bool propto__, typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T1__>
-bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
+template <bool propto__, typename Tn__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline stan::return_type_t<Tn__, Tmu__>
+bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
+template <bool propto__, typename Tx__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline stan::return_type_t<Tx__, Tmu__>
+foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return foo_lpdf<propto__>(x, mu, pstream__);
@@ -17398,29 +17513,34 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  int
-  operator()(const int& y, std::ostream* pstream__) const;
+  template <typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline int
+  operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
   template <bool propto__, typename T_lp__, typename T_lp_accum__>
-  int
+  inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& x, const int& y, T_lp__& lp__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline void
+  operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline void
+  nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -17436,8 +17556,10 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int rfun(const int& y, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline int rfun(const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -17455,7 +17577,7 @@ int rfun(const int& y, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -17470,23 +17592,27 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int rfun_functor__::operator()(const int& y, std::ostream* pstream__)  const
+template <typename Ty__, stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline int
+rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
 template <bool propto__, typename T_lp__, typename T_lp_accum__>
-int
+inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-void
-nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline void
+nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
                                std::ostream* pstream__)  const
 {
@@ -18203,16 +18329,21 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  double
-  operator()(const int& x, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__> dumb(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  dumb(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -18225,8 +18356,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double dumb(const int& x, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  dumb(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -18239,15 +18373,16 @@ double dumb(const int& x, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-double dumb_functor__::operator()(const int& x, std::ostream* pstream__) 
-const
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
+template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -680,11 +680,11 @@ static constexpr std::array<const char*, 37> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -692,11 +692,11 @@ struct simple_SIR_functor__ {
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -747,11 +747,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -1832,15 +1832,15 @@ static constexpr std::array<const char*, 76> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -1849,13 +1849,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1879,7 +1879,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1907,8 +1907,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -1972,7 +1972,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -1981,8 +1981,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -1995,7 +1995,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -7088,15 +7088,15 @@ static constexpr std::array<const char*, 81> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -7105,13 +7105,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7135,7 +7135,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7163,8 +7163,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -7232,7 +7232,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -7241,8 +7241,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -7255,7 +7255,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8174,7 +8174,7 @@ static constexpr std::array<const char*, 158> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -8187,7 +8187,7 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -8196,12 +8196,12 @@ struct js_super_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
             typename T_lp__, typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
@@ -8212,7 +8212,7 @@ struct js_super_lp_functor__ {
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -8236,7 +8236,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -8332,12 +8332,12 @@ template <typename Tp__, typename Tphi__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
@@ -8582,7 +8582,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -8601,7 +8601,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8612,12 +8612,12 @@ const
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>*,
+          stan::require_t<stan::is_stan_scalar<Tpsi__>>*,
           stan::require_t<stan::is_col_vector<Tnu__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
@@ -11007,15 +11007,15 @@ static constexpr std::array<const char*, 76> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -11024,13 +11024,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11054,7 +11054,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11082,8 +11082,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -11147,7 +11147,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -11156,8 +11156,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -11170,7 +11170,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12086,9 +12086,9 @@ struct jolly_seber_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
@@ -12101,7 +12101,7 @@ struct jolly_seber_lp_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -12113,7 +12113,7 @@ struct seq_cprob_functor__ {
 };
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -12126,7 +12126,7 @@ struct prob_uncaptured_functor__ {
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -12150,7 +12150,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -12246,9 +12246,9 @@ template <typename Tp__, typename Tphi__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
@@ -12538,9 +12538,9 @@ template <typename Tgamma__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
           stan::require_t<stan::is_col_vector<Tgamma__>>*,
@@ -12559,7 +12559,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12576,7 +12576,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14636,15 +14636,15 @@ static constexpr std::array<const char*, 71> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -14653,13 +14653,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14683,7 +14683,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14711,8 +14711,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -14776,7 +14776,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14785,8 +14785,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -14799,7 +14799,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -15486,28 +15486,28 @@ static constexpr std::array<const char*, 14> locations_array__ =
 
 struct baz_lpdf_functor__ {
   template <bool propto__, typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
   template <bool propto__, typename Tn__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<std::is_integral<Tn__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Tx__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
@@ -15522,8 +15522,8 @@ template <bool propto__, typename Tx__, typename Tmu__,
     }
     }
 template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<std::is_integral<Tn__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
@@ -15538,7 +15538,7 @@ template <bool propto__, typename Tn__, typename Tmu__,
     }
     }
 template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   baz_lpdf(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -15553,7 +15553,7 @@ template <bool propto__, typename Tx__,
     }
     }
 template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -15561,8 +15561,8 @@ baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 }
 
 template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+          stan::require_t<std::is_integral<Tn__>>*,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tn__, Tmu__>
 bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -15571,8 +15571,8 @@ bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
 }
 
 template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tx__, Tmu__>
 foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -17513,8 +17513,7 @@ static constexpr std::array<const char*, 146> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  template <typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline int
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
@@ -17526,8 +17525,8 @@ struct rfun_lp_functor__ {
 struct nrfun_lp_functor__ {
   template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline void
   operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
@@ -17535,9 +17534,8 @@ struct nrfun_lp_functor__ {
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
-  inline void
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<std::is_integral<Ty__>>* = nullptr> inline void
   nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -17556,8 +17554,7 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline int rfun(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
@@ -17592,7 +17589,7 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+template <typename Ty__, stan::require_t<std::is_integral<Ty__>>*>
 inline int
 rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
@@ -17609,8 +17606,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<std::is_integral<Ty__>>*>
 inline void
 nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -18329,18 +18326,17 @@ static constexpr std::array<const char*, 6> locations_array__ =
  " (in 'overloaded-fn.stan', line 6, column 19 to line 8, column 4)"};
 
 struct dumb_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
   template <typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
 template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -18356,8 +18352,7 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_t<std::is_integral<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   dumb(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -18373,14 +18368,14 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<std::is_integral<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return dumb(x, pstream__);
 }
 
-template <typename Tx__, stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+template <typename Tx__, stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 dumb_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -678,14 +678,22 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -735,8 +743,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -1821,7 +1832,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -1878,7 +1891,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -1941,7 +1956,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -1949,8 +1963,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -1959,7 +1974,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -7056,7 +7070,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -7113,7 +7129,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -7180,7 +7198,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -7188,8 +7205,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -7198,7 +7216,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -8121,7 +8138,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -8130,7 +8149,14 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
+  template <bool propto__, typename T3__, typename T4__, typename T5__,
+            typename T6__, typename T7__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -8186,7 +8212,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -8254,8 +8282,14 @@ template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
-  void
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T7__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr> void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
               const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
@@ -8499,7 +8533,6 @@ template <bool propto__, typename T3__, typename T4__, typename T5__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -8507,15 +8540,15 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -8524,8 +8557,13 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T7__, typename T_lp__,
+          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
+          stan::require_eigen_matrix_dynamic_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_eigen_matrix_dynamic_t<T7__>*>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -10918,7 +10956,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -10975,7 +11015,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -11038,7 +11080,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -11046,8 +11087,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -11056,7 +11098,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -11969,7 +12010,12 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
+  template <bool propto__, typename T3__, typename T4__, typename T5__,
+            typename T6__, typename T_lp__, typename T_lp_accum__,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+            stan::require_col_vector_t<T5__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11991,7 +12037,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -12043,7 +12091,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -12111,8 +12161,12 @@ template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
-  void
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T_lp__, typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+          stan::require_col_vector_t<T5__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr> void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
                  const T3__& p_arg__, const T4__& phi_arg__,
@@ -12397,8 +12451,12 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T_lp__, typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>*,
+          stan::require_eigen_matrix_dynamic_t<T4__>*,
+          stan::require_col_vector_t<T5__>*,
+          stan::require_eigen_matrix_dynamic_t<T6__>*>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -12412,7 +12470,6 @@ jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
            lp_accum__, pstream__);
 }
 
-
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
                                    std::ostream* pstream__)  const
@@ -12420,15 +12477,13 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
 {
   return seq_cprob(gamma, pstream__);
 }
-
 
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -12437,8 +12492,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -14491,7 +14547,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -14548,7 +14606,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -14611,7 +14671,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -14619,8 +14678,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -14629,7 +14689,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -15316,22 +15375,28 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T1__,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -15345,7 +15410,8 @@ template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -15359,7 +15425,8 @@ template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -15373,16 +15440,14 @@ template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -15390,8 +15455,9 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -17336,17 +17402,21 @@ struct rfun_functor__ {
   operator()(const int& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
@@ -17400,22 +17470,21 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int rfun_functor__::operator()(const int& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
-
-template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
+int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -18170,15 +18239,13 @@ double dumb(const int& x, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 double dumb_functor__::operator()(const int& x, std::ostream* pstream__) 
 const
 {
   return dumb(x, pstream__);
 }
 
-
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -1376,8 +1376,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -1441,7 +1440,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -1514,8 +1514,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -6583,8 +6582,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -6648,7 +6646,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -6721,8 +6720,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -7652,8 +7650,7 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -7674,8 +7671,8 @@ struct js_super_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p_arg__, const Tphi__& phi_arg__, const Tpsi__& psi,
-             const Tnu__& nu_arg__, const Tchi__& chi_arg__, T_lp__& lp__,
+             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
@@ -7732,7 +7729,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+  prob_uncaptured(const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -7804,8 +7802,9 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
-              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+              const Tp__& p_arg__, const Tphi__& phi_arg__,
+              const Tpsi__& psi, const Tnu__& nu_arg__,
+              const Tchi__& chi_arg__, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
@@ -8051,8 +8050,7 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -8078,11 +8076,10 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p_arg__,
-                                  const Tphi__& phi_arg__, const Tpsi__& psi,
-                                  const Tnu__& nu_arg__,
-                                  const Tchi__& chi_arg__, T_lp__& lp__,
-                                  T_lp_accum__& lp_accum__,
+                                  const Tlast__& last, const Tp__& p,
+                                  const Tphi__& phi, const Tpsi__& psi,
+                                  const Tnu__& nu, const Tchi__& chi,
+                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10458,8 +10455,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -10523,7 +10519,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -10596,8 +10593,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -11523,9 +11519,9 @@ struct jolly_seber_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
-             T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11535,7 +11531,7 @@ struct last_capture_functor__ {
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  operator()(const Tgamma__& gamma_arg__, std::ostream* pstream__) const;
+  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11547,8 +11543,7 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11604,7 +11599,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+  prob_uncaptured(const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
@@ -11676,8 +11672,9 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-                 const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
-                 const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+                 const Tp__& p_arg__, const Tphi__& phi_arg__,
+                 const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
+                 T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
@@ -11911,7 +11908,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
     }
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
+  seq_cprob(const Tgamma__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tgamma__>;
     int current_statement__ = 0; 
     const auto& gamma = stan::math::to_ref(gamma_arg__);
@@ -11962,11 +11959,10 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last,
-                                     const Tp__& p_arg__,
-                                     const Tphi__& phi_arg__,
-                                     const Tgamma__& gamma_arg__,
-                                     const Tchi__& chi_arg__, T_lp__& lp__,
+                                     const Tlast__& last, const Tp__& p,
+                                     const Tphi__& phi,
+                                     const Tgamma__& gamma,
+                                     const Tchi__& chi, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
@@ -11984,7 +11980,7 @@ const
 
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-seq_cprob_functor__::operator()(const Tgamma__& gamma_arg__,
+seq_cprob_functor__::operator()(const Tgamma__& gamma,
                                 std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
@@ -12002,8 +11998,7 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -14047,8 +14042,7 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p_arg__, const Tphi__& phi_arg__,
-             std::ostream* pstream__) const;
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -14112,7 +14106,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+                  const Tp__& p_arg__, const Tphi__& phi_arg__,
+                  std::ostream* pstream__) {
     using local_scalar_t__ =
             stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
@@ -14185,8 +14180,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p_arg__,
-                                      const Tphi__& phi_arg__,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -669,14 +669,14 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__>
+  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -727,7 +727,7 @@ template <typename T0__, typename T1__, typename T2__, typename T3__>
     }
     }
 
-template <typename T0__, typename T1__, typename T2__, typename T3__>
+template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -1356,7 +1356,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -1413,7 +1413,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -1484,7 +1484,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -6548,7 +6548,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -6605,7 +6605,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -6676,7 +6676,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -7605,7 +7605,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -7614,7 +7614,7 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -7670,7 +7670,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -7736,7 +7736,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
@@ -7986,7 +7986,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -8003,7 +8003,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -10379,7 +10379,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -10436,7 +10436,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -10507,7 +10507,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -11425,7 +11425,7 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11438,7 +11438,7 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   operator()(const T0__& gamma, std::ostream* pstream__) const;
 };
@@ -11447,7 +11447,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -11499,7 +11499,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -11565,7 +11565,7 @@ template <typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
@@ -11805,7 +11805,7 @@ template <bool propto__, typename T3__, typename T4__, typename T5__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -11847,7 +11847,7 @@ template <typename T0__>
     }
     }
 
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -11870,7 +11870,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
@@ -11887,7 +11887,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -13925,7 +13925,7 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__>
+  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -13982,7 +13982,7 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -14053,7 +14053,7 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 
-template <typename T2__, typename T3__>
+template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -14749,20 +14749,22 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__>
+  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -14776,7 +14778,8 @@ template <bool propto__, typename T0__, typename T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
     int current_statement__ = 0; 
@@ -14789,7 +14792,8 @@ template <bool propto__, typename T1__> stan::promote_args_t<T1__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -14803,14 +14807,16 @@ template <bool propto__, typename T0__> stan::promote_args_t<T0__>
     }
     }
 
-template <bool propto__, typename T0__> stan::promote_args_t<T0__>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
 
-template <bool propto__, typename T1__> stan::promote_args_t<T1__>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
 {
@@ -14818,7 +14824,7 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
 }
 
 
-template <bool propto__, typename T0__, typename T1__>
+template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -16719,13 +16725,13 @@ struct rfun_lp_functor__ {
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
@@ -16794,7 +16800,7 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -1376,7 +1376,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -1513,7 +1514,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -6581,7 +6583,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -6718,7 +6721,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -7648,7 +7652,8 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -7669,8 +7674,8 @@ struct js_super_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
-             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+             const Tp__& p_arg__, const Tphi__& phi_arg__, const Tpsi__& psi,
+             const Tnu__& nu_arg__, const Tchi__& chi_arg__, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
@@ -8046,7 +8051,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
+prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -8072,10 +8078,11 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p,
-                                  const Tphi__& phi, const Tpsi__& psi,
-                                  const Tnu__& nu, const Tchi__& chi,
-                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
+                                  const Tlast__& last, const Tp__& p_arg__,
+                                  const Tphi__& phi_arg__, const Tpsi__& psi,
+                                  const Tnu__& nu_arg__,
+                                  const Tchi__& chi_arg__, T_lp__& lp__,
+                                  T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10451,7 +10458,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -10588,7 +10596,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
@@ -11514,9 +11523,9 @@ struct jolly_seber_lp_functor__ {
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
-             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
-             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
-             std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
+             T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11526,7 +11535,7 @@ struct last_capture_functor__ {
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
+  operator()(const Tgamma__& gamma_arg__, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11538,7 +11547,8 @@ struct prob_uncaptured_functor__ {
             typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  operator()(const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -11952,10 +11962,11 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last, const Tp__& p,
-                                     const Tphi__& phi,
-                                     const Tgamma__& gamma,
-                                     const Tchi__& chi, T_lp__& lp__,
+                                     const Tlast__& last,
+                                     const Tp__& p_arg__,
+                                     const Tphi__& phi_arg__,
+                                     const Tgamma__& gamma_arg__,
+                                     const Tchi__& chi_arg__, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
@@ -11973,7 +11984,7 @@ const
 
 template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
-seq_cprob_functor__::operator()(const Tgamma__& gamma,
+seq_cprob_functor__::operator()(const Tgamma__& gamma_arg__,
                                 std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
@@ -11991,7 +12002,8 @@ template <typename Tp__,
           typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
+prob_uncaptured_functor__::operator()(const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -14035,7 +14047,8 @@ struct prob_uncaptured_functor__ {
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+             const Tp__& p_arg__, const Tphi__& phi_arg__,
+             std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
   template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
@@ -14172,7 +14185,8 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
-                                      const Tp__& p, const Tphi__& phi,
+                                      const Tp__& p_arg__,
+                                      const Tphi__& phi_arg__,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -671,11 +671,11 @@ static constexpr std::array<const char*, 37> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -683,11 +683,11 @@ struct simple_SIR_functor__ {
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -738,11 +738,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -1367,15 +1367,15 @@ static constexpr std::array<const char*, 76> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -1384,13 +1384,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1414,7 +1414,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1442,8 +1442,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -1506,7 +1506,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -1515,8 +1515,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -1529,7 +1529,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -6580,15 +6580,15 @@ static constexpr std::array<const char*, 81> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -6597,13 +6597,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -6627,7 +6627,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -6655,8 +6655,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -6719,7 +6719,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -6728,8 +6728,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -6742,7 +6742,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -7658,7 +7658,7 @@ static constexpr std::array<const char*, 158> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -7671,7 +7671,7 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -7680,12 +7680,12 @@ struct js_super_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
             typename T_lp__, typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
@@ -7696,7 +7696,7 @@ struct js_super_lp_functor__ {
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7720,7 +7720,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7814,12 +7814,12 @@ template <typename Tp__, typename Tphi__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
@@ -8060,7 +8060,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -8079,7 +8079,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8090,12 +8090,12 @@ const
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>*,
+          stan::require_t<stan::is_stan_scalar<Tpsi__>>*,
           stan::require_t<stan::is_col_vector<Tnu__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
@@ -10468,15 +10468,15 @@ static constexpr std::array<const char*, 76> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -10485,13 +10485,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -10515,7 +10515,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -10543,8 +10543,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -10607,7 +10607,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -10616,8 +10616,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -10630,7 +10630,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11542,9 +11542,9 @@ struct jolly_seber_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
             stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
@@ -11557,7 +11557,7 @@ struct jolly_seber_lp_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11569,7 +11569,7 @@ struct seq_cprob_functor__ {
 };
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11582,7 +11582,7 @@ struct prob_uncaptured_functor__ {
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11606,7 +11606,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11700,9 +11700,9 @@ template <typename Tp__, typename Tphi__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
           stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
@@ -11987,9 +11987,9 @@ template <typename Tgamma__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
           stan::require_t<stan::is_col_vector<Tgamma__>>*,
@@ -12008,7 +12008,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12025,7 +12025,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14070,15 +14070,15 @@ static constexpr std::array<const char*, 71> locations_array__ =
 
 struct first_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
             typename Tphi__,
-            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -14087,13 +14087,13 @@ struct prob_uncaptured_functor__ {
 };
 struct last_capture_functor__ {
   template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14117,7 +14117,7 @@ template <typename Ty_i__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14145,8 +14145,8 @@ template <typename Ty_i__,
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
           typename Tphi__,
-          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
+          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -14209,7 +14209,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
     }
     }
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14218,8 +14218,8 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
+          stan::require_t<std::is_integral<Tn_occasions__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
@@ -14232,7 +14232,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
 }
 
 template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -14919,28 +14919,28 @@ static constexpr std::array<const char*, 14> locations_array__ =
 
 struct baz_lpdf_functor__ {
   template <bool propto__, typename Tx__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
   template <bool propto__, typename Tn__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<std::is_integral<Tn__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Tx__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
@@ -14955,8 +14955,8 @@ template <bool propto__, typename Tx__, typename Tmu__,
     }
     }
 template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+          stan::require_t<std::is_integral<Tn__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
@@ -14971,7 +14971,7 @@ template <bool propto__, typename Tn__, typename Tmu__,
     }
     }
 template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   baz_lpdf(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -14986,7 +14986,7 @@ template <bool propto__, typename Tx__,
     }
     }
 template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
@@ -14994,8 +14994,8 @@ baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 }
 
 template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tn__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+          stan::require_t<std::is_integral<Tn__>>*,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tn__, Tmu__>
 bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -15004,8 +15004,8 @@ bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
 }
 
 template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tx__, Tmu__>
 foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -16898,8 +16898,7 @@ static constexpr std::array<const char*, 109> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  template <typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline int
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
@@ -16911,8 +16910,8 @@ struct rfun_lp_functor__ {
 struct nrfun_lp_functor__ {
   template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+            stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline void
   operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
@@ -16920,9 +16919,8 @@ struct nrfun_lp_functor__ {
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
-  inline void
+          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
+          stan::require_t<std::is_integral<Ty__>>* = nullptr> inline void
   nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -16941,8 +16939,7 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
   inline int rfun(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
@@ -16977,7 +16974,7 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+template <typename Ty__, stan::require_t<std::is_integral<Ty__>>*>
 inline int
 rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
@@ -16994,8 +16991,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+          stan::require_t<stan::is_stan_scalar<Tx__>>*,
+          stan::require_t<std::is_integral<Ty__>>*>
 inline void
 nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -669,27 +669,30 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  operator()(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) const;
+  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+            typename Tx_i__,
+            stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+  operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
-  std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-  simple_SIR(const T0__& t, const std::vector<T1__>& y,
-             const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
-             const std::vector<int>& x_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__, T2__, T3__>;
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__,
+          stan::require_t<stan::is_stan_scalar_t<Tt__>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+  simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
+             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+    using local_scalar_t__ =
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -734,17 +737,17 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
-std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
-simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
-                                 const std::vector<T2__>& theta,
-                                 const std::vector<T3__>& x_r,
-                                 const std::vector<int>& x_i,
-                                 std::ostream* pstream__)  const
+template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
+          typename Tx_i__, stan::require_t<stan::is_stan_scalar_t<Tt__>>*,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar_t<value_type_t<Ty__>>>*,
+          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar_t<value_type_t<Ttheta__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar_t<value_type_t<Tx_r__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tx_i__>, stan::is_stan_scalar_t<value_type_t<Tx_i__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
+                                 const Ttheta__& theta, const Tx_r__& x_r,
+                                 const Tx_i__& x_i, std::ostream* pstream__) 
+const
 {
   return simple_SIR(t, y, theta, x_r, x_i, pstream__);
 }
@@ -1363,24 +1366,33 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1401,8 +1413,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1426,16 +1440,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -1490,28 +1505,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -6558,24 +6579,33 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -6596,8 +6626,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -6621,16 +6653,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -6685,28 +6718,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -7618,39 +7657,48 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
+  template <typename Tp__, typename Tphi__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__,
-            typename T6__, typename T7__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
-  void
-  operator()(const std::vector<std::vector<int>>& y,
-             const std::vector<int>& first, const std::vector<int>& last,
-             const T3__& p, const T4__& phi, const T5__& psi, const T6__& nu,
-             const T7__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
-             std::ostream* pstream__) const;
+  template <bool propto__, typename Ty__, typename Tfirst__,
+            typename Tlast__, typename Tp__, typename Tphi__,
+            typename Tpsi__, typename Tnu__, typename Tchi__,
+            typename T_lp__, typename T_lp_accum__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+             const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+             const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
+             T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7671,8 +7719,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7696,15 +7746,12 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -7764,24 +7811,25 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr> void
-  js_super_lp(const std::vector<std::vector<int>>& y,
-              const std::vector<int>& first, const std::vector<int>& last,
-              const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
-              const T6__& nu_arg__, const T7__& chi_arg__, T_lp__& lp__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
+          typename Tchi__, typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
+              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T3__>,
-                                 stan::value_type_t<T4__>, T5__,
-                                 stan::value_type_t<T6__>,
-                                 stan::value_type_t<T7__>>;
+            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
+                                stan::return_type_t<Tpsi__, Tnu__, Tchi__>>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -8011,45 +8059,51 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*>
-void
-js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
-                                  const std::vector<int>& first,
-                                  const std::vector<int>& last,
-                                  const T3__& p, const T4__& phi,
-                                  const T5__& psi, const T6__& nu,
-                                  const T7__& chi, T_lp__& lp__,
-                                  T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
+          typename Tchi__, typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tpsi__>>*,
+          stan::require_t<stan::is_col_vector<Tnu__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+inline void
+js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
+                                  const Tlast__& last, const Tp__& p,
+                                  const Tphi__& phi, const Tpsi__& psi,
+                                  const Tnu__& nu, const Tchi__& chi,
+                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10413,24 +10467,33 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -10451,8 +10514,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -10476,16 +10541,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -10540,28 +10606,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -11466,42 +11538,53 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__,
-            typename T6__, typename T_lp__, typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
-  void
-  operator()(const std::vector<std::vector<int>>& y,
-             const std::vector<int>& first, const std::vector<int>& last,
-             const T3__& p, const T4__& phi, const T5__& gamma,
-             const T6__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
+  template <bool propto__, typename Ty__, typename Tfirst__,
+            typename Tlast__, typename Tp__, typename Tphi__,
+            typename Tgamma__, typename Tchi__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+            stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+             const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+             const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  operator()(const T0__& gamma, std::ostream* pstream__) const;
+  template <typename Tgamma__,
+            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+  operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
+  template <typename Tp__, typename Tphi__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11522,8 +11605,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11547,15 +11632,12 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-  prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T0__>,
-                                 stan::value_type_t<T1__>>;
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11615,23 +11697,24 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr> void
-  jolly_seber_lp(const std::vector<std::vector<int>>& y,
-                 const std::vector<int>& first, const std::vector<int>& last,
-                 const T3__& p_arg__, const T4__& phi_arg__,
-                 const T5__& gamma_arg__, const T6__& chi_arg__,
-                 T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
+          typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>* = nullptr,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
+          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+  inline void
+  jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+                 const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
+                 const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T3__>,
-                                 stan::value_type_t<T4__>,
-                                 stan::value_type_t<T5__>,
-                                 stan::value_type_t<T6__>>;
+            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
+                                stan::return_type_t<Tgamma__, Tchi__>>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11859,10 +11942,11 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tgamma__,
+          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+  seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tgamma__>;
     int current_statement__ = 0; 
     const auto& gamma = stan::math::to_ref(gamma_arg__);
     static constexpr bool propto__ = true;
@@ -11900,52 +11984,60 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__,
-          typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_eigen_matrix_dynamic_t<T6__>*>
-void
-jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
-                                     const std::vector<int>& first,
-                                     const std::vector<int>& last,
-                                     const T3__& p, const T4__& phi,
-                                     const T5__& gamma, const T6__& chi,
-                                     T_lp__& lp__, T_lp_accum__& lp_accum__,
+template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
+          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
+          typename T_lp__, typename T_lp_accum__,
+          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, stan::is_stan_scalar_t<value_type_t<value_type_t<Ty__>>>>*,
+          stan::require_all_t<stan::is_std_vector<Tfirst__>, stan::is_stan_scalar_t<value_type_t<Tfirst__>>>*,
+          stan::require_all_t<stan::is_std_vector<Tlast__>, stan::is_stan_scalar_t<value_type_t<Tlast__>>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
+          stan::require_t<stan::is_col_vector<Tgamma__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+inline void
+jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
+                                     const Tlast__& last, const Tp__& p,
+                                     const Tphi__& phi,
+                                     const Tgamma__& gamma,
+                                     const Tchi__& chi, T_lp__& lp__,
+                                     T_lp_accum__& lp_accum__,
                                      std::ostream* pstream__)  const
 {
   return jolly_seber_lp<propto__>(y, first, last, p, phi, gamma, chi, lp__,
            lp_accum__, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
-const
+template <typename Tgamma__, stan::require_t<stan::is_col_vector<Tgamma__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
+seq_cprob_functor__::operator()(const Tgamma__& gamma,
+                                std::ostream* pstream__)  const
 {
   return seq_cprob(gamma, pstream__);
 }
 
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
+template <typename Tp__, typename Tphi__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
@@ -13977,24 +14069,33 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  operator()(const int& nind, const int& n_occasions, const T2__& p,
-             const T3__& phi, std::ostream* pstream__) const;
+  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+            typename Tphi__,
+            stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
+             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  int
-  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
+  template <typename Ty_i__,
+            stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int
+  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14015,8 +14116,10 @@ int first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>* = nullptr>
+  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14040,16 +14143,17 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-  prob_uncaptured(const int& nind, const int& n_occasions,
-                  const T2__& p_arg__, const T3__& phi_arg__,
-                  std::ostream* pstream__) {
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__,
+          stan::require_t<stan::is_stan_scalar_t<Tnind__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
+                  const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::promote_args_t<stan::value_type_t<T2__>,
-                                 stan::value_type_t<T3__>>;
+            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -14104,28 +14208,34 @@ template <typename T2__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int
-first_capture_functor__::operator()(const std::vector<int>& y_i,
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
-prob_uncaptured_functor__::operator()(const int& nind,
-                                      const int& n_occasions, const T2__& p,
-                                      const T3__& phi,
+template <typename Tnind__, typename Tn_occasions__, typename Tp__,
+          typename Tphi__, stan::require_t<stan::is_stan_scalar_t<Tnind__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tn_occasions__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const Tnind__& nind,
+                                      const Tn_occasions__& n_occasions,
+                                      const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-int
-last_capture_functor__::operator()(const std::vector<int>& y_i,
-                                   std::ostream* pstream__)  const
+template <typename Ty_i__,
+          stan::require_all_t<stan::is_std_vector<Ty_i__>, stan::is_stan_scalar_t<value_type_t<Ty_i__>>>*>
+inline int
+last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
+const
 {
   return last_capture(y_i, pstream__);
 }
@@ -14808,31 +14918,32 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <bool propto__, typename Tx__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
+  template <bool propto__, typename Tn__, typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tn__, Tmu__>
+  operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
+  template <bool propto__, typename Tx__, typename Tmu__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Tmu__>
+  operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T0__, T1__>
-  foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
+template <bool propto__, typename Tx__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tx__, Tmu__>
+  foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -14843,11 +14954,12 @@ template <bool propto__, typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
-  stan::promote_args_t<T1__>
-  bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T1__>;
+template <bool propto__, typename Tn__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tn__, Tmu__>
+  bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -14858,11 +14970,11 @@ template <bool propto__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
-  stan::promote_args_t<T0__>
-  baz_lpdf(const T0__& x, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+template <bool propto__, typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr>
+  inline stan::return_type_t<Tx__>
+  baz_lpdf(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -14873,26 +14985,29 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
-stan::promote_args_t<T0__>
-baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
+template <bool propto__, typename Tx__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*>
+inline stan::return_type_t<Tx__>
+baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T1__>
-bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
+template <bool propto__, typename Tn__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tn__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline stan::return_type_t<Tn__, Tmu__>
+bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
-stan::promote_args_t<T0__, T1__>
-foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
+template <bool propto__, typename Tx__, typename Tmu__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Tmu__>>*>
+inline stan::return_type_t<Tx__, Tmu__>
+foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return foo_lpdf<propto__>(x, mu, pstream__);
@@ -16783,29 +16898,34 @@ static constexpr std::array<const char*, 109> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  int
-  operator()(const int& y, std::ostream* pstream__) const;
+  template <typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline int
+  operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
   template <bool propto__, typename T_lp__, typename T_lp_accum__>
-  int
+  inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__,
+  template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  operator()(const T0__& x, const int& y, T_lp__& lp__,
+            stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline void
+  operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
-  nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline void
+  nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<T0__>;
+    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -16821,8 +16941,10 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int rfun(const int& y, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>* = nullptr>
+  inline int rfun(const Ty__& y, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -16840,7 +16962,7 @@ int rfun(const int& y, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -16855,23 +16977,27 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int rfun_functor__::operator()(const int& y, std::ostream* pstream__)  const
+template <typename Ty__, stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline int
+rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
 template <bool propto__, typename T_lp__, typename T_lp_accum__>
-int
+inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
-void
-nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_t<stan::is_stan_scalar_t<Tx__>>*,
+          stan::require_t<stan::is_stan_scalar_t<Ty__>>*>
+inline void
+nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
                                std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -669,14 +669,22 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr,
+            stan::require_stan_scalar_t<T2__>* = nullptr,
+            stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
              const std::vector<int>& x_i, std::ostream* pstream__) const;
 };
 
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr,
+          stan::require_stan_scalar_t<T2__>* = nullptr,
+          stan::require_stan_scalar_t<T3__>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -726,8 +734,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__, stan::requ
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr, stan::require_stan_scalar_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+template <typename T0__, typename T1__, typename T2__, typename T3__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*,
+          stan::require_stan_scalar_t<T2__>*,
+          stan::require_stan_scalar_t<T3__>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -1356,7 +1367,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -1413,7 +1426,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -1475,7 +1490,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -1483,8 +1497,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -1493,7 +1508,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -6548,7 +6562,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -6605,7 +6621,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -6667,7 +6685,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -6675,8 +6692,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -6685,7 +6703,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -7605,7 +7622,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -7614,7 +7633,14 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
+  template <bool propto__, typename T3__, typename T4__, typename T5__,
+            typename T6__, typename T7__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+            stan::require_stan_scalar_t<T5__>* = nullptr,
+            stan::require_col_vector_t<T6__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -7670,7 +7696,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -7736,8 +7764,14 @@ template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
-  void
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T7__, typename T_lp__,
+          typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+          stan::require_stan_scalar_t<T5__>* = nullptr,
+          stan::require_col_vector_t<T6__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr> void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
               const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
@@ -7977,7 +8011,6 @@ template <bool propto__, typename T3__, typename T4__, typename T5__, typename T
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -7985,15 +8018,15 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -8002,8 +8035,13 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T7__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_stan_scalar_t<T5__>* = nullptr, stan::require_col_vector_t<T6__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr>
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T7__, typename T_lp__,
+          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
+          stan::require_eigen_matrix_dynamic_t<T4__>*,
+          stan::require_stan_scalar_t<T5__>*,
+          stan::require_col_vector_t<T6__>*,
+          stan::require_eigen_matrix_dynamic_t<T7__>*>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -10379,7 +10417,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -10436,7 +10476,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -10498,7 +10540,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -10506,8 +10547,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -10516,7 +10558,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -11425,7 +11466,12 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
+  template <bool propto__, typename T3__, typename T4__, typename T5__,
+            typename T6__, typename T_lp__, typename T_lp_accum__,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+            stan::require_col_vector_t<T5__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11447,7 +11493,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -11499,7 +11547,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -11565,8 +11615,12 @@ template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
-  void
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T_lp__, typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
+          stan::require_col_vector_t<T5__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr> void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
                  const T3__& p_arg__, const T4__& phi_arg__,
@@ -11846,8 +11900,12 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T3__, typename T4__, typename T5__, typename T6__, typename T_lp__, typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr, stan::require_col_vector_t<T5__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr>
+template <bool propto__, typename T3__, typename T4__, typename T5__,
+          typename T6__, typename T_lp__, typename T_lp_accum__,
+          stan::require_eigen_matrix_dynamic_t<T3__>*,
+          stan::require_eigen_matrix_dynamic_t<T4__>*,
+          stan::require_col_vector_t<T5__>*,
+          stan::require_eigen_matrix_dynamic_t<T6__>*>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -11861,7 +11919,6 @@ jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
            lp_accum__, pstream__);
 }
 
-
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
                                    std::ostream* pstream__)  const
@@ -11869,15 +11926,13 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
 {
   return seq_cprob(gamma, pstream__);
 }
-
 
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -11886,8 +11941,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_eigen_matrix_dynamic_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -13925,7 +13981,9 @@ struct first_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+  template <typename T2__, typename T3__,
+            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -13982,7 +14040,9 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -14044,7 +14104,6 @@ template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2_
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int
 first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
@@ -14052,8 +14111,9 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
   return first_capture(y_i, pstream__);
 }
 
-
-template <typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr>
+template <typename T2__, typename T3__,
+          stan::require_eigen_matrix_dynamic_t<T2__>*,
+          stan::require_eigen_matrix_dynamic_t<T3__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T2__>, stan::value_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -14062,7 +14122,6 @@ prob_uncaptured_functor__::operator()(const int& nind,
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
-
 
 int
 last_capture_functor__::operator()(const std::vector<int>& y_i,
@@ -14749,22 +14808,28 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T1__,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <bool propto__, typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -14778,7 +14843,8 @@ template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__,
+          stan::require_stan_scalar_t<T1__>* = nullptr>
   stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -14792,7 +14858,8 @@ template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__,
+          stan::require_stan_scalar_t<T0__>* = nullptr>
   stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -14806,16 +14873,14 @@ template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
 stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -14823,8 +14888,9 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <bool propto__, typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>*,
+          stan::require_stan_scalar_t<T1__>*>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -16721,17 +16787,21 @@ struct rfun_functor__ {
   operator()(const int& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <bool propto__, typename T0__, typename T_lp__,
+            typename T_lp_accum__,
+            stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
   void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
@@ -16785,22 +16855,21 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int rfun_functor__::operator()(const int& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
-
-template <bool propto__, typename T_lp__, typename T_lp_accum__> int
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
+int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
 {
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-
-template <bool propto__, typename T0__, typename T_lp__, typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <bool propto__, typename T0__, typename T_lp__,
+          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -671,10 +671,10 @@ static constexpr std::array<const char*, 37> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
             typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
@@ -682,10 +682,10 @@ struct simple_SIR_functor__ {
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -737,10 +737,10 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
           typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
-          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
-          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -1364,7 +1364,7 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -1379,12 +1379,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1407,7 +1407,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1497,7 +1497,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -1519,7 +1519,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -6569,7 +6569,7 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -6584,12 +6584,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -6612,7 +6612,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -6702,7 +6702,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -6724,7 +6724,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -7639,7 +7639,7 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -7651,7 +7651,7 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -7660,9 +7660,9 @@ struct js_super_lp_functor__ {
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
             typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
             stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -7674,7 +7674,7 @@ struct js_super_lp_functor__ {
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7697,7 +7697,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7791,9 +7791,9 @@ template <typename Tp__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -8034,7 +8034,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -8052,7 +8052,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8063,9 +8063,9 @@ const
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
           typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
@@ -10439,7 +10439,7 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -10454,12 +10454,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -10482,7 +10482,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -10572,7 +10572,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -10594,7 +10594,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11505,9 +11505,9 @@ struct jolly_seber_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
             stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_col_vector<Tgamma__>,
@@ -11519,7 +11519,7 @@ struct jolly_seber_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11529,7 +11529,7 @@ struct seq_cprob_functor__ {
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -11541,7 +11541,7 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11564,7 +11564,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11658,9 +11658,9 @@ template <typename Tp__,
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
@@ -11943,9 +11943,9 @@ template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
           typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
           stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
@@ -11963,7 +11963,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11979,7 +11979,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14023,7 +14023,7 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -14038,12 +14038,12 @@ struct prob_uncaptured_functor__ {
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14066,7 +14066,7 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14156,7 +14156,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14178,7 +14178,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -669,28 +669,28 @@ static constexpr std::array<const char*, 37> locations_array__ =
  " (in 'ad-level-failing.stan', line 11, column 61 to line 20, column 3)"};
 
 struct simple_SIR_functor__ {
-  template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+  template <typename Tt__, typename Ty__, typename Ttheta__,
+            typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
             stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
             stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-            stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) const;
 };
 
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>* = nullptr>
-  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>* = nullptr>
+  inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
-             const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
+             const Tx_r__& x_r, const std::vector<int>& x_i,
+             std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>;
+            stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -735,17 +735,16 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+template <typename Tt__, typename Ty__, typename Ttheta__,
+          typename Tx_r__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
           stan::is_std_vector<Ty__>, stan::is_stan_scalar<stan::value_type_t<Ty__>>,
           stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<stan::value_type_t<Ttheta__>>,
-          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>,
-          stan::is_std_vector<Tx_i__>, std::is_integral<stan::value_type_t<Tx_i__>>>*>
-inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<stan::value_type_t<Tx_r__>>>*>
+inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
-                                 const Tx_i__& x_i, std::ostream* pstream__) 
-const
+                                 const std::vector<int>& x_i,
+                                 std::ostream* pstream__)  const
 {
   return simple_SIR(t, y, theta, x_r, x_i, pstream__);
 }
@@ -1364,29 +1363,25 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1407,9 +1402,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -1433,17 +1428,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -1498,32 +1489,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -6570,29 +6556,25 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -6613,9 +6595,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -6639,17 +6621,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -6704,32 +6682,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -7641,9 +7614,8 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tp__,
@@ -7653,32 +7625,27 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct js_super_lp_functor__ {
-  template <bool propto__, typename Ty__, typename Tfirst__,
-            typename Tlast__, typename Tp__, typename Tphi__,
-            typename Tpsi__, typename Tnu__, typename Tchi__,
-            typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+            typename Tnu__, typename Tchi__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
-  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  operator()(const std::vector<std::vector<int>>& y,
+             const std::vector<int>& first, const std::vector<int>& last,
              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
              const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7699,9 +7666,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -7791,24 +7758,20 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+          typename Tnu__, typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
-  js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  js_super_lp(const std::vector<std::vector<int>>& y,
+              const std::vector<int>& first, const std::vector<int>& last,
               const Tp__& p_arg__, const Tphi__& phi_arg__,
               const Tpsi__& psi, const Tnu__& nu_arg__,
               const Tchi__& chi_arg__, T_lp__& lp__,
               T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
-                                stan::return_type_t<Tpsi__, Tnu__, Tchi__>>;
+            stan::return_type_t<Tp__, Tphi__, Tpsi__, Tnu__, Tchi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -8038,9 +8001,8 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
@@ -8056,30 +8018,27 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
 
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tpsi__,
+          typename Tnu__, typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
-js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                  const Tlast__& last, const Tp__& p,
-                                  const Tphi__& phi, const Tpsi__& psi,
-                                  const Tnu__& nu, const Tchi__& chi,
-                                  T_lp__& lp__, T_lp_accum__& lp_accum__,
+js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
+                                  const std::vector<int>& first,
+                                  const std::vector<int>& last,
+                                  const Tp__& p, const Tphi__& phi,
+                                  const Tpsi__& psi, const Tnu__& nu,
+                                  const Tchi__& chi, T_lp__& lp__,
+                                  T_lp_accum__& lp_accum__,
                                   std::ostream* pstream__)  const
 {
   return js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
@@ -10443,29 +10402,25 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -10486,9 +10441,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -10512,17 +10467,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -10577,32 +10528,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -11507,26 +11453,22 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'inlining-fail2.stan', line 148, column 33 to line 158, column 3)"};
 
 struct jolly_seber_lp_functor__ {
-  template <bool propto__, typename Ty__, typename Tfirst__,
-            typename Tlast__, typename Tp__, typename Tphi__,
-            typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-            stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-            stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+            typename Tchi__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>,
             stan::is_col_vector<Tgamma__>,
             stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
-  operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  operator()(const std::vector<std::vector<int>>& y,
+             const std::vector<int>& first, const std::vector<int>& last,
              const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
              const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
   template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
@@ -11534,9 +11476,8 @@ struct seq_cprob_functor__ {
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tp__,
@@ -11546,9 +11487,9 @@ struct prob_uncaptured_functor__ {
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11569,9 +11510,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -11661,24 +11602,20 @@ template <typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
-  jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
+  jolly_seber_lp(const std::vector<std::vector<int>>& y,
+                 const std::vector<int>& first, const std::vector<int>& last,
                  const Tp__& p_arg__, const Tphi__& phi_arg__,
                  const Tgamma__& gamma_arg__, const Tchi__& chi_arg__,
                  T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ =
-            stan::return_type_t<Ty__, Tfirst__, Tlast__, Tp__, Tphi__,
-                                stan::return_type_t<Tgamma__, Tchi__>>;
+            stan::return_type_t<Tp__, Tphi__, Tgamma__, Tchi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -11947,20 +11884,17 @@ template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
-          typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<stan::value_type_t<Ty__>>, std::is_integral<stan::value_type_t<stan::value_type_t<Ty__>>>,
-          stan::is_std_vector<Tfirst__>, std::is_integral<stan::value_type_t<Tfirst__>>,
-          stan::is_std_vector<Tlast__>, std::is_integral<stan::value_type_t<Tlast__>>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <bool propto__, typename Tp__, typename Tphi__, typename Tgamma__,
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>,
           stan::is_col_vector<Tgamma__>,
           stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
-jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
-                                     const Tlast__& last, const Tp__& p,
-                                     const Tphi__& phi,
+jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
+                                     const std::vector<int>& first,
+                                     const std::vector<int>& last,
+                                     const Tp__& p, const Tphi__& phi,
                                      const Tgamma__& gamma,
                                      const Tchi__& chi, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -11970,10 +11904,9 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -11986,9 +11919,8 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
@@ -14030,29 +13962,25 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-            std::is_integral<Tn_occasions__>,
-            stan::is_eigen_matrix_dynamic<Tp__>,
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
             stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
-             const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  operator()(const int nind, const int n_occasions, const Tp__& p,
+             const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
   inline int
-  operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
+  operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  first_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14073,9 +14001,9 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>* = nullptr>
-  inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty_i__>;
+inline int
+  last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -14099,17 +14027,13 @@ template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std:
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
-  inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-  prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
-                  const Tp__& p_arg__, const Tphi__& phi_arg__,
-                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>;
+  inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+  prob_uncaptured(const int nind, const int n_occasions, const Tp__& p_arg__,
+                  const Tphi__& phi_arg__, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
     int current_statement__ = 0; 
     const auto& p = stan::math::to_ref(p_arg__);
     const auto& phi = stan::math::to_ref(phi_arg__);
@@ -14164,32 +14088,27 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-first_capture_functor__::operator()(const Ty_i__& y_i,
+first_capture_functor__::operator()(const std::vector<int>& y_i,
                                     std::ostream* pstream__)  const
 {
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
-          std::is_integral<Tn_occasions__>,
-          stan::is_eigen_matrix_dynamic<Tp__>,
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
           stan::is_eigen_matrix_dynamic<Tphi__>>*>
-inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
-prob_uncaptured_functor__::operator()(const Tnind__& nind,
-                                      const Tn_occasions__& n_occasions,
+inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
+prob_uncaptured_functor__::operator()(const int nind, const int n_occasions,
                                       const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
 {
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<stan::value_type_t<Ty_i__>>>*>
 inline int
-last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
-const
+last_capture_functor__::operator()(const std::vector<int>& y_i,
+                                   std::ostream* pstream__)  const
 {
   return last_capture(y_i, pstream__);
 }
@@ -14878,11 +14797,10 @@ struct baz_lpdf_functor__ {
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename Tn__,
-            typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-            stan::is_stan_scalar<Tmu__>>* = nullptr>
-  inline stan::return_type_t<Tn__, Tmu__>
-  operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
+  template <bool propto__,
+            typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tmu__>
+  operator()(const int n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename Tx__,
@@ -14908,12 +14826,11 @@ template <bool propto__, typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tn__,
-          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-          stan::is_stan_scalar<Tmu__>>* = nullptr>
-  inline stan::return_type_t<Tn__, Tmu__>
-  bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
+template <bool propto__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  inline stan::return_type_t<Tmu__>
+  bar_lpmf(const int n, const Tmu__& mu, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tmu__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -14947,11 +14864,10 @@ baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename Tn__,
-          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
-          stan::is_stan_scalar<Tmu__>>*>
-inline stan::return_type_t<Tn__, Tmu__>
-bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
+template <bool propto__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tmu__>>*>
+inline stan::return_type_t<Tmu__>
+bar_lpmf_functor__::operator()(const int n, const Tmu__& mu,
                                std::ostream* pstream__)  const
 {
   return bar_lpmf<propto__>(n, mu, pstream__);
@@ -16852,31 +16768,28 @@ static constexpr std::array<const char*, 109> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int
-  operator()(const Ty__& y, std::ostream* pstream__) const;
+  operator()(const int y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<>* = nullptr>
+  template <bool propto__, typename T_lp__, typename T_lp_accum__>
   inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
-  template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-            std::is_integral<Ty__>>* = nullptr>
+  template <bool propto__, typename Tx__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline void
-  operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
+  operator()(const Tx__& x, const int y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-          std::is_integral<Ty__>>* = nullptr> inline void
-  nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  inline void
+  nrfun_lp(const Tx__& x, const int y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     (void) DUMMY_VAR__;  // suppress unused var warning
@@ -16892,9 +16805,8 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
-  inline int rfun(const Ty__& y, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ty__>;
+inline int rfun(const int y, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -16912,8 +16824,7 @@ template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<>* = nullptr> inline int
+template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -16928,15 +16839,13 @@ template <bool propto__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
-inline int
-rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
+inline int rfun_functor__::operator()(const int y, std::ostream* pstream__) 
+const
 {
   return rfun(y, pstream__);
 }
 
-template <bool propto__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<>*>
+template <bool propto__, typename T_lp__, typename T_lp_accum__>
 inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
@@ -16944,11 +16853,10 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
   return rfun_lp<propto__>(lp__, lp_accum__, pstream__);
 }
 
-template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
-          std::is_integral<Ty__>>*>
+template <bool propto__, typename Tx__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline void
-nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
+nrfun_lp_functor__::operator()(const Tx__& x, const int y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
                                std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -670,24 +670,22 @@ static constexpr std::array<const char*, 37> locations_array__ =
 
 struct simple_SIR_functor__ {
   template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-            typename Tx_i__,
-            stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+            typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+            stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+            stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+            stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+            stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   operator()(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) const;
 };
 
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__,
-          stan::require_t<stan::is_stan_scalar<Tt__>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>* = nullptr>
   inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
   simple_SIR(const Tt__& t, const Ty__& y, const Ttheta__& theta,
              const Tx_r__& x_r, const Tx_i__& x_i, std::ostream* pstream__) {
@@ -738,11 +736,11 @@ template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
     }
     }
 template <typename Tt__, typename Ty__, typename Ttheta__, typename Tx_r__,
-          typename Tx_i__, stan::require_t<stan::is_stan_scalar<Tt__>>*,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>>*,
-          stan::require_all_t<stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
+          typename Tx_i__, stan::require_all_t<stan::is_stan_scalar<Tt__>,
+          stan::is_std_vector<Ty__>, stan::is_stan_scalar<value_type_t<Ty__>>,
+          stan::is_std_vector<Ttheta__>, stan::is_stan_scalar<value_type_t<Ttheta__>>,
+          stan::is_std_vector<Tx_r__>, stan::is_stan_scalar<value_type_t<Tx_r__>>,
+          stan::is_std_vector<Tx_i__>, std::is_integral<value_type_t<Tx_i__>>>*>
 inline std::vector<stan::return_type_t<Tt__, Ty__, Ttheta__, Tx_r__, Tx_i__>>
 simple_SIR_functor__::operator()(const Tt__& t, const Ty__& y,
                                  const Ttheta__& theta, const Tx_r__& x_r,
@@ -1366,31 +1364,27 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'copy_fail.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1413,8 +1407,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -1441,11 +1434,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -1505,8 +1497,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -1515,10 +1506,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -1528,8 +1519,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -6579,31 +6569,27 @@ static constexpr std::array<const char*, 81> locations_array__ =
  " (in 'expr-prop-fail5.stan', line 24, column 74 to line 48, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -6626,8 +6612,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -6654,11 +6639,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -6718,8 +6702,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -6728,10 +6711,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -6741,8 +6724,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -7657,21 +7639,19 @@ static constexpr std::array<const char*, 158> locations_array__ =
  " (in 'expr-prop-fail6.stan', line 81, column 74 to line 143, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tp__, typename Tphi__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
@@ -7679,15 +7659,14 @@ struct js_super_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tpsi__, typename Tnu__, typename Tchi__,
-            typename T_lp__, typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+            typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>,
+            stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+            stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
              const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
@@ -7695,8 +7674,7 @@ struct js_super_lp_functor__ {
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7719,8 +7697,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -7746,9 +7723,9 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
@@ -7813,16 +7790,14 @@ template <typename Tp__, typename Tphi__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tpsi__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tnu__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
-  inline void
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   js_super_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
               const Tp__& p, const Tphi__& phi, const Tpsi__& psi,
               const Tnu__& nu, const Tchi__& chi, T_lp__& lp__,
@@ -8059,8 +8034,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -8068,9 +8042,9 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
@@ -8078,8 +8052,7 @@ prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
   return prob_uncaptured(p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -8089,15 +8062,14 @@ const
 
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tpsi__, typename Tnu__,
-          typename Tchi__, typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_stan_scalar<Tpsi__>>*,
-          stan::require_t<stan::is_col_vector<Tnu__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+          typename Tchi__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_stan_scalar<Tpsi__>, stan::is_col_vector<Tnu__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 js_super_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
                                   const Tlast__& last, const Tp__& p,
@@ -10467,31 +10439,27 @@ static constexpr std::array<const char*, 76> locations_array__ =
  " (in 'fails-test.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -10514,8 +10482,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -10542,11 +10509,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -10606,8 +10572,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -10616,10 +10581,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -10629,8 +10594,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -11541,14 +11505,13 @@ struct jolly_seber_lp_functor__ {
   template <bool propto__, typename Ty__, typename Tfirst__,
             typename Tlast__, typename Tp__, typename Tphi__,
             typename Tgamma__, typename Tchi__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-            stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+            stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+            stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>,
+            stan::is_col_vector<Tgamma__>,
+            stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
   inline void
   operator()(const Ty__& y, const Tfirst__& first, const Tlast__& last,
              const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
@@ -11556,33 +11519,29 @@ struct jolly_seber_lp_functor__ {
              std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename Tgamma__,
-            stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+  template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
   operator()(const Tgamma__& gamma, std::ostream* pstream__) const;
 };
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
-  template <typename Tp__, typename Tphi__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+  template <typename Tp__,
+            typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   operator()(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11605,8 +11564,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -11632,9 +11590,9 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tp__, Tphi__>;
@@ -11699,15 +11657,14 @@ template <typename Tp__, typename Tphi__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>* = nullptr,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr,
-          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr>
-  inline void
+          typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_col_vector<Tgamma__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>* = nullptr> inline void
   jolly_seber_lp(const Ty__& y, const Tfirst__& first, const Tlast__& last,
                  const Tp__& p, const Tphi__& phi, const Tgamma__& gamma,
                  const Tchi__& chi, T_lp__& lp__, T_lp_accum__& lp_accum__,
@@ -11942,8 +11899,7 @@ template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tgamma__,
-          stan::require_t<stan::is_col_vector<Tgamma__>>* = nullptr>
+template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
   seq_cprob(const Tgamma__& gamma, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tgamma__>;
@@ -11986,14 +11942,14 @@ template <typename Tgamma__,
     }
 template <bool propto__, typename Ty__, typename Tfirst__, typename Tlast__,
           typename Tp__, typename Tphi__, typename Tgamma__, typename Tchi__,
-          typename T_lp__, typename T_lp_accum__,
-          stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>>*,
-          stan::require_all_t<stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>>*,
-          stan::require_all_t<stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*,
-          stan::require_t<stan::is_col_vector<Tgamma__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tchi__>>*>
+          typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<stan::is_std_vector<Ty__>, stan::is_std_vector<value_type_t<Ty__>>, std::is_integral<value_type_t<value_type_t<Ty__>>>,
+          stan::is_std_vector<Tfirst__>, std::is_integral<value_type_t<Tfirst__>>,
+          stan::is_std_vector<Tlast__>, std::is_integral<value_type_t<Tlast__>>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>,
+          stan::is_col_vector<Tgamma__>,
+          stan::is_eigen_matrix_dynamic<Tchi__>>*>
 inline void
 jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
                                      const Tlast__& last, const Tp__& p,
@@ -12007,8 +11963,7 @@ jolly_seber_lp_functor__::operator()(const Ty__& y, const Tfirst__& first,
            lp_accum__, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -12016,7 +11971,7 @@ const
   return last_capture(y_i, pstream__);
 }
 
-template <typename Tgamma__, stan::require_t<stan::is_col_vector<Tgamma__>>*>
+template <typename Tgamma__, stan::require_all_t<stan::is_col_vector<Tgamma__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tgamma__>, -1, 1>
 seq_cprob_functor__::operator()(const Tgamma__& gamma,
                                 std::ostream* pstream__)  const
@@ -12024,8 +11979,7 @@ seq_cprob_functor__::operator()(const Tgamma__& gamma,
   return seq_cprob(gamma, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -12033,9 +11987,9 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
   return first_capture(y_i, pstream__);
 }
 
-template <typename Tp__, typename Tphi__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+template <typename Tp__,
+          typename Tphi__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tp__& p, const Tphi__& phi,
                                       std::ostream* pstream__)  const
@@ -14069,31 +14023,27 @@ static constexpr std::array<const char*, 71> locations_array__ =
  " (in 'lcm-fails2.stan', line 24, column 74 to line 46, column 3)"};
 
 struct first_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 struct prob_uncaptured_functor__ {
   template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-            typename Tphi__,
-            stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-            stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+            typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+            std::is_integral<Tn_occasions__>,
+            stan::is_eigen_matrix_dynamic<Tp__>,
+            stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   operator()(const Tnind__& nind, const Tn_occasions__& n_occasions,
              const Tp__& p, const Tphi__& phi, std::ostream* pstream__) const;
 };
 struct last_capture_functor__ {
-  template <typename Ty_i__,
-            stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+  template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int
   operator()(const Ty_i__& y_i, std::ostream* pstream__) const;
 };
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int first_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14116,8 +14066,7 @@ template <typename Ty_i__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>* = nullptr>
   inline int last_capture(const Ty_i__& y_i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty_i__>;
     int current_statement__ = 0; 
@@ -14144,11 +14093,10 @@ template <typename Ty_i__,
     }
     }
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__,
-          stan::require_t<std::is_integral<Tnind__>>* = nullptr,
-          stan::require_t<std::is_integral<Tn_occasions__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
   prob_uncaptured(const Tnind__& nind, const Tn_occasions__& n_occasions,
                   const Tp__& p, const Tphi__& phi, std::ostream* pstream__) {
@@ -14208,8 +14156,7 @@ template <typename Tnind__, typename Tn_occasions__, typename Tp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 first_capture_functor__::operator()(const Ty_i__& y_i,
                                     std::ostream* pstream__)  const
@@ -14218,10 +14165,10 @@ first_capture_functor__::operator()(const Ty_i__& y_i,
 }
 
 template <typename Tnind__, typename Tn_occasions__, typename Tp__,
-          typename Tphi__, stan::require_t<std::is_integral<Tnind__>>*,
-          stan::require_t<std::is_integral<Tn_occasions__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tp__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tphi__>>*>
+          typename Tphi__, stan::require_all_t<std::is_integral<Tnind__>,
+          std::is_integral<Tn_occasions__>,
+          stan::is_eigen_matrix_dynamic<Tp__>,
+          stan::is_eigen_matrix_dynamic<Tphi__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tnind__, Tn_occasions__, Tp__, Tphi__>, -1, -1>
 prob_uncaptured_functor__::operator()(const Tnind__& nind,
                                       const Tn_occasions__& n_occasions,
@@ -14231,8 +14178,7 @@ prob_uncaptured_functor__::operator()(const Tnind__& nind,
   return prob_uncaptured(nind, n_occasions, p, phi, pstream__);
 }
 
-template <typename Ty_i__,
-          stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
+template <typename Ty_i__, stan::require_all_t<stan::is_std_vector<Ty_i__>, std::is_integral<value_type_t<Ty_i__>>>*>
 inline int
 last_capture_functor__::operator()(const Ty_i__& y_i, std::ostream* pstream__) 
 const
@@ -14918,29 +14864,29 @@ static constexpr std::array<const char*, 14> locations_array__ =
  " (in 'lupdf-inlining.stan', line 8, column 26 to line 10, column 5)"};
 
 struct baz_lpdf_functor__ {
-  template <bool propto__, typename Tx__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+  template <bool propto__,
+            typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
-  template <bool propto__, typename Tn__, typename Tmu__,
-            stan::require_t<std::is_integral<Tn__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <bool propto__, typename Tn__,
+            typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+            stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   operator()(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
-  template <bool propto__, typename Tx__, typename Tmu__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+  template <bool propto__, typename Tx__,
+            typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   operator()(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) const;
 };
 
-template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <bool propto__, typename Tx__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tx__, Tmu__>
   foo_lpdf(const Tx__& x, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Tmu__>;
@@ -14954,9 +14900,9 @@ template <bool propto__, typename Tx__, typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<std::is_integral<Tn__>>* = nullptr,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>* = nullptr>
+template <bool propto__, typename Tn__,
+          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+          stan::is_stan_scalar<Tmu__>>* = nullptr>
   inline stan::return_type_t<Tn__, Tmu__>
   bar_lpmf(const Tn__& n, const Tmu__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tn__, Tmu__>;
@@ -14970,8 +14916,8 @@ template <bool propto__, typename Tn__, typename Tmu__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr>
+template <bool propto__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>* = nullptr>
   inline stan::return_type_t<Tx__>
   baz_lpdf(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -14985,17 +14931,17 @@ template <bool propto__, typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename Tx__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*>
+template <bool propto__,
+          typename Tx__, stan::require_all_t<stan::is_stan_scalar<Tx__>>*>
 inline stan::return_type_t<Tx__>
 baz_lpdf_functor__::operator()(const Tx__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename Tn__, typename Tmu__,
-          stan::require_t<std::is_integral<Tn__>>*,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <bool propto__, typename Tn__,
+          typename Tmu__, stan::require_all_t<std::is_integral<Tn__>,
+          stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tn__, Tmu__>
 bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -15003,9 +14949,9 @@ bar_lpmf_functor__::operator()(const Tn__& n, const Tmu__& mu,
   return bar_lpmf<propto__>(n, mu, pstream__);
 }
 
-template <bool propto__, typename Tx__, typename Tmu__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<stan::is_stan_scalar<Tmu__>>*>
+template <bool propto__, typename Tx__,
+          typename Tmu__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          stan::is_stan_scalar<Tmu__>>*>
 inline stan::return_type_t<Tx__, Tmu__>
 foo_lpdf_functor__::operator()(const Tx__& x, const Tmu__& mu,
                                std::ostream* pstream__)  const
@@ -16898,29 +16844,28 @@ static constexpr std::array<const char*, 109> locations_array__ =
  " (in 'optimizations.stan', line 14, column 18 to line 17, column 5)"};
 
 struct rfun_functor__ {
-  template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
+  template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int
   operator()(const Ty__& y, std::ostream* pstream__) const;
 };
 struct rfun_lp_functor__ {
-  template <bool propto__, typename T_lp__, typename T_lp_accum__>
+  template <bool propto__, typename T_lp__,
+            typename T_lp_accum__, stan::require_all_t<>* = nullptr>
   inline int
   operator()(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 struct nrfun_lp_functor__ {
   template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-            typename T_lp_accum__,
-            stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-            stan::require_t<std::is_integral<Ty__>>* = nullptr>
+            typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+            std::is_integral<Ty__>>* = nullptr>
   inline void
   operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>* = nullptr,
-          stan::require_t<std::is_integral<Ty__>>* = nullptr> inline void
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          std::is_integral<Ty__>>* = nullptr> inline void
   nrfun_lp(const Tx__& x, const Ty__& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -16939,7 +16884,7 @@ template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
+template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>* = nullptr>
   inline int rfun(const Ty__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ty__>;
     int current_statement__ = 0; 
@@ -16959,7 +16904,8 @@ template <typename Ty__, stan::require_t<std::is_integral<Ty__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
+template <bool propto__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<>* = nullptr> inline int
   rfun_lp(T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
@@ -16974,14 +16920,15 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> inline int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ty__, stan::require_t<std::is_integral<Ty__>>*>
+template <typename Ty__, stan::require_all_t<std::is_integral<Ty__>>*>
 inline int
 rfun_functor__::operator()(const Ty__& y, std::ostream* pstream__)  const
 {
   return rfun(y, pstream__);
 }
 
-template <bool propto__, typename T_lp__, typename T_lp_accum__>
+template <bool propto__, typename T_lp__,
+          typename T_lp_accum__, stan::require_all_t<>*>
 inline int
 rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
                               std::ostream* pstream__)  const
@@ -16990,9 +16937,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 template <bool propto__, typename Tx__, typename Ty__, typename T_lp__,
-          typename T_lp_accum__,
-          stan::require_t<stan::is_stan_scalar<Tx__>>*,
-          stan::require_t<std::is_integral<Ty__>>*>
+          typename T_lp_accum__, stan::require_all_t<stan::is_stan_scalar<Tx__>,
+          std::is_integral<Ty__>>*>
 inline void
 nrfun_lp_functor__::operator()(const Tx__& x, const Ty__& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2610,7 +2610,7 @@ struct mask_fun_functor__ {
 struct udf_fun_functor__ {
   template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
-  operator()(const TA__& A_arg__, std::ostream* pstream__) const;
+  operator()(const TA__& A, std::ostream* pstream__) const;
 };
 
 template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>* = nullptr>
@@ -2630,7 +2630,7 @@ template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>* = nullptr>
     }
 template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
-  udf_fun(const TA__& A, std::ostream* pstream__) {
+  udf_fun(const TA__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<TA__>;
     int current_statement__ = 0; 
     const auto& A = stan::math::to_ref(A_arg__);
@@ -2654,8 +2654,7 @@ mask_fun_functor__::operator()(const Ti__& i, std::ostream* pstream__)  const
 
 template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>*>
 inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
-udf_fun_functor__::operator()(const TA__& A_arg__, std::ostream* pstream__) 
-const
+udf_fun_functor__::operator()(const TA__& A, std::ostream* pstream__)  const
 {
   return udf_fun(A, pstream__);
 }
@@ -4836,18 +4835,17 @@ struct okay_reduction_functor__ {
             typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
             stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-  operator()(const Tsum_x__& sum_x, const Ty__& y_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-  nono_func(const Tx__& x, std::ostream* pstream__) {
+  nono_func(const Tx__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
@@ -4866,7 +4864,7 @@ template <typename Tsum_x__,
           typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
           stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-  okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
+  okay_reduction(const Tsum_x__& sum_x, const Ty__& y_arg__,
                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tsum_x__, Ty__>;
     int current_statement__ = 0; 
@@ -4886,8 +4884,7 @@ template <typename Tsum_x__,
           typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
           stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-okay_reduction_functor__::operator()(const Tsum_x__& sum_x,
-                                     const Ty__& y_arg__,
+okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
                                      std::ostream* pstream__)  const
 {
   return okay_reduction(sum_x, y, pstream__);
@@ -4895,7 +4892,7 @@ okay_reduction_functor__::operator()(const Tsum_x__& sum_x,
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-nono_func_functor__::operator()(const Tx__& x_arg__, std::ostream* pstream__) 
+nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return nono_func(x, pstream__);
@@ -5457,7 +5454,7 @@ struct empty_user_func_functor__ {
 struct mat_ret_user_func_functor__ {
   template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
-  operator()(const TA__& A_arg__, std::ostream* pstream__) const;
+  operator()(const TA__& A, std::ostream* pstream__) const;
 };
 
 inline Eigen::Matrix<double, -1, -1>
@@ -5480,7 +5477,7 @@ inline Eigen::Matrix<double, -1, -1>
     }
 template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
-  mat_ret_user_func(const TA__& A, std::ostream* pstream__) {
+  mat_ret_user_func(const TA__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<TA__>;
     int current_statement__ = 0; 
     const auto& A = stan::math::to_ref(A_arg__);
@@ -5503,7 +5500,7 @@ empty_user_func_functor__::operator()(std::ostream* pstream__)  const
 
 template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>*>
 inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
-mat_ret_user_func_functor__::operator()(const TA__& A_arg__,
+mat_ret_user_func_functor__::operator()(const TA__& A,
                                         std::ostream* pstream__)  const
 {
   return mat_ret_user_func(A, pstream__);
@@ -6577,18 +6574,17 @@ struct okay_reduction_functor__ {
             typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
             stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-  operator()(const Tsum_x__& sum_x, const Ty__& y_arg__,
-             std::ostream* pstream__) const;
+  operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-  nono_func(const Tx__& x, std::ostream* pstream__) {
+  nono_func(const Tx__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
@@ -6607,7 +6603,7 @@ template <typename Tsum_x__,
           typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
           stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-  okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
+  okay_reduction(const Tsum_x__& sum_x, const Ty__& y_arg__,
                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tsum_x__, Ty__>;
     int current_statement__ = 0; 
@@ -6627,8 +6623,7 @@ template <typename Tsum_x__,
           typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
           stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-okay_reduction_functor__::operator()(const Tsum_x__& sum_x,
-                                     const Ty__& y_arg__,
+okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
                                      std::ostream* pstream__)  const
 {
   return okay_reduction(sum_x, y, pstream__);
@@ -6636,7 +6631,7 @@ okay_reduction_functor__::operator()(const Tsum_x__& sum_x,
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-nono_func_functor__::operator()(const Tx__& x_arg__, std::ostream* pstream__) 
+nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return nono_func(x, pstream__);

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2607,7 +2607,7 @@ struct mask_fun_functor__ {
   operator()(const int& i, std::ostream* pstream__) const;
 };
 struct udf_fun_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   operator()(const T0__& A, std::ostream* pstream__) const;
 };
@@ -2626,7 +2626,7 @@ int mask_fun(const int& i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
   udf_fun(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -2651,7 +2651,7 @@ const
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
 {
@@ -4830,17 +4830,17 @@ static constexpr std::array<const char*, 12> locations_array__ =
  " (in 'reductions_allowed.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   nono_func(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -4857,7 +4857,7 @@ template <typename T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   okay_reduction(const T0__& sum_x, const T1__& y_arg__,
                  std::ostream* pstream__) {
@@ -4877,7 +4877,7 @@ template <typename T0__, typename T1__>
     }
     }
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
 okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
                                      std::ostream* pstream__)  const
@@ -4886,7 +4886,7 @@ okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -5448,7 +5448,7 @@ struct empty_user_func_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct mat_ret_user_func_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& A, std::ostream* pstream__) const;
 };
@@ -5470,7 +5470,7 @@ Eigen::Matrix<double, -1, -1> empty_user_func(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   mat_ret_user_func(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -5495,7 +5495,7 @@ empty_user_func_functor__::operator()(std::ostream* pstream__)  const
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 mat_ret_user_func_functor__::operator()(const T0__& A,
                                         std::ostream* pstream__)  const
@@ -6567,17 +6567,17 @@ static constexpr std::array<const char*, 10> locations_array__ =
  " (in 'tp_reused.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename T0__, typename T1__>
+  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename T0__>
+  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   nono_func(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -6594,7 +6594,7 @@ template <typename T0__>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   okay_reduction(const T0__& sum_x, const T1__& y_arg__,
                  std::ostream* pstream__) {
@@ -6614,7 +6614,7 @@ template <typename T0__, typename T1__>
     }
     }
 
-template <typename T0__, typename T1__>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
 okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
                                      std::ostream* pstream__)  const
@@ -6623,7 +6623,7 @@ okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
 }
 
 
-template <typename T0__>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2603,17 +2603,22 @@ static constexpr std::array<const char*, 116> locations_array__ =
  " (in 'indexing.stan', line 5, column 27 to line 7, column 3)"};
 
 struct mask_fun_functor__ {
-  int
-  operator()(const int& i, std::ostream* pstream__) const;
+  template <typename Ti__,
+            stan::require_t<stan::is_stan_scalar_t<Ti__>>* = nullptr>
+  inline int
+  operator()(const Ti__& i, std::ostream* pstream__) const;
 };
 struct udf_fun_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  operator()(const T0__& A, std::ostream* pstream__) const;
+  template <typename TA__,
+            stan::require_t<stan::is_col_vector<TA__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
+  operator()(const TA__& A, std::ostream* pstream__) const;
 };
 
-int mask_fun(const int& i, std::ostream* pstream__) {
-    using local_scalar_t__ = double;
+template <typename Ti__,
+          stan::require_t<stan::is_stan_scalar_t<Ti__>>* = nullptr>
+  inline int mask_fun(const Ti__& i, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Ti__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2626,10 +2631,11 @@ int mask_fun(const int& i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-  udf_fun(const T0__& A_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename TA__,
+          stan::require_t<stan::is_col_vector<TA__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
+  udf_fun(const TA__& A, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<TA__>;
     int current_statement__ = 0; 
     const auto& A = stan::math::to_ref(A_arg__);
     static constexpr bool propto__ = true;
@@ -2643,15 +2649,16 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-int mask_fun_functor__::operator()(const int& i, std::ostream* pstream__) 
-const
+template <typename Ti__, stan::require_t<stan::is_stan_scalar_t<Ti__>>*>
+inline int
+mask_fun_functor__::operator()(const Ti__& i, std::ostream* pstream__)  const
 {
   return mask_fun(i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
-udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
+template <typename TA__, stan::require_t<stan::is_col_vector<TA__>>*>
+inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
+udf_fun_functor__::operator()(const TA__& A, std::ostream* pstream__)  const
 {
   return udf_fun(A, pstream__);
 }
@@ -4828,24 +4835,24 @@ static constexpr std::array<const char*, 12> locations_array__ =
  " (in 'reductions_allowed.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
+  template <typename Tsum_x__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
+  operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  nono_func(const T0__& x_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tx__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
+  nono_func(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     static constexpr bool propto__ = true;
@@ -4859,14 +4866,13 @@ template <typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
-  okay_reduction(const T0__& sum_x, const T1__& y_arg__,
+template <typename Tsum_x__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
+  okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>>;
+    using local_scalar_t__ = stan::return_type_t<Tsum_x__, Ty__>;
     int current_statement__ = 0; 
     const auto& y = stan::math::to_ref(y_arg__);
     static constexpr bool propto__ = true;
@@ -4880,18 +4886,20 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
-okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
+template <typename Tsum_x__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
+okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
                                      std::ostream* pstream__)  const
 {
   return okay_reduction(sum_x, y, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
+nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return nono_func(x, pstream__);
@@ -5447,17 +5455,18 @@ static constexpr std::array<const char*, 13> locations_array__ =
  " (in 'return_types_and_udfs_demotes.stan', line 14, column 39 to line 16, column 5)"};
 
 struct empty_user_func_functor__ {
-  Eigen::Matrix<double, -1, -1>
+  inline Eigen::Matrix<double, -1, -1>
   operator()(std::ostream* pstream__) const;
 };
 struct mat_ret_user_func_functor__ {
-  template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  operator()(const T0__& A, std::ostream* pstream__) const;
+  template <typename TA__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
+  operator()(const TA__& A, std::ostream* pstream__) const;
 };
 
-Eigen::Matrix<double, -1, -1> empty_user_func(std::ostream* pstream__) {
+inline Eigen::Matrix<double, -1, -1>
+  empty_user_func(std::ostream* pstream__) {
     using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -5474,11 +5483,11 @@ Eigen::Matrix<double, -1, -1> empty_user_func(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  mat_ret_user_func(const T0__& A_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename TA__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
+  mat_ret_user_func(const TA__& A, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<TA__>;
     int current_statement__ = 0; 
     const auto& A = stan::math::to_ref(A_arg__);
     static constexpr bool propto__ = true;
@@ -5492,15 +5501,16 @@ template <typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-Eigen::Matrix<double, -1, -1>
+inline Eigen::Matrix<double, -1, -1>
 empty_user_func_functor__::operator()(std::ostream* pstream__)  const
 {
   return empty_user_func(pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-mat_ret_user_func_functor__::operator()(const T0__& A,
+template <typename TA__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<TA__>>*>
+inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
+mat_ret_user_func_functor__::operator()(const TA__& A,
                                         std::ostream* pstream__)  const
 {
   return mat_ret_user_func(A, pstream__);
@@ -6570,24 +6580,24 @@ static constexpr std::array<const char*, 10> locations_array__ =
  " (in 'tp_reused.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
-  operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
+  template <typename Tsum_x__, typename Ty__,
+            stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
+  operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  template <typename Tx__,
+            stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
+  operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-  nono_func(const T0__& x_arg__, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
+template <typename Tx__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
+  nono_func(const Tx__& x, std::ostream* pstream__) {
+    using local_scalar_t__ = stan::return_type_t<Tx__>;
     int current_statement__ = 0; 
     const auto& x = stan::math::to_ref(x_arg__);
     static constexpr bool propto__ = true;
@@ -6601,14 +6611,13 @@ template <typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
-  okay_reduction(const T0__& sum_x, const T1__& y_arg__,
+template <typename Tsum_x__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+  inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
+  okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
                  std::ostream* pstream__) {
-    using local_scalar_t__ =
-            stan::promote_args_t<T0__, stan::value_type_t<T1__>>;
+    using local_scalar_t__ = stan::return_type_t<Tsum_x__, Ty__>;
     int current_statement__ = 0; 
     const auto& y = stan::math::to_ref(y_arg__);
     static constexpr bool propto__ = true;
@@ -6622,18 +6631,20 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
-okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
+template <typename Tsum_x__, typename Ty__,
+          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>*,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
+okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
                                      std::ostream* pstream__)  const
 {
   return okay_reduction(sum_x, y, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
-Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
-nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
+template <typename Tx__,
+          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
+inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
+nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
 {
   return nono_func(x, pstream__);

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2603,8 +2603,7 @@ static constexpr std::array<const char*, 116> locations_array__ =
  " (in 'indexing.stan', line 5, column 27 to line 7, column 3)"};
 
 struct mask_fun_functor__ {
-  template <typename Ti__,
-            stan::require_t<stan::is_stan_scalar_t<Ti__>>* = nullptr>
+  template <typename Ti__, stan::require_t<std::is_integral<Ti__>>* = nullptr>
   inline int
   operator()(const Ti__& i, std::ostream* pstream__) const;
 };
@@ -2615,8 +2614,7 @@ struct udf_fun_functor__ {
   operator()(const TA__& A, std::ostream* pstream__) const;
 };
 
-template <typename Ti__,
-          stan::require_t<stan::is_stan_scalar_t<Ti__>>* = nullptr>
+template <typename Ti__, stan::require_t<std::is_integral<Ti__>>* = nullptr>
   inline int mask_fun(const Ti__& i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ti__>;
     int current_statement__ = 0; 
@@ -2649,7 +2647,7 @@ template <typename TA__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ti__, stan::require_t<stan::is_stan_scalar_t<Ti__>>*>
+template <typename Ti__, stan::require_t<std::is_integral<Ti__>>*>
 inline int
 mask_fun_functor__::operator()(const Ti__& i, std::ostream* pstream__)  const
 {
@@ -4836,7 +4834,7 @@ static constexpr std::array<const char*, 12> locations_array__ =
 
 struct okay_reduction_functor__ {
   template <typename Tsum_x__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
@@ -4867,7 +4865,7 @@ template <typename Tx__,
     }
     }
 template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
@@ -4887,7 +4885,7 @@ template <typename Tsum_x__, typename Ty__,
     }
     }
 template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>*,
+          stan::require_t<stan::is_stan_scalar<Tsum_x__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
 okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
@@ -6581,7 +6579,7 @@ static constexpr std::array<const char*, 10> locations_array__ =
 
 struct okay_reduction_functor__ {
   template <typename Tsum_x__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+            stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
             stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
@@ -6612,7 +6610,7 @@ template <typename Tx__,
     }
     }
 template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>* = nullptr,
+          stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
           stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
@@ -6632,7 +6630,7 @@ template <typename Tsum_x__, typename Ty__,
     }
     }
 template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar_t<Tsum_x__>>*,
+          stan::require_t<stan::is_stan_scalar<Tsum_x__>>*,
           stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
 okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2643,15 +2643,13 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 int mask_fun_functor__::operator()(const int& i, std::ostream* pstream__) 
 const
 {
   return mask_fun(i, pstream__);
 }
 
-
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr>
+template <typename T0__, stan::require_col_vector_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, 1>
 udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
 {
@@ -4830,17 +4828,21 @@ static constexpr std::array<const char*, 12> locations_array__ =
  " (in 'reductions_allowed.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   nono_func(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -4857,7 +4859,9 @@ template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   okay_reduction(const T0__& sum_x, const T1__& y_arg__,
                  std::ostream* pstream__) {
@@ -4876,8 +4880,8 @@ template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
 okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
                                      std::ostream* pstream__)  const
@@ -4885,8 +4889,7 @@ okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
   return okay_reduction(sum_x, y, pstream__);
 }
 
-
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -5448,7 +5451,8 @@ struct empty_user_func_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct mat_ret_user_func_functor__ {
-  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& A, std::ostream* pstream__) const;
 };
@@ -5470,7 +5474,8 @@ Eigen::Matrix<double, -1, -1> empty_user_func(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   mat_ret_user_func(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -5487,15 +5492,13 @@ template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
 Eigen::Matrix<double, -1, -1>
 empty_user_func_functor__::operator()(std::ostream* pstream__)  const
 {
   return empty_user_func(pstream__);
 }
 
-
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 mat_ret_user_func_functor__::operator()(const T0__& A,
                                         std::ostream* pstream__)  const
@@ -6567,17 +6570,21 @@ static constexpr std::array<const char*, 10> locations_array__ =
  " (in 'tp_reused.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+  template <typename T0__, typename T1__,
+            stan::require_stan_scalar_t<T0__>* = nullptr,
+            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
   nono_func(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::value_type_t<T0__>>;
@@ -6594,7 +6601,9 @@ template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__,
+          stan::require_stan_scalar_t<T0__>* = nullptr,
+          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
   okay_reduction(const T0__& sum_x, const T1__& y_arg__,
                  std::ostream* pstream__) {
@@ -6613,8 +6622,8 @@ template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nul
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>* = nullptr, stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr>
+template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
+          stan::require_eigen_matrix_dynamic_t<T1__>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::value_type_t<T1__>>, -1, -1>
 okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
                                      std::ostream* pstream__)  const
@@ -6622,8 +6631,7 @@ okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
   return okay_reduction(sum_x, y, pstream__);
 }
 
-
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr>
+template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*>
 Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>>, -1, -1>
 nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2603,18 +2603,17 @@ static constexpr std::array<const char*, 116> locations_array__ =
  " (in 'indexing.stan', line 5, column 27 to line 7, column 3)"};
 
 struct mask_fun_functor__ {
-  template <typename Ti__, stan::require_t<std::is_integral<Ti__>>* = nullptr>
+  template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>* = nullptr>
   inline int
   operator()(const Ti__& i, std::ostream* pstream__) const;
 };
 struct udf_fun_functor__ {
-  template <typename TA__,
-            stan::require_t<stan::is_col_vector<TA__>>* = nullptr>
+  template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
   operator()(const TA__& A, std::ostream* pstream__) const;
 };
 
-template <typename Ti__, stan::require_t<std::is_integral<Ti__>>* = nullptr>
+template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>* = nullptr>
   inline int mask_fun(const Ti__& i, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Ti__>;
     int current_statement__ = 0; 
@@ -2629,8 +2628,7 @@ template <typename Ti__, stan::require_t<std::is_integral<Ti__>>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename TA__,
-          stan::require_t<stan::is_col_vector<TA__>>* = nullptr>
+template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
   udf_fun(const TA__& A, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<TA__>;
@@ -2647,14 +2645,14 @@ template <typename TA__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ti__, stan::require_t<std::is_integral<Ti__>>*>
+template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>*>
 inline int
 mask_fun_functor__::operator()(const Ti__& i, std::ostream* pstream__)  const
 {
   return mask_fun(i, pstream__);
 }
 
-template <typename TA__, stan::require_t<stan::is_col_vector<TA__>>*>
+template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>*>
 inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
 udf_fun_functor__::operator()(const TA__& A, std::ostream* pstream__)  const
 {
@@ -4833,21 +4831,19 @@ static constexpr std::array<const char*, 12> locations_array__ =
  " (in 'reductions_allowed.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename Tsum_x__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+  template <typename Tsum_x__,
+            typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
+            stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename Tx__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
   nono_func(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -4864,9 +4860,9 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+template <typename Tsum_x__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
+          stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
                  std::ostream* pstream__) {
@@ -4884,9 +4880,9 @@ template <typename Tsum_x__, typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tsum_x__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>*>
+template <typename Tsum_x__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
+          stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
 okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
                                      std::ostream* pstream__)  const
@@ -4894,8 +4890,7 @@ okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
   return okay_reduction(sum_x, y, pstream__);
 }
 
-template <typename Tx__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
 nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const
@@ -5457,8 +5452,7 @@ struct empty_user_func_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct mat_ret_user_func_functor__ {
-  template <typename TA__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
+  template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
   operator()(const TA__& A, std::ostream* pstream__) const;
 };
@@ -5481,8 +5475,7 @@ inline Eigen::Matrix<double, -1, -1>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename TA__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
+template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
   mat_ret_user_func(const TA__& A, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<TA__>;
@@ -5505,8 +5498,7 @@ empty_user_func_functor__::operator()(std::ostream* pstream__)  const
   return empty_user_func(pstream__);
 }
 
-template <typename TA__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<TA__>>*>
+template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>*>
 inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
 mat_ret_user_func_functor__::operator()(const TA__& A,
                                         std::ostream* pstream__)  const
@@ -6578,21 +6570,19 @@ static constexpr std::array<const char*, 10> locations_array__ =
  " (in 'tp_reused.stan', line 6, column 48 to line 8, column 5)"};
 
 struct okay_reduction_functor__ {
-  template <typename Tsum_x__, typename Ty__,
-            stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+  template <typename Tsum_x__,
+            typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
+            stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
-  template <typename Tx__,
-            stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+  template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
   operator()(const Tx__& x, std::ostream* pstream__) const;
 };
 
-template <typename Tx__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
+template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
   nono_func(const Tx__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::return_type_t<Tx__>;
@@ -6609,9 +6599,9 @@ template <typename Tx__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tsum_x__>>* = nullptr,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
+template <typename Tsum_x__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
+          stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
   okay_reduction(const Tsum_x__& sum_x, const Ty__& y,
                  std::ostream* pstream__) {
@@ -6629,9 +6619,9 @@ template <typename Tsum_x__, typename Ty__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Tsum_x__, typename Ty__,
-          stan::require_t<stan::is_stan_scalar<Tsum_x__>>*,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Ty__>>*>
+template <typename Tsum_x__,
+          typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
+          stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
 okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
                                      std::ostream* pstream__)  const
@@ -6639,8 +6629,7 @@ okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
   return okay_reduction(sum_x, y, pstream__);
 }
 
-template <typename Tx__,
-          stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
+template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
 nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
 const

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2603,9 +2603,8 @@ static constexpr std::array<const char*, 116> locations_array__ =
  " (in 'indexing.stan', line 5, column 27 to line 7, column 3)"};
 
 struct mask_fun_functor__ {
-  template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>* = nullptr>
   inline int
-  operator()(const Ti__& i, std::ostream* pstream__) const;
+  operator()(const int i, std::ostream* pstream__) const;
 };
 struct udf_fun_functor__ {
   template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>* = nullptr>
@@ -2613,9 +2612,8 @@ struct udf_fun_functor__ {
   operator()(const TA__& A, std::ostream* pstream__) const;
 };
 
-template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>* = nullptr>
-  inline int mask_fun(const Ti__& i, std::ostream* pstream__) {
-    using local_scalar_t__ = stan::return_type_t<Ti__>;
+inline int mask_fun(const int i, std::ostream* pstream__) {
+    using local_scalar_t__ = double;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
     (void) propto__;
@@ -2645,9 +2643,8 @@ template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>* = nullp
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>*>
 inline int
-mask_fun_functor__::operator()(const Ti__& i, std::ostream* pstream__)  const
+mask_fun_functor__::operator()(const int i, std::ostream* pstream__)  const
 {
   return mask_fun(i, pstream__);
 }

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2610,7 +2610,7 @@ struct mask_fun_functor__ {
 struct udf_fun_functor__ {
   template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
-  operator()(const TA__& A, std::ostream* pstream__) const;
+  operator()(const TA__& A_arg__, std::ostream* pstream__) const;
 };
 
 template <typename Ti__, stan::require_all_t<std::is_integral<Ti__>>* = nullptr>
@@ -2654,7 +2654,8 @@ mask_fun_functor__::operator()(const Ti__& i, std::ostream* pstream__)  const
 
 template <typename TA__, stan::require_all_t<stan::is_col_vector<TA__>>*>
 inline Eigen::Matrix<stan::return_type_t<TA__>, -1, 1>
-udf_fun_functor__::operator()(const TA__& A, std::ostream* pstream__)  const
+udf_fun_functor__::operator()(const TA__& A_arg__, std::ostream* pstream__) 
+const
 {
   return udf_fun(A, pstream__);
 }
@@ -4835,12 +4836,13 @@ struct okay_reduction_functor__ {
             typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
             stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-  operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
+  operator()(const Tsum_x__& sum_x, const Ty__& y_arg__,
+             std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-  operator()(const Tx__& x, std::ostream* pstream__) const;
+  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
 };
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
@@ -4884,7 +4886,8 @@ template <typename Tsum_x__,
           typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
           stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
+okay_reduction_functor__::operator()(const Tsum_x__& sum_x,
+                                     const Ty__& y_arg__,
                                      std::ostream* pstream__)  const
 {
   return okay_reduction(sum_x, y, pstream__);
@@ -4892,7 +4895,7 @@ okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
+nono_func_functor__::operator()(const Tx__& x_arg__, std::ostream* pstream__) 
 const
 {
   return nono_func(x, pstream__);
@@ -5454,7 +5457,7 @@ struct empty_user_func_functor__ {
 struct mat_ret_user_func_functor__ {
   template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
-  operator()(const TA__& A, std::ostream* pstream__) const;
+  operator()(const TA__& A_arg__, std::ostream* pstream__) const;
 };
 
 inline Eigen::Matrix<double, -1, -1>
@@ -5500,7 +5503,7 @@ empty_user_func_functor__::operator()(std::ostream* pstream__)  const
 
 template <typename TA__, stan::require_all_t<stan::is_eigen_matrix_dynamic<TA__>>*>
 inline Eigen::Matrix<stan::return_type_t<TA__>, -1, -1>
-mat_ret_user_func_functor__::operator()(const TA__& A,
+mat_ret_user_func_functor__::operator()(const TA__& A_arg__,
                                         std::ostream* pstream__)  const
 {
   return mat_ret_user_func(A, pstream__);
@@ -6574,12 +6577,13 @@ struct okay_reduction_functor__ {
             typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
             stan::is_eigen_matrix_dynamic<Ty__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-  operator()(const Tsum_x__& sum_x, const Ty__& y, std::ostream* pstream__) const;
+  operator()(const Tsum_x__& sum_x, const Ty__& y_arg__,
+             std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
   template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
   inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-  operator()(const Tx__& x, std::ostream* pstream__) const;
+  operator()(const Tx__& x_arg__, std::ostream* pstream__) const;
 };
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr>
@@ -6623,7 +6627,8 @@ template <typename Tsum_x__,
           typename Ty__, stan::require_all_t<stan::is_stan_scalar<Tsum_x__>,
           stan::is_eigen_matrix_dynamic<Ty__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tsum_x__, Ty__>, -1, -1>
-okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
+okay_reduction_functor__::operator()(const Tsum_x__& sum_x,
+                                     const Ty__& y_arg__,
                                      std::ostream* pstream__)  const
 {
   return okay_reduction(sum_x, y, pstream__);
@@ -6631,7 +6636,7 @@ okay_reduction_functor__::operator()(const Tsum_x__& sum_x, const Ty__& y,
 
 template <typename Tx__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>>*>
 inline Eigen::Matrix<stan::return_type_t<Tx__>, -1, -1>
-nono_func_functor__::operator()(const Tx__& x, std::ostream* pstream__) 
+nono_func_functor__::operator()(const Tx__& x_arg__, std::ostream* pstream__) 
 const
 {
   return nono_func(x, pstream__);

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -82,7 +82,7 @@ let%expect_test "udf-expressions" =
     template <typename Tx__, typename Ty__, typename Tz__,
               typename Tw__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>,
               stan::is_row_vector<Ty__>, stan::is_row_vector<Tz__>,
-              stan::is_std_vector<Tw__>, stan::is_eigen_matrix_dynamic<value_type_t<Tw__>>>* = nullptr>
+              stan::is_std_vector<Tw__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tw__>>>* = nullptr>
     inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tz__, Tw__>, -1, -1>
     sars(const Tx__& x, const Ty__& y, const Tz__& z, const Tw__& w,
          std::ostream* pstream__) {

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -34,7 +34,9 @@ let%expect_test "udf" =
   |> print_endline ;
   [%expect
     {|
-    template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_row_vector_t<T1__>* = nullptr>
+    template <typename T0__, typename T1__,
+              stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+              stan::require_row_vector_t<T1__>* = nullptr>
     void
     sars(const T0__& x_arg__, const T1__& y_arg__, std::ostream* pstream__) {
       using local_scalar_t__ =
@@ -79,7 +81,11 @@ let%expect_test "udf-expressions" =
   |> print_endline ;
   [%expect
     {|
-    template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_row_vector_t<T1__>* = nullptr, stan::require_row_vector_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
+    template <typename T0__, typename T1__, typename T2__, typename T3__,
+              stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
+              stan::require_row_vector_t<T1__>* = nullptr,
+              stan::require_row_vector_t<T2__>* = nullptr,
+              stan::require_stan_scalar_t<T3__>* = nullptr>
     Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>,
                          stan::value_type_t<T2__>, T3__>, -1, -1>
     sars(const T0__& x_arg__, const T1__& y_arg__, const T2__& z_arg__,

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -34,7 +34,7 @@ let%expect_test "udf" =
   |> print_endline ;
   [%expect
     {|
-    template <typename T0__, typename T1__>
+    template <typename T0__, typename T1__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_row_vector_t<T1__>* = nullptr>
     void
     sars(const T0__& x_arg__, const T1__& y_arg__, std::ostream* pstream__) {
       using local_scalar_t__ =
@@ -79,7 +79,7 @@ let%expect_test "udf-expressions" =
   |> print_endline ;
   [%expect
     {|
-    template <typename T0__, typename T1__, typename T2__, typename T3__>
+    template <typename T0__, typename T1__, typename T2__, typename T3__, stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr, stan::require_row_vector_t<T1__>* = nullptr, stan::require_row_vector_t<T2__>* = nullptr, stan::require_stan_scalar_t<T3__>* = nullptr>
     Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>,
                          stan::value_type_t<T2__>, T3__>, -1, -1>
     sars(const T0__& x_arg__, const T1__& y_arg__, const T2__& z_arg__,

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -38,7 +38,7 @@ let%expect_test "udf" =
               typename Ty__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>,
               stan::is_row_vector<Ty__>>* = nullptr>
     inline void
-    sars(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
+    sars(const Tx__& x_arg__, const Ty__& y_arg__, std::ostream* pstream__) {
       using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
       int current_statement__ = 0;
       const auto& x = stan::math::to_ref(x_arg__);
@@ -84,8 +84,8 @@ let%expect_test "udf-expressions" =
               stan::is_row_vector<Ty__>, stan::is_row_vector<Tz__>,
               stan::is_std_vector<Tw__>, stan::is_eigen_matrix_dynamic<stan::value_type_t<Tw__>>>* = nullptr>
     inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tz__, Tw__>, -1, -1>
-    sars(const Tx__& x, const Ty__& y, const Tz__& z, const Tw__& w,
-         std::ostream* pstream__) {
+    sars(const Tx__& x_arg__, const Ty__& y_arg__, const Tz__& z_arg__,
+         const Tw__& w, std::ostream* pstream__) {
       using local_scalar_t__ = stan::return_type_t<Tx__, Ty__, Tz__, Tw__>;
       int current_statement__ = 0;
       const auto& x = stan::math::to_ref(x_arg__);

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -34,9 +34,9 @@ let%expect_test "udf" =
   |> print_endline ;
   [%expect
     {|
-    template <typename Tx__, typename Ty__,
-              stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr,
-              stan::require_t<stan::is_row_vector<Ty__>>* = nullptr>
+    template <typename Tx__,
+              typename Ty__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>,
+              stan::is_row_vector<Ty__>>* = nullptr>
     inline void
     sars(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
       using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
@@ -79,11 +79,10 @@ let%expect_test "udf-expressions" =
   |> print_endline ;
   [%expect
     {|
-    template <typename Tx__, typename Ty__, typename Tz__, typename Tw__,
-              stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr,
-              stan::require_t<stan::is_row_vector<Ty__>>* = nullptr,
-              stan::require_t<stan::is_row_vector<Tz__>>* = nullptr,
-              stan::require_all_t<stan::is_std_vector<Tw__>, stan::is_eigen_matrix_dynamic<value_type_t<Tw__>>>* = nullptr>
+    template <typename Tx__, typename Ty__, typename Tz__,
+              typename Tw__, stan::require_all_t<stan::is_eigen_matrix_dynamic<Tx__>,
+              stan::is_row_vector<Ty__>, stan::is_row_vector<Tz__>,
+              stan::is_std_vector<Tw__>, stan::is_eigen_matrix_dynamic<value_type_t<Tw__>>>* = nullptr>
     inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tz__, Tw__>, -1, -1>
     sars(const Tx__& x, const Ty__& y, const Tz__& z, const Tw__& w,
          std::ostream* pstream__) {

--- a/test/unit/Stan_math_code_gen_tests.ml
+++ b/test/unit/Stan_math_code_gen_tests.ml
@@ -34,14 +34,12 @@ let%expect_test "udf" =
   |> print_endline ;
   [%expect
     {|
-    template <typename T0__, typename T1__,
-              stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-              stan::require_row_vector_t<T1__>* = nullptr>
-    void
-    sars(const T0__& x_arg__, const T1__& y_arg__, std::ostream* pstream__) {
-      using local_scalar_t__ =
-              stan::promote_args_t<stan::value_type_t<T0__>,
-                                   stan::value_type_t<T1__>>;
+    template <typename Tx__, typename Ty__,
+              stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr,
+              stan::require_t<stan::is_row_vector<Ty__>>* = nullptr>
+    inline void
+    sars(const Tx__& x, const Ty__& y, std::ostream* pstream__) {
+      using local_scalar_t__ = stan::return_type_t<Tx__, Ty__>;
       int current_statement__ = 0;
       const auto& x = stan::math::to_ref(x_arg__);
       const auto& y = stan::math::to_ref(y_arg__);
@@ -81,20 +79,15 @@ let%expect_test "udf-expressions" =
   |> print_endline ;
   [%expect
     {|
-    template <typename T0__, typename T1__, typename T2__, typename T3__,
-              stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-              stan::require_row_vector_t<T1__>* = nullptr,
-              stan::require_row_vector_t<T2__>* = nullptr,
-              stan::require_stan_scalar_t<T3__>* = nullptr>
-    Eigen::Matrix<stan::promote_args_t<stan::value_type_t<T0__>, stan::value_type_t<T1__>,
-                         stan::value_type_t<T2__>, T3__>, -1, -1>
-    sars(const T0__& x_arg__, const T1__& y_arg__, const T2__& z_arg__,
-         const std::vector<Eigen::Matrix<T3__, -1, -1>>& w,
+    template <typename Tx__, typename Ty__, typename Tz__, typename Tw__,
+              stan::require_t<stan::is_eigen_matrix_dynamic<Tx__>>* = nullptr,
+              stan::require_t<stan::is_row_vector<Ty__>>* = nullptr,
+              stan::require_t<stan::is_row_vector<Tz__>>* = nullptr,
+              stan::require_all_t<stan::is_std_vector<Tw__>, stan::is_eigen_matrix_dynamic<value_type_t<Tw__>>>* = nullptr>
+    inline Eigen::Matrix<stan::return_type_t<Tx__, Ty__, Tz__, Tw__>, -1, -1>
+    sars(const Tx__& x, const Ty__& y, const Tz__& z, const Tw__& w,
          std::ostream* pstream__) {
-      using local_scalar_t__ =
-              stan::promote_args_t<stan::value_type_t<T0__>,
-                                   stan::value_type_t<T1__>,
-                                   stan::value_type_t<T2__>, T3__>;
+      using local_scalar_t__ = stan::return_type_t<Tx__, Ty__, Tz__, Tw__>;
       int current_statement__ = 0;
       const auto& x = stan::math::to_ref(x_arg__);
       const auto& y = stan::math::to_ref(y_arg__);


### PR DESCRIPTION
#### Summary

This tries to generalize some of the `requires` logic for stan UDFs. 

1. All arguments are templated instead of allowing some to get `int` or `std::vector<int>`. I need to check how this is going to effect multiple declarations that have int and double inputs.

2. Instead of using `std::vector<T0__>` in the signature we use `T{arg_name}__`

3. `promote_scalar_t<>` has been bumped to use `return_type_t<>` which is what we tend to use in the math library

4. `inline` keyword is added to functions and functor `operator()`

5. All `requires` are placed into one template parameter. This is to help cut down on the compile time cost of using requires since instead of having an extra template parameter for each argument we will always only have one additional template parameter

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Replace this text with a short note on what will change if this pull request is merged. This will be included in the release notes.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
