### PR TITLE
Only show assignment operators which match the lhs in error messages

### DIFF
--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -103,17 +103,16 @@ module TypeError = struct
           UnsizedType.pp ut
     | IllTypedAssignment (Operator.Equals, lt, rt) ->
         Fmt.pf ppf
-          "Ill-typed arguments supplied to assignment operator %s: lhs has \
-           type %a and rhs has type %a"
-          "=" UnsizedType.pp lt UnsizedType.pp rt
+          "Ill-typed arguments supplied to assignment operator =: lhs has type \
+           %a and rhs has type %a"
+          UnsizedType.pp lt UnsizedType.pp rt
     | IllTypedAssignment (op, lt, rt) ->
         Fmt.pf ppf
-          "@[<h>Ill-typed arguments supplied to assignment operator %s: lhs \
-           has type %a and rhs has type %a. Available signatures:@]%s"
-          (Fmt.str "%a=" Operator.pp op)
-          UnsizedType.pp lt UnsizedType.pp rt
-          ( Stan_math_signatures.pretty_print_math_lib_assignmentoperator_sigs op
-          |> Option.value ~default:"no matching signatures" )
+          "@[<v>Ill-typed arguments supplied to assignment operator %a=: lhs \
+           has type %a and rhs has type %a.@ Available signatures for given \
+           lhs:@]@ %a"
+          Operator.pp op UnsizedType.pp lt UnsizedType.pp rt
+          SignatureMismatch.pp_math_lib_assignmentoperator_sigs (lt, op)
     | IllTypedTernaryIf (UInt, ut, _) when UnsizedType.is_fun_type ut ->
         Fmt.pf ppf "Ternary expression cannot have a function type: %a"
           UnsizedType.pp ut

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -368,21 +368,17 @@ let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
 
 let pp_math_lib_assignmentoperator_sigs ppf (lt, op) =
   let signatures =
-    match op with
-    | Operator.Plus | Minus | Times | Divide | EltTimes | EltDivide -> (
-        let errors =
-          Stan_math_signatures.make_assignmentoperator_stan_math_signatures op
-        in
-        let errors =
-          List.filter
-            ~f:(fun (_, args, _) ->
-              Result.is_ok (check_same_type 0 lt (snd (List.hd_exn args))) )
-            errors in
-        match List.split_n errors max_n_errors with
-        | [], _ -> None
-        | errors, [] -> Some (errors, false)
-        | errors, _ -> Some (errors, true) )
-    | _ -> None in
+    let errors =
+      Stan_math_signatures.make_assignmentoperator_stan_math_signatures op in
+    let errors =
+      List.filter
+        ~f:(fun (_, args, _) ->
+          Result.is_ok (check_same_type 0 lt (snd (List.hd_exn args))) )
+        errors in
+    match List.split_n errors max_n_errors with
+    | [], _ -> None
+    | errors, [] -> Some (errors, false)
+    | errors, _ -> Some (errors, true) in
   let pp_sigs ppf (signatures, omitted) =
     Fmt.pf ppf "@[<v>%a%a@]"
       (Fmt.list ~sep:Fmt.cut Stan_math_signatures.pp_math_sig)

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -365,3 +365,30 @@ let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
     name pp_args arg_tys
     (list ~sep:cut pp_signature)
     sigs pp_omitted ()
+
+let pp_math_lib_assignmentoperator_sigs ppf (lt, op) =
+  let signatures =
+    match op with
+    | Operator.Plus | Minus | Times | Divide | EltTimes | EltDivide -> (
+        let errors =
+          Stan_math_signatures.make_assignmentoperator_stan_math_signatures op
+        in
+        let errors =
+          List.filter
+            ~f:(fun (_, args, _) ->
+              Result.is_ok (check_same_type 0 lt (snd (List.hd_exn args))) )
+            errors in
+        match List.split_n errors 10 with
+        | [], _ -> None
+        | errors, [] -> Some (errors, false)
+        | errors, _ -> Some (errors, true) )
+    | _ -> None in
+  let pp_sigs ppf (signatures, omitted) =
+    Fmt.pf ppf "@[<v>%a@ %a@]"
+      (Fmt.list ~sep:Fmt.cut Stan_math_signatures.pp_math_sig)
+      signatures
+      (if omitted then Fmt.string else Fmt.nop)
+      "(Additional signatures omitted)" in
+  Fmt.pf ppf "%a"
+    (Fmt.option ~none:(Fmt.any "No matching signatures") pp_sigs)
+    signatures

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -378,17 +378,17 @@ let pp_math_lib_assignmentoperator_sigs ppf (lt, op) =
             ~f:(fun (_, args, _) ->
               Result.is_ok (check_same_type 0 lt (snd (List.hd_exn args))) )
             errors in
