### PR TITLE
Adds documentation for exposing a distribution function signature.

### DIFF
--- a/docs/exposing_new_functions.mld
+++ b/docs/exposing_new_functions.mld
@@ -1,0 +1,31 @@
+{0 Exposing New Functions to stanc3}
+
+
+
+{1 Background}
+
+For a function to be built into Stan, it has to be included in the Stan Math library and its signature has to be
+exposed to the parser. To do the latter, we have to add a corresponding line in [src/middle/Stan_math_signatures.ml].
+The parser uses the signatures defined there to do the type checking. 
+
+
+{1 Adding a distribution function }
+To add a distribution, we have to find the line containing [let distributions =]. The existing distributions can be
+used for reference. The first argument defines the type of function we want to add.
+The second argument is the function name without the [_...] part. The third argument specifies
+the argument types of the function. The last argument describes whether the return type can be represented as an
+Array of Structs (AoS) or as a Struct of Arrays (SoA). The following line exposes a function [foo_lpdf] which takes in
+two real numbers:
+{[
+  ; ([Lpdf], "foo", [DVReal; DVReal], SoA)
+]}
+
+For overloaded functions, we need to add a signature for each combination of variable types. If [foo_lpdf] admits either
+an integer or a real as its first argument, the proper way to expose the function would be:
+{[
+  ; ([Lpdf], "foo", [DVReal; DVReal], SoA)
+  ; ([Lpdf], "foo", [DVInt; DVReal], SoA)
+]}
+
+Once we modified [Stan_math_signatures.ml], we need to compile stanc3.
+

--- a/docs/index.mld
+++ b/docs/index.mld
@@ -19,6 +19,8 @@ to a new developer.
   Wiki on using [Format]/[Fmt] module}
 - {{!page-parser_messages}
   Page on modifying the parser's error messages}
+- {{!page-exposing_new_functions}
+  Page on exposing a new function of the Stan Math library}
 - {{:https://github.com/stan-dev/stanc3/wiki/Software-Engineering-best-practices}
   Wiki on generic software best practices}
 


### PR DESCRIPTION
See [Issue (stan-dev/stan): Wiki section outdated: Contributing New Functions to Stan 4) Exposing Functions to Stan #3109 ](https://github.com/stan-dev/stan/issues/3109)
The process of adding a new function to Stan involves changes
to src/middle/Stan_math_signatures.ml, but is currently not documented.
This commit adds very basic documentation for exposing a distribution
function to stanc3. It is incomplete, as only few examples and little
explanation is given.
@WardBrian: There was some guesswork involved, could you review the
text so no wrong information is supplied? Some further information on the
format would probably be helpful, but I lack the knowledge to add more.

#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes
Documentation: Process of exposing Stan Math library functions is explained


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
