### PR TITLE
Add --dump-stan-math-distributions

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -49,6 +49,8 @@ let rec expand_arg = function
             map (range 0 8) ~f:(fun i -> bare_array_type (a, i)) ))
 
 type fkind = Lpmf | Lpdf | Rng | Cdf | Ccdf | UnaryVectorized
+[@@deriving show {with_path= false}]
+
 type fun_arg = UnsizedType.autodifftype * UnsizedType.t
 
 type stan_math_table_values =
@@ -493,6 +495,14 @@ let pretty_print_all_math_sigs ppf () =
   pf ppf "@[<v>%a@]"
     (list ~sep:cut pp_sigs_for_name)
     (List.sort ~compare (Hashtbl.keys stan_math_signatures))
+
+let pretty_print_all_math_distributions ppf () =
+  let open Fmt in
+  let pp_dist ppf (kinds, name, _, _) =
+    pf ppf "@[%s: %a@]" name
+      (list ~sep:comma Fmt.string)
+      (List.map ~f:(Fn.compose String.lowercase show_fkind) kinds) in
+  pf ppf "@[<v>%a@]" (list ~sep:cut pp_dist) distributions
 
 let pretty_print_math_lib_operator_sigs op =
   if op = Operator.IntDivide then

--- a/src/middle/dune
+++ b/src/middle/dune
@@ -4,4 +4,9 @@
  (libraries core_kernel str fmt common re)
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_deriving.map ppx_deriving.fold ppx_deriving.create)))
+  (pps
+   ppx_jane
+   ppx_deriving.map
+   ppx_deriving.fold
+   ppx_deriving.create
+   ppx_deriving.show)))

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -29,6 +29,7 @@ let dump_tx_mir_pretty = ref false
 let dump_opt_mir = ref false
 let dump_opt_mir_pretty = ref false
 let dump_stan_math_sigs = ref false
+let dump_stan_math_distributions = ref false
 let opt_lvl = ref Optimize.O0
 let no_soa_opt = ref false
 let soa_opt = ref false
@@ -100,6 +101,10 @@ let options =
       , Arg.Set dump_stan_math_sigs
       , " Dump out the list of supported type signatures for Stan Math backend."
       )
