### PR TITLE
Set O=0 in compile tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,9 @@ pipeline {
                                 cd performance-tests-cmdstan
                                 mkdir cmdstan/bin
                                 cp ../bin/stanc cmdstan/bin/linux-stanc
-                                cd cmdstan; make clean-all; make -j${env.PARALLEL} build; cd ..
+                                cd cmdstan; make clean-all;
+                                echo 'O=0' >> make/local
+                                make -j${env.PARALLEL} build; cd ..
                                 ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ../test/integration/good
                                 ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 example-models
                                 """

--- a/test/integration/good/function-signatures/distributions/multivariate/continuous/dirichlet_lpdf.stan
+++ b/test/integration/good/function-signatures/distributions/multivariate/continuous/dirichlet_lpdf.stan
@@ -4,7 +4,7 @@ data {
   row_vector[d_int] d_row_vector;
   array[d_int] vector[d_int] d_vector_arr;
   array[d_int] row_vector[d_int] d_row_vector_arr;
-}
+} 
 transformed data {
   real transformed_data_real;
   transformed_data_real = dirichlet_lpdf(d_vector | d_vector);


### PR DESCRIPTION
#### Submission Checklist

- [x Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

Sets O=0 in compile tests to speed them up. This is also the same thing we do in integration tests in stan-dev/stan.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
