### PR TITLE
Split compile tests into smaller chunks to improve CI times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('StanUtils')
 import org.stan.Utils
 
-def utils = new org.stan.Utils()
+utils = new org.stan.Utils()
 
 def skipExpressionTests = false
 def skipRemainingStages = false
@@ -22,6 +22,28 @@ def tagName() {
     } else {
         'unknown-tag'
     }
+}
+
+def runPerformanceTests(String testsPath){
+    unstash 'ubuntu-exe'
+
+    sh """
+        git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
+    """
+
+    writeFile(file:"performance-tests-cmdstan/cmdstan/make/local", text:"O=0\nCXX=${CXX}")
+
+    utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
+    utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
+    utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
+
+    sh """
+        cd performance-tests-cmdstan
+        mkdir cmdstan/bin
+        cp ../bin/stanc cmdstan/bin/linux-stanc
+        cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ..
+        ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ${testsPath}
+    """
 }
 
 pipeline {
@@ -174,45 +196,6 @@ pipeline {
                 }
             }
         }
-        stage("Prepare - Compile tests") {
-            when {
-                beforeAgent true
-                expression {
-                    !skipCompileTests
-                }
-            }
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                }
-            }
-            steps {
-                script {
-                    unstash 'ubuntu-exe'
-
-                    sh """
-                        git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
-                    """
-
-                    writeFile(file:"performance-tests-cmdstan/cmdstan/make/local", text:"O=0\nCXX=${CXX}")
-
-                    utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
-                    utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
-                    utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-
-                    sh """
-                        cd performance-tests-cmdstan
-                        mkdir cmdstan/bin
-                        cp ../bin/stanc cmdstan/bin/linux-stanc
-                        cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ../..
-                    """
-
-                    stash "CompileTestSetup"
-                }
-            }
-            post { always { runShell("rm -rf ./*") }}
-        }
         stage("CmdStan & Math tests") {
             parallel {
 
@@ -231,11 +214,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            unstash 'CompileTestSetup'
-                            sh """
-                                cd performance-tests-cmdstan
-                                ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ../test/integration/good
-                            """
+                            runPerformanceTests("../test/integration/good")
                         }
 
                         xunit([GoogleTest(
@@ -264,11 +243,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            unstash 'CompileTestSetup'
-                            sh """
-                                cd performance-tests-cmdstan
-                                ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 example-models
-                            """
+                            runPerformanceTests("example-models")
                         }
 
                         xunit([GoogleTest(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,7 +205,7 @@ pipeline {
                         cd performance-tests-cmdstan
                         mkdir cmdstan/bin
                         cp ../bin/stanc cmdstan/bin/linux-stanc
-                        cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ..
+                        cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ../..
                     """
 
                     stash "CompileTestSetup"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
     options {parallelsAlwaysFailFast()}
     environment {
         CXX = 'clang++-6.0'
-        PARALLEL = 4 // There are 4 cores/executor
+        PARALLEL = 4 // There are ~4 cores/executor
     }
     stages {
         stage('Kill previous builds') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
     options {parallelsAlwaysFailFast()}
     environment {
         CXX = 'clang++-6.0'
-        PARALLEL = 4 // There are ~4 cores/executor
+        PARALLEL = 4 // There are 4 cores/executor
     }
     stages {
         stage('Kill previous builds') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('StanUtils')
+@Library('StanUtils@add-ci-skip')
 import org.stan.Utils
 
 utils = new org.stan.Utils()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
     options {parallelsAlwaysFailFast()}
     environment {
         CXX = 'clang++-6.0'
-        PARALLEL = 4 // There are ~4 cores/executor
+        PARALLEL = 8
     }
     stages {
         stage('Kill previous builds') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ def runPerformanceTests(String testsPath){
         git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
     """
 
-    writeFile(file:"performance-tests-cmdstan/cmdstan/make/local", text:"O=0\nCXX=${CXX}")
+    writeFile(file:"performance-tests-cmdstan/cmdstan/make/local", text:"CXX=${CXX}")
 
     utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
     utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
@@ -41,7 +41,9 @@ def runPerformanceTests(String testsPath){
         cd performance-tests-cmdstan
         mkdir cmdstan/bin
         cp ../bin/stanc cmdstan/bin/linux-stanc
-        cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ..
+        cd cmdstan; make clean-all;
+        echo 'O=0' >> make/local
+        make -j${env.PARALLEL} build; cd ..
         ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ${testsPath}
     """
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('StanUtils@add-ci-skip')
+@Library('StanUtils')
 import org.stan.Utils
 
 utils = new org.stan.Utils()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
     options {parallelsAlwaysFailFast()}
     environment {
         CXX = 'clang++-6.0'
-        PARALLEL = 8
+        PARALLEL = 4
     }
     stages {
         stage('Kill previous builds') {

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ This repo contains a new compiler for Stan, stanc3, written in OCaml.
 Since version 2.26, this has been the default compiler for Stan. See [this wiki](https://github.com/stan-dev/stanc3/wiki/changes-from-stanc2) for a list of minor differences between this compiler and the previous Stan compiler.
 
 To read more about why we built this, see this [introductory blog post](https://statmodeling.stat.columbia.edu/2019/03/13/stanc3-rewriting-the-stan-compiler/). For some discussion as to how we chose OCaml, see [this accidental flamewar](https://discourse.mc-stan.org/t/choosing-the-new-stan-compilers-implementation-language/6203).
-We're testing [these models](https://jenkins.mc-stan.org/job/stanc3/job/master/) (listed under Test Results) on every pull request.
+We're testing [these models](https://jenkins.flatironinstitute.org/job/stanc3/job/master/) (listed under Test Results) on every pull request.
 
-[![Build Status](https://jenkins.mc-stan.org/buildStatus/icon?job=stanc3%2Fmaster&style=flat-square)](https://jenkins.mc-stan.org/job/stanc3/job/master/)
+[![Build Status](https://jenkins.flatironinstitute.org/buildStatus/icon?job=stanc3%2Fmaster&style=flat-square)](https://jenkins.flatironinstitute.org/job/stanc3/job/master/)
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@ This repo contains a new compiler for Stan, stanc3, written in OCaml.
 Since version 2.26, this has been the default compiler for Stan. See [this wiki](https://github.com/stan-dev/stanc3/wiki/changes-from-stanc2) for a list of minor differences between this compiler and the previous Stan compiler.
 
 To read more about why we built this, see this [introductory blog post](https://statmodeling.stat.columbia.edu/2019/03/13/stanc3-rewriting-the-stan-compiler/). For some discussion as to how we chose OCaml, see [this accidental flamewar](https://discourse.mc-stan.org/t/choosing-the-new-stan-compilers-implementation-language/6203).
-We're testing [these models](https://jenkins.flatironinstitute.org/job/stanc3/job/master/) (listed under Test Results) on every pull request.
+We're testing [these models](https://jenkins.flatironinstitute.org/job/Stan/job/Stanc3/job/master/) (listed under Test Results) on every pull request.
 
-[![Build Status](https://jenkins.flatironinstitute.org/buildStatus/icon?job=stanc3%2Fmaster&style=flat-square)](https://jenkins.flatironinstitute.org/job/stanc3/job/master/)
-
+[![Build Status](https://jenkins.flatironinstitute.org/job/Stan/job/Stanc3/job/master/badge/icon?style=flat-square)](https://jenkins.flatironinstitute.org/job/Stan/job/Stanc3/job/master/)
 
 ## Documentation
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Improve CI builds times by splitting compile tests and running them in parallel.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
