### PR TITLE
Debug_data_generation fixes

### DIFF
--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -78,9 +78,7 @@ let gen_bounded m gen e =
   | Some unpacked_e -> List.map ~f:gen unpacked_e
   | None ->
       Common.FatalError.fatal_error_msg
-        [%message
-          "Bad bounded (upper OR lower) expr: "
-            (e : Expr.Typed.Meta.t Expr.Fixed.t)]
+        [%message "Bad bounded (upper OR lower) expr: " (e : Expr.Typed.t)]
 
 let gen_ul_bounded m gen e1 e2 =
   let create_bounds l u =

--- a/src/analysis_and_optimization/Debug_data_generation.mli
+++ b/src/analysis_and_optimization/Debug_data_generation.mli
@@ -1,1 +1,5 @@
-val print_data_prog : Frontend.Ast.typed_program -> string
+open Middle
+
+val print_data_prog :
+     (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
+  -> string

--- a/src/analysis_and_optimization/Dependence_analysis.ml
+++ b/src/analysis_and_optimization/Dependence_analysis.ml
@@ -203,8 +203,7 @@ let mir_uninitialized_variables (mir : Program.Typed.t) :
                    (Set.Poly.union arg_vars globals)
                    fdbody ) ) ) ]
 
-let build_dep_info_map (mir : Program.Typed.t)
-    (stmt : (Expr.Typed.Meta.t, Stmt.Located.Meta.t) Stmt.Fixed.t) :
+let build_dep_info_map (mir : Program.Typed.t) (stmt : Stmt.Located.t) :
     ( label
     , (Expr.Typed.t, label) Stmt.Fixed.Pattern.t * node_dep_info )
     Map.Poly.t =

--- a/src/analysis_and_optimization/Dependence_analysis.mli
+++ b/src/analysis_and_optimization/Dependence_analysis.mli
@@ -68,7 +68,7 @@ val node_vars_dependencies :
 
 val build_dep_info_map :
      Program.Typed.t
