### PR TITLE
Always print () around ternary operator in MIR

### DIFF
--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -33,10 +33,10 @@ module Fixed = struct
             Fmt.(list pp_e ~sep:Fmt.comma)
             args
       | TernaryIf (pred, texpr, fexpr) ->
-          Fmt.pf ppf {|@[%a@ %a@,%a@,%a@ %a@]|} pp_e pred pp_builtin_syntax "?"
+          Fmt.pf ppf "(@[%a@ %a@ %a@ %a@ %a@])" pp_e pred pp_builtin_syntax "?"
             pp_e texpr pp_builtin_syntax ":" pp_e fexpr
       | Indexed (expr, indices) ->
-          Fmt.pf ppf {|@[%a%a@]|} pp_e expr
+          Fmt.pf ppf "@[%a%a@]" pp_e expr
             ( if List.is_empty indices then fun _ _ -> ()
             else Fmt.(list (Index.pp pp_e) ~sep:comma |> brackets) )
             indices

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -907,7 +907,7 @@ let%expect_test "inline function in ternary if " =
               break;
             }
           }
-          FnPrint__(inline_sym1__ ?inline_sym4__: inline_sym7__);
+          FnPrint__((inline_sym1__ ? inline_sym4__ : inline_sym7__));
         }
       }
 


### PR DESCRIPTION
Spotted while debugging #1151, the MIR pretty-printer will print expressions which look incorrect due to the lack of parenthesis. For example, the code ` (1 ? x : y) * 3` would be printed as ` 1 ?x :y * 3` which would have a different associativity. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

MIR pretty printing now always adds ( and ) around the ternary operator `?:`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
