### PR TITLE
Improve tilde statement type errors

### DIFF
--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -405,7 +405,7 @@ module StatementError = struct
     | InvalidSamplingNoSuchDistribution name ->
         Fmt.pf ppf
           "Ill-typed arguments to '~' statement. No distribution '%s' was \
-           found with the correct signature."
+           found."
           name
     | InvalidTruncationCDForCCDF ->
         Fmt.pf ppf

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -124,6 +124,17 @@ let rec compare_errors e1 e2 =
       | SuffixMismatch _, _ | _, InputMismatch _ -> -1
       | InputMismatch _, _ | _, SuffixMismatch _ -> 1 ) )
 
+let compare_match_results e1 e2 =
+  (* Prefer informative errors *)
+  match (e1, e2) with
+  | AmbiguousMatch _, _ -> 1
+  | _, AmbiguousMatch _ -> -1
+  | SignatureErrors (l1, _), SignatureErrors (l2, _) ->
+      Int.compare (List.length l1) (List.length l2)
+  | SignatureErrors _, _ -> 1
+  | _, SignatureErrors _ -> -1
+  | _, _ -> 0
+
 let rec check_same_type depth t1 t2 =
   let wrap_func = Result.map_error ~f:(fun e -> TypeMismatch (t1, t2, Some e)) in
   match (t1, t2) with

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -133,7 +133,7 @@ let compare_match_results e1 e2 =
       Int.compare (List.length l1) (List.length l2)
   | SignatureErrors _, _ -> 1
   | _, SignatureErrors _ -> -1
-  | _, _ -> 0
+  | UniqueMatch _, UniqueMatch _ -> 0
 
 let rec check_same_type depth t1 t2 =
   let wrap_func = Result.map_error ~f:(fun e -> TypeMismatch (t1, t2, Some e)) in

--- a/src/frontend/SignatureMismatch.mli
+++ b/src/frontend/SignatureMismatch.mli
@@ -87,3 +87,4 @@ val pp_signature_mismatch :
   -> unit
 
 val compare_errors : function_mismatch -> function_mismatch -> int
+val compare_match_results : match_result -> match_result -> int

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1082,8 +1082,7 @@ let verify_sampling_distribution loc tenv id arguments =
   let name_w_suffix_sampling_dist suffix =
     SignatureMismatch.matching_function tenv (name ^ suffix) argumenttypes in
   let sampling_dists =
-    List.map ~f:name_w_suffix_sampling_dist
-      (Utils.distribution_suffices @ Utils.unnormalized_suffices) in
+    List.map ~f:name_w_suffix_sampling_dist Utils.distribution_suffices in
   let is_sampling_dist_defined =
     List.exists
       ~f:(function UniqueMatch (ReturnType UReal, _, _) -> true | _ -> false)

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1079,54 +1079,49 @@ let verify_valid_sampling_pos loc cf =
 let verify_sampling_distribution loc tenv id arguments =
   let name = id.name in
   let argumenttypes = List.map ~f:arg_type arguments in
-  let is_name_w_suffix_sampling_dist suffix =
-    match
-      SignatureMismatch.matching_stanlib_function (name ^ suffix) argumenttypes
-    with
-    | UniqueMatch (ReturnType UReal, _, _) -> true
-    | _ -> false in
-  let is_sampling_dist_in_math =
-    List.exists ~f:is_name_w_suffix_sampling_dist
-      (Utils.distribution_suffices @ Utils.unnormalized_suffices)
+  let name_w_suffix_sampling_dist suffix =
+    SignatureMismatch.matching_function tenv (name ^ suffix) argumenttypes in
+  let sampling_dists =
+    List.map ~f:name_w_suffix_sampling_dist
+      (Utils.distribution_suffices @ Utils.unnormalized_suffices) in
+  let is_sampling_dist_defined =
+    List.exists
+      ~f:(function UniqueMatch (ReturnType UReal, _, _) -> true | _ -> false)
+      sampling_dists
     && name <> "binomial_coefficient"
     && name <> "multiply" in
-  let is_name_w_suffix_udf_sampling_dist suffix =
+  if is_sampling_dist_defined then ()
+  else
     match
-      SignatureMismatch.matching_function tenv (name ^ suffix) argumenttypes
+      List.max_elt sampling_dists
+        ~compare:SignatureMismatch.compare_match_results
     with