-        match List.split_n errors 10 with
+        match List.split_n errors max_n_errors with
         | [], _ -> None
         | errors, [] -> Some (errors, false)
         | errors, _ -> Some (errors, true) )
     | _ -> None in
   let pp_sigs ppf (signatures, omitted) =
-    Fmt.pf ppf "@[<v>%a@ %a@]"
+    Fmt.pf ppf "@[<v>%a%a@]"
       (Fmt.list ~sep:Fmt.cut Stan_math_signatures.pp_math_sig)
       signatures
-      (if omitted then Fmt.string else Fmt.nop)
-      "(Additional signatures omitted)" in
+      (if omitted then Fmt.pf else Fmt.nop)
+      "@ (Additional signatures omitted)" in
   Fmt.pf ppf "%a"
     (Fmt.option ~none:(Fmt.any "No matching signatures") pp_sigs)
     signatures

--- a/src/frontend/SignatureMismatch.mli
+++ b/src/frontend/SignatureMismatch.mli
@@ -86,4 +86,7 @@ val pp_signature_mismatch :
        * bool )
   -> unit
 
+val pp_math_lib_assignmentoperator_sigs :
+  Format.formatter -> UnsizedType.t * Operator.t -> unit
+
 val compare_errors : function_mismatch -> function_mismatch -> int

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -499,15 +499,6 @@ let pretty_print_math_lib_operator_sigs op =
     [Fmt.str "@[<v>@,%a@]" pp_math_sig int_divide_type]
   else operator_to_stan_math_fns op |> List.map ~f:pretty_print_math_sigs
 
-let pretty_print_math_lib_assignmentoperator_sigs op =
-  match op with
-  | Operator.Plus | Minus | Times | Divide | EltTimes | EltDivide ->
-      Some
-        (Fmt.str "@[<v>@,%a@]"
-           (Fmt.list ~sep:Fmt.cut pp_math_sig)
-           (make_assignmentoperator_stan_math_signatures op) )
-  | _ -> None
-
 (* -- Some helper definitions to populate stan_math_signatures -- *)
 let bare_types =
   [UnsizedType.UInt; UReal; UComplex; UVector; URowVector; UMatrix]

--- a/test/integration/bad/compound-assign/stanc.expected
+++ b/test/integration/bad/compound-assign/stanc.expected
@@ -8,16 +8,9 @@ Semantic error in 'elt_divide_equals_prim.stan', line 4, column 2 to column 10:
      5:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator ./=: lhs has type real and rhs has type real. Available signatures:
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+Ill-typed arguments supplied to assignment operator ./=: lhs has type real and rhs has type real.
+Available signatures for given lhs:
+No matching signatures
   $ ../../../../../install/default/bin/stanc elt_times_equals_prim.stan
 Semantic error in 'elt_times_equals_prim.stan', line 4, column 2 to column 10:
    -------------------------------------------------
@@ -28,10 +21,9 @@ Semantic error in 'elt_times_equals_prim.stan', line 4, column 2 to column 10:
      5:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator .*=: lhs has type real and rhs has type real. Available signatures:
-(vector, vector) => void
-(row_vector, row_vector) => void
-(matrix, matrix) => void
+Ill-typed arguments supplied to assignment operator .*=: lhs has type real and rhs has type real.
+Available signatures for given lhs:
+No matching signatures
   $ ../../../../../install/default/bin/stanc plus_equals_bad_init.stan
 Syntax error in 'plus_equals_bad_init.stan', line 3, column 20 to column 22, parsing error:
    -------------------------------------------------