+    ; ( "--dump-stan-math-distributions"
+      , Arg.Set dump_stan_math_distributions
+      , " Dump out the list of supported probability distributions and their \
+         supported suffix types for the Stan Math backend." )
     ; ( "--warn-uninitialized"
       , Arg.Set warn_uninitialized
       , " Emit warnings about uninitialized variables to stderr. Currently an \
@@ -316,10 +321,13 @@ let main () =
   (* Parse the arguments. *)
   Arg.parse options add_file usage ;
   print_deprecated_arg_warning ;
-  (* print_deprecated_arg_warning options; *)
   (* Deal with multiple modalities *)
   if !dump_stan_math_sigs then (
     Stan_math_signatures.pretty_print_all_math_sigs Format.std_formatter () ;
+    exit 0 ) ;
+  if !dump_stan_math_distributions then (
+    Stan_math_signatures.pretty_print_all_math_distributions
+      Format.std_formatter () ;
     exit 0 ) ;
   if !model_file = "" then model_file_err () ;
   (* if we only have functions, always compile as standalone *)

--- a/test/integration/cli-args/canonicalize/canonicalize.t
+++ b/test/integration/cli-args/canonicalize/canonicalize.t
@@ -15,6 +15,7 @@ Test that a nonsense argument is caught
     --debug-transformed-mir         For debugging purposes: print the MIR after the backend has transformed it.
     --debug-transformed-mir-pretty  For debugging purposes: pretty print the MIR after the backend has transformed it.
     --dump-stan-math-signatures     Dump out the list of supported type signatures for Stan Math backend.
+    --dump-stan-math-distributions  Dump out the list of supported probability distributions and their supported suffix types for the Stan Math backend.
     --warn-uninitialized            Emit warnings about uninitialized variables to stderr. Currently an experimental feature.
     --warn-pedantic                 Emit warnings about common mistakes in Stan programs.
     --auto-format                   Pretty prints a formatted version of the Stan program.
@@ -59,6 +60,7 @@ Test capitalization - this should fail due to the lack of model_name, not the ca
     --debug-transformed-mir         For debugging purposes: print the MIR after the backend has transformed it.
     --debug-transformed-mir-pretty  For debugging purposes: pretty print the MIR after the backend has transformed it.
     --dump-stan-math-signatures     Dump out the list of supported type signatures for Stan Math backend.
+    --dump-stan-math-distributions  Dump out the list of supported probability distributions and their supported suffix types for the Stan Math backend.
     --warn-uninitialized            Emit warnings about uninitialized variables to stderr. Currently an experimental feature.
     --warn-pedantic                 Emit warnings about common mistakes in Stan programs.
     --auto-format                   Pretty prints a formatted version of the Stan program.

--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -13,6 +13,7 @@ Show help
     --debug-transformed-mir         For debugging purposes: print the MIR after the backend has transformed it.
     --debug-transformed-mir-pretty  For debugging purposes: pretty print the MIR after the backend has transformed it.
     --dump-stan-math-signatures     Dump out the list of supported type signatures for Stan Math backend.
+    --dump-stan-math-distributions  Dump out the list of supported probability distributions and their supported suffix types for the Stan Math backend.
     --warn-uninitialized            Emit warnings about uninitialized variables to stderr. Currently an experimental feature.
     --warn-pedantic                 Emit warnings about common mistakes in Stan programs.
     --auto-format                   Pretty prints a formatted version of the Stan program.

--- a/test/integration/signatures/stan_math_distributions.t
+++ b/test/integration/signatures/stan_math_distributions.t
@@ -1,0 +1,67 @@
+Display all Stan math distributions exposed in the language
+  $ stanc --dump-stan-math-distributions
+  beta_binomial: lpmf, rng, ccdf, cdf
+  beta: lpdf, rng, ccdf, cdf
+  beta_proportion: lpdf, ccdf, cdf
+  bernoulli: lpmf, rng, ccdf, cdf
+  bernoulli_logit: lpmf, rng
+  bernoulli_logit_glm: lpmf
+  binomial: lpmf, rng, ccdf, cdf
+  binomial_logit: lpmf
+  categorical: lpmf
+  categorical_logit: lpmf
+  categorical_logit_glm: lpmf
+  cauchy: lpdf, rng, ccdf, cdf
+  chi_square: lpdf, rng, ccdf, cdf
+  dirichlet: lpdf
+  discrete_range: lpmf, rng, ccdf, cdf
+  double_exponential: lpdf, rng, ccdf, cdf
+  exp_mod_normal: lpdf, rng, ccdf, cdf
+  exponential: lpdf, rng, ccdf, cdf
+  frechet: lpdf, rng, ccdf, cdf
+  gamma: lpdf, rng, ccdf, cdf
+  gaussian_dlm_obs: lpdf
+  gumbel: lpdf, rng, ccdf, cdf
+  hmm_latent: rng
+  hypergeometric: lpmf, rng
+  inv_chi_square: lpdf, rng, ccdf, cdf
+  inv_gamma: lpdf, rng, ccdf, cdf
+  inv_wishart: lpdf
+  lkj_corr: lpdf
+  lkj_corr_cholesky: lpdf
+  logistic: lpdf, rng, ccdf, cdf
+  loglogistic: lpdf, rng, cdf
+  lognormal: lpdf, rng, ccdf, cdf
+  multi_gp: lpdf
+  multi_gp_cholesky: lpdf
+  multinomial: lpmf
+  multinomial_logit: lpmf
+  multi_normal: lpdf
+  multi_normal_cholesky: lpdf
+  multi_normal_prec: lpdf
+  multi_student_t: lpdf
+  neg_binomial: lpmf, rng, ccdf, cdf
+  neg_binomial_2: lpmf, rng, ccdf, cdf
+  neg_binomial_2_log: lpmf, rng
+  neg_binomial_2_log_glm: lpmf
+  normal: lpdf, rng, ccdf, cdf
+  normal_id_glm: lpdf
+  ordered_logistic: lpmf
+  ordered_logistic_glm: lpmf
+  ordered_probit: lpmf
+  pareto: lpdf, rng, ccdf, cdf
+  pareto_type_2: lpdf, rng, ccdf, cdf
+  poisson: lpmf, rng, ccdf, cdf
+  poisson_log: lpmf, rng
+  poisson_log_glm: lpmf
+  rayleigh: lpdf, rng, ccdf, cdf
+  scaled_inv_chi_square: lpdf, rng, ccdf, cdf
+  skew_normal: lpdf, rng, ccdf, cdf
+  skew_double_exponential: lpdf, rng, ccdf, cdf
+  student_t: lpdf, rng, ccdf, cdf
+  std_normal: lpdf, rng, ccdf, cdf
+  uniform: lpdf, rng, ccdf, cdf
+  von_mises: lpdf, rng, ccdf, cdf
+  weibull: lpdf, rng, ccdf, cdf
+  wiener: lpdf
+  wishart: lpdf


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made (like `--dump-stan-math-signatures` we don't want to guarantee this by documenting an API)

## Release notes

Add `--dump-stan-math-distributions`. This lists the name of the distribution (like `normal`) and which kinds of function are supported (e.g. `lpdf, rng, cdf, ccdf`)

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