-    | UniqueMatch (rt, f, _)
-      when rt = ReturnType UReal && f FnPlain = UserDefined FnPlain ->
-        true
-    | _ (* TODO don't throw away this information, improve errors *) -> false
-  in
-  let is_udf_sampling_dist =
-    List.exists ~f:is_name_w_suffix_udf_sampling_dist
-      (Utils.distribution_suffices @ Utils.unnormalized_suffices) in
-  if is_sampling_dist_in_math || is_udf_sampling_dist then ()
-  else Semantic_error.invalid_sampling_no_such_dist loc name |> error
+    | None | Some (UniqueMatch _) | Some (SignatureErrors ([], _)) ->
+        (* Either non-existant or a very odd case,
+           output the old non-informative error *)
+        Semantic_error.invalid_sampling_no_such_dist loc name |> error
+    | Some (AmbiguousMatch sigs) ->
+        Semantic_error.ambiguous_function_promotion loc id.name
+          (Some (List.map ~f:type_of_expr_typed arguments))
+          sigs
+        |> error
+    | Some (SignatureErrors (l, b)) ->
+        arguments
+        |> List.map ~f:(fun e -> e.emeta.type_)
+        |> Semantic_error.illtyped_fn_app loc id.name (l, b)
+        |> error
 
 let is_cumulative_density_defined tenv id arguments =
   let name = id.name in
   let argumenttypes = List.map ~f:arg_type arguments in
-  let is_real_rt_for_suffix suffix =
-    match
-      SignatureMismatch.matching_stanlib_function (name ^ suffix) argumenttypes
-    with
-    | UniqueMatch (ReturnType UReal, _, _) -> true
-    | _ -> false in
   let valid_arg_types_for_suffix suffix =
     match
       SignatureMismatch.matching_function tenv (name ^ suffix) argumenttypes
     with
-    | UniqueMatch (rt, _, _) when rt = ReturnType UReal -> true
+    | UniqueMatch (ReturnType UReal, _, _) -> true
     | _ -> false in
-  ( is_real_rt_for_suffix "_lcdf"
-  || valid_arg_types_for_suffix "_lcdf"
-  || is_real_rt_for_suffix "_cdf_log"
-  || valid_arg_types_for_suffix "_cdf_log" )
-  && ( is_real_rt_for_suffix "_lccdf"
-     || valid_arg_types_for_suffix "_lccdf"
-     || is_real_rt_for_suffix "_ccdf_log"
+  (valid_arg_types_for_suffix "_lcdf" || valid_arg_types_for_suffix "_cdf_log")
+  && ( valid_arg_types_for_suffix "_lccdf"
      || valid_arg_types_for_suffix "_ccdf_log" )
 
 let verify_can_truncate_distribution loc (arg : typed_expression) = function

--- a/test/integration/bad/function-signatures/overloading/stanc.expected
+++ b/test/integration/bad/function-signatures/overloading/stanc.expected
@@ -97,7 +97,13 @@ Semantic error in 'no_minimum_tilde.stan', line 12, column 3 to column 14:
     14:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'foo' was found with the correct signature.
+No unique minimum promotion found for function 'foo'.
+Overloaded functions must not have multiple equally valid promotion paths.
+For args (int, int), this function has several:
+(int, real) => real
+(real, int) => real
+Consider defining a new signature for the exact types needed or
+re-thinking existing definitions.
   $ ../../../../../../install/default/bin/stanc no_minimum_tilde2.stan
 Semantic error in 'no_minimum_tilde2.stan', line 12, column 3 to column 16:
    -------------------------------------------------
@@ -108,7 +114,13 @@ Semantic error in 'no_minimum_tilde2.stan', line 12, column 3 to column 16:
     13:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'foo' was found with the correct signature.
+No unique minimum promotion found for function 'foo'.
+Overloaded functions must not have multiple equally valid promotion paths.
+For args (int, int, int), this function has several:
+(int, real, int) => real
+(int, int, real) => real
+Consider defining a new signature for the exact types needed or
+re-thinking existing definitions.
   $ ../../../../../../install/default/bin/stanc no_minimum_variadic.stan
 Semantic error in 'no_minimum_variadic.stan', line 82, column 37 to line 84, column 81:
    -------------------------------------------------

--- a/test/integration/bad/signature_sampling_udf.stan
+++ b/test/integration/bad/signature_sampling_udf.stan
@@ -1,0 +1,9 @@
+functions {
+   real foo_lpdf(real x, int y, real z){
+     return 1.0;
+   }
+}
+
+model {
+  1.0 ~ foo(3.5,3);
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -158,7 +158,7 @@ Semantic error in 'bad_prob_fun_suffix.stan', line 10, column 2 to column 19:
     11:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'foo' was found with the correct signature.
+Ill-typed arguments to '~' statement. No distribution 'foo' was found.
   $ ../../../../install/default/bin/stanc bad_var_assignment_type1.stan
 Semantic error in 'bad_var_assignment_type1.stan', line 4, column 2 to column 8:
    -------------------------------------------------
@@ -216,7 +216,7 @@ Semantic error in 'binomial_coefficient_sample.stan', line 5, column 2 to column
      6:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'binomial_coefficient' was found with the correct signature.
+Ill-typed arguments to '~' statement. No distribution 'binomial_coefficient' was found.
   $ ../../../../install/default/bin/stanc break1.stan
 Semantic error in 'break1.stan', line 4, column 2 to column 8:
    -------------------------------------------------
@@ -1465,7 +1465,7 @@ Semantic error in 'multiply_sample.stan', line 5, column 2 to column 18:
      6:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'multiply' was found with the correct signature.
+Ill-typed arguments to '~' statement. No distribution 'multiply' was found.
   $ ../../../../install/default/bin/stanc oneline-error.stan
 Syntax error in 'oneline-error.stan', line 1, column 20 to column 21, parsing error:
    -------------------------------------------------
@@ -2076,7 +2076,7 @@ Semantic error in 'signature_sampling_unknown.stan', line 8, column 2 to column 
      9:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'foo_whatev' was found with the correct signature.
+Ill-typed arguments to '~' statement. No distribution 'foo_whatev' was found.
   $ ../../../../install/default/bin/stanc stanc_helper.stan
 Semantic error in 'stanc_helper.stan', line 5, column 2 to column 18:
    -------------------------------------------------
@@ -2087,7 +2087,7 @@ Semantic error in 'stanc_helper.stan', line 5, column 2 to column 18:
      6:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'ormal' was found with the correct signature.
+Ill-typed arguments to '~' statement. No distribution 'ormal' was found.
   $ ../../../../install/default/bin/stanc string_literal_newline.stan
 Syntax error in 'string_literal_newline.stan', line 3, column 1, lexing error:
    -------------------------------------------------

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2037,7 +2037,35 @@ Semantic error in 'signature_sampling_known.stan', line 8, column 2 to column 29
      9:  }
    -------------------------------------------------
 
-Ill-typed arguments to '~' statement. No distribution 'bernoulli_logit' was found with the correct signature.
+Ill-typed arguments supplied to function 'bernoulli_logit':
+(vector, vector)
+Available signatures:
+(int, row_vector) => real
+  The first argument must be int but got vector
+(int, vector) => real
+  The first argument must be int but got vector
+(int, array[] real) => real
+  The first argument must be int but got vector
+(int, real) => real
+  The first argument must be int but got vector
+(array[] int, row_vector) => real
+  The first argument must be array[] int but got vector
+(Additional signatures omitted)
+  $ ../../../../install/default/bin/stanc signature_sampling_udf.stan
+Semantic error in 'signature_sampling_udf.stan', line 8, column 2 to column 19:
+   -------------------------------------------------
+     6:  
+     7:  model {
+     8:    1.0 ~ foo(3.5,3);
+           ^
+     9:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to function 'foo':
+(real, real, int)
+Available signatures:
+(real, int, real) => real
+  The second argument must be int but got real
   $ ../../../../install/default/bin/stanc signature_sampling_unknown.stan
 Semantic error in 'signature_sampling_unknown.stan', line 8, column 2 to column 24:
    -------------------------------------------------


### PR DESCRIPTION
Currently, no matter what goes wrong when typechecking a statement like `x ~ foo(3)`, the same error is output if `foo` is invalid:
`Ill-typed arguments to '~' statement. No distribution 'foo' was found with the correct signature.`

This is much weaker than for other function errors, which will output valid signatures or ambiguous match results. This PR simply tries to make them look more like function signature errors. It's not perfect (a 100% ideal error might try to re-construct the `~` notation rather than formatting them like the function calls they are under the hood) but it's certainly much more informative than before.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improve type errors generated in `~` statements.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