-  -> (Expr.Typed.Meta.t, Stmt.Located.Meta.t) Stmt.Fixed.t
+  -> Stmt.Located.t
   -> ( label
      , (Expr.Typed.t, label) Stmt.Fixed.Pattern.t * node_dep_info )
      Map.Poly.t

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -12,7 +12,7 @@ let rec fold_expr ~take_expr ~(init : 'c) (expr : Expr.Typed.t) : 'c =
 
 let fold_stmts ~take_expr ~take_stmt ~(init : 'c) (stmts : Stmt.Located.t List.t)
     : 'c =
-  (* let rec fold_expr (state : 'c) (expr : Expr.Typed.Meta.t Expr.Fixed.t) =
+  (* let rec fold_expr (state : 'c) (expr : Expr.t) =
    *   Expr.Fixed.Pattern.fold_left
    *     ~f:(fun a e -> fold_expr (take_expr a e) e)
    *     ~init:state
@@ -313,7 +313,7 @@ let rec fn_subst_expr m e =
   match m e with
   | Some e' ->
       (* let print_expr (e:Expr.Typed.t) = *)
-      (* [%sexp (e.pattern : Expr.Typed.Meta.t Expr.Fixed.t Expr.Fixed.Pattern.t)] |> Sexp.to_string *)
+      (* [%sexp (e.pattern : Expr.Typed.t Expr.Fixed.Pattern.t)] |> Sexp.to_string *)
       (* in *)
       (* let _ = print_endline ("Replaced expr: " ^ print_expr e ^ " -> " ^ print_expr e') in *)
       e'

--- a/src/analysis_and_optimization/Mir_utils.mli
+++ b/src/analysis_and_optimization/Mir_utils.mli
@@ -28,13 +28,10 @@ val parameter_names_set :
   ?include_transformed:bool -> Program.Typed.t -> string Set.Poly.t
 
 val fold_expr :
-     take_expr:('c -> Expr.Typed.Meta.t Expr.Fixed.t -> 'c)
-  -> init:'c
-  -> Expr.Typed.t
-  -> 'c
+  take_expr:('c -> Expr.Typed.t -> 'c) -> init:'c -> Expr.Typed.t -> 'c
 
 val fold_stmts :
-     take_expr:('c -> Expr.Typed.Meta.t Expr.Fixed.t -> 'c)
+     take_expr:('c -> Expr.Typed.t -> 'c)
   -> take_stmt:('c -> Stmt.Located.t -> 'c)
   -> init:'c
   -> Stmt.Located.t List.t
@@ -137,8 +134,7 @@ val index_var_set :
    For use in RHS sets, not LHS assignment sets, except in a target term
 *)
 
-val expr_var_names_set :
-  Expr.Typed.Meta.t Expr.Fixed.t -> string Core_kernel.Set.Poly.t
+val expr_var_names_set : Expr.Typed.t -> string Core_kernel.Set.Poly.t
 (** 
    Return the names of the variables in an expression.
 *)

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -765,8 +765,7 @@ let rec find_assignment_idx (name : string) Stmt.Fixed.{pattern; _} =
  *  in their first assignment and mark them as not needing to be
  *  initialized.
  *)
-and unenforce_initialize
-    (lst : (Expr.Typed.Meta.t, Stmt.Located.Meta.t) Stmt.Fixed.t list) =
+and unenforce_initialize (lst : Stmt.Located.t list) =
   let rec unenforce_initialize_patt (Stmt.Fixed.{pattern; _} as stmt) sub_lst =
     match pattern with
     | Stmt.Fixed.Pattern.Decl ({decl_id; _} as decl_pat) -> (
@@ -817,9 +816,8 @@ and unenforce_initialize
  *    Stmts.
  *)
 let transform_mir_blocks (mir : (Expr.Typed.t, Stmt.Located.t) Program.t)
-    (transformer :
-         (Expr.Typed.Meta.t, Stmt.Located.Meta.t) Stmt.Fixed.t list
-      -> Stmt.Located.t list ) : (Expr.Typed.t, Stmt.Located.t) Program.t =
+    (transformer : Stmt.Located.t list -> Stmt.Located.t list) :
+    (Expr.Typed.t, Stmt.Located.t) Program.t =
   let transformed_functions =
     List.map mir.functions_block ~f:(fun fs ->
         let new_body =
@@ -1049,11 +1047,11 @@ let optimize_minimal_variables
        -> string Set.Poly.t )
     ~(update_expr : string Set.Poly.t -> Expr.Typed.t -> Expr.Typed.t)
     ~(update_stmt :
-          ( Expr.Typed.Meta.t Expr.Fixed.t
+          ( Expr.Typed.t
           , (Expr.Typed.Meta.t, 'a) Stmt.Fixed.t )
           Stmt.Fixed.Pattern.t
        -> string Core_kernel.Set.Poly.t
-       -> ( Expr.Typed.Meta.t Expr.Fixed.t
+       -> ( Expr.Typed.t
           , (Expr.Typed.Meta.t, 'a) Stmt.Fixed.t )
           Stmt.Fixed.Pattern.t )
     ~(extra_variables : string -> string Set.Poly.t)
@@ -1169,10 +1167,7 @@ let optimize_soa (mir : Program.Typed.t) =
       stmt ~extra_variables:(fun _ -> initial_variables) in
   let transform' s =
     match transform {pattern= SList s; meta= Location_span.empty} with
-    | { pattern=
-          SList (l : (Expr.Typed.Meta.t, Stmt.Located.Meta.t) Stmt.Fixed.t list)
-      ; _ } ->
-        l
+    | {pattern= SList (l : Stmt.Located.t list); _} -> l
     | _ ->
         raise
           (Failure "Something went wrong with program transformation packing!")

--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -206,9 +206,7 @@ let expr_collect_exprs (expr : Expr.Typed.t) ~f : 'a Set.Poly.t =
     match f expr with Some a -> Set.Poly.add s a | _ -> s in
   fold_expr ~init:Set.Poly.empty ~take_expr:(fun s e -> collect_expr s e) expr
 
-let stmts_collect_exprs
-    (stmts : (Expr.Typed.Meta.t, Stmt.Located.Meta.t) Stmt.Fixed.t List.t) ~f :
-    'a Set.Poly.t =
+let stmts_collect_exprs (stmts : Stmt.Located.t List.t) ~f : 'a Set.Poly.t =
   let collect_expr s (expr : Expr.Typed.t) =
     match f expr with Some a -> Set.Poly.add s a | _ -> s in
   fold_stmts ~init:Set.Poly.empty

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -679,6 +679,22 @@ let migrate_checks_to_end_of_block stmts =
   let checks, not_checks = List.partition_tf ~f:stmt_contains_check stmts in
   not_checks @ checks
 
+let trans_data (p : Ast.typed_program) =
+  let data = Ast.get_stmts p.datablock in
+  List.filter_map data ~f:(function
+    | { stmt=
+          VarDecl
+            { decl_type= Sized sizedtype
+            ; transformation
+            ; identifier= {name; _}
+            ; _ }
+      ; _ } ->
+        Some
+          ( SizedType.map trans_expr sizedtype
+          , Transformation.map trans_expr transformation
+          , name )
+    | _ -> None )
+
 let trans_prog filename (p : Ast.typed_program) : Program.Typed.t =
   let {Ast.functionblock; datablock; transformeddatablock; modelblock; _} = p in
   let map f list_op =

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -679,7 +679,7 @@ let migrate_checks_to_end_of_block stmts =
   let checks, not_checks = List.partition_tf ~f:stmt_contains_check stmts in
   not_checks @ checks
 
-let trans_data (p : Ast.typed_program) =
+let gather_data (p : Ast.typed_program) =
   let data = Ast.get_stmts p.datablock in
   List.filter_map data ~f:(function
     | { stmt=

--- a/src/frontend/Ast_to_Mir.mli
+++ b/src/frontend/Ast_to_Mir.mli
@@ -3,9 +3,6 @@ open Middle
 
 val trans_data :
      Ast.typed_program
-  -> ( Expr.Typed.Meta.t Expr.Fixed.t SizedType.t
-     * Expr.Typed.Meta.t Expr.Fixed.t Transformation.t
-     * string )
-     list
+  -> (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
 
 val trans_prog : string -> Ast.typed_program -> Program.Typed.t

--- a/src/frontend/Ast_to_Mir.mli
+++ b/src/frontend/Ast_to_Mir.mli
@@ -1,7 +1,7 @@
 (** Translate from the AST to the MIR *)
 open Middle
 
-val trans_data :
+val gather_data :
      Ast.typed_program
   -> (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
 

--- a/src/frontend/Ast_to_Mir.mli
+++ b/src/frontend/Ast_to_Mir.mli
@@ -1,4 +1,11 @@
 (** Translate from the AST to the MIR *)
+open Middle
 
-val trans_prog : string -> Ast.typed_program -> Middle.Program.Typed.t
-val trans_expr : Ast.typed_expression -> Middle.Expr.Typed.t
+val trans_data :
+     Ast.typed_program
+  -> ( Expr.Typed.Meta.t Expr.Fixed.t SizedType.t
+     * Expr.Typed.Meta.t Expr.Fixed.t Transformation.t
+     * string )
+     list
+
+val trans_prog : string -> Ast.typed_program -> Program.Typed.t

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -267,9 +267,7 @@ module Helpers = struct
       | _ ->
           (* These should go away with Ryan's LHS *)
           Common.FatalError.fatal_error_msg
-            [%message
-              "Expected Var or Indexed but found " (e : Typed.Meta.t Fixed.t)]
-    in
+            [%message "Expected Var or Indexed but found " (e : Typed.t)] in
     Fixed.{meta; pattern}
 
   (** TODO: Make me tail recursive *)

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Core_kernel.Poly
 open Common
 open Helpers
 
@@ -163,12 +162,17 @@ module Helpers = struct
   let int i = {Fixed.meta= Typed.Meta.empty; pattern= Lit (Int, string_of_int i)}
 
   let float i =
-    {Fixed.meta= Typed.Meta.empty; pattern= Lit (Real, string_of_float i)}
+    { Fixed.meta= {Typed.Meta.empty with type_= UReal}
+    ; pattern= Lit (Real, Float.to_string i) }
 
   let str i = {Fixed.meta= Typed.Meta.empty; pattern= Lit (Str, i)}
   let variable v = {Fixed.meta= Typed.Meta.empty; pattern= Var v}
   let zero = int 0
   let one = int 1
+
+  let unary_op op e =
+    { Fixed.meta= Typed.Meta.empty
+    ; pattern= FunApp (StanLib (Operator.to_string op, FnPlain, AoS), [e]) }
 
   let binop e1 op e2 =
     { Fixed.meta= Typed.Meta.empty
@@ -180,6 +184,41 @@ module Helpers = struct
     | [] -> default
     | head :: rest ->
         List.fold ~init:head ~f:(fun accum next -> binop accum op next) rest
+
+  let row_vector l =
+    { Fixed.meta= {Typed.Meta.empty with type_= URowVector}
+    ; pattern= FunApp (CompilerInternal FnMakeRowVec, List.map ~f:float l) }
+
+  let vector l =
+    let v = unary_op Transpose (row_vector l) in
+    {v with meta= {Typed.Meta.empty with type_= UVector}}
+
+  let matrix l =
+    { Fixed.meta= {Typed.Meta.empty with type_= UMatrix}
+    ; pattern= FunApp (CompilerInternal FnMakeRowVec, List.map ~f:row_vector l)
+    }
+
+  let matrix_from_rows l =
+    { Fixed.meta= {Typed.Meta.empty with type_= UMatrix}
+    ; pattern= FunApp (CompilerInternal FnMakeRowVec, l) }
+
+  let array_expr l =
+    let type_ =
+      List.hd l |> Option.value_map ~f:Typed.type_of ~default:UnsizedType.UReal
+    in
+    { Fixed.meta= {Typed.Meta.empty with type_= UArray type_}
+    ; pattern= FunApp (CompilerInternal FnMakeArray, l) }
+
+  let try_unpack e =
+    (* FIXME: what about matrices? *)
+    match e.Fixed.pattern with
+    | FunApp (CompilerInternal (FnMakeRowVec | FnMakeArray), l) -> Some l
+    | FunApp
+        ( StanLib (transpose, FnPlain, _)
+        , [{pattern= FunApp (CompilerInternal FnMakeRowVec, l); _}] )
+      when String.equal transpose (Operator.to_string Transpose) ->
+        Some l
+    | _ -> None
 
   let loop_bottom = one
 
@@ -197,7 +236,9 @@ module Helpers = struct
 
   let%test "expr contains fn" =
     internal_funapp FnReadData [] ()
-    |> contains_fn_kind (fun kind -> kind = CompilerInternal FnReadData)
+    |> contains_fn_kind (function
+         | CompilerInternal FnReadData -> true
+         | _ -> false )
 
   let rec infer_type_of_indexed ut indices =
     match (ut, indices) with

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -210,7 +210,6 @@ module Helpers = struct
     ; pattern= FunApp (CompilerInternal FnMakeArray, l) }
 
   let try_unpack e =
-    (* FIXME: what about matrices? *)
     match e.Fixed.pattern with
     | FunApp (CompilerInternal (FnMakeRowVec | FnMakeArray), l) -> Some l
     | FunApp

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -213,9 +213,8 @@ module Helpers = struct
     match e.Fixed.pattern with
     | FunApp (CompilerInternal (FnMakeRowVec | FnMakeArray), l) -> Some l
     | FunApp
-        ( StanLib (transpose, FnPlain, _)
-        , [{pattern= FunApp (CompilerInternal FnMakeRowVec, l); _}] )
-      when String.equal transpose (Operator.to_string Transpose) ->
+        ( StanLib ("Transpose__", FnPlain, _)
+        , [{pattern= FunApp (CompilerInternal FnMakeRowVec, l); _}] ) ->
         Some l
     | _ -> None
 

--- a/src/middle/Expr.mli
+++ b/src/middle/Expr.mli
@@ -87,8 +87,15 @@ module Helpers : sig
   val variable : string -> Typed.t
   val zero : Typed.t
   val one : Typed.t
+  val unary_op : Operator.t -> Typed.t -> Typed.t
   val binop : Typed.t -> Operator.t -> Typed.t -> Typed.t
   val binop_list : Typed.t list -> Operator.t -> default:Typed.t -> Typed.t
+  val row_vector : float list -> Typed.Meta.t Fixed.t
+  val vector : float list -> Typed.Meta.t Fixed.t
+  val matrix : float list list -> Typed.Meta.t Fixed.t
+  val matrix_from_rows : Typed.Meta.t Fixed.t list -> Typed.Meta.t Fixed.t
+  val array_expr : Typed.Meta.t Fixed.t list -> Typed.Meta.t Fixed.t
+  val try_unpack : Typed.Meta.t Fixed.t -> Typed.Meta.t Fixed.t list option
   val loop_bottom : Typed.t
 
   val internal_funapp :

--- a/src/middle/Expr.mli
+++ b/src/middle/Expr.mli
@@ -90,12 +90,12 @@ module Helpers : sig
   val unary_op : Operator.t -> Typed.t -> Typed.t
   val binop : Typed.t -> Operator.t -> Typed.t -> Typed.t
   val binop_list : Typed.t list -> Operator.t -> default:Typed.t -> Typed.t
-  val row_vector : float list -> Typed.Meta.t Fixed.t
-  val vector : float list -> Typed.Meta.t Fixed.t
-  val matrix : float list list -> Typed.Meta.t Fixed.t
-  val matrix_from_rows : Typed.Meta.t Fixed.t list -> Typed.Meta.t Fixed.t
-  val array_expr : Typed.Meta.t Fixed.t list -> Typed.Meta.t Fixed.t
-  val try_unpack : Typed.Meta.t Fixed.t -> Typed.Meta.t Fixed.t list option
+  val row_vector : float list -> Typed.t
+  val vector : float list -> Typed.t
+  val matrix : float list list -> Typed.t
+  val matrix_from_rows : Typed.t list -> Typed.t
+  val array_expr : Typed.t list -> Typed.t
+  val try_unpack : Typed.t -> Typed.t list option
   val loop_bottom : Typed.t
 
   val internal_funapp :

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -272,7 +272,7 @@ let use_file filename =
       (Deprecation_analysis.collect_warnings typed_ast) ;
   if !generate_data then
     print_endline
-      (Debug_data_generation.print_data_prog (Ast_to_Mir.trans_data typed_ast)) ;
+      (Debug_data_generation.print_data_prog (Ast_to_Mir.gather_data typed_ast)) ;
   Debugging.typed_ast_logger typed_ast ;
   if not !pretty_print_program then (
     let mir = Ast_to_Mir.trans_prog filename typed_ast in

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -271,7 +271,8 @@ let use_file filename =
     Warnings.pp_warnings Fmt.stderr ?printed_filename
       (Deprecation_analysis.collect_warnings typed_ast) ;
   if !generate_data then
-    print_endline (Debug_data_generation.print_data_prog typed_ast) ;
+    print_endline
+      (Debug_data_generation.print_data_prog (Ast_to_Mir.trans_data typed_ast)) ;
   Debugging.typed_ast_logger typed_ast ;
   if not !pretty_print_program then (
     let mir = Ast_to_Mir.trans_prog filename typed_ast in

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -90,7 +90,9 @@ let stan2cpp model_name model_string is_flag_set flag_val =
           r.return (Result.Ok (Fmt.str "%a" Program.Typed.pp mir), warnings, []) ;
         if is_flag_set "debug-generate-data" then
           r.return
-            ( Result.Ok (Debug_data_generation.print_data_prog typed_ast)
+            ( Result.Ok
+                (Debug_data_generation.print_data_prog
+                   (Ast_to_Mir.trans_data typed_ast) )
             , warnings
             , [] ) ;
         let opt_mir =

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -92,7 +92,7 @@ let stan2cpp model_name model_string is_flag_set flag_val =
           r.return
             ( Result.Ok
                 (Debug_data_generation.print_data_prog
-                   (Ast_to_Mir.trans_data typed_ast) )
+                   (Ast_to_Mir.gather_data typed_ast) )
             , warnings
             , [] ) ;
         let opt_mir =

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -341,6 +341,9 @@ let%expect_test "whole program data generation check" =
           row_vector<lower=[1,2,3,4,5],upper=[2,3,4,5,6]>[5] y_row_lu_given_bound;
           row_vector<lower=x_row_vect,upper=x_row_vect_up>[5] y_row_lu_vector_bound;
           row_vector<lower=[1,2,3,4,5],upper=x_row_vect_up>[5] y_row_lu_vector_bound_mixed;
+
+          matrix<upper=2.0>[2,2] upper_matrix;
+          matrix<lower=upper_matrix, upper=5>[2,2] lower_upper_matrix;
         }
       |}
   in
@@ -426,7 +429,13 @@ let%expect_test "whole program data generation check" =
     \n    19.572734365483463, 12.348137644499662],\
     \n\"y_row_lu_vector_bound_mixed\":\
     \n  [23.68117004588095, 21.859463377110153, 16.93731450392735,\
-    \n    19.994339965018462, 16.065041740638126]\
+    \n    19.994339965018462, 16.065041740638126],\
+    \n\"upper_matrix\":\
+    \n  [[1.0341237330520263, 1.5089128377972285],\
+    \n    [-2.334114450641863, 1.2726909686498331]],\
+    \n\"lower_upper_matrix\":\
+    \n  [[2.700035909998304, 3.3701108882979232],\
+    \n    [4.412857964089933, 1.5133491301453186]]\
     \n}" |}]
 
 let%expect_test "whole program data generation check" =

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -3,6 +3,8 @@ open Core_kernel
 open Frontend
 open Debug_data_generation
 
+let print_data_prog ast = print_data_prog (Ast_to_Mir.trans_data ast)
+
 let%expect_test "whole program data generation check" =
   let ast =
     Frontend_utils.typed_ast_of_string_exn

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -3,7 +3,7 @@ open Core_kernel
 open Frontend
 open Debug_data_generation
 
-let print_data_prog ast = print_data_prog (Ast_to_Mir.trans_data ast)
+let print_data_prog ast = print_data_prog (Ast_to_Mir.gather_data ast)
 
 let%expect_test "whole program data generation check" =
   let ast =


### PR DESCRIPTION
After #1115 `Debug_data_generation.ml` lives in `analysis_and_optimization` instead of `frontend` and it should no longer use `Frontend.Ast`. This PR removes Ast from data generation.
Also, generation of matrices with non-scalar lower/upper bounds was broken; I fixed that too.

#### Submission Checklist

- [X] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [X] OR, no user-facing changes were made

## Copyright and Licensing
Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
