### PR TITLE
Prevent assignments of function types

### DIFF
--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -345,6 +345,7 @@ module StatementError = struct
   type t =
     | CannotAssignToReadOnly of string
     | CannotAssignToGlobal of string
+    | CannotAssignFunction of UnsizedType.t * string
     | LValueMultiIndexing
     | InvalidSamplingPDForPMF
     | InvalidSamplingCDForCCDF of string
@@ -380,6 +381,9 @@ module StatementError = struct
         Fmt.pf ppf
           "Cannot assign to global variable '%s' declared in previous blocks."
           name
+    | CannotAssignFunction (ut, name) ->
+        Fmt.pf ppf "Cannot assign a function type '%a' to variable '%s'."
+          UnsizedType.pp ut name
     | LValueMultiIndexing ->
         Fmt.pf ppf
           "Left hand side of an assignment cannot have nested multi-indexing."
@@ -657,6 +661,9 @@ let cannot_assign_to_read_only loc name =
 
 let cannot_assign_to_global loc name =
   StatementError (loc, StatementError.CannotAssignToGlobal name)
+
+let cannot_assign_function loc ut name =
+  StatementError (loc, StatementError.CannotAssignFunction (ut, name))
 
 let cannot_assign_to_multiindex loc =
   StatementError (loc, StatementError.LValueMultiIndexing)

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -119,6 +119,7 @@ val empty_array : Location_span.t -> t
 val bad_int_literal : Location_span.t -> t
 val cannot_assign_to_read_only : Location_span.t -> string -> t
 val cannot_assign_to_global : Location_span.t -> string -> t
+val cannot_assign_function : Location_span.t -> UnsizedType.t -> string -> t
 val cannot_assign_to_multiindex : Location_span.t -> t
 val invalid_sampling_pdf_or_pmf : Location_span.t -> t
 val invalid_sampling_cdf_or_ccdf : Location_span.t -> string -> t

--- a/test/integration/bad/assigment-to-function-stanmath.stan
+++ b/test/integration/bad/assigment-to-function-stanmath.stan
@@ -1,0 +1,16 @@
+functions {
+   real foo(real x, real y){
+     return 1.0;
+   }
+
+   void baz(){
+     // NB: putting this in later blocks produce an error due to assigning to a global variable
+     foo = pow;
+   }
+}
+
+model {
+     print(foo(2,3));
+    baz();
+   print(foo(2,3));
+}

--- a/test/integration/bad/assignment-to-function.stan
+++ b/test/integration/bad/assignment-to-function.stan
@@ -1,0 +1,20 @@
+functions {
+   real foo(int x){
+     return 1.0;
+   }
+
+   real bar(int y){
+     return 2.0;
+   }
+
+   void baz(){
+     // NB: putting this in later blocks produce an error due to assigning to a global variable
+     foo = bar;
+   }
+}
+
+model {
+     print(foo(1));
+    baz();
+   print(foo(1));
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -79,6 +79,18 @@ Semantic error in 'array_expr_bad2.stan', line 2, column 40 to column 41:
    -------------------------------------------------
 
 Array expression must have entries of consistent type. Expected array[] int but found int.
+  $ ../../../../install/default/bin/stanc assigment-to-function-stanmath.stan
+Semantic error in 'assigment-to-function-stanmath.stan', line 8, column 5 to column 15:
+   -------------------------------------------------
+     6:     void baz(){
+     7:       // NB: putting this in later blocks produce an error due to assigning to a global variable
+     8:       foo = pow;
+              ^
+     9:     }
+    10:  }
+   -------------------------------------------------
+
+Cannot assign a function type '<Stan Math function>' to variable 'foo'.
   $ ../../../../install/default/bin/stanc assign_real_to_int.stan
 Semantic error in 'assign_real_to_int.stan', line 11, column 2 to column 8:
    -------------------------------------------------
@@ -90,6 +102,18 @@ Semantic error in 'assign_real_to_int.stan', line 11, column 2 to column 8:
    -------------------------------------------------
 
 Ill-typed arguments supplied to assignment operator =: lhs has type int and rhs has type real
+  $ ../../../../install/default/bin/stanc assignment-to-function.stan
+Semantic error in 'assignment-to-function.stan', line 12, column 5 to column 15:
+   -------------------------------------------------
+    10:     void baz(){
+    11:       // NB: putting this in later blocks produce an error due to assigning to a global variable
+    12:       foo = bar;
+              ^
+    13:     }
+    14:  }
+   -------------------------------------------------
+
+Cannot assign a function type '(int) => real' to variable 'foo'.
   $ ../../../../install/default/bin/stanc bad_fundef_returntypes1.stan
 Semantic error in 'bad_fundef_returntypes1.stan', line 2, column 13 to line 6, column 3:
    -------------------------------------------------


### PR DESCRIPTION
Closes #1101

#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fixed a bug in the typechecker which permitted assignments to function values and produced un-compilable C++

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