@@ -65,20 +57,10 @@ Semantic error in 'plus_equals_bad_var_lhs.stan', line 3, column 4 to column 14:
      5:    }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type (real) => real and rhs has type real. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+Ill-typed arguments supplied to assignment operator +=: lhs has type 
+(real) => real and rhs has type real.
+Available signatures for given lhs:
+No matching signatures
   $ ../../../../../install/default/bin/stanc plus_equals_bad_var_lhs2.stan
 Semantic error in 'plus_equals_bad_var_lhs2.stan', line 6, column 2 to column 9:
    -------------------------------------------------
@@ -112,20 +94,9 @@ Semantic error in 'plus_equals_matrix_array.stan', line 7, column 2 to column 9:
      8:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type array[] matrix and rhs has type array[] matrix. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+Ill-typed arguments supplied to assignment operator +=: lhs has type array[] matrix and rhs has type array[] matrix.
+Available signatures for given lhs:
+No matching signatures
   $ ../../../../../install/default/bin/stanc plus_equals_matrix_array2.stan
 Semantic error in 'plus_equals_matrix_array2.stan', line 7, column 2 to column 17:
    -------------------------------------------------
@@ -136,20 +107,12 @@ Semantic error in 'plus_equals_matrix_array2.stan', line 7, column 2 to column 1
      8:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type matrix and rhs has type row_vector. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
