### PR TITLE
Remove | if only one argument is supplied

### DIFF
--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -256,6 +256,10 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
     | [] ->
         Common.FatalError.fatal_error_msg
           [%message "CondDistApp with no arguments: " id.name]
+    | [e] ->
+        pf ppf "@[<h>%a(%a%a)@]" pp_identifier id pp_expression e
+          (pp_comments_spacing true get_comments)
+          loc.end_loc
     | e :: es' ->
         let begin_loc =
           List.hd es'

--- a/test/integration/cli-args/canonicalize/canonical.expected
+++ b/test/integration/cli-args/canonicalize/canonical.expected
@@ -203,7 +203,7 @@ model {
     x ~ normal_log(0, 1);
     x ~ normal_log(0, 1);
     target += normal_log_lpdf(x | 1, 2);
-    target += std_normal_lpdf(x | );
+    target += std_normal_lpdf(x);
   } else {
     x ~ exponential(1);
     x ~ exponential(1);

--- a/test/integration/cli-args/canonicalize/deprecations-only.expected
+++ b/test/integration/cli-args/canonicalize/deprecations-only.expected
@@ -183,7 +183,7 @@ model {
     x ~ normal_log(0, 1);
     x ~ normal_log(0, 1);
     target += normal_log_lpdf(x | 1, 2);
-    target += std_normal_lpdf(x | );
+    target += std_normal_lpdf(x);
   } else {
     x ~ exponential(1);
     x ~ exponential(1);

--- a/test/integration/good/fun_log_forward_decl.stan
+++ b/test/integration/good/fun_log_forward_decl.stan
@@ -4,7 +4,7 @@
  */
 functions {
   real n_lpdf(real y);
-  
+
   real n_lpdf(real y) {
     return -0.5 * square(y);
   }
@@ -14,6 +14,7 @@ parameters {
 }
 model {
   mu ~ n();
-  target += n_lpdf(mu | ); // check both instantiations
+  target += n_lpdf(mu /*check*/|// both instantiations
+   );
 }
 

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -3036,7 +3036,8 @@ parameters {
 }
 model {
   mu ~ n();
-  target += n_lpdf(mu | ); // check both instantiations
+  target += n_lpdf(mu /*check*/// both instantiations
+            );
 }
 
   $ ../../../../install/default/bin/stanc --auto-format functions-fwd-ref.stan
@@ -3143,8 +3144,8 @@ transformed data {
   c = foo2(2, b);
   c = foo2(2, 3);
   
-  a = foo0_lpmf(2 | );
-  b = foo1_lpdf(N[6] | );
+  a = foo0_lpmf(2);
+  b = foo1_lpdf(N[6]);
   c = foo2_lpdf(a | b);
   c = foo2_lpdf(a | 1);
   c = foo2_lpdf(2 | b);
@@ -3202,11 +3203,11 @@ transformed parameters {
   
   //   phi3 = foo2_lp(phi1,phi2);
   
-  phi1 = foo0_lpmf(3 | );
+  phi1 = foo0_lpmf(3);
   
-  phi2 = foo1_lpdf(1 | );
-  phi2 = foo1_lpdf(2.0 | );
-  phi2 = foo1_lpdf(phi1 | );
+  phi2 = foo1_lpdf(1);
+  phi2 = foo1_lpdf(2.0);
+  phi2 = foo1_lpdf(phi1);
   
   phi3 = foo2_lpdf(1.0 | 2.0);
   phi3 = foo2_lpdf(1.0 | 2);
@@ -3262,10 +3263,10 @@ model {
   
   psi3 = foo2_lp(psi1, psi2);
   
-  psi1 = foo0_lpmf(3 | );
-  psi2 = foo1_lpdf(1 | );
-  psi2 = foo1_lpdf(2.0 | );
-  psi2 = foo1_lpdf(psi1 | );
+  psi1 = foo0_lpmf(3);
+  psi2 = foo1_lpdf(1);
+  psi2 = foo1_lpdf(2.0);
+  psi2 = foo1_lpdf(psi1);
   
   psi3 = foo2_lpdf(1.0 | 2.0);
   psi3 = foo2_lpdf(1.0 | 2);
@@ -3297,9 +3298,9 @@ generated quantities {
   z = foo2(x, 2);
   z = foo2(1, 2);
   
-  x = foo0_lpmf(3 | );
-  y = foo1_lpdf(x | );
-  y = foo1_lpdf(1 | );
+  x = foo0_lpmf(3);
+  y = foo1_lpdf(x);
+  y = foo1_lpdf(1);
   z = foo2_lpdf(x | y);
   z = foo2_lpdf(1 | y);
   z = foo2_lpdf(x | 2);
@@ -3427,7 +3428,7 @@ parameters {
   real y;
 }
 model {
-  target += unit_normal_lpdf(y | );
+  target += unit_normal_lpdf(y);
 }
 
   $ ../../../../install/default/bin/stanc --auto-format funs5.stan
@@ -4682,16 +4683,16 @@ parameters {
   real x;
 }
 model {
-  target += std_normal_lpdf(x | );
-  target += std_normal_lpdf(x | );
-  target += std_normal_lupdf(x | );
-  target += std_normal_lupdf(x | );
-  target += foo_lpdf(x | );
-  target += foo_lpdf(x | );
-  target += goo_lpmf(y | );
-  target += goo_lpmf(y | );
-  target += goo_lupmf(y | );
-  target += goo_lupmf(y | );
+  target += std_normal_lpdf(x);
+  target += std_normal_lpdf(x);
+  target += std_normal_lupdf(x);
+  target += std_normal_lupdf(x);
+  target += foo_lpdf(x);
+  target += foo_lpdf(x);
+  target += goo_lpmf(y);
+  target += goo_lpmf(y);
+  target += goo_lupmf(y);
+  target += goo_lupmf(y);
 }
 
   $ ../../../../install/default/bin/stanc --auto-format stanc_helper.stan
@@ -4841,7 +4842,7 @@ functions {
     r += rayleigh_lupdf(y1 | y2);
     r += scaled_inv_chi_square_lupdf(y1 | y2, y2);
     r += skew_normal_lupdf(y1 | y2, y2, y2);
-    r += std_normal_lupdf(y1 | );
+    r += std_normal_lupdf(y1);
     r += student_t_lupdf(y1 | y2, y2, y2);
     r += uniform_lupdf(y1 | y2, y2);
     r += von_mises_lupdf(y1 | y2, y2);
@@ -4895,7 +4896,7 @@ model {
   r += rayleigh_lupdf(y1 | y2);
   r += scaled_inv_chi_square_lupdf(y1 | y2, y2);
   r += skew_normal_lupdf(y1 | y2, y2, y2);
-  r += std_normal_lupdf(y1 | );
+  r += std_normal_lupdf(y1);
   r += student_t_lupdf(y1 | y2, y2, y2);
   r += uniform_lupdf(y1 | y2, y2);
   r += von_mises_lupdf(y1 | y2, y2);


### PR DESCRIPTION
Closes #1119 
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Do not print `|` if a distribution is called with only one argument.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