+Ill-typed arguments supplied to assignment operator +=: lhs has type matrix and rhs has type row_vector.
+Available signatures for given lhs:
 (matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
+
   $ ../../../../../install/default/bin/stanc plus_equals_matrix_shape_mismatch.stan
 Syntax error in 'plus_equals_matrix_shape_mismatch.stan', line 4, column 10 to column 11, parsing error:
    -------------------------------------------------
@@ -172,20 +135,9 @@ Semantic error in 'plus_equals_prim_array.stan', line 5, column 2 to column 9:
      6:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type array[] real and rhs has type array[] real. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+Ill-typed arguments supplied to assignment operator +=: lhs has type array[] real and rhs has type array[] real.
+Available signatures for given lhs:
+No matching signatures
   $ ../../../../../install/default/bin/stanc plus_equals_row_vec_array.stan
 Semantic error in 'plus_equals_row_vec_array.stan', line 5, column 2 to column 9:
    -------------------------------------------------
@@ -196,20 +148,9 @@ Semantic error in 'plus_equals_row_vec_array.stan', line 5, column 2 to column 9
      6:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type array[] row_vector and rhs has type array[] row_vector. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+Ill-typed arguments supplied to assignment operator +=: lhs has type array[] row_vector and rhs has type array[] row_vector.
+Available signatures for given lhs:
+No matching signatures
   $ ../../../../../install/default/bin/stanc plus_equals_sliced.stan
 Semantic error in 'plus_equals_sliced.stan', line 6, column 4 to column 27:
    -------------------------------------------------
@@ -221,20 +162,12 @@ Semantic error in 'plus_equals_sliced.stan', line 6, column 4 to column 27:
      8:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type vector and rhs has type matrix. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
+Ill-typed arguments supplied to assignment operator +=: lhs has type vector and rhs has type matrix.
+Available signatures for given lhs:
 (vector, int) => void
 (vector, real) => void
 (vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch.stan
 Semantic error in 'plus_equals_type_mismatch.stan', line 4, column 2 to column 9:
    -------------------------------------------------
@@ -245,20 +178,10 @@ Semantic error in 'plus_equals_type_mismatch.stan', line 4, column 2 to column 9
      5:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type int and rhs has type real. Available signatures:
+Ill-typed arguments supplied to assignment operator +=: lhs has type int and rhs has type real.
+Available signatures for given lhs:
 (int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch2.stan
 Semantic error in 'plus_equals_type_mismatch2.stan', line 4, column 2 to column 9:
    -------------------------------------------------
@@ -269,20 +192,12 @@ Semantic error in 'plus_equals_type_mismatch2.stan', line 4, column 2 to column 
      5:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type real and rhs has type vector. Available signatures:
+Ill-typed arguments supplied to assignment operator +=: lhs has type real and rhs has type vector.
+Available signatures for given lhs:
 (int, int) => void
 (real, int) => void
 (real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+
   $ ../../../../../install/default/bin/stanc plus_equals_vector_array.stan
 Semantic error in 'plus_equals_vector_array.stan', line 5, column 2 to column 9:
    -------------------------------------------------
@@ -293,20 +208,9 @@ Semantic error in 'plus_equals_vector_array.stan', line 5, column 2 to column 9:
      6:  }
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator +=: lhs has type array[] vector and rhs has type array[] vector. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(vector, vector) => void
-(complex, complex) => void
-(row_vector, int) => void
-(row_vector, real) => void
-(row_vector, row_vector) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+Ill-typed arguments supplied to assignment operator +=: lhs has type array[] vector and rhs has type array[] vector.
+Available signatures for given lhs:
+No matching signatures
   $ ../../../../../install/default/bin/stanc times_equals_matrix_array.stan
 Semantic error in 'times_equals_matrix_array.stan', line 5, column 2 to column 19:
    -------------------------------------------------
@@ -318,16 +222,9 @@ Semantic error in 'times_equals_matrix_array.stan', line 5, column 2 to column 1
      7:    x *= y;
    -------------------------------------------------
 
-Ill-typed arguments supplied to assignment operator *=: lhs has type row_vector and rhs has type row_vector. Available signatures:
-(int, int) => void
-(real, int) => void
-(real, real) => void
-(vector, int) => void
-(vector, real) => void
-(complex, complex) => void
+Ill-typed arguments supplied to assignment operator *=: lhs has type row_vector and rhs has type row_vector.
+Available signatures for given lhs:
 (row_vector, int) => void
 (row_vector, real) => void
 (row_vector, matrix) => void
-(matrix, int) => void
-(matrix, real) => void
-(matrix, matrix) => void
+

--- a/test/integration/bad/compound-assign/stanc.expected
+++ b/test/integration/bad/compound-assign/stanc.expected
@@ -112,7 +112,6 @@ Available signatures for given lhs:
 (matrix, int) => void
 (matrix, real) => void
 (matrix, matrix) => void
-
   $ ../../../../../install/default/bin/stanc plus_equals_matrix_shape_mismatch.stan
 Syntax error in 'plus_equals_matrix_shape_mismatch.stan', line 4, column 10 to column 11, parsing error:
    -------------------------------------------------
@@ -167,7 +166,6 @@ Available signatures for given lhs:
 (vector, int) => void
 (vector, real) => void
 (vector, vector) => void
-
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch.stan
 Semantic error in 'plus_equals_type_mismatch.stan', line 4, column 2 to column 9:
    -------------------------------------------------
@@ -181,7 +179,6 @@ Semantic error in 'plus_equals_type_mismatch.stan', line 4, column 2 to column 9
 Ill-typed arguments supplied to assignment operator +=: lhs has type int and rhs has type real.
 Available signatures for given lhs:
 (int, int) => void
-
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch2.stan
 Semantic error in 'plus_equals_type_mismatch2.stan', line 4, column 2 to column 9:
    -------------------------------------------------
@@ -197,7 +194,6 @@ Available signatures for given lhs:
 (int, int) => void
 (real, int) => void
 (real, real) => void
-
   $ ../../../../../install/default/bin/stanc plus_equals_vector_array.stan
 Semantic error in 'plus_equals_vector_array.stan', line 5, column 2 to column 9:
    -------------------------------------------------
@@ -227,4 +223,3 @@ Available signatures for given lhs:
 (row_vector, int) => void
 (row_vector, real) => void
 (row_vector, matrix) => void
-


### PR DESCRIPTION
Currently our type errors produced from assignment operators like `*=` are very different than something like `operator*`. In particular, we don't truncate the list at all. This PR introduces two changes:

1. Truncate the shown signatures at 5 (same as any other signature error)
2. Only show signatures which match the LHS provided. For example,
    ```stan
    row_vector[N] x;
    x *= x;
    ```
    Does not need to show the `int*int` signature, but should show `row_vector*real`, etc.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improve error messages when an assignment operator like `+=` is given bad types.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
